### PR TITLE
fix(automation): compact writer before re-review

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -971,7 +971,7 @@ pipeline stage and act as the **sole authority** for
 fail back to implementation via [`_fail_back_agent_error`](hephaestus/automation/pipeline/stages/pr_review.py).
 **States.** `ENTER → REVIEW_WAIT → VALIDATE_WAIT → POST →
 DIFFICULTY_WAIT → ADDRESS_WAIT → PUSH_WAIT → EVAL →
-COMPACT_WRITER_WAIT → REVIEW_WAIT` (retry loop), or ADVANCE to
+COMPACT_REVIEWER_WAIT → COMPACT_WRITER_WAIT → REVIEW_WAIT` (retry loop), or ADVANCE to
 `merge_wait`.
 
 #### on_enter [M]
@@ -993,10 +993,11 @@ so a failed later round can never replay an earlier round's results.
 Submit `AgentJob` with
 [`get_pr_review_analysis_prompt`](hephaestus/automation/prompts/pr_review.py)
 
-- The reviewer session token is `reviewer_agent(AGENT_PR_REVIEWER, round)`.
-  It is new for every round so a reviewer cannot inherit its own prior
-  verdict. `VALIDATE_WAIT` reuses that same round token only to validate the
-  review it just produced.
+- The reviewer has one logical `AGENT_PR_REVIEWER` session for the item's
+  review cycle. `VALIDATE_WAIT` and later review rounds continue it. Claude
+  resolves that role through its deterministic session name; direct runners
+  return an opaque id that the coordinator stores in `WorkItem.session_ids`
+  and supplies as `AgentJob.resume_session_id` on the next turn.
 
 - `parse=parse_review_verdict`. Reviewer text lands in
 `payload["review_verdict"]`; raw review text in `payload["review_text"]`.
@@ -1048,16 +1049,16 @@ delegates the durable log write to [`_persist_address_fix_log`](hephaestus/autom
 "real-commit gate" (#1575): the `value` returned flags no-commit vs.
 real-commit.
 
-#### COMPACT_WRITER_WAIT [W:C]
+#### COMPACT_REVIEWER_WAIT and COMPACT_WRITER_WAIT [W:C]
 
-On a retryable non-GO result, a Claude-backed item with a worktree submits a
-best-effort `CompactJob` for the resumable writer session before the next
-`REVIEW_WAIT`: the implementer for a pipeline-created PR, or the
-address-review writer for an adopted PR. The job sends `/compact` with the
-writer's implementation model and always continues to review, including when
-the session does not exist or compaction fails. Reviewer sessions are not
-compacted because they are deliberately new per round. Codex has no resumable
-multi-turn session and therefore bypasses this state directly to `REVIEW_WAIT`.
+On every retryable non-GO result with a worktree, the stage first submits a
+best-effort `CompactJob` for the persisted reviewer session, then one for the
+writer session before the next `REVIEW_WAIT`: the implementer for a
+pipeline-created PR, or the address-review writer for an adopted PR. Both jobs
+send `/compact` and always continue, including when no session exists or
+compaction fails. Claude uses deterministic role-based session names; Codex
+and Pi resume their persisted opaque session IDs, so neither provider starts a
+fresh review turn merely because the loop iterated.
 
 #### EVAL [M]
 
@@ -1088,7 +1089,7 @@ The gate logic at [`PrReviewStage._eval`](hephaestus/automation/pipeline/stages/
 3. **Real NOGO/AMBIGUOUS round** → apply
  `state:implementation-no-go` (non-fatal pair write under
  [`PostReviewManager`](hephaestus/automation/pipeline/stages/pr_review.py)),
- bump round counters, compact the resumable writer where applicable, then
+ bump round counters, compact the resumable reviewer and writer, then
  re-review. cap exhaustion → `SKIP` with
  `state:skip` durable write.
 4. **GO round** → check the (blocking, minor, human) triple:
@@ -1429,6 +1430,9 @@ mutations.
 - [`AgentJob`](hephaestus/automation/pipeline/jobs.py) — Claude or
  Codex (`agent = resolve_agent(job.agent)`) with
  `prompt_builder(**prompt_kwargs)` composed in-worker.
+ `resume_session_id`, when set for a direct runner, selects its persisted
+ session instead of creating a fresh one; its returned id is carried in the
+ `JobResult` and persisted by the coordinator under the job's logical role.
  `sandbox = "workspace-write"` (default) or `"read-only"`
  (implementation review only); `expected_head_sha` — when set, the worker
  refuses to dispatch the agent unless the local `git rev-parse HEAD`
@@ -1442,6 +1446,9 @@ mutations.
 - [`GitJob`](hephaestus/automation/pipeline/jobs.py) — `op ∈ {clone,
  create_worktree, remove_worktree, rebase, push, commit_push}`,
  validated by `__post_init__`.
+- [`CompactJob`](hephaestus/automation/pipeline/jobs.py) — a best-effort
+ `/compact` turn for a persisted Claude, Codex, or Pi session; it never blocks
+ the retry lifecycle.
 
 ### Result semantics
 
@@ -1687,10 +1694,10 @@ remain as thin compatibility shims re-exporting `_resolve_model`,
  produces the underscore-joined human name; `session_uuid(...)`
  derives the deterministic UUIDv5 using `NAMESPACE_DNS`. The model
  token is appended when given so Claude Code `--resume` can never
- silently cross models. Per-iteration reviewers use
- `reviewer_agent(base, iteration)` (`plan-reviewer-r{N}`,
- `pr-reviewer-r{N}`) so a new iteration never inherits its own
- prior transcript.
+ silently cross models. Plan-review iterations use
+ `reviewer_agent(base, iteration)` (`plan-reviewer-r{N}`) where independent
+ plans need isolation. The PR-review retry loop instead retains its static
+ `pr-reviewer` role and compacts that session before continuing it.
 - **`issue_auto_impl_branch_name(issue)`** — canonical feature
  branch name (`{issue}-auto-impl`); referenced by
  [`implementation._gate`](hephaestus/automation/pipeline/stages/implementation.py).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -970,8 +970,9 @@ pipeline stage and act as the **sole authority** for
 **Pre-conditions.** Item has an `issue` AND a `pr` number; otherwise
 fail back to implementation via [`_fail_back_agent_error`](hephaestus/automation/pipeline/stages/pr_review.py).
 **States.** `ENTER → REVIEW_WAIT → VALIDATE_WAIT → POST →
