### PR TITLE
fix(automation): keep org dry runs read-only

### DIFF
--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -211,7 +211,7 @@ def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
     return sorted(pulls, key=lambda pr: pr["number"])
 
 
-def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
+def _list_open_issue_numbers(org: str, repo: str, *, dry_run: bool = False) -> list[int]:
     """Return open NON-epic issue numbers in ``org/repo``, sorted ascending.
 
     This is the loop's single canonical issue-discovery call: the result is
@@ -225,7 +225,8 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
     of child work, not code tasks, so the loop must never plan/implement them.
     Each excluded epic is tagged ``state:skip`` (best-effort) via
     :func:`skip_epics` so dashboards see it as intentionally bypassed; that
-    tagging never raises and never affects the returned list. Detection uses
+    tagging never raises and never affects the returned list. In dry-run mode,
+    the prospective write is logged but never sent to GitHub. Detection uses
     label names + title because native GitHub issue types are not exposed by the
     installed ``gh`` — see :func:`~hephaestus.automation.state_labels.is_epic`.
 
@@ -248,15 +249,20 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
         # The owning repo is passed explicitly — this runs in the multi-repo
         # parent process, where ambient cwd resolution wrote other repos'
         # epic numbers onto the launch-directory repo (#2245).
-        try:
-            skip_epics(epic_labels, repo=(org, repo))
-        except Exception as exc:  # pragma: no cover - defensive
-            LOG.warning("[%s] could not tag excluded epics state:skip: %s", repo, exc)
+        if dry_run:
+            LOG.info("[dry-run] [%s] would tag excluded epics state:skip", repo)
+        else:
+            try:
+                skip_epics(epic_labels, repo=(org, repo))
+            except Exception as exc:  # pragma: no cover - defensive
+                LOG.warning("[%s] could not tag excluded epics state:skip: %s", repo, exc)
     return kept
 
 
-def _count_open_issues(org: str, repo: str) -> int:
+def _count_open_issues(org: str, repo: str, *, dry_run: bool = False) -> int:
     """Return count of open issues in ``org/repo``."""
+    if dry_run:
+        return len(_list_open_issue_numbers(org, repo, dry_run=True))
     return len(_list_open_issue_numbers(org, repo))
 
 
@@ -301,11 +307,15 @@ def _count_failing_prs(org: str, repo: str) -> int:
     return sum(1 for pr in pulls if not pr.get("isDraft") and pr.get("state", "OPEN") == "OPEN")
 
 
-def _sort_repos_by_open_count(org: str, repos: list[str]) -> list[str]:
+def _sort_repos_by_open_count(org: str, repos: list[str], *, dry_run: bool = False) -> list[str]:
     """Order repos ascending by open-issue count (smallest backlog first)."""
     counted: list[tuple[int, int, str]] = []
     for idx, repo in enumerate(repos):
-        counted.append((_count_open_issues(org, repo), idx, repo))
+        if dry_run:
+            count = _count_open_issues(org, repo, dry_run=True)
+        else:
+            count = _count_open_issues(org, repo)
+        counted.append((count, idx, repo))
     counted.sort()
     return [name for _, _, name in counted]
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -607,7 +607,11 @@ def _resolve_org_and_repos(
         if not candidates:
             return (org, [], "No repos returned from gh repo list — possible rate limit.")
         LOG.info("Sorting %d repos by open-issue count ...", len(candidates))
-        return (org, _sort_repos_by_open_count(org, candidates), None)
+        if args.dry_run:
+            repos = _sort_repos_by_open_count(org, candidates, dry_run=True)
+        else:
+            repos = _sort_repos_by_open_count(org, candidates)
+        return (org, repos, None)
 
     # Branch 4: no flags — default to cwd repo
     detected_org, detected_repo = _detect_cwd_repo()

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -329,6 +329,29 @@ def test_resolve_org_and_repos_org_named() -> None:
     mock_detect.assert_not_called()
 
 
+def test_resolve_org_and_repos_dry_run_never_tags_discovered_epics() -> None:
+    """Organization discovery stays read-only when the loop is a dry run."""
+    args = loop_runner._parse_args(["--org", "ExplicitOrg", "--dry-run"])
+    epic = {"number": 81, "title": "Epic: roadmap", "labels": ["epic"]}
+    with (
+        patch(
+            "hephaestus.automation.loop_runner._gh_list_repos",
+            return_value=["Proteus"],
+        ),
+        patch(
+            "hephaestus.automation.loop_repo_manager._list_open_issue_meta",
+            return_value=[epic],
+        ),
+        patch("hephaestus.automation.loop_repo_manager.skip_epics") as mock_skip,
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+
+    assert err is None
+    assert org == "ExplicitOrg"
+    assert repos == ["Proteus"]
+    mock_skip.assert_not_called()
+
+
 def test_resolve_org_and_repos_repos_flag_uses_cwd_org() -> None:
     """``--repos foo,bar`` uses cwd-detected org without enumerating."""
     args = loop_runner._parse_args(["--repos", "foo,bar"])


### PR DESCRIPTION
## Summary

Propagate `--dry-run` through organization discovery so pre-pipeline epic filtering logs its intended `state:skip` action instead of mutating GitHub.

## Validation

- Added a regression test for `--org NAME --dry-run` discovery with an epic issue.
- `uv run pytest --override-ini=addopts= -q tests/unit/automation/test_loop_repo_manager.py tests/unit/automation/test_loop_runner.py`
- `uv run mypy hephaestus/ scripts/ tests/`
- Full pre-push suite: 6588 passed, 6 skipped.

Closes #2405