### PR TITLE
fix(automation): preserve sandboxed review sessions

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -531,7 +531,15 @@ def _codex_base_cmd(
         ]
     )
     cmd.extend(_codex_model_args(model, use_default=resume_id is None))
-    if resume_id is None:
+    if resume_id is not None:
+        # ``codex exec resume`` does not accept the new-session --sandbox or
+        # --ask-for-approval flags.  Its generic config overrides are the
+        # enforceable equivalent, and must not inherit a permissive user
+        # profile when a pipeline review resumes.
+        if sandbox is not None:
+            cmd.extend(["-c", f"sandbox_mode={json.dumps(sandbox)}"])
+        cmd.extend(["-c", f"approval_policy={json.dumps(approval)}"])
+    else:
         if cwd is None:
             raise ValueError("cwd is required for new Codex exec sessions")
         cmd.extend(["--cd", str(cwd)])
@@ -649,9 +657,16 @@ def resume_codex_session(
     cwd: Path,
     timeout: int,
     model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
 ) -> AgentRunResult:
     """Resume a persisted Codex exec session and capture its latest output."""
-    cmd = _codex_base_cmd(model=model, sandbox=None, resume_id=session_id)
+    cmd = _codex_base_cmd(
+        model=model,
+        sandbox=sandbox,
+        approval=approval,
+        resume_id=session_id,
+    )
     return _run_codex_command(cmd, prompt=prompt, cwd=cwd, timeout=timeout)
 
 
@@ -844,15 +859,18 @@ def resume_pi_session(
     cwd: Path,
     timeout: int,
     model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
 ) -> AgentRunResult:
     """Resume a Pi JSON-mode session by id."""
+    del approval
     cmd = _pi_base_cmd(session_id=session_id)
     result = _run_pi_command(
         cmd,
         prompt=prompt,
         cwd=cwd,
         timeout=timeout,
-        sandbox="workspace-write",
+        sandbox=sandbox,
         model=model,
     )
     parsed_session_id, event_message = _parse_pi_json_events(result.stdout or "")
@@ -936,12 +954,30 @@ def resume_agent_session(
     cwd: Path,
     timeout: int,
     model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
 ) -> AgentRunResult:
     """Resume a direct-runner agent session."""
     if is_codex(agent):
-        return resume_codex_session(session_id, prompt, cwd=cwd, timeout=timeout, model=model)
+        return resume_codex_session(
+            session_id,
+            prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            sandbox=sandbox,
+            approval=approval,
+        )
     if is_pi(agent):