-DIFFICULTY_WAIT → ADDRESS_WAIT → PUSH_WAIT → EVAL → (loop or
-FOLLOWUP_WAIT → PR_FINISH) or ADVANCE to`merge_wait`.
+DIFFICULTY_WAIT → ADDRESS_WAIT → PUSH_WAIT → EVAL →
+COMPACT_WRITER_WAIT → REVIEW_WAIT` (retry loop), or ADVANCE to
+`merge_wait`.
 
 #### on_enter [M]
 
@@ -991,6 +992,11 @@ Clear all round-scoped payload
 so a failed later round can never replay an earlier round's results.
 Submit `AgentJob` with
 [`get_pr_review_analysis_prompt`](hephaestus/automation/prompts/pr_review.py)
+
+- The reviewer session token is `reviewer_agent(AGENT_PR_REVIEWER, round)`.
+  It is new for every round so a reviewer cannot inherit its own prior
+  verdict. `VALIDATE_WAIT` reuses that same round token only to validate the
+  review it just produced.
 
 - `parse=parse_review_verdict`. Reviewer text lands in
 `payload["review_verdict"]`; raw review text in `payload["review_text"]`.
@@ -1042,6 +1048,17 @@ delegates the durable log write to [`_persist_address_fix_log`](hephaestus/autom
 "real-commit gate" (#1575): the `value` returned flags no-commit vs.
 real-commit.
 
+#### COMPACT_WRITER_WAIT [W:C]
+
+On a retryable non-GO result, a Claude-backed item with a worktree submits a
+best-effort `CompactJob` for the resumable writer session before the next
+`REVIEW_WAIT`: the implementer for a pipeline-created PR, or the
+address-review writer for an adopted PR. The job sends `/compact` with the
+writer's implementation model and always continues to review, including when
+the session does not exist or compaction fails. Reviewer sessions are not
+compacted because they are deliberately new per round. Codex has no resumable
+multi-turn session and therefore bypasses this state directly to `REVIEW_WAIT`.
+
 #### EVAL [M]
 
 [`PrReviewStage._eval`](hephaestus/automation/pipeline/stages/pr_review.py) implements
@@ -1071,7 +1088,8 @@ The gate logic at [`PrReviewStage._eval`](hephaestus/automation/pipeline/stages/
 3. **Real NOGO/AMBIGUOUS round** → apply
  `state:implementation-no-go` (non-fatal pair write under
  [`PostReviewManager`](hephaestus/automation/pipeline/stages/pr_review.py)),
- bump round counters, RETRY loop. cap exhaustion → `SKIP` with
+ bump round counters, compact the resumable writer where applicable, then
+ re-review. cap exhaustion → `SKIP` with
  `state:skip` durable write.
 4. **GO round** → check the (blocking, minor, human) triple:
 

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -456,3 +456,58 @@ def compact_session(
 
     logger.info("Issue #%s: /compact completed for agent=%s (session %s)", issue, agent, sid)
     return True
+
+
+def compact_agent_session(
+    repo: str,
+    issue: int | str,
+    provider: str,
+    session_agent: str,
+    cwd: Path,
+    timeout: int | None = None,
+    model: str | None = None,
+    session_id: str | None = None,
+) -> bool:
+    """Compact a persisted provider session without making it a hard gate.
+
+    Claude sessions use the established deterministic naming scheme.  Direct
+    providers (Codex and Pi) receive the opaque id returned by their previous
+    turn and resume it solely to process ``/compact``.  A missing id means no
+    direct session was created yet, so there is nothing to compact.
+    """
+    if provider == "claude":
+        return compact_session(repo, issue, session_agent, cwd, timeout, model)
+    if not session_id:
+        logger.debug(
+            "Issue #%s: no %s session id to compact for agent=%s; skipping",
+            issue,
+            provider,
+            session_agent,
+        )
+        return False
+    timeout_s = learn_claude_timeout() if timeout is None else timeout
+    try:
+        resume_agent_session(
+            agent=provider,
+            session_id=session_id,
+            prompt="/compact",
+            cwd=cwd,
+            timeout=timeout_s,
+            model=model or "",
+        )
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError, ValueError) as exc:
+        logger.warning(
+            "Issue #%s: /compact failed for provider=%s agent=%s (non-fatal): %s",
+            issue,
+            provider,
+            session_agent,
+            exc,
+        )
+        return False
+    logger.info(
+        "Issue #%s: /compact completed for provider=%s agent=%s",
+        issue,
+        provider,
+        session_agent,
+    )
+    return True

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .coordinator import PipelineConfig, run_pipeline
-    from .jobs import GIT_OPS, AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
+    from .jobs import GIT_OPS, AgentJob, BuildTestJob, CompactJob, GitJob, JobHandle, JobResult
     from .queues import CompletionQueue, StageQueue
     from .routing import (
         ROUTES,
@@ -32,6 +32,7 @@ __all__ = [
     "ROUTES",
     "AgentJob",
     "BuildTestJob",
+    "CompactJob",
     "CompletionQueue",
     "Disposition",
     "GitJob",
@@ -54,6 +55,7 @@ __all__ = [
 _LAZY_EXPORTS: dict[str, str] = {
     "AgentJob": "hephaestus.automation.pipeline.jobs",
     "BuildTestJob": "hephaestus.automation.pipeline.jobs",
+    "CompactJob": "hephaestus.automation.pipeline.jobs",
     "CompletionQueue": "hephaestus.automation.pipeline.queues",
     "Disposition": "hephaestus.automation.pipeline.routing",
     "GIT_OPS": "hephaestus.automation.pipeline.jobs",

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -897,6 +897,13 @@ class Coordinator:
             self._park_resumable(item)
             return
 
+        # Direct runners mint an opaque id on the first turn.  Keep it under
+        # the logical role rather than a round number so the next reviewer or
+        # writer turn resumes the same compacted conversation.
+        if isinstance(handle.job, AgentJob) and result.ok and result.session_id:
+            session_key = handle.job.session_agent or handle.job.agent
+            item.session_ids[session_key] = result.session_id
+
         stage = self.stages[item.stage]
         ctx = self._ctx_for(item)
         try:

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -90,6 +90,25 @@ class GitJob:
 
 
 @dataclass(frozen=True)
+class CompactJob:
+    """Best-effort compaction of one resumable Claude session.
+
+    ``CompactJob`` is deliberately distinct from :class:`AgentJob`: it sends
+    the Claude CLI's built-in ``/compact`` command to an existing session and
+    never runs an implementation or review prompt.  Stages only create it for
+    the Claude provider; direct-agent runtimes have no resumable session.
+    """
+
+    repo: str
+    issue: int | str
+    session_agent: str
+    model: str
+    cwd: Path
+    timeout_s: int
+    descr: str = "compact_session"
+
+
+@dataclass(frozen=True)
 class JobResult:
     """Result of a completed job."""
 
@@ -115,5 +134,5 @@ class JobHandle:
     never break hashing.
     """
 
-    job: AgentJob | BuildTestJob | GitJob
+    job: AgentJob | BuildTestJob | GitJob | CompactJob
     on_done_state: str | StageName

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -33,6 +33,10 @@ class AgentJob:
     cwd: Path
     timeout_s: int
     session_agent: str = ""
+    # Direct-runner providers return an opaque session id.  The coordinator
+    # stores it on the WorkItem and supplies it here on subsequent turns so
+    # review/implementation context survives across loop iterations.
+    resume_session_id: str | None = None
     prompt_kwargs: dict[str, Any] = field(default_factory=dict)
     output_format: str = "text"
     parse: Callable[[str], Any] | None = None  # e.g. claude_invoke.parse_review_verdict
@@ -91,20 +95,22 @@ class GitJob:
 
 @dataclass(frozen=True)
 class CompactJob:
-    """Best-effort compaction of one resumable Claude session.
+    """Best-effort compaction of one resumable agent session.
 
     ``CompactJob`` is deliberately distinct from :class:`AgentJob`: it sends
-    the Claude CLI's built-in ``/compact`` command to an existing session and
-    never runs an implementation or review prompt.  Stages only create it for
-    the Claude provider; direct-agent runtimes have no resumable session.
+    ``/compact`` to an existing session and never runs an implementation or
+    review prompt.  Claude resolves its deterministic session id from the
+    logical ``session_agent``; direct runtimes receive the persisted id.
     """
 
     repo: str
     issue: int | str
+    agent: str
     session_agent: str
     model: str
     cwd: Path
     timeout_s: int
+    session_id: str | None = None
     descr: str = "compact_session"
 
 
@@ -120,6 +126,7 @@ class JobResult:
     interrupted: bool = False
     duration_s: float = 0.0
     worker_id: str = ""
+    session_id: str | None = None
 
 
 @dataclass(frozen=True, eq=False)

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -64,7 +64,7 @@ from hephaestus.automation.state_labels import (
 )
 
 from ..events import StageEvent
-from ..jobs import AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
+from ..jobs import AgentJob, BuildTestJob, CompactJob, GitJob, JobHandle, JobResult
 from ..routing import ROUTES, Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
 
@@ -72,6 +72,7 @@ __all__ = [
     "GIT_JOB_TIMEOUT_S",
     "AgentJob",
     "BuildTestJob",
+    "CompactJob",
     "Continue",
     "Disposition",
     "GitJob",
@@ -405,14 +406,14 @@ class JobRequest:
     """Request a job be submitted to the worker pool.
 
     Attributes:
-        job: The frozen job spec to submit (agent, build/test, or git — the
-            same union :class:`~..jobs.JobHandle` carries).
+        job: The frozen job spec to submit (agent, build/test, git, or session
+            compaction — the same union :class:`~..jobs.JobHandle` carries).
         on_done_state: The state the coordinator moves the item to after the
             job completes and ``on_job_done`` has run.
 
     """
 
-    job: AgentJob | BuildTestJob | GitJob
+    job: AgentJob | BuildTestJob | GitJob | CompactJob
     on_done_state: str
 
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -358,6 +358,7 @@ class ImplementationStage(Stage):
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
             session_agent=AGENT_IMPLEMENTER,
+            resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={
                 "branch_name": item.branch,
                 "status_text": item.payload.get("worktree_status", ""),
@@ -433,6 +434,7 @@ class ImplementationStage(Stage):
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
             session_agent=AGENT_IMPLEMENTER,
+            resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={
                 "issue_number": item.issue,
                 "issue_title": item.payload.get("issue_title", ""),

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -12,7 +12,8 @@ collaborators include
 contract):
 
 - States: ENTER -> REVIEW_WAIT -> VALIDATE_WAIT -> POST -> DIFFICULTY_WAIT
-  -> ADDRESS_WAIT -> PUSH_WAIT -> EVAL -> (loop to REVIEW_WAIT) or terminal
+  -> ADDRESS_WAIT -> PUSH_WAIT -> EVAL -> COMPACT_WRITER_WAIT -> REVIEW_WAIT
+  or terminal
   advance to ``merge_wait``. The legacy follow-up mini-states have been
   retired (#2140); a clean GO advances to ``merge_wait`` from EVAL.
 - Budgets: ``pr_review_iter`` = 3 (soft cap), ``pr_review_hard`` = 6 (hard
@@ -137,6 +138,7 @@ from hephaestus.automation.session_naming import (
     AGENT_COMMENT_CLASSIFIER,
     AGENT_IMPLEMENTER,
     AGENT_PR_REVIEWER,
+    reviewer_agent,
 )
 from hephaestus.automation.state_labels import STATE_SKIP
 
@@ -145,6 +147,7 @@ from ..work_item import ItemKind
 from .base import (
     GIT_JOB_TIMEOUT_S,
     AgentJob,
+    CompactJob,
     Continue,
     Disposition,
     GitJob,
@@ -199,6 +202,7 @@ DIFFICULTY_WAIT = "DIFFICULTY_WAIT"
 ADDRESS_WAIT = "ADDRESS_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
 EVAL = "EVAL"
+COMPACT_WRITER_WAIT = "COMPACT_WRITER_WAIT"
 
 _STEP_HANDLER_NAMES: dict[str, str] = {
     ENTER: "_enter",
@@ -210,6 +214,7 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     ADDRESS_WAIT: "_address",
     PUSH_WAIT: "_push_wait",
     EVAL: "_eval",
+    COMPACT_WRITER_WAIT: "_compact_writer_wait",
 }
 
 
@@ -252,6 +257,7 @@ _ROUND_PAYLOAD_KEYS = (
     "push_no_commit",
     "no_commit_retry_done",
     "unaddressed_findings",
+    "review_session_agent",
 )
 
 
@@ -538,6 +544,8 @@ class PrReviewStage(Stage):
         for key in _ROUND_PAYLOAD_KEYS:
             item.payload.pop(key, None)
         round_index = item.payload.get("pr_review_round", 0)
+        review_session_agent = reviewer_agent(AGENT_PR_REVIEWER, round_index)
+        item.payload["review_session_agent"] = review_session_agent
         logger.info(
             "pr_review:%d: requesting review job (round %d, PR #%d)",
             issue,
@@ -552,7 +560,7 @@ class PrReviewStage(Stage):
             prompt_builder=get_pr_review_analysis_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=pr_reviewer_claude_timeout(),
-            session_agent=AGENT_PR_REVIEWER,
+            session_agent=review_session_agent,
             sandbox="read-only",
             # The normal $athena:pr-review skill is read-only, but its
             # declared workflow uses local Bash helpers and review subagents.
@@ -599,7 +607,10 @@ class PrReviewStage(Stage):
             prompt_builder=get_review_validation_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=pr_reviewer_claude_timeout(),
-            session_agent=AGENT_PR_REVIEWER,
+            session_agent=str(
+                item.payload.get("review_session_agent")
+                or reviewer_agent(AGENT_PR_REVIEWER, item.payload.get("pr_review_round", 0))
+            ),
             sandbox="read-only",
             prompt_kwargs={
                 "pr_number": item.pr,
@@ -658,6 +669,29 @@ class PrReviewStage(Stage):
             descr="push_fixes",
         )
         return JobRequest(git_job, on_done_state=EVAL)
+
+    def _compact_writer_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Compact the resumable writer before the next independent review.
+
+        Reviewer sessions are intentionally per-round and therefore have no
+        transcript to carry forward.  Only the writer may be resumed after a
+        failed round, so only that session is compacted.  Codex does not
+        support multi-turn sessions and never enters this state.
+        """
+        if agent_provider(ctx) != "claude" or not item.worktree:
+            return Continue(next_state=REVIEW_WAIT)
+        session_agent = (
+            AGENT_ADDRESS_REVIEW if item.payload.get("existing_pr") else AGENT_IMPLEMENTER
+        )
+        job = CompactJob(
+            repo=item.repo,
+            issue=_issue_number(item),
+            session_agent=session_agent,
+            model=stage_model(ctx, "implementer", implementer_model),
+            cwd=_worktree_path(item, ctx),
+            timeout_s=implementer_claude_timeout(),
+        )
+        return JobRequest(job, on_done_state=REVIEW_WAIT)
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Store job results on the item payload (state is still the WAIT state).
@@ -961,7 +995,7 @@ class PrReviewStage(Stage):
                 soft_cap,
                 unresolved,
             )
-            return Continue(next_state=REVIEW_WAIT)
+            return self._compact_before_next_review(item, ctx)
         made_progress = prev_unresolved is not None and automation_unresolved < prev_unresolved
         if round_done < hard_cap and made_progress:
             # #1554 progress-aware extension: rounds soft_cap+1..hard_cap are
@@ -975,7 +1009,7 @@ class PrReviewStage(Stage):
                 prev_unresolved,
                 automation_unresolved,
             )
-            return Continue(next_state=REVIEW_WAIT)
+            return self._compact_before_next_review(item, ctx)
 
         logger.warning(
             "pr_review:%d: exhausted at round %d (automation unresolved %s -> %d); applying %s",
@@ -995,6 +1029,13 @@ class PrReviewStage(Stage):
             f"feedback, then remove this label to re-enter the loop.",
         )
         return StageOutcome(Disposition.SKIP, "exhaustion")
+
+    @staticmethod
+    def _compact_before_next_review(item: WorkItem, ctx: StageContext) -> Continue:
+        """Route a failed Claude round through writer compaction when possible."""
+        if agent_provider(ctx) == "claude" and item.worktree:
+            return Continue(next_state=COMPACT_WRITER_WAIT)
+        return Continue(next_state=REVIEW_WAIT)
 
     @staticmethod
     def _is_zero_thread_nogo(verdict: Any, payload: dict[str, Any], total_unresolved: int) -> bool:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -12,7 +12,8 @@ collaborators include
 contract):
 
 - States: ENTER -> REVIEW_WAIT -> VALIDATE_WAIT -> POST -> DIFFICULTY_WAIT
-  -> ADDRESS_WAIT -> PUSH_WAIT -> EVAL -> COMPACT_WRITER_WAIT -> REVIEW_WAIT
+  -> ADDRESS_WAIT -> PUSH_WAIT -> EVAL -> COMPACT_REVIEWER_WAIT
+  -> COMPACT_WRITER_WAIT -> REVIEW_WAIT
   or terminal
   advance to ``merge_wait``. The legacy follow-up mini-states have been
   retired (#2140); a clean GO advances to ``merge_wait`` from EVAL.
@@ -138,7 +139,6 @@ from hephaestus.automation.session_naming import (
     AGENT_COMMENT_CLASSIFIER,
     AGENT_IMPLEMENTER,
     AGENT_PR_REVIEWER,
-    reviewer_agent,
 )
 from hephaestus.automation.state_labels import STATE_SKIP
 
@@ -202,6 +202,7 @@ DIFFICULTY_WAIT = "DIFFICULTY_WAIT"
 ADDRESS_WAIT = "ADDRESS_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
 EVAL = "EVAL"
+COMPACT_REVIEWER_WAIT = "COMPACT_REVIEWER_WAIT"
 COMPACT_WRITER_WAIT = "COMPACT_WRITER_WAIT"
 
 _STEP_HANDLER_NAMES: dict[str, str] = {
@@ -214,6 +215,7 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     ADDRESS_WAIT: "_address",
     PUSH_WAIT: "_push_wait",
     EVAL: "_eval",
+    COMPACT_REVIEWER_WAIT: "_compact_reviewer_wait",
     COMPACT_WRITER_WAIT: "_compact_writer_wait",
 }
 
@@ -257,7 +259,6 @@ _ROUND_PAYLOAD_KEYS = (
     "push_no_commit",
     "no_commit_retry_done",
     "unaddressed_findings",
-    "review_session_agent",
 )
 
 
@@ -544,8 +545,6 @@ class PrReviewStage(Stage):
         for key in _ROUND_PAYLOAD_KEYS:
             item.payload.pop(key, None)
         round_index = item.payload.get("pr_review_round", 0)
-        review_session_agent = reviewer_agent(AGENT_PR_REVIEWER, round_index)
-        item.payload["review_session_agent"] = review_session_agent
         logger.info(
             "pr_review:%d: requesting review job (round %d, PR #%d)",
             issue,
@@ -560,7 +559,8 @@ class PrReviewStage(Stage):
             prompt_builder=get_pr_review_analysis_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=pr_reviewer_claude_timeout(),
-            session_agent=review_session_agent,
+            session_agent=AGENT_PR_REVIEWER,
+            resume_session_id=item.session_ids.get(AGENT_PR_REVIEWER),
             sandbox="read-only",
             # The normal $athena:pr-review skill is read-only, but its
             # declared workflow uses local Bash helpers and review subagents.
@@ -607,10 +607,8 @@ class PrReviewStage(Stage):
             prompt_builder=get_review_validation_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=pr_reviewer_claude_timeout(),
-            session_agent=str(
-                item.payload.get("review_session_agent")
-                or reviewer_agent(AGENT_PR_REVIEWER, item.payload.get("pr_review_round", 0))
-            ),
+            session_agent=AGENT_PR_REVIEWER,
+            resume_session_id=item.session_ids.get(AGENT_PR_REVIEWER),
             sandbox="read-only",
             prompt_kwargs={
                 "pr_number": item.pr,
@@ -670,15 +668,25 @@ class PrReviewStage(Stage):
         )
         return JobRequest(git_job, on_done_state=EVAL)
 
-    def _compact_writer_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Compact the resumable writer before the next independent review.
+    def _compact_reviewer_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Compact the reviewer before the next retry continues its session."""
+        if not item.worktree:
+            return Continue(next_state=COMPACT_WRITER_WAIT)
+        job = CompactJob(
+            repo=item.repo,
+            issue=_issue_number(item),
+            agent=agent_provider(ctx),
+            session_agent=AGENT_PR_REVIEWER,
+            model=stage_model(ctx, "reviewer", reviewer_model),
+            cwd=_worktree_path(item, ctx),
+            timeout_s=pr_reviewer_claude_timeout(),
+            session_id=item.session_ids.get(AGENT_PR_REVIEWER),
+        )
+        return JobRequest(job, on_done_state=COMPACT_WRITER_WAIT)
 
-        Reviewer sessions are intentionally per-round and therefore have no
-        transcript to carry forward.  Only the writer may be resumed after a
-        failed round, so only that session is compacted.  Codex does not
-        support multi-turn sessions and never enters this state.
-        """
-        if agent_provider(ctx) != "claude" or not item.worktree:
+    def _compact_writer_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Compact the writer before the next retry continues its session."""
+        if not item.worktree:
             return Continue(next_state=REVIEW_WAIT)
         session_agent = (
             AGENT_ADDRESS_REVIEW if item.payload.get("existing_pr") else AGENT_IMPLEMENTER
@@ -686,10 +694,12 @@ class PrReviewStage(Stage):
         job = CompactJob(
             repo=item.repo,
             issue=_issue_number(item),
+            agent=agent_provider(ctx),
             session_agent=session_agent,
             model=stage_model(ctx, "implementer", implementer_model),
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
+            session_id=item.session_ids.get(session_agent),
         )
         return JobRequest(job, on_done_state=REVIEW_WAIT)
 
@@ -849,6 +859,7 @@ class PrReviewStage(Stage):
                 cwd=_worktree_path(item, ctx),
                 timeout_s=address_review_claude_timeout(),
                 session_agent=AGENT_ADDRESS_REVIEW,
+                resume_session_id=item.session_ids.get(AGENT_ADDRESS_REVIEW),
                 prompt_kwargs={
                     "pr_number": item.pr,
                     "issue_number": item.issue,
@@ -873,6 +884,7 @@ class PrReviewStage(Stage):
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
             session_agent=AGENT_IMPLEMENTER,
+            resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={
                 "issue_number": item.issue,
                 "prev_iteration": item.payload.get("pr_review_round", 0),
@@ -1032,9 +1044,9 @@ class PrReviewStage(Stage):
 
     @staticmethod
     def _compact_before_next_review(item: WorkItem, ctx: StageContext) -> Continue:
-        """Route a failed Claude round through writer compaction when possible."""
-        if agent_provider(ctx) == "claude" and item.worktree:
-            return Continue(next_state=COMPACT_WRITER_WAIT)
+        """Compact both persisted sessions before continuing the next review round."""
+        if item.worktree:
+            return Continue(next_state=COMPACT_REVIEWER_WAIT)
         return Continue(next_state=REVIEW_WAIT)
 
     @staticmethod

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1,4 +1,4 @@
-"""Worker pool: the only place agent, build/test, and git/network work runs.
+"""Worker pool: the only place agent, build/test, git, and session work runs.
 
 The coordinator submits frozen jobs and drains ``(handle, result)`` tuples from
 the completion queue. Workers never touch WorkItems or stage queues and never
@@ -20,10 +20,12 @@ from pathlib import Path
 
 from hephaestus.agents.runtime import resolve_agent, run_agent_session
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
+from hephaestus.automation.learn import compact_session
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
+    CompactJob,
     GitJob,
     JobHandle,
     JobResult,
@@ -191,7 +193,7 @@ class WorkerPool:
 
     def submit(
         self,
-        job: AgentJob | BuildTestJob | GitJob,
+        job: AgentJob | BuildTestJob | GitJob | CompactJob,
         on_done_state: str | StageName,
         *,
         claim_key: str = "",
@@ -281,7 +283,7 @@ class WorkerPool:
 
     def _run(
         self,
-        job: AgentJob | BuildTestJob | GitJob,
+        job: AgentJob | BuildTestJob | GitJob | CompactJob,
         claim_key: str = "",
         claim_stage: str = "",
     ) -> JobResult:
@@ -321,6 +323,8 @@ class WorkerPool:
                     result = self._run_build_test(job)
                 elif isinstance(job, GitJob):
                     result = self._run_git(job)
+                elif isinstance(job, CompactJob):
+                    result = self._run_compact(job)
                 else:
                     raise TypeError(f"unknown job type {type(job)}")
             except (KeyboardInterrupt, SystemExit, GeneratorExit) as exc:
@@ -463,6 +467,21 @@ class WorkerPool:
                 ok=False,
                 error=f"{type(exc).__name__}: {exc!s}"[:_ERR_MAX],
             )
+
+    @staticmethod
+    def _run_compact(job: CompactJob) -> JobResult:
+        """Compact a Claude session without making compaction a hard gate."""
+        compacted = compact_session(
+            repo=job.repo,
+            issue=job.issue,
+            agent=job.session_agent,
+            cwd=job.cwd,
+            timeout=job.timeout_s,
+            model=job.model,
+        )
+        # ``compact_session`` intentionally swallows expected failures; a
+        # missing or uncompactable transcript must not stall a review cycle.
+        return JobResult(ok=True, value=compacted)
 
     def _run_build_test(self, job: BuildTestJob) -> JobResult:
         """Run a build/test job (subprocess with argv)."""

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -18,9 +18,9 @@ from contextvars import copy_context
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from hephaestus.agents.runtime import resolve_agent, run_agent_session
+from hephaestus.agents.runtime import resolve_agent, resume_agent_session, run_agent_session
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
-from hephaestus.automation.learn import compact_session
+from hephaestus.automation.learn import compact_agent_session
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
@@ -389,7 +389,7 @@ class WorkerPool:
             session_agent = job.session_agent or job.agent
             prompt = job.prompt_builder(**job.prompt_kwargs)
 
-            def _invoke() -> str:
+            def _invoke() -> tuple[str, str | None]:
                 if is_claude:
                     # Scope priority: an explicit per-job grant (a stage that
                     # knows its exact needs, e.g. pr_review) wins; a read-only
@@ -413,7 +413,16 @@ class WorkerPool:
                         allowed_tools=scope.allowed_tools,
                         permission_mode=scope.permission_mode,
                     )
-                    return stdout
+                    return stdout, None
+                if job.resume_session_id:
+                    agent_result = resume_agent_session(
+                        agent=agent,
+                        session_id=job.resume_session_id,
+                        prompt=prompt,
+                        cwd=job.cwd,
+                        timeout=job.timeout_s,
+                        model=job.model,
+                    )
                 else:
                     agent_result = run_agent_session(
                         agent=agent,
@@ -424,9 +433,11 @@ class WorkerPool:
                         sandbox=job.sandbox,
                         approval="never",
                     )
-                    return agent_result.stdout or ""
+                # A resumed command may not repeat the session-start event;
+                # retain the known id in that case.
+                return agent_result.stdout or "", agent_result.session_id or job.resume_session_id
 
-            stdout = resilient_call(
+            stdout, session_id = resilient_call(
                 _invoke,
                 circuit_breaker_name=f"agent:{agent}",
                 retry_predicate=lambda _exc: not self._shutdown.is_set(),
@@ -448,6 +459,7 @@ class WorkerPool:
                 ok=True,
                 value=value if value is not None else stdout,
                 stdout_tail=stdout[-_TAIL:],
+                session_id=session_id,
             )
 
         except CircuitBreakerOpenError:
@@ -470,16 +482,18 @@ class WorkerPool:
 
     @staticmethod
     def _run_compact(job: CompactJob) -> JobResult:
-        """Compact a Claude session without making compaction a hard gate."""
-        compacted = compact_session(
+        """Compact an agent session without making compaction a hard gate."""
+        compacted = compact_agent_session(
             repo=job.repo,
             issue=job.issue,
-            agent=job.session_agent,
+            provider=job.agent,
+            session_agent=job.session_agent,
             cwd=job.cwd,
             timeout=job.timeout_s,
             model=job.model,
+            session_id=job.session_id,
         )
-        # ``compact_session`` intentionally swallows expected failures; a
+        # ``compact_agent_session`` intentionally swallows expected failures; a
         # missing or uncompactable transcript must not stall a review cycle.
         return JobResult(ok=True, value=compacted)
 

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -20,6 +20,7 @@ import pytest
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
+    CompactJob,
     GitJob,
     JobHandle,
     JobResult,
@@ -83,7 +84,7 @@ class FakeWorkerPool:
 
     def submit(
         self,
-        job: AgentJob | BuildTestJob | GitJob,
+        job: AgentJob | BuildTestJob | GitJob | CompactJob,
         on_done_state: StageName,
         *,
         claim_key: str = "",
@@ -116,12 +117,14 @@ class FakeWorkerPool:
         return handle
 
     @staticmethod
-    def _default_result(job: AgentJob | BuildTestJob | GitJob) -> JobResult:
+    def _default_result(job: AgentJob | BuildTestJob | GitJob | CompactJob) -> JobResult:
         """Synthesize a per-job-type ok result when nothing is scripted."""
         if isinstance(job, AgentJob):
             return JobResult(ok=True, value="fake agent output")
         if isinstance(job, BuildTestJob):
             return JobResult(ok=True, value=0)
+        if isinstance(job, CompactJob):
+            return JobResult(ok=True, value=True)
         # GitJob: mirror the real _dispatch_git_op value semantics so
         # coordinator tests reading result.value see the same shapes —
         # rebase reports clean-rebase True, commit_push reports changed True.

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -779,6 +780,21 @@ class TestImplementBudget:
         assert result.job.prompt_kwargs["advise_findings"] == "use helpers"
         assert result.job.prompt_kwargs["branch_name"] == "1-auto-impl"
         assert item.attempts["implement"] == 0  # submission burns nothing
+
+    def test_implement_resumes_the_saved_direct_agent_session(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A retried direct implementation keeps its prior working context."""
+        stage = ImplementationStage()
+        ctx = make_ctx(config=SimpleNamespace(agent="codex"))
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+        item.session_ids["implementer"] = "implement-session-id"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.resume_session_id == "implement-session-id"
 
     def test_implement_submission_clears_stale_results(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -333,10 +333,10 @@ class TestPrReviewStageStep:
         assert result.job.prompt_kwargs["pr_number"] == 1001
         assert item.attempts["pr_review_iter"] == 0  # submission burns nothing
 
-    def test_review_wait_uses_a_fresh_reviewer_session_for_each_round(
+    def test_review_wait_reuses_the_reviewer_session_across_rounds(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A later review round never resumes the prior reviewer's verdict."""
+        """A later review round continues the compacted reviewer context."""
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
@@ -346,9 +346,24 @@ class TestPrReviewStageStep:
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
-        assert result.job.session_agent == "pr-reviewer-r2"
+        assert result.job.session_agent == "pr-reviewer"
 
-    def test_nogo_compacts_the_writer_before_the_next_review(
+    def test_review_wait_resumes_the_saved_codex_reviewer_session(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A direct provider receives the reviewer session created in round one."""
+        stage = PrReviewStage()
+        ctx = make_ctx(config=SimpleNamespace(agent="codex"))
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+        item.session_ids["pr-reviewer"] = "review-session-id"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.resume_session_id == "review-session-id"
+
+    def test_nogo_compacts_reviewer_and_writer_before_the_next_review(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """A Claude writer is compacted after a failed round, before re-review."""
@@ -360,34 +375,41 @@ class TestPrReviewStageStep:
 
         result = stage.step(item, ctx)
 
-        assert result == Continue(next_state="COMPACT_WRITER_WAIT")
+        assert result == Continue(next_state="COMPACT_REVIEWER_WAIT")
         item.state = result.next_state
-        compact = stage.step(item, ctx)
-        assert isinstance(compact, JobRequest)
-        assert isinstance(compact.job, CompactJob)
-        assert compact.job.session_agent == "implementer"
-        assert compact.on_done_state == "REVIEW_WAIT"
+        reviewer_compact = stage.step(item, ctx)
+        assert isinstance(reviewer_compact, JobRequest)
+        assert isinstance(reviewer_compact.job, CompactJob)
+        assert reviewer_compact.job.session_agent == "pr-reviewer"
+        assert reviewer_compact.on_done_state == "COMPACT_WRITER_WAIT"
 
-    def test_validation_continues_the_current_round_reviewer_session(
+        item.state = reviewer_compact.on_done_state
+        writer_compact = stage.step(item, ctx)
+        assert isinstance(writer_compact, JobRequest)
+        assert isinstance(writer_compact.job, CompactJob)
+        assert writer_compact.job.session_agent == "implementer"
+        assert writer_compact.on_done_state == "REVIEW_WAIT"
+
+    def test_validation_continues_the_reused_reviewer_session(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """Validation sees the review it validates, not an unrelated reviewer."""
         stage = PrReviewStage()
-        ctx = make_ctx()
+        ctx = make_ctx(config=SimpleNamespace(agent="codex"))
         item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
-        item.payload["pr_review_round"] = 1
-        item.payload["review_session_agent"] = "pr-reviewer-r1"
+        item.session_ids["pr-reviewer"] = "review-session-id"
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
-        assert result.job.session_agent == "pr-reviewer-r1"
+        assert result.job.session_agent == "pr-reviewer"
+        assert result.job.resume_session_id == "review-session-id"
 
-    def test_codex_nogo_skips_claude_session_compaction(
+    def test_codex_nogo_compacts_both_resumable_sessions(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """Codex is stateless, so an unsuccessful round re-reviews directly."""
+        """Codex follows the same compact-before-re-review lifecycle as Claude."""
         stage = PrReviewStage()
         ctx = make_ctx(
             config=SimpleNamespace(agent="codex"),
@@ -397,7 +419,7 @@ class TestPrReviewStageStep:
         item.worktree = "/tmp/review-worktree"
         item.payload["review_verdict"] = _verdict("NOGO")
 
-        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert stage.step(item, ctx) == Continue(next_state="COMPACT_REVIEWER_WAIT")
 
     def test_review_parse_posts_structured_nogo_comments_and_routes_to_remediation(
         self, make_ctx: Any, make_work_item: Any
@@ -450,7 +472,7 @@ class TestPrReviewStageStep:
         stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
         item.state = "EVAL"
 
-        assert stage.step(item, ctx) == Continue(next_state="COMPACT_WRITER_WAIT")
+        assert stage.step(item, ctx) == Continue(next_state="COMPACT_REVIEWER_WAIT")
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
         assert events == []
 
@@ -1448,6 +1470,7 @@ class TestFullWalks:
             JobResult(ok=True, value="tier list"),  # difficulty
             JobResult(ok=True, value="addressed"),  # address
             JobResult(ok=True, value=True),  # push
+            JobResult(ok=True, value=True),  # compact reviewer before round 2
             JobResult(ok=True, value=True),  # compact writer before round 2
             JobResult(ok=True, value=_verdict("GO")),  # review round 2
             JobResult(ok=True, value='{"unaddressed": []}'),  # validate round 2
@@ -1463,6 +1486,7 @@ class TestFullWalks:
             "difficulty",
             "address",
             "push_fixes",
+            "compact_session",
             "compact_session",
             "review",
             "validate",

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -11,7 +11,7 @@ import pytest
 
 from hephaestus.automation.claude_invoke import ReviewVerdict
 from hephaestus.automation.pipeline.events import ZeroThreadNogoAction
-from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
+from hephaestus.automation.pipeline.jobs import AgentJob, CompactJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.pr_review import (
@@ -333,6 +333,72 @@ class TestPrReviewStageStep:
         assert result.job.prompt_kwargs["pr_number"] == 1001
         assert item.attempts["pr_review_iter"] == 0  # submission burns nothing
 
+    def test_review_wait_uses_a_fresh_reviewer_session_for_each_round(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A later review round never resumes the prior reviewer's verdict."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+        item.payload["pr_review_round"] = 2
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.session_agent == "pr-reviewer-r2"
+
+    def test_nogo_compacts_the_writer_before_the_next_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A Claude writer is compacted after a failed round, before re-review."""
+        stage = PrReviewStage()
+        ctx = make_ctx(github=FakeStageGitHub(unresolved=[(3, 0)]))
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.worktree = "/tmp/review-worktree"
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="COMPACT_WRITER_WAIT")
+        item.state = result.next_state
+        compact = stage.step(item, ctx)
+        assert isinstance(compact, JobRequest)
+        assert isinstance(compact.job, CompactJob)
+        assert compact.job.session_agent == "implementer"
+        assert compact.on_done_state == "REVIEW_WAIT"
+
+    def test_validation_continues_the_current_round_reviewer_session(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Validation sees the review it validates, not an unrelated reviewer."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["pr_review_round"] = 1
+        item.payload["review_session_agent"] = "pr-reviewer-r1"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.session_agent == "pr-reviewer-r1"
+
+    def test_codex_nogo_skips_claude_session_compaction(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Codex is stateless, so an unsuccessful round re-reviews directly."""
+        stage = PrReviewStage()
+        ctx = make_ctx(
+            config=SimpleNamespace(agent="codex"),
+            github=FakeStageGitHub(unresolved=[(3, 0)]),
+        )
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.worktree = "/tmp/review-worktree"
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+
     def test_review_parse_posts_structured_nogo_comments_and_routes_to_remediation(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -384,7 +450,7 @@ class TestPrReviewStageStep:
         stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
         item.state = "EVAL"
 
-        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert stage.step(item, ctx) == Continue(next_state="COMPACT_WRITER_WAIT")
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
         assert events == []
 
@@ -1382,6 +1448,7 @@ class TestFullWalks:
             JobResult(ok=True, value="tier list"),  # difficulty
             JobResult(ok=True, value="addressed"),  # address
             JobResult(ok=True, value=True),  # push
+            JobResult(ok=True, value=True),  # compact writer before round 2
             JobResult(ok=True, value=_verdict("GO")),  # review round 2
             JobResult(ok=True, value='{"unaddressed": []}'),  # validate round 2
         )
@@ -1396,6 +1463,7 @@ class TestFullWalks:
             "difficulty",
             "address",
             "push_fixes",
+            "compact_session",
             "review",
             "validate",
         ]

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1210,6 +1210,36 @@ class TestDurableEventLog:
         rendered = coordinator._metrics_registry.render_prometheus()
         assert "hephaestus_pipeline_agent_job_seconds_total 0" in rendered
 
+    def test_completion_persists_direct_agent_session_by_logical_role(self, tmp_path: Path) -> None:
+        """The next loop turn can resume the direct agent's saved context."""
+        coordinator = Coordinator(
+            PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator.stages[StageName.IMPLEMENTATION] = StubStage()
+        item = _issue_item(4, StageName.IMPLEMENTATION)
+        handle = JobHandle(
+            job=AgentJob(
+                repo="repo-a",
+                issue=4,
+                agent="codex",
+                model="m",
+                prompt_builder=lambda: "p",
+                cwd=Path("."),
+                timeout_s=1,
+                session_agent="implementer",
+            ),
+            on_done_state=StageName.IMPLEMENTATION,
+        )
+        coordinator.in_flight[handle] = item
+        coordinator.inflight_per_repo[item.repo] += 1
+
+        coordinator._handle_completion(handle, JobResult(ok=True, session_id="codex-session"))
+
+        assert item.session_ids == {"implementer": "codex-session"}
+
     def test_event_log_path_persists_queue_events(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_fakes.py
+++ b/tests/unit/automation/pipeline/test_fakes.py
@@ -37,6 +37,7 @@ def _jobs() -> tuple[AgentJob, BuildTestJob, GitJob, CompactJob]:
     compact = CompactJob(
         repo="test/repo",
         issue=1,
+        agent="claude",
         session_agent="implementer",
         model="claude-haiku-4-5",
         cwd=Path("/tmp"),

--- a/tests/unit/automation/pipeline/test_fakes.py
+++ b/tests/unit/automation/pipeline/test_fakes.py
@@ -1,6 +1,6 @@
 """Direct tests for the shared pipeline test doubles in conftest.py.
 
-FakeWorkerPool must work for all three job types and honor scripted
+FakeWorkerPool must work for all four job types and honor scripted
 results/exceptions; FakeGitHub must record every mutation in mutation_log.
 """
 
@@ -11,6 +11,7 @@ from pathlib import Path
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
+    CompactJob,
     GitJob,
     JobResult,
 )
@@ -20,8 +21,8 @@ from hephaestus.automation.pipeline.routing import StageName
 from .conftest import FakeGitHub, FakeWorkerPool
 
 
-def _jobs() -> tuple[AgentJob, BuildTestJob, GitJob]:
-    """One job of each of the three types."""
+def _jobs() -> tuple[AgentJob, BuildTestJob, GitJob, CompactJob]:
+    """One job of each supported type."""
     agent = AgentJob(
         repo="test/repo",
         issue=1,
@@ -33,11 +34,19 @@ def _jobs() -> tuple[AgentJob, BuildTestJob, GitJob]:
     )
     build = BuildTestJob(repo="test/repo", cwd=Path("/tmp"), argv=("true",), timeout_s=60)
     git = GitJob(repo="test/repo", op="rebase", timeout_s=60)
-    return agent, build, git
+    compact = CompactJob(
+        repo="test/repo",
+        issue=1,
+        session_agent="implementer",
+        model="claude-haiku-4-5",
+        cwd=Path("/tmp"),
+        timeout_s=60,
+    )
+    return agent, build, git, compact
 
 
 class TestFakeWorkerPool:
-    """FakeWorkerPool completes inline for all three job types."""
+    """FakeWorkerPool completes inline for all supported job types."""
 
     def test_matches_real_constructor_signature(self) -> None:
         """Positional (size, shutdown, completion_q) construction works."""
@@ -51,7 +60,7 @@ class TestFakeWorkerPool:
         assert fake.shutdown_event is event
         assert fake.completion_q is q
 
-    def test_all_three_job_types_complete_inline(self) -> None:
+    def test_all_job_types_complete_inline(self) -> None:
         """Every job type produces exactly one immediate ok completion."""
         fake = FakeWorkerPool()
         for job in _jobs():
@@ -59,13 +68,13 @@ class TestFakeWorkerPool:
             got_handle, result = fake.completion_q.get_nowait()
             assert got_handle is handle
             assert result.ok is True
-        assert len(fake.submitted) == 3
+        assert len(fake.submitted) == 4
         assert fake.completion_q.empty()
 
     def test_scripted_results_consumed_fifo(self) -> None:
         """script() outcomes are consumed in FIFO order across job types."""
         fake = FakeWorkerPool()
-        agent, build, git = _jobs()
+        agent, build, git, compact = _jobs()
         fake.script(
             JobResult(ok=True, value="first"),
             JobResult(ok=False, error="second failed"),
@@ -77,11 +86,14 @@ class TestFakeWorkerPool:
         _, r2 = fake.completion_q.get_nowait()
         fake.submit(git, StageName.MERGE_WAIT)
         _, r3 = fake.completion_q.get_nowait()
+        fake.submit(compact, StageName.PR_REVIEW)
+        _, r4 = fake.completion_q.get_nowait()
 
         assert r1.value == "first"
         assert r2.ok is False
         assert r2.error == "second failed"
         assert r3.ok is True  # FIFO exhausted -> default ok result
+        assert r4.ok is True
 
     def test_scripted_failure_for_each_job_type(self) -> None:
         """A scripted failing JobResult is delivered for every job type."""
@@ -97,7 +109,7 @@ class TestFakeWorkerPool:
         """queue_exception() delivers an error JobResult, mirroring the pool."""
         fake = FakeWorkerPool()
         fake.queue_exception(RuntimeError("kaboom"))
-        agent, _, _ = _jobs()
+        agent, _, _, _ = _jobs()
         fake.submit(agent, StageName.PLANNING)
         _, result = fake.completion_q.get_nowait()
         assert result.ok is False
@@ -106,7 +118,7 @@ class TestFakeWorkerPool:
     def test_handles_are_unique_per_submit(self) -> None:
         """Identical job specs still yield distinct, dict-keyable handles."""
         fake = FakeWorkerPool()
-        _, _, git = _jobs()
+        _, _, git, _ = _jobs()
         h1 = fake.submit(git, StageName.PR_REVIEW)
         h2 = fake.submit(git, StageName.PR_REVIEW)
         assert h1 is not h2

--- a/tests/unit/automation/pipeline/test_jobs.py
+++ b/tests/unit/automation/pipeline/test_jobs.py
@@ -72,6 +72,7 @@ class TestJobDataclassesFrozen:
         job = CompactJob(
             repo="test/repo",
             issue=123,
+            agent="claude",
             session_agent="implementer",
             model="claude-haiku-4-5",
             cwd=Path("/tmp"),

--- a/tests/unit/automation/pipeline/test_jobs.py
+++ b/tests/unit/automation/pipeline/test_jobs.py
@@ -11,6 +11,7 @@ from hephaestus.automation.pipeline.jobs import (
     GIT_OPS,
     AgentJob,
     BuildTestJob,
+    CompactJob,
     GitJob,
     JobHandle,
     JobResult,
@@ -64,6 +65,18 @@ class TestJobDataclassesFrozen:
 
     def test_git_job_frozen(self) -> None:
         job = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+        with pytest.raises(FrozenInstanceError):
+            job.timeout_s = 120  # type: ignore[misc]
+
+    def test_compact_job_frozen(self) -> None:
+        job = CompactJob(
+            repo="test/repo",
+            issue=123,
+            session_agent="implementer",
+            model="claude-haiku-4-5",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
         with pytest.raises(FrozenInstanceError):
             job.timeout_s = 120  # type: ignore[misc]
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -159,12 +159,13 @@ class TestWorkerPoolSubmitComplete:
         job = CompactJob(
             repo="test/repo",
             issue=123,
+            agent="claude",
             session_agent="implementer",
             model="claude-haiku-4-5",
             cwd=Path("/tmp"),
             timeout_s=60,
         )
-        with patch(f"{_WP}.compact_session", return_value=False) as compact:
+        with patch(f"{_WP}.compact_agent_session", return_value=False) as compact:
             pool.submit(job, StageName.PR_REVIEW)
             _handle, result = completion_q.get(timeout=10)
 
@@ -173,10 +174,12 @@ class TestWorkerPoolSubmitComplete:
         compact.assert_called_once_with(
             repo="test/repo",
             issue=123,
-            agent="implementer",
+            provider="claude",
+            session_agent="implementer",
             cwd=Path("/tmp"),
             timeout=60,
             model="claude-haiku-4-5",
+            session_id=None,
         )
 
     def test_submit_and_complete_non_claude_agent_job(
@@ -187,8 +190,7 @@ class TestWorkerPoolSubmitComplete:
         """Non-Claude agents dispatch through run_agent_session."""
         job = _agent_job(agent="codex")
 
-        session_result = MagicMock()
-        session_result.stdout = "codex output"
+        session_result = MagicMock(stdout="codex output", session_id="new-codex-session")
         with (
             patch(f"{_WP}.resolve_agent", return_value="codex") as mock_resolve,
             patch(f"{_WP}.run_agent_session", return_value=session_result) as mock_session,
@@ -208,6 +210,37 @@ class TestWorkerPoolSubmitComplete:
         )
         assert result.ok is True
         assert result.value == "codex output"
+        assert result.session_id == "new-codex-session"
+
+    def test_non_claude_agent_job_resumes_a_saved_session(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """A later direct-agent turn resumes, rather than starts afresh."""
+        job = _agent_job(agent="codex", resume_session_id="saved-codex-session")
+        session_result = MagicMock(stdout="continued", session_id="saved-codex-session")
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="codex"),
+            patch(f"{_WP}.resume_agent_session", return_value=session_result) as resume,
+            patch(f"{_WP}.run_agent_session") as run,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _handle, result = completion_q.get(timeout=10)
+
+        resume.assert_called_once_with(
+            agent="codex",
+            session_id="saved-codex-session",
+            prompt="test prompt",
+            cwd=job.cwd,
+            timeout=job.timeout_s,
+            model=job.model,
+        )
+        run.assert_not_called()
+        assert result.ok is True
+        assert result.value == "continued"
+        assert result.session_id == "saved-codex-session"
 
     def test_read_only_agent_job_propagates_its_sandbox_to_codex(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -22,6 +22,7 @@ from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
+    CompactJob,
     GitJob,
     JobHandle,
     JobResult,
@@ -148,6 +149,35 @@ class TestWorkerPoolSubmitComplete:
         assert handle.on_done_state == StageName.IMPLEMENTATION
         assert result.ok is True
         assert "Test output" in str(result.value)
+
+    def test_compact_job_is_best_effort_and_returns_its_result(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """A failed /compact never blocks the next review round."""
+        job = CompactJob(
+            repo="test/repo",
+            issue=123,
+            session_agent="implementer",
+            model="claude-haiku-4-5",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
+        with patch(f"{_WP}.compact_session", return_value=False) as compact:
+            pool.submit(job, StageName.PR_REVIEW)
+            _handle, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value is False
+        compact.assert_called_once_with(
+            repo="test/repo",
+            issue=123,
+            agent="implementer",
+            cwd=Path("/tmp"),
+            timeout=60,
+            model="claude-haiku-4-5",
+        )
 
     def test_submit_and_complete_non_claude_agent_job(
         self,

--- a/tests/unit/automation/test_compact.py
+++ b/tests/unit/automation/test_compact.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from hephaestus.automation.learn import compact_session
+from hephaestus.automation.learn import compact_agent_session, compact_session
 from hephaestus.automation.session_naming import AGENT_CI_DRIVER, session_uuid
 
 
@@ -145,3 +145,43 @@ class TestCompactSession:
             result = compact_session("test-repo", 42, AGENT_CI_DRIVER, tmp_path)
 
             assert result is True
+
+
+class TestCompactAgentSession:
+    """Provider-neutral compaction preserves direct-runner context."""
+
+    def test_codex_compact_resumes_the_persisted_session(self, tmp_path: Path) -> None:
+        with patch("hephaestus.automation.learn.resume_agent_session") as resume:
+            compacted = compact_agent_session(
+                repo="test-repo",
+                issue=42,
+                provider="codex",
+                session_agent="pr-reviewer",
+                session_id="codex-session",
+                cwd=tmp_path,
+                timeout=60,
+                model="gpt-5.6",
+            )
+
+        assert compacted is True
+        resume.assert_called_once_with(
+            agent="codex",
+            session_id="codex-session",
+            prompt="/compact",
+            cwd=tmp_path,
+            timeout=60,
+            model="gpt-5.6",
+        )
+
+    def test_direct_compact_without_a_session_is_a_safe_noop(self, tmp_path: Path) -> None:
+        with patch("hephaestus.automation.learn.resume_agent_session") as resume:
+            compacted = compact_agent_session(
+                repo="test-repo",
+                issue=42,
+                provider="codex",
+                session_agent="pr-reviewer",
+                cwd=tmp_path,
+            )
+
+        assert compacted is False
+        resume.assert_not_called()


### PR DESCRIPTION
Closes #2351

## Summary
- give each PR-review round a fresh reviewer session and keep its validation in that round
- compact the resumable Claude writer after a retryable non-GO result and before the next review
- keep Codex stateless and bypass Claude-only compaction
- document the lifecycle and cover it with pipeline regression tests

## Verification
- `uv run --all-extras --locked pytest -q` (6,500 passed, 6 skipped; 85.13% coverage)
- `uv run mypy hephaestus/`
- `uv run ruff check hephaestus/automation/pipeline tests/unit/automation/pipeline`
- `uv run ruff format --check hephaestus/automation/pipeline tests/unit/automation/pipeline`