### PR TITLE
Session --resume silently misses when agent_stage (repo_root cwd) and pipeline stages (worktree cwd) share a session key

### DIFF
--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -54,7 +54,9 @@ the SAME Claude CLI session — first call creates it via ``--session-id``,
 every later call resumes it via ``--resume``. This restores prompt-cache
 reuse across loop iterations *and* across main-bumps (#841): the artifact
 being worked on is the issue/PR, not the commit at which the loop started,
-so the session must persist as long as the issue does.
+so the session must persist as long as the issue does. The UUID remains
+artifact-stable, while transcript lookup is limited to the current Git
+checkout's registered worktree family.
 
 Human-readable name: ``<repo>_<issue>_<agent>``; the session ID is
 ``str(uuid.uuid5(NAMESPACE_DNS, <human-readable>))``. UUIDv5 is
@@ -553,6 +555,47 @@ def session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     return Path.home() / ".claude" / "projects" / encoded / f"{uuid_str}.jsonl"
 
 
+def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
+    """Return worktree roots registered to cwd's exact Git repository."""
+    resolved_cwd = cwd.resolve()
+    roots = {resolved_cwd}
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(resolved_cwd),
+                "worktree",
+                "list",
+                "--porcelain",
+                "-z",
+            ],
+            check=True,
+            capture_output=True,
+            env=_repo_scoped_git_env(),
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (resolved_cwd,)
+
+    for field in result.stdout.split("\0"):
+        if field.startswith("worktree "):
+            roots.add(Path(field.removeprefix("worktree ")).resolve())
+    return tuple(sorted(roots, key=str))
+
+
+def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
+    """Resolve an existing transcript within cwd's registered worktree family."""
+    expected = session_jsonl_path(uuid_str, cwd)
+    candidates = {
+        expected,
+        *(session_jsonl_path(uuid_str, root) for root in _registered_worktree_roots(cwd)),
+    }
+    existing = sorted((candidate for candidate in candidates if candidate.is_file()), key=str)
+    return existing[0] if existing else expected
+
+
 __all__ = [
     # Session naming
     "AGENT_ADDRESS_REVIEW",
@@ -615,6 +658,7 @@ __all__ = [
     "planner_model",
     "pr_reviewer_claude_timeout",
     "read_timeout_env",
+    "resolve_session_jsonl_path",
     "reviewer_agent",
     "reviewer_model",
     "session_jsonl_path",

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -55,8 +55,8 @@ every later call resumes it via ``--resume``. This restores prompt-cache
 reuse across loop iterations *and* across main-bumps (#841): the artifact
 being worked on is the issue/PR, not the commit at which the loop started,
 so the session must persist as long as the issue does. The UUID remains
-artifact-stable, while transcript lookup is limited to the current Git
-checkout's registered worktree family.
+artifact-stable, while transcript lookup is verified against the stable
+checkout root shared by current and historical worktrees.
 
 Human-readable name: ``<repo>_<issue>_<agent>``; the session ID is
 ``str(uuid.uuid5(NAMESPACE_DNS, <human-readable>))``. UUIDv5 is
@@ -624,13 +624,24 @@ def _recorded_transcript_cwds(transcript: Path) -> set[Path]:
     return recorded
 
 
+def _checkout_root(roots: set[Path]) -> Path | None:
+    """Return the registered root that contains this checkout's worktree family."""
+    candidates = [root for root in roots if all(path.is_relative_to(root) for path in roots)]
+    return min(candidates, key=lambda path: (len(path.parts), str(path)), default=None)
+
+
 def _transcript_belongs_to_worktree_family(transcript: Path, roots: set[Path]) -> bool:
-    """Return whether *transcript* records only cwd values in *roots*."""
+    """Return whether *transcript* belongs to this checkout's stable root."""
     recorded_cwds = _recorded_transcript_cwds(transcript)
     if not recorded_cwds:
         logger.warning("Ignoring Claude transcript without recorded cwd: %s", transcript)
         return False
-    if not recorded_cwds.issubset(roots):
+    checkout_root = _checkout_root(roots)
+    if any(
+        recorded not in roots
+        and (checkout_root is None or not recorded.is_relative_to(checkout_root))
+        for recorded in recorded_cwds
+    ):
         logger.warning(
             "Ignoring Claude transcript outside the current worktree family: %s",
             transcript,
@@ -639,17 +650,35 @@ def _transcript_belongs_to_worktree_family(transcript: Path, roots: set[Path]) -
     return True
 
 
-def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
-    """Resolve a verified transcript within cwd's registered worktree family.
+def _session_transcript_candidates(uuid_str: str, roots: set[Path]) -> set[Path]:
+    """Return registered and historical Claude transcript paths for a session ID."""
+    candidates = {session_jsonl_path(uuid_str, root) for root in roots}
+    projects_dir = Path.home() / ".claude" / "projects"
+    try:
+        candidates.update(projects_dir.glob(f"*/{uuid_str}.jsonl"))
+    except OSError as exc:
+        logger.warning("Unable to scan Claude transcript directory %s: %s", projects_dir, exc)
+    return candidates
 
-    Claude's transcript-directory encoding maps both dots and slashes to dashes,
-    so its path alone cannot establish which checkout created a transcript. A
-    candidate is resumable only when every recorded Claude ``cwd`` belongs to
-    the caller's registered worktree family.
+
+def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
+    """Resolve a verified transcript from the caller's stable checkout root.
+
+    A stage may remove a worktree before a later stage recreates it elsewhere.
+    Search the session ID across Claude's project directories, then accept only
+    transcripts whose recorded cwd belongs to the current checkout root. This
+    preserves the session across replacement while rejecting transcripts from
+    another checkout that collide under Claude's lossy cwd path encoding.
     """
     roots = set(_registered_worktree_roots(cwd))
-    candidates = {session_jsonl_path(uuid_str, root) for root in roots}
-    existing = sorted((candidate for candidate in candidates if candidate.is_file()), key=str)
+    existing = sorted(
+        (
+            candidate
+            for candidate in _session_transcript_candidates(uuid_str, roots)
+            if candidate.is_file()
+        ),
+        key=str,
+    )
     for candidate in existing:
         if _transcript_belongs_to_worktree_family(candidate, roots):
             return candidate

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -69,6 +69,7 @@ iterations.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -560,6 +561,25 @@ def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
     resolved_cwd = cwd.resolve()
     roots = {resolved_cwd}
     try:
+        repository = subprocess.run(
+            ["git", "-C", str(resolved_cwd), "rev-parse", "--is-inside-work-tree"],
+            check=True,
+            capture_output=True,
+            env=_repo_scoped_git_env(),
+            text=True,
+            timeout=5,
+        )
+    except subprocess.CalledProcessError:
+        # A non-repository has no registered family; its exact cwd remains a
+        # valid transcript owner without masking a Git discovery failure.
+        return (resolved_cwd,)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"unable to determine whether {resolved_cwd} is a Git checkout") from exc
+
+    if repository.stdout.strip() != "true":
+        return (resolved_cwd,)
+
+    try:
         result = subprocess.run(
             [
                 "git",
@@ -576,8 +596,10 @@ def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
             text=True,
             timeout=5,
         )
-    except (OSError, subprocess.SubprocessError):
-        return (resolved_cwd,)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(
+            f"unable to discover registered Git worktrees for {resolved_cwd}"
+        ) from exc
 
     for field in result.stdout.split("\0"):
         if field.startswith("worktree "):
@@ -585,15 +607,53 @@ def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
     return tuple(sorted(roots, key=str))
 
 
-def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
-    """Resolve an existing transcript within cwd's registered worktree family."""
-    expected = session_jsonl_path(uuid_str, cwd)
-    candidates = {
-        expected,
-        *(session_jsonl_path(uuid_str, root) for root in _registered_worktree_roots(cwd)),
-    }
+def _recorded_transcript_cwds(transcript: Path) -> set[Path]:
+    """Return normalized cwd values recorded in a Claude transcript."""
+    recorded: set[Path] = set()
+    try:
+        with transcript.open(encoding="utf-8") as stream:
+            for line in stream:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(entry, dict) and isinstance(entry.get("cwd"), str):
+                    recorded.add(Path(entry["cwd"]).resolve())
+    except OSError as exc:
+        logger.warning("Unable to read Claude transcript %s: %s", transcript, exc)
+    return recorded
+
+
+def _transcript_belongs_to_worktree_family(transcript: Path, roots: set[Path]) -> bool:
+    """Return whether *transcript* records only cwd values in *roots*."""
+    recorded_cwds = _recorded_transcript_cwds(transcript)
+    if not recorded_cwds:
+        logger.warning("Ignoring Claude transcript without recorded cwd: %s", transcript)
+        return False
+    if not recorded_cwds.issubset(roots):
+        logger.warning(
+            "Ignoring Claude transcript outside the current worktree family: %s",
+            transcript,
+        )
+        return False
+    return True
+
+
+def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
+    """Resolve a verified transcript within cwd's registered worktree family.
+
+    Claude's transcript-directory encoding maps both dots and slashes to dashes,
+    so its path alone cannot establish which checkout created a transcript. A
+    candidate is resumable only when every recorded Claude ``cwd`` belongs to
+    the caller's registered worktree family.
+    """
+    roots = set(_registered_worktree_roots(cwd))
+    candidates = {session_jsonl_path(uuid_str, root) for root in roots}
     existing = sorted((candidate for candidate in candidates if candidate.is_file()), key=str)
-    return existing[0] if existing else expected
+    for candidate in existing:
+        if _transcript_belongs_to_worktree_family(candidate, roots):
+            return candidate
+    return None
 
 
 __all__ = [

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -624,30 +624,86 @@ def _recorded_transcript_cwds(transcript: Path) -> set[Path]:
     return recorded
 
 
-def _checkout_root(roots: set[Path]) -> Path | None:
-    """Return the registered root that contains this checkout's worktree family."""
-    candidates = [root for root in roots if all(path.is_relative_to(root) for path in roots)]
-    return min(candidates, key=lambda path: (len(path.parts), str(path)), default=None)
+def _git_common_dir(cwd: Path) -> Path | None:
+    """Return *cwd*'s absolute Git common directory, or ``None`` outside Git."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(cwd),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            check=True,
+            capture_output=True,
+            env=_repo_scoped_git_env(),
+            text=True,
+            timeout=5,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"unable to determine Git common directory for {cwd}") from exc
+    common_dir = result.stdout.strip()
+    return Path(common_dir).resolve() if common_dir else None
 
 
-def _transcript_belongs_to_worktree_family(transcript: Path, roots: set[Path]) -> bool:
-    """Return whether *transcript* belongs to this checkout's stable root."""
+def _managed_worktree_dirs(roots: set[Path], common_dir: Path | None) -> set[Path]:
+    """Return constrained directories that may contain removed managed worktrees."""
+    managed: set[Path] = set()
+
+    # A normal checkout's common directory is ``<main-worktree>/.git`` even
+    # when the caller is a linked worktree in a sibling filesystem tree.
+    if common_dir is not None and common_dir.name == ".git":
+        main_root = common_dir.parent.resolve()
+        if main_root in roots:
+            managed.add(main_root / "build" / ".worktrees")
+
+    # Retain a structural fallback for mocked/nonstandard discovery: only a
+    # registered root that currently owns a direct managed child is eligible.
+    for root in roots:
+        candidate = root / "build" / ".worktrees"
+        if any(other.parent == candidate for other in roots):
+            managed.add(candidate)
+    return managed
+
+
+def _transcript_belongs_to_worktree_family(
+    transcript: Path,
+    roots: set[Path],
+    common_dir: Path | None,
+) -> bool:
+    """Return whether *transcript* belongs to this exact Git worktree family."""
     recorded_cwds = _recorded_transcript_cwds(transcript)
     if not recorded_cwds:
         logger.warning("Ignoring Claude transcript without recorded cwd: %s", transcript)
         return False
-    checkout_root = _checkout_root(roots)
-    if any(
-        recorded not in roots
-        and (checkout_root is None or not recorded.is_relative_to(checkout_root))
-        for recorded in recorded_cwds
-    ):
-        logger.warning(
-            "Ignoring Claude transcript outside the current worktree family: %s",
-            transcript,
-        )
-        return False
-    return True
+
+    managed_dirs = _managed_worktree_dirs(roots, common_dir)
+    for recorded in recorded_cwds:
+        if recorded.exists():
+            recorded_common_dir = _git_common_dir(recorded)
+            if common_dir is not None:
+                if recorded_common_dir != common_dir:
+                    break
+            elif recorded not in roots:
+                # Non-repository callers have no family beyond their exact cwd.
+                break
+        elif not any(recorded.parent == managed_dir for managed_dir in managed_dirs):
+            # A removed worktree no longer has Git metadata to authenticate.
+            # Accept only automation's direct ``build/.worktrees/<name>`` path
+            # beneath the main checkout, never arbitrary lexical descendants.
+            break
+    else:
+        return True
+
+    logger.warning(
+        "Ignoring Claude transcript outside the current Git worktree family: %s",
+        transcript,
+    )
+    return False
 
 
 def _session_transcript_candidates(uuid_str: str, roots: set[Path]) -> set[Path]:
@@ -671,6 +727,7 @@ def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
     another checkout that collide under Claude's lossy cwd path encoding.
     """
     roots = set(_registered_worktree_roots(cwd))
+    common_dir = _git_common_dir(cwd)
     existing = sorted(
         (
             candidate
@@ -680,7 +737,7 @@ def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
         key=str,
     )
     for candidate in existing:
-        if _transcript_belongs_to_worktree_family(candidate, roots):
+        if _transcript_belongs_to_worktree_family(candidate, roots, common_dir):
             return candidate
     return None
 

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -684,9 +684,9 @@ def _transcript_belongs_to_worktree_family(
     transcript: Path,
     roots: set[Path],
     common_dir: Path | None,
+    recorded_cwds: set[Path],
 ) -> bool:
     """Return whether *transcript* belongs to this exact Git worktree family."""
-    recorded_cwds = _recorded_transcript_cwds(transcript)
     if not recorded_cwds:
         logger.warning("Ignoring Claude transcript without recorded cwd: %s", transcript)
         return False
@@ -711,6 +711,25 @@ def _transcript_belongs_to_worktree_family(
 
     logger.warning(
         "Ignoring Claude transcript outside the current Git worktree family: %s",
+        transcript,
+    )
+    return False
+
+
+def _transcript_matches_recorded_project_dir(
+    transcript: Path,
+    uuid_str: str,
+    recorded_cwds: set[Path],
+) -> bool:
+    """Return whether Claude stored *transcript* for one of its recorded cwd values."""
+    expected_dirs = {
+        session_jsonl_path(uuid_str, recorded_cwd).parent for recorded_cwd in recorded_cwds
+    }
+    if transcript.parent in expected_dirs:
+        return True
+
+    logger.warning(
+        "Ignoring Claude transcript outside its recorded cwd project directory: %s",
         transcript,
     )
     return False
@@ -747,7 +766,15 @@ def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
         key=str,
     )
     for candidate in existing:
-        if _transcript_belongs_to_worktree_family(candidate, roots, common_dir):
+        recorded_cwds = _recorded_transcript_cwds(candidate)
+        if not _transcript_matches_recorded_project_dir(candidate, uuid_str, recorded_cwds):
+            continue
+        if _transcript_belongs_to_worktree_family(
+            candidate,
+            roots,
+            common_dir,
+            recorded_cwds,
+        ):
             return candidate
     return None
 

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -569,10 +569,20 @@ def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
             text=True,
             timeout=5,
         )
-    except subprocess.CalledProcessError:
-        # A non-repository has no registered family; its exact cwd remains a
-        # valid transcript owner without masking a Git discovery failure.
-        return (resolved_cwd,)
+    except subprocess.CalledProcessError as exc:
+        # ``rev-parse`` uses exit 128 for both an ordinary non-repository
+        # directory and operational failures (for example, dubious ownership
+        # or corrupt metadata). Only the former is an exact-cwd transcript
+        # owner; silently treating the latter as non-repository would recreate
+        # sessions after a Git discovery failure.
+        stderr = exc.stderr
+        if (
+            exc.returncode == 128
+            and isinstance(stderr, str)
+            and "not a git repository" in stderr.lower()
+        ):
+            return (resolved_cwd,)
+        raise RuntimeError(f"unable to determine whether {resolved_cwd} is a Git checkout") from exc
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise RuntimeError(f"unable to determine whether {resolved_cwd} is a Git checkout") from exc
 

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -556,6 +556,35 @@ def session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     return Path.home() / ".claude" / "projects" / encoded / f"{uuid_str}.jsonl"
 
 
+def _is_expected_non_repository_error(exc: subprocess.CalledProcessError, cwd: Path) -> bool:
+    """Return whether *exc* is Git's ordinary no-checkout result for *cwd*.
+
+    A corrupt ``.git`` entry can produce Git's generic "not a git repository"
+    diagnostic too.  Treat that as a discovery failure rather than an ordinary
+    non-repository directory: resuming must fail closed instead of silently
+    creating a second deterministic session.
+    """
+    expected_stderr = "fatal: not a git repository (or any of the parent directories): .git"
+    if (
+        exc.returncode != 128
+        or not isinstance(exc.stderr, str)
+        or exc.stderr.strip().lower() != expected_stderr
+    ):
+        return False
+
+    for directory in (cwd, *cwd.parents):
+        try:
+            (directory / ".git").lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as marker_error:
+            raise RuntimeError(
+                f"unable to inspect Git metadata while discovering {cwd}"
+            ) from marker_error
+        return False
+    return True
+
+
 def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
     """Return worktree roots registered to cwd's exact Git repository."""
     resolved_cwd = cwd.resolve()
@@ -575,12 +604,7 @@ def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
         # or corrupt metadata). Only the former is an exact-cwd transcript
         # owner; silently treating the latter as non-repository would recreate
         # sessions after a Git discovery failure.
-        stderr = exc.stderr
-        if (
-            exc.returncode == 128
-            and isinstance(stderr, str)
-            and "not a git repository" in stderr.lower()
-        ):
+        if _is_expected_non_repository_error(exc, resolved_cwd):
             return (resolved_cwd,)
         raise RuntimeError(f"unable to determine whether {resolved_cwd} is a Git checkout") from exc
     except (OSError, subprocess.TimeoutExpired) as exc:
@@ -754,9 +778,28 @@ def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path | None:
     transcripts whose recorded cwd belongs to the current checkout root. This
     preserves the session across replacement while rejecting transcripts from
     another checkout that collide under Claude's lossy cwd path encoding.
+
+    The caller's exact cwd remains available without Git discovery. A transcript
+    recorded only for that cwd can be resumed directly; if wider worktree-family
+    discovery fails, returning ``None`` still lets the caller create its exact-cwd
+    session without trusting a transcript from another checkout.
     """
-    roots = set(_registered_worktree_roots(cwd))
-    common_dir = _git_common_dir(cwd)
+    resolved_cwd = cwd.resolve()
+    exact = session_jsonl_path(uuid_str, resolved_cwd)
+    if exact.is_file() and _recorded_transcript_cwds(exact) == {resolved_cwd}:
+        return exact
+
+    try:
+        roots = set(_registered_worktree_roots(resolved_cwd))
+        common_dir = _git_common_dir(resolved_cwd)
+    except RuntimeError as exc:
+        logger.warning(
+            "Git worktree discovery unavailable for %s; using exact-cwd session availability: %s",
+            resolved_cwd,
+            exc,
+        )
+        return None
+
     existing = sorted(
         (
             candidate

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -306,7 +306,7 @@ def _invoke_claude_once(
     # re-sending full prompts 3x and crossing models); a ``--resume`` or
     # ``--session-id`` failure simply propagates.
     transcript = resolve_session_jsonl_path(sid, cwd)
-    create = not transcript.is_file()
+    create = transcript is None
     mode_args = ["--session-id", sid, "--name", display_name] if create else ["--resume", sid]
     cmd: list[str] = [
         "claude",

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -38,7 +38,7 @@ from hephaestus.automation import subprocess_registry
 from hephaestus.automation.agent_config import (
     agent_default_timeout,
     fallback_model,
-    session_jsonl_path,
+    resolve_session_jsonl_path,
     session_name,
 )
 from hephaestus.github.client import ClaudeUsageCapError, PromptTooLongError
@@ -299,12 +299,14 @@ def _invoke_claude_once(
     # Create on FIRST use, resume after (#1168). ``claude --resume`` does NOT
     # auto-create — it errors "No conversation found" for an unknown id — so the
     # first call for a (repo, issue, agent, model) key must use ``--session-id``
-    # to create the transcript; every later call ``--resume``s it to reuse cached
-    # context. The probe is the transcript file's existence, which is model-keyed
-    # because ``sid`` is. This is NOT the old recreate-on-failure cascade (that
-    # mis-fired on 429s, re-sending full prompts 3x and crossing models); a
-    # ``--resume``/``--session-id`` failure now simply propagates.
-    create = not session_jsonl_path(sid, cwd).exists()
+    # to create the transcript under the caller's exact cwd; every later call
+    # searches only this checkout's registered worktree family and ``--resume``s
+    # it to reuse cached context. The probe is model-keyed because ``sid`` is.
+    # This is NOT the old recreate-on-failure cascade (that mis-fired on 429s,
+    # re-sending full prompts 3x and crossing models); a ``--resume`` or
+    # ``--session-id`` failure simply propagates.
+    transcript = resolve_session_jsonl_path(sid, cwd)
+    create = not transcript.is_file()
     mode_args = ["--session-id", sid, "--name", display_name] if create else ["--resume", sid]
     cmd: list[str] = [
         "claude",

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -132,19 +132,17 @@ class PostMergeProcessor:
         self._last_learn_evidence = mnemosyne_update_evidence("")
         try:
             repo_slug = get_repo_slug(repo_root)
-            # Best-effort: try to resume in the original worktree (so the
-            # AGENT_CI_DRIVER transcript is found by ``session_jsonl_path``).
-            # In the post-merge code path (#840) the PR's head branch may be
-            # gone from the remote, so ``_get_worktree_path`` could fail. In
-            # that case fall back to ``repo_root`` cwd — the prompt is
-            # self-contained, and a fresh ``--session-id`` create still
-            # captures the lesson.
+            # Prefer the original worktree for agent tool context. If it is
+            # unavailable, repo_root remains safe: checkout-family transcript
+            # resolution can resume a transcript from any still-registered
+            # worktree, otherwise it creates under repo_root without searching
+            # unrelated repositories.
             try:
                 cwd = self._get_worktree_path(issue_number, pr_number)
             except Exception as wt_err:
                 logger.info(
                     "Issue #%s: no worktree available for /learn (%s); "
-                    "falling back to repo root for a fresh session",
+                    "falling back to repo root",
                     issue_number,
                     wt_err,
                 )
@@ -197,10 +195,10 @@ class PostMergeProcessor:
     def run_drive_green_compact(self, issue_number: int, pr_number: int) -> bool:
         """Compact the AGENT_CI_DRIVER session transcript after /learn (#842).
 
-        Mirrors the cwd-derivation of ``run_drive_green_learnings``: try the
-        worktree first so the deterministic JSONL probe in ``session_jsonl_path``
-        finds the transcript, fall back to ``repo_root`` when the branch is
-        already gone post-merge. Non-fatal.
+        Mirrors the cwd-derivation of ``run_drive_green_learnings``: prefer the
+        worktree, then fall back to ``repo_root`` when the branch is already
+        gone post-merge. Checkout-family transcript resolution may still resume
+        a transcript from a registered worktree. Non-fatal.
 
         Args:
             issue_number: GitHub issue number.

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -141,8 +141,7 @@ class PostMergeProcessor:
                 cwd = self._get_worktree_path(issue_number, pr_number)
             except Exception as wt_err:
                 logger.info(
-                    "Issue #%s: no worktree available for /learn (%s); "
-                    "falling back to repo root",
+                    "Issue #%s: no worktree available for /learn (%s); falling back to repo root",
                     issue_number,
                     wt_err,
                 )

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -14,6 +14,7 @@ from hephaestus.automation.agent_config import (
     AGENT_PR_REVIEWER as AGENT_PR_REVIEWER,
     current_trunk_githash as current_trunk_githash,
     issue_auto_impl_branch_name as issue_auto_impl_branch_name,
+    resolve_session_jsonl_path as resolve_session_jsonl_path,
     reviewer_agent as reviewer_agent,
     session_jsonl_path as session_jsonl_path,
     session_name as session_name,

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation import claude_invoke
+from hephaestus.automation import agent_config, claude_invoke
 from hephaestus.automation.agent_config import OPUS_48
 from hephaestus.automation.claude_invoke import (
     _session_expired,
@@ -113,6 +113,56 @@ class TestCreateThenResume:
         assert sid in argv
         assert "--session-id" not in argv
         assert "--name" not in argv
+
+    def test_registered_worktree_resumes_repo_root_transcript(
+        self,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stage worktree resumes the same checkout family's root session."""
+        repo_root = fake_home / "owner" / "Repo"
+        worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+        worktree.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "sonnet")
+        calls: list[list[str]] = []
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            calls.append(argv)
+            if len(calls) == 1:
+                transcript = session_jsonl_path(sid, repo_root)
+                transcript.parent.mkdir(parents=True, exist_ok=True)
+                transcript.write_text("{}\n", encoding="utf-8")
+            return MagicMock(stdout="ok", stderr="", returncode=0)
+
+        monkeypatch.setattr(
+            agent_config,
+            "_registered_worktree_roots",
+            lambda _cwd: (repo_root.resolve(), worktree.resolve()),
+        )
+        with patch("hephaestus.automation.claude_invoke._run_tracked", side_effect=fake_run):
+            invoke_claude_with_session(
+                repo="Repo",
+                issue=2284,
+                agent=AGENT_PLAN_REVIEWER,
+                prompt="first",
+                model="sonnet",
+                cwd=repo_root,
+            )
+            invoke_claude_with_session(
+                repo="Repo",
+                issue=2284,
+                agent=AGENT_PLAN_REVIEWER,
+                prompt="second",
+                model="sonnet",
+                cwd=worktree,
+            )
+
+        assert "--session-id" in calls[0]
+        assert "--resume" not in calls[0]
+        assert "--resume" in calls[1]
+        assert "--session-id" not in calls[1]
+        assert sid in calls[0]
+        assert sid in calls[1]
 
     def test_different_models_get_different_uuids(
         self, stub_run: MagicMock, fake_home: Path

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -57,7 +57,7 @@ def _make_existing_jsonl(home: Path, cwd: Path, sid: str) -> None:
     del home
     target = session_jsonl_path(sid, cwd)
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text("{}\n")
+    target.write_text(f'{{"cwd": "{cwd.resolve()}"}}\n')
 
 
 class TestCreateThenResume:
@@ -131,7 +131,7 @@ class TestCreateThenResume:
             if len(calls) == 1:
                 transcript = session_jsonl_path(sid, repo_root)
                 transcript.parent.mkdir(parents=True, exist_ok=True)
-                transcript.write_text("{}\n", encoding="utf-8")
+                transcript.write_text(f'{{"cwd": "{repo_root.resolve()}"}}\n', encoding="utf-8")
             return MagicMock(stdout="ok", stderr="", returncode=0)
 
         monkeypatch.setattr(

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -164,6 +164,42 @@ class TestCreateThenResume:
         assert sid in calls[0]
         assert sid in calls[1]
 
+    def test_recreated_worktree_resumes_removed_worktree_transcript(
+        self,
+        stub_run: MagicMock,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A replacement worktree resumes a transcript from its removed predecessor."""
+        repo_root = fake_home / "owner" / "Repo"
+        removed_worktree = repo_root / "build" / ".worktrees" / "issue-2284-a"
+        replacement_worktree = repo_root / "build" / ".worktrees" / "issue-2284-c"
+        removed_worktree.mkdir(parents=True)
+        replacement_worktree.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "sonnet")
+        _make_existing_jsonl(fake_home, removed_worktree, sid)
+        removed_worktree.rmdir()
+
+        monkeypatch.setattr(
+            agent_config,
+            "_registered_worktree_roots",
+            lambda _cwd: (repo_root.resolve(), replacement_worktree.resolve()),
+        )
+
+        invoke_claude_with_session(
+            repo="Repo",
+            issue=2284,
+            agent=AGENT_PLAN_REVIEWER,
+            prompt="resume",
+            model="sonnet",
+            cwd=replacement_worktree,
+        )
+
+        argv = _argv(stub_run.call_args)
+        assert "--resume" in argv
+        assert sid in argv
+        assert "--session-id" not in argv
+
     def test_different_models_get_different_uuids(
         self, stub_run: MagicMock, fake_home: Path
     ) -> None:

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -114,6 +114,51 @@ class TestCreateThenResume:
         assert "--session-id" not in argv
         assert "--name" not in argv
 
+    @pytest.mark.parametrize(
+        ("cwd_suffix", "transcript_exists", "expected_mode"),
+        [
+            (Path("owner/Repo"), False, "--session-id"),
+            (Path("owner/Repo"), True, "--resume"),
+            (Path("owner/Repo/build/.worktrees/issue-1"), False, "--session-id"),
+            (Path("owner/Repo/build/.worktrees/issue-1"), True, "--resume"),
+        ],
+    )
+    def test_exact_cwd_availability_survives_git_discovery_failure_across_callers(
+        self,
+        stub_run: MagicMock,
+        fake_home: Path,
+        cwd_suffix: Path,
+        transcript_exists: bool,
+        expected_mode: str,
+    ) -> None:
+        """Repo-root and worktree callers can create or resume without Git discovery."""
+        cwd = fake_home / cwd_suffix
+        cwd.mkdir(parents=True)
+        sid = session_uuid("Repo", 1, AGENT_PLANNER, "sonnet")
+        if transcript_exists:
+            _make_existing_jsonl(fake_home, cwd, sid)
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            side_effect=RuntimeError("transient Git discovery failure"),
+        ):
+            invoke_claude_with_session(
+                repo="Repo",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="sonnet",
+                cwd=cwd,
+            )
+
+        argv = _argv(stub_run.call_args)
+        assert expected_mode in argv
+        if expected_mode == "--resume":
+            assert "--session-id" not in argv
+        else:
+            assert "--resume" not in argv
+
     def test_registered_worktree_resumes_repo_root_transcript(
         self,
         fake_home: Path,

--- a/tests/unit/automation/test_session_cwd_resume.py
+++ b/tests/unit/automation/test_session_cwd_resume.py
@@ -1,0 +1,96 @@
+"""Regression coverage for Claude sessions shared by root and worktree callers."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation import agent_config
+from hephaestus.automation.models import PlanReviewerOptions
+from hephaestus.automation.pipeline.jobs import AgentJob
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.worker_pool import WorkerPool
+from hephaestus.automation.plan_reviewer import PlanReviewer
+from hephaestus.automation.session_naming import (
+    AGENT_PLAN_REVIEWER,
+    session_jsonl_path,
+    session_uuid,
+)
+
+
+def test_plan_reviewer_then_pipeline_worker_resumes_same_transcript(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root review and worktree pipeline jobs resume one deterministic session."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo_root = tmp_path / "owner" / "Repo"
+    worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+    worktree.mkdir(parents=True)
+    model = "fable"
+    sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, model)
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+        calls.append(argv)
+        if len(calls) == 1:
+            transcript = session_jsonl_path(sid, repo_root)
+            transcript.parent.mkdir(parents=True, exist_ok=True)
+            transcript.write_text("{}\n", encoding="utf-8")
+        return MagicMock(stdout="Verdict: GO", stderr="", returncode=0)
+
+    monkeypatch.setattr(
+        agent_config,
+        "_registered_worktree_roots",
+        lambda _cwd: (repo_root.resolve(), worktree.resolve()),
+    )
+    reviewer = PlanReviewer(PlanReviewerOptions(issues=[2284], enable_ui=False))
+    completions: queue.Queue[object] = queue.Queue()
+    pool = WorkerPool(
+        size=1,
+        shutdown=threading.Event(),
+        completion_q=completions,
+        lock_dir=tmp_path / "locks",
+    )
+    try:
+        with (
+            patch("hephaestus.automation.claude_invoke._run_tracked", side_effect=fake_run),
+            patch("hephaestus.automation.plan_reviewer.get_repo_root", return_value=repo_root),
+            patch("hephaestus.automation.plan_reviewer.get_repo_slug", return_value="Repo"),
+            patch("hephaestus.automation.plan_reviewer.reviewer_model", return_value=model),
+            patch(
+                "hephaestus.automation.pipeline.worker_pool.resolve_agent",
+                return_value="claude",
+            ),
+        ):
+            assert (
+                reviewer._run_claude_analysis(2284, "title", "body", "# Implementation Plan")
+                == "Verdict: GO"
+            )
+            job = AgentJob(
+                repo="Repo",
+                issue=2284,
+                agent="claude",
+                session_agent=AGENT_PLAN_REVIEWER,
+                model=model,
+                prompt_builder=lambda: "pipeline prompt",
+                cwd=worktree,
+                timeout_s=60,
+                descr="resume review session",
+            )
+            pool.submit(job, StageName.PLAN_REVIEW)
+            _, result = completions.get(timeout=10)
+    finally:
+        pool.shutdown()
+
+    assert result.ok is True
+    assert "--session-id" in calls[0]
+    assert "--resume" not in calls[0]
+    assert "--resume" in calls[1]
+    assert "--session-id" not in calls[1]
+    assert sid in calls[0]
+    assert sid in calls[1]

--- a/tests/unit/automation/test_session_cwd_resume.py
+++ b/tests/unit/automation/test_session_cwd_resume.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import queue
 import threading
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -40,7 +41,7 @@ def test_plan_reviewer_then_pipeline_worker_resumes_same_transcript(
         if len(calls) == 1:
             transcript = session_jsonl_path(sid, repo_root)
             transcript.parent.mkdir(parents=True, exist_ok=True)
-            transcript.write_text("{}\n", encoding="utf-8")
+            transcript.write_text(f'{{"cwd": "{repo_root.resolve()}"}}\n', encoding="utf-8")
         return MagicMock(stdout="Verdict: GO", stderr="", returncode=0)
 
     monkeypatch.setattr(
@@ -49,7 +50,7 @@ def test_plan_reviewer_then_pipeline_worker_resumes_same_transcript(
         lambda _cwd: (repo_root.resolve(), worktree.resolve()),
     )
     reviewer = PlanReviewer(PlanReviewerOptions(issues=[2284], enable_ui=False))
-    completions: queue.Queue[object] = queue.Queue()
+    completions: queue.Queue[tuple[Any, Any]] = queue.Queue()
     pool = WorkerPool(
         size=1,
         shutdown=threading.Event(),

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -7,9 +7,11 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation import agent_config
 from hephaestus.automation.session_naming import (
     AGENT_ADDRESS_REVIEW,
     AGENT_ADVISE,
@@ -20,6 +22,7 @@ from hephaestus.automation.session_naming import (
     AGENT_PLANNER,
     AGENT_PR_REVIEWER,
     current_trunk_githash,
+    resolve_session_jsonl_path,
     reviewer_agent,
     session_jsonl_path,
     session_name,
@@ -289,6 +292,119 @@ class TestSessionJsonlPath:
         p = session_jsonl_path("u", target)
         assert "v1-2-3" in p.parent.name
         assert "v1.2.3" not in p.parent.name
+
+
+class TestSessionTranscriptResolver:
+    """Checkout-family lookup for Claude's cwd-encoded transcript paths."""
+
+    @pytest.mark.parametrize("created_in", ["repo_root", "worktree"])
+    def test_registered_family_cwds_resolve_same_existing_transcript(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        created_in: str,
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "owner-a" / "Repo"
+        worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+        worktree.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        source = repo_root if created_in == "repo_root" else worktree
+        transcript = session_jsonl_path(sid, source)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text("{}\n", encoding="utf-8")
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            return_value=(repo_root.resolve(), worktree.resolve()),
+        ):
+            assert resolve_session_jsonl_path(sid, repo_root) == transcript
+            assert resolve_session_jsonl_path(sid, worktree) == transcript
+
+    def test_unrelated_checkout_transcript_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        local = tmp_path / "owner-a" / "Repo"
+        local_worktree = local / "build" / ".worktrees" / "issue-2284"
+        unrelated = tmp_path / "owner-b" / "Repo"
+        local_worktree.mkdir(parents=True)
+        unrelated.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        foreign_transcript = session_jsonl_path(sid, unrelated)
+        foreign_transcript.parent.mkdir(parents=True, exist_ok=True)
+        foreign_transcript.write_text("{}\n", encoding="utf-8")
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            return_value=(local.resolve(), local_worktree.resolve()),
+        ):
+            resolved = resolve_session_jsonl_path(sid, local_worktree)
+
+        assert resolved == session_jsonl_path(sid, local_worktree)
+        assert resolved != foreign_transcript
+        assert not resolved.exists()
+
+    def test_registered_worktree_discovery_uses_explicit_cwd_and_scrubbed_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo_root = tmp_path / "Repo"
+        worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+        worktree.mkdir(parents=True)
+        monkeypatch.setenv("GIT_DIR", "/foreign/.git")
+        result = MagicMock(
+            stdout=f"worktree {worktree}\0HEAD deadbeef\0\0worktree {repo_root}\0"
+        )
+
+        with patch.object(agent_config.subprocess, "run", return_value=result) as run:
+            roots = agent_config._registered_worktree_roots(worktree)
+
+        assert roots == tuple(sorted((repo_root.resolve(), worktree.resolve()), key=str))
+        argv = run.call_args.args[0]
+        assert argv[:3] == ["git", "-C", str(worktree.resolve())]
+        assert argv[3:] == ["worktree", "list", "--porcelain", "-z"]
+        assert "GIT_DIR" not in run.call_args.kwargs["env"]
+        assert run.call_args.kwargs["timeout"] == 5
+
+    def test_git_discovery_failure_uses_exact_cwd_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        cwd = tmp_path / "not-a-repository"
+        cwd.mkdir()
+
+        with patch.object(agent_config.subprocess, "run", side_effect=FileNotFoundError):
+            resolved = resolve_session_jsonl_path("session-id", cwd)
+
+        assert resolved == session_jsonl_path("session-id", cwd)
+
+    def test_duplicate_transcripts_choose_lexicographically_first_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "Repo"
+        worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+        worktree.mkdir(parents=True)
+        paths = [
+            session_jsonl_path("session-id", repo_root),
+            session_jsonl_path("session-id", worktree),
+        ]
+        for path in paths:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{}\n", encoding="utf-8")
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            return_value=(repo_root.resolve(), worktree.resolve()),
+        ):
+            resolved = resolve_session_jsonl_path("session-id", worktree)
+
+        assert resolved == min(paths, key=str)
 
 
 @pytest.mark.requires_posix

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -323,6 +323,29 @@ class TestSessionTranscriptResolver:
             assert resolve_session_jsonl_path(sid, repo_root) == transcript
             assert resolve_session_jsonl_path(sid, worktree) == transcript
 
+    def test_root_transcript_allows_removed_worktree_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A root-held transcript survives replacement of its recorded worktree."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "owner" / "Repo"
+        removed_worktree = repo_root / "build" / ".worktrees" / "issue-2284-a"
+        replacement_worktree = repo_root / "build" / ".worktrees" / "issue-2284-c"
+        removed_worktree.mkdir(parents=True)
+        replacement_worktree.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+        transcript = session_jsonl_path(sid, repo_root)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(f'{{"cwd": "{removed_worktree.resolve()}"}}\n', encoding="utf-8")
+        removed_worktree.rmdir()
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            return_value=(repo_root.resolve(), replacement_worktree.resolve()),
+        ):
+            assert resolve_session_jsonl_path(sid, replacement_worktree) == transcript
+
     def test_unrelated_checkout_transcript_is_ignored(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -313,7 +313,7 @@ class TestSessionTranscriptResolver:
         source = repo_root if created_in == "repo_root" else worktree
         transcript = session_jsonl_path(sid, source)
         transcript.parent.mkdir(parents=True, exist_ok=True)
-        transcript.write_text("{}\n", encoding="utf-8")
+        transcript.write_text(f'{{"cwd": "{source.resolve()}"}}\n', encoding="utf-8")
 
         with patch.object(
             agent_config,
@@ -336,7 +336,7 @@ class TestSessionTranscriptResolver:
 
         foreign_transcript = session_jsonl_path(sid, unrelated)
         foreign_transcript.parent.mkdir(parents=True, exist_ok=True)
-        foreign_transcript.write_text("{}\n", encoding="utf-8")
+        foreign_transcript.write_text(f'{{"cwd": "{unrelated.resolve()}"}}\n', encoding="utf-8")
 
         with patch.object(
             agent_config,
@@ -345,9 +345,30 @@ class TestSessionTranscriptResolver:
         ):
             resolved = resolve_session_jsonl_path(sid, local_worktree)
 
-        assert resolved == session_jsonl_path(sid, local_worktree)
-        assert resolved != foreign_transcript
-        assert not resolved.exists()
+        assert resolved is None
+
+    def test_lossy_cwd_encoding_does_not_resume_foreign_transcript(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reject a transcript whose recorded cwd is outside this worktree family."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        local = tmp_path / "team-a" / "Repo"
+        unrelated = tmp_path / "team.a" / "Repo"
+        local.mkdir(parents=True)
+        unrelated.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        foreign_transcript = session_jsonl_path(sid, unrelated)
+        assert foreign_transcript == session_jsonl_path(sid, local)
+        foreign_transcript.parent.mkdir(parents=True, exist_ok=True)
+        foreign_transcript.write_text(f'{{"cwd": "{unrelated.resolve()}"}}\n', encoding="utf-8")
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            return_value=(local.resolve(),),
+        ):
+            assert resolve_session_jsonl_path(sid, local) is None
 
     def test_registered_worktree_discovery_uses_explicit_cwd_and_scrubbed_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -356,31 +377,47 @@ class TestSessionTranscriptResolver:
         worktree = repo_root / "build" / ".worktrees" / "issue-2284"
         worktree.mkdir(parents=True)
         monkeypatch.setenv("GIT_DIR", "/foreign/.git")
-        result = MagicMock(
-            stdout=f"worktree {worktree}\0HEAD deadbeef\0\0worktree {repo_root}\0"
-        )
+        repository = MagicMock(stdout="true\n")
+        result = MagicMock(stdout=f"worktree {worktree}\0HEAD deadbeef\0\0worktree {repo_root}\0")
 
-        with patch.object(agent_config.subprocess, "run", return_value=result) as run:
+        with patch.object(subprocess, "run", side_effect=(repository, result)) as run:
             roots = agent_config._registered_worktree_roots(worktree)
 
         assert roots == tuple(sorted((repo_root.resolve(), worktree.resolve()), key=str))
-        argv = run.call_args.args[0]
+        argv = run.call_args_list[1].args[0]
         assert argv[:3] == ["git", "-C", str(worktree.resolve())]
         assert argv[3:] == ["worktree", "list", "--porcelain", "-z"]
-        assert "GIT_DIR" not in run.call_args.kwargs["env"]
-        assert run.call_args.kwargs["timeout"] == 5
+        assert "GIT_DIR" not in run.call_args_list[1].kwargs["env"]
+        assert run.call_args_list[1].kwargs["timeout"] == 5
 
-    def test_git_discovery_failure_uses_exact_cwd_path(
+    def test_non_repository_uses_exact_cwd_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path / "home"))
         cwd = tmp_path / "not-a-repository"
         cwd.mkdir()
+        transcript = session_jsonl_path("session-id", cwd)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(f'{{"cwd": "{cwd.resolve()}"}}\n', encoding="utf-8")
 
-        with patch.object(agent_config.subprocess, "run", side_effect=FileNotFoundError):
+        with patch.object(
+            subprocess, "run", side_effect=subprocess.CalledProcessError(128, ["git"])
+        ):
             resolved = resolve_session_jsonl_path("session-id", cwd)
 
-        assert resolved == session_jsonl_path("session-id", cwd)
+        assert resolved == transcript
+
+    def test_git_discovery_failure_raises_explicitly(self, tmp_path: Path) -> None:
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+
+        with patch.object(
+            subprocess,
+            "run",
+            side_effect=(MagicMock(stdout="true\n"), subprocess.TimeoutExpired(["git"], 5)),
+        ):
+            with pytest.raises(RuntimeError, match="unable to discover registered Git worktrees"):
+                resolve_session_jsonl_path("session-id", cwd)
 
     def test_duplicate_transcripts_choose_lexicographically_first_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -389,13 +426,13 @@ class TestSessionTranscriptResolver:
         repo_root = tmp_path / "Repo"
         worktree = repo_root / "build" / ".worktrees" / "issue-2284"
         worktree.mkdir(parents=True)
-        paths = [
-            session_jsonl_path("session-id", repo_root),
-            session_jsonl_path("session-id", worktree),
-        ]
-        for path in paths:
+        paths = {
+            session_jsonl_path("session-id", repo_root): repo_root,
+            session_jsonl_path("session-id", worktree): worktree,
+        }
+        for path, transcript_cwd in paths.items():
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text("{}\n", encoding="utf-8")
+            path.write_text(f'{{"cwd": "{transcript_cwd.resolve()}"}}\n', encoding="utf-8")
 
         with patch.object(
             agent_config,

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -393,6 +393,42 @@ class TestSessionTranscriptResolver:
         ):
             assert resolve_session_jsonl_path(sid, local) is None
 
+    def test_nested_foreign_checkout_is_rejected_by_common_dir_identity(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lexical ancestry cannot make an independent nested repository trusted."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        local = tmp_path / "owner" / "Repo"
+        nested_foreign = local / "nested" / "Repo"
+        nested_foreign.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        foreign_transcript = session_jsonl_path(sid, nested_foreign)
+        foreign_transcript.parent.mkdir(parents=True, exist_ok=True)
+        foreign_transcript.write_text(
+            f'{{"cwd": "{nested_foreign.resolve()}"}}\n',
+            encoding="utf-8",
+        )
+        assert nested_foreign.is_relative_to(local)
+
+        common_dirs = {
+            local.resolve(): tmp_path / "local-common.git",
+            nested_foreign.resolve(): tmp_path / "foreign-common.git",
+        }
+        with (
+            patch.object(
+                agent_config,
+                "_registered_worktree_roots",
+                return_value=(local.resolve(),),
+            ),
+            patch.object(
+                agent_config,
+                "_git_common_dir",
+                side_effect=lambda cwd: common_dirs[cwd.resolve()],
+            ),
+        ):
+            assert resolve_session_jsonl_path(sid, local) is None
+
     def test_registered_worktree_discovery_uses_explicit_cwd_and_scrubbed_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -465,6 +501,109 @@ class TestSessionTranscriptResolver:
             resolved = resolve_session_jsonl_path("session-id", worktree)
 
         assert resolved == min(paths, key=str)
+
+
+@pytest.mark.requires_posix
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Creates throwaway repositories and linked worktrees; skipped on win32",
+)
+class TestSessionTranscriptResolverRealWorktrees:
+    """Integration coverage for Git-identity transcript validation."""
+
+    @staticmethod
+    def _init_repo(repo_root: Path) -> None:
+        repo_root.mkdir(parents=True)
+        env = _git_test_env()
+        subprocess.run(["git", "init", "-q", str(repo_root)], check=True, env=env)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "commit",
+                "--allow-empty",
+                "-m",
+                "initial",
+                "--no-gpg-sign",
+            ],
+            check=True,
+            env=env,
+        )
+
+    @staticmethod
+    def _add_worktree(repo_root: Path, worktree: Path, branch: str) -> None:
+        worktree.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                branch,
+                str(worktree),
+            ],
+            check=True,
+            env=_git_test_env(),
+        )
+
+    def test_sibling_worktree_resumes_main_checkout_transcript(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "main" / "Repo"
+        sibling_worktree = tmp_path / "separate-root" / "issue-2284"
+        self._init_repo(repo_root)
+        self._add_worktree(repo_root, sibling_worktree, "issue-2284")
+
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+        transcript = session_jsonl_path(sid, repo_root)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(f'{{"cwd": "{repo_root.resolve()}"}}\n', encoding="utf-8")
+
+        assert resolve_session_jsonl_path(sid, sibling_worktree) == transcript
+
+    def test_removed_managed_predecessor_resumes_from_replacement(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "main" / "Repo"
+        predecessor = repo_root / "build" / ".worktrees" / "issue-2284-a"
+        replacement = tmp_path / "separate-root" / "issue-2284-b"
+        self._init_repo(repo_root)
+        self._add_worktree(repo_root, predecessor, "issue-2284-a")
+
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+        transcript = session_jsonl_path(sid, predecessor)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(f'{{"cwd": "{predecessor.resolve()}"}}\n', encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "remove", str(predecessor)],
+            check=True,
+            env=_git_test_env(),
+        )
+        self._add_worktree(repo_root, replacement, "issue-2284-b")
+
+        assert resolve_session_jsonl_path(sid, replacement) == transcript
+
+    def test_nested_independent_clone_is_not_same_worktree_family(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "main" / "Repo"
+        nested_clone = repo_root / "nested" / "Repo"
+        self._init_repo(repo_root)
+        self._init_repo(nested_clone)
+
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+        transcript = session_jsonl_path(sid, nested_clone)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(f'{{"cwd": "{nested_clone.resolve()}"}}\n', encoding="utf-8")
+
+        assert resolve_session_jsonl_path(sid, repo_root) is None
 
 
 @pytest.mark.requires_posix

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -460,11 +460,33 @@ class TestSessionTranscriptResolver:
         transcript.write_text(f'{{"cwd": "{cwd.resolve()}"}}\n', encoding="utf-8")
 
         with patch.object(
-            subprocess, "run", side_effect=subprocess.CalledProcessError(128, ["git"])
+            subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(
+                128,
+                ["git"],
+                stderr="fatal: not a git repository (or any of the parent directories): .git\n",
+            ),
         ):
             resolved = resolve_session_jsonl_path("session-id", cwd)
 
         assert resolved == transcript
+
+    def test_operational_git_failure_is_not_treated_as_non_repository(self, tmp_path: Path) -> None:
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+
+        with patch.object(
+            subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(
+                128,
+                ["git"],
+                stderr="fatal: detected dubious ownership in repository\n",
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="unable to determine whether"):
+                agent_config._registered_worktree_roots(cwd)
 
     def test_git_discovery_failure_raises_explicitly(self, tmp_path: Path) -> None:
         cwd = tmp_path / "checkout"

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -336,7 +336,10 @@ class TestSessionTranscriptResolver:
         sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
         transcript = session_jsonl_path(sid, repo_root)
         transcript.parent.mkdir(parents=True, exist_ok=True)
-        transcript.write_text(f'{{"cwd": "{removed_worktree.resolve()}"}}\n', encoding="utf-8")
+        transcript.write_text(
+            f'{{"cwd": "{repo_root.resolve()}"}}\n{{"cwd": "{removed_worktree.resolve()}"}}\n',
+            encoding="utf-8",
+        )
         removed_worktree.rmdir()
 
         with patch.object(
@@ -369,6 +372,30 @@ class TestSessionTranscriptResolver:
             resolved = resolve_session_jsonl_path(sid, local_worktree)
 
         assert resolved is None
+
+    def test_foreign_project_path_with_forged_local_cwd_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A scanned candidate must live in its recorded cwd's project directory."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        local = tmp_path / "owner-a" / "Repo"
+        foreign = tmp_path / "owner-b" / "Repo"
+        local.mkdir(parents=True)
+        foreign.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        foreign_transcript = session_jsonl_path(sid, foreign)
+        local_transcript = session_jsonl_path(sid, local)
+        assert foreign_transcript.parent != local_transcript.parent
+        foreign_transcript.parent.mkdir(parents=True, exist_ok=True)
+        foreign_transcript.write_text(f'{{"cwd": "{local.resolve()}"}}\n', encoding="utf-8")
+
+        with patch.object(
+            agent_config,
+            "_registered_worktree_roots",
+            return_value=(local.resolve(),),
+        ):
+            assert resolve_session_jsonl_path(sid, local) is None
 
     def test_lossy_cwd_encoding_does_not_resume_foreign_transcript(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -472,7 +499,17 @@ class TestSessionTranscriptResolver:
 
         assert resolved == transcript
 
-    def test_operational_git_failure_is_not_treated_as_non_repository(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "fatal: detected dubious ownership in repository\n",
+            "fatal: cannot access '.git': Permission denied\n",
+            "fatal: invalid gitfile format: .git\n",
+        ],
+    )
+    def test_operational_git_failure_is_not_treated_as_non_repository(
+        self, tmp_path: Path, stderr: str
+    ) -> None:
         cwd = tmp_path / "checkout"
         cwd.mkdir()
 
@@ -482,7 +519,7 @@ class TestSessionTranscriptResolver:
             side_effect=subprocess.CalledProcessError(
                 128,
                 ["git"],
-                stderr="fatal: detected dubious ownership in repository\n",
+                stderr=stderr,
             ),
         ):
             with pytest.raises(RuntimeError, match="unable to determine whether"):

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -525,7 +525,26 @@ class TestSessionTranscriptResolver:
             with pytest.raises(RuntimeError, match="unable to determine whether"):
                 agent_config._registered_worktree_roots(cwd)
 
-    def test_git_discovery_failure_raises_explicitly(self, tmp_path: Path) -> None:
+    def test_corrupt_git_metadata_with_generic_diagnostic_is_not_non_repository(
+        self, tmp_path: Path
+    ) -> None:
+        """Fail closed when corrupt metadata imitates Git's no-repository result."""
+        cwd = tmp_path / "checkout"
+        (cwd / ".git").mkdir(parents=True)
+
+        with patch.object(
+            subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(
+                128,
+                ["git"],
+                stderr="fatal: not a git repository (or any of the parent directories): .git\n",
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="unable to determine whether"):
+                agent_config._registered_worktree_roots(cwd)
+
+    def test_git_discovery_failure_allows_exact_cwd_session_creation(self, tmp_path: Path) -> None:
         cwd = tmp_path / "checkout"
         cwd.mkdir()
 
@@ -534,8 +553,31 @@ class TestSessionTranscriptResolver:
             "run",
             side_effect=(MagicMock(stdout="true\n"), subprocess.TimeoutExpired(["git"], 5)),
         ):
-            with pytest.raises(RuntimeError, match="unable to discover registered Git worktrees"):
-                resolve_session_jsonl_path("session-id", cwd)
+            assert resolve_session_jsonl_path("session-id", cwd) is None
+
+    def test_exact_cwd_transcript_does_not_require_git_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        cwd = tmp_path / "checkout"
+        cwd.mkdir()
+        transcript = session_jsonl_path("session-id", cwd)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(f'{{"cwd": "{cwd.resolve()}"}}\n', encoding="utf-8")
+
+        with (
+            patch.object(
+                agent_config,
+                "_registered_worktree_roots",
+                side_effect=AssertionError("exact-cwd resume must not invoke Git"),
+            ),
+            patch.object(
+                agent_config,
+                "_git_common_dir",
+                side_effect=AssertionError("exact-cwd resume must not invoke Git"),
+            ),
+        ):
+            assert resolve_session_jsonl_path("session-id", cwd) == transcript
 
     def test_duplicate_transcripts_choose_lexicographically_first_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: checkout-scoped transcript resolution added in `agent_config.py:558`, Claude now resumes via it at `claude_invoke.py:308`; regression coverage includes real reviewer→worker dispatch. `uv run python -m pytest tests/ -v` passed (6,508 tests); Ruff and mypy passed.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2284

Generated by Hephaestus automation