-        return resume_pi_session(session_id, prompt, cwd=cwd, timeout=timeout, model=model)
+        return resume_pi_session(
+            session_id,
+            prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            sandbox=sandbox,
+            approval=approval,
+        )
     raise ValueError(f"Agent '{agent}' does not support direct session resume")
 
 

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -467,6 +467,7 @@ def compact_agent_session(
     timeout: int | None = None,
     model: str | None = None,
     session_id: str | None = None,
+    sandbox: str = "read-only",
 ) -> bool:
     """Compact a persisted provider session without making it a hard gate.
 
@@ -494,6 +495,8 @@ def compact_agent_session(
             cwd=cwd,
             timeout=timeout_s,
             model=model or "",
+            sandbox=sandbox,
+            approval="never",
         )
     except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError, ValueError) as exc:
         logger.warning(

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -111,6 +111,9 @@ class CompactJob:
     cwd: Path
     timeout_s: int
     session_id: str | None = None
+    # Direct-provider compaction only sends ``/compact`` and never needs write
+    # access.  Keep the policy explicit so it cannot inherit user defaults.
+    sandbox: str = "read-only"
     descr: str = "compact_session"
 
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -491,6 +491,7 @@ class ImplementationStage(Stage):
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
             session_agent=AGENT_IMPLEMENTER,
+            resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={
                 "issue_number": item.issue,
                 "prev_iteration": item.attempts.get("test_fix", 0),

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -681,6 +681,7 @@ class PrReviewStage(Stage):
             cwd=_worktree_path(item, ctx),
             timeout_s=pr_reviewer_claude_timeout(),
             session_id=item.session_ids.get(AGENT_PR_REVIEWER),
+            sandbox="read-only",
         )
         return JobRequest(job, on_done_state=COMPACT_WRITER_WAIT)
 
@@ -700,6 +701,7 @@ class PrReviewStage(Stage):
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
             session_id=item.session_ids.get(session_agent),
+            sandbox="read-only",
         )
         return JobRequest(job, on_done_state=REVIEW_WAIT)
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -422,6 +422,8 @@ class WorkerPool:
                         cwd=job.cwd,
                         timeout=job.timeout_s,
                         model=job.model,
+                        sandbox=job.sandbox,
+                        approval="never",
                     )
                 else:
                     agent_result = run_agent_session(
@@ -492,6 +494,7 @@ class WorkerPool:
             timeout=job.timeout_s,
             model=job.model,
             session_id=job.session_id,
+            sandbox=job.sandbox,
         )
         # ``compact_agent_session`` intentionally swallows expected failures; a
         # missing or uncompactable transcript must not stall a review cycle.

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -519,7 +519,15 @@ def test_codex_base_cmd_resume_without_model_preserves_session_model() -> None:
     """Resume should not force the default model unless a model is requested."""
     cmd = agent_runtime._codex_base_cmd(resume_id="session-123", sandbox=None)
 
-    assert cmd == ["codex", "exec", "resume", "session-123", "--json"]
+    assert cmd == [
+        "codex",
+        "exec",
+        "resume",
+        "session-123",
+        "-c",
+        'approval_policy="never"',
+        "--json",
+    ]
 
 
 def test_resume_codex_session_uses_exec_resume(tmp_path: Path) -> None:
@@ -547,6 +555,29 @@ def test_resume_codex_session_uses_exec_resume(tmp_path: Path) -> None:
     ]
     assert result.stdout == "resumed"
     assert result.session_id == "019e1e57-7652-7892-b1ca-c31c93d4b160"
+
+
+def test_resume_codex_session_applies_the_requested_sandbox_and_approval(tmp_path: Path) -> None:
+    """A resumed read-only session must override permissive local defaults."""
+    captured_cmd: list[str] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        captured_cmd.extend(cmd)
+        stdout = '{"type":"session_meta","payload":{"id":"session-123"}}\\n'
+        return _FakeCodexPopen(cmd, proc_stdout=stdout, final_message="resumed", **kwargs)
+
+    with patch("subprocess.Popen", side_effect=fake_popen):
+        agent_runtime.resume_codex_session(
+            "session-123",
+            "review again",
+            cwd=tmp_path,
+            timeout=1,
+            sandbox="read-only",
+            approval="never",
+        )
+
+    assert 'sandbox_mode="read-only"' in captured_cmd
+    assert 'approval_policy="never"' in captured_cmd
 
 
 def test_run_pi_session_uses_json_mode_and_captures_session(tmp_path: Path) -> None:
@@ -734,9 +765,12 @@ def test_resume_pi_session_passes_resume_id_without_alias_argv_leak(tmp_path: Pa
             cwd=tmp_path,
             timeout=30,
             model="private-alias",
+            sandbox="read-only",
         )
 
-    assert captured["cmd"][:-1] == ["pi", "--mode", "json", "--session", "pi-session-789"]
+    tools_index = captured["cmd"].index("--tools")
+    assert captured["cmd"][:tools_index] == ["pi", "--mode", "json", "--session", "pi-session-789"]
+    assert captured["cmd"][tools_index + 1] == agent_runtime.PI_READ_ONLY_TOOLS
     assert captured["cmd"][-1].startswith("@")
     assert "--model" not in captured["cmd"]
     assert "private-alias" not in captured["cmd"]

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -971,6 +971,21 @@ class TestTestsAndFix:
         stage.on_job_done(item, JobResult(ok=True, value="fixed"), ctx)
         assert item.attempts["test_fix"] == 1
 
+    def test_testfix_resumes_the_saved_direct_implementer_session(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A test repair continues the implementation conversation."""
+        stage = ImplementationStage()
+        ctx = make_ctx(config=SimpleNamespace(agent="codex"))
+        item = make_work_item(issue=1, state="TESTFIX_WAIT")
+        item.session_ids["implementer"] = "implement-session-id"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.resume_session_id == "implement-session-id"
+
     def test_testfix_budget_exhaustion_finishes_failed(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -381,6 +381,7 @@ class TestPrReviewStageStep:
         assert isinstance(reviewer_compact, JobRequest)
         assert isinstance(reviewer_compact.job, CompactJob)
         assert reviewer_compact.job.session_agent == "pr-reviewer"
+        assert reviewer_compact.job.sandbox == "read-only"
         assert reviewer_compact.on_done_state == "COMPACT_WRITER_WAIT"
 
         item.state = reviewer_compact.on_done_state
@@ -388,6 +389,7 @@ class TestPrReviewStageStep:
         assert isinstance(writer_compact, JobRequest)
         assert isinstance(writer_compact.job, CompactJob)
         assert writer_compact.job.session_agent == "implementer"
+        assert writer_compact.job.sandbox == "read-only"
         assert writer_compact.on_done_state == "REVIEW_WAIT"
 
     def test_validation_continues_the_reused_reviewer_session(

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -180,6 +180,7 @@ class TestWorkerPoolSubmitComplete:
             timeout=60,
             model="claude-haiku-4-5",
             session_id=None,
+            sandbox="read-only",
         )
 
     def test_submit_and_complete_non_claude_agent_job(
@@ -236,11 +237,37 @@ class TestWorkerPoolSubmitComplete:
             cwd=job.cwd,
             timeout=job.timeout_s,
             model=job.model,
+            sandbox="workspace-write",
+            approval="never",
         )
         run.assert_not_called()
         assert result.ok is True
         assert result.value == "continued"
         assert result.session_id == "saved-codex-session"
+
+    def test_resumed_read_only_agent_job_preserves_its_sandbox(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Resuming review work must not widen the direct agent's tools."""
+        job = _agent_job(
+            agent="pi",
+            sandbox="read-only",
+            resume_session_id="saved-pi-session",
+        )
+        session_result = MagicMock(stdout="continued", session_id="saved-pi-session")
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="pi"),
+            patch(f"{_WP}.resume_agent_session", return_value=session_result) as resume,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _handle, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert resume.call_args.kwargs["sandbox"] == "read-only"
+        assert resume.call_args.kwargs["approval"] == "never"
 
     def test_read_only_agent_job_propagates_its_sandbox_to_codex(
         self,

--- a/tests/unit/automation/test_compact.py
+++ b/tests/unit/automation/test_compact.py
@@ -161,6 +161,7 @@ class TestCompactAgentSession:
                 cwd=tmp_path,
                 timeout=60,
                 model="gpt-5.6",
+                sandbox="read-only",
             )
 
         assert compacted is True
@@ -171,6 +172,8 @@ class TestCompactAgentSession:
             cwd=tmp_path,
             timeout=60,
             model="gpt-5.6",
+            sandbox="read-only",
+            approval="never",
         )
 
     def test_direct_compact_without_a_session_is_a_safe_noop(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #2355

## Summary
- preserve each direct agent job's sandbox and non-interactive approval policy when resuming Codex or Pi sessions
- compact direct reviewer and writer sessions with an explicit read-only sandbox before the next review iteration
- preserve the direct implementer session while repairing failed pre-PR tests
- add regression coverage for resumed provider policy, compact-job policy, and test-fix continuity

## Verification
- `uv run --all-extras --locked pytest -q` (6,509 passed, 6 skipped; 85.14% coverage)
- `uv run ruff check hephaestus tests`
- `uv run ruff format --check hephaestus tests`
- `uv run mypy hephaestus`
- `git diff --check`