### PR TITLE
fix(automation): sync existing checkouts before discovery

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1069,7 +1069,7 @@ mutations.
  coordinator constructs them from vetted templates
  (`PRE_PR_TEST_ARGV` for the pre-PR test gate).
 - [`GitJob`](hephaestus/automation/pipeline/jobs.py) — `op ∈ {clone,
- create_worktree, remove_worktree, rebase, push, commit_push}`,
+ sync_checkout, create_worktree, remove_worktree, rebase, push, commit_push}`,
  validated by `__post_init__`.
 - [`CompactJob`](hephaestus/automation/pipeline/jobs.py) — a best-effort
  `/compact` turn for a persisted Claude, Codex, or Pi session; it never blocks

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -17,7 +17,15 @@ from typing import Any
 from hephaestus.automation.pipeline.routing import StageName
 
 GIT_OPS: frozenset[str] = frozenset(
-    {"clone", "create_worktree", "remove_worktree", "rebase", "push", "commit_push"}
+    {
+        "clone",
+        "sync_checkout",
+        "create_worktree",
+        "remove_worktree",
+        "rebase",
+        "push",
+        "commit_push",
+    }
 )
 
 

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -8,9 +8,11 @@ Steps:
 
 1. [M] ``on_enter``: ``ctx.github.ensure_state_labels()`` — idempotent label
    vocabulary setup.
-2. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing
-   (skipped when already cloned, and logged-skipped under dry-run — the
-   coordinator's ``_submit`` asserts no job is ever submitted in dry-run).
+2. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing, or
+   ``GitJob(op="sync_checkout")`` when it already exists. Synchronization
+   validates the expected remote and fast-forwards only a clean default-branch
+   checkout. Both operations are logged-skipped under dry-run — the
+   coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
 3. [M] DISCOVER: list issues (read-only ``_list_open_issue_meta``), dedup,
    ``partition_epics`` -> tag epics ``state:skip`` via
@@ -173,7 +175,7 @@ class RepoStage(Stage):
         return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
 
     def _clone_or_skip(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Submit the clone GitJob, or skip when present / dry-run / exhausted."""
+        """Prepare a checkout by cloning or safely synchronizing it."""
         # Clone failure handling (budget clone=2): on_job_done recorded the
         # failure; classify it here so retry re-submits and exhaustion fails.
         if item.payload.pop("clone_failed", False):
@@ -190,12 +192,22 @@ class RepoStage(Stage):
             )
 
         dest = _repo_checkout_path(item, ctx)
-        if dest.exists():
-            logger.info("repo:%s: already cloned at %s", item.repo, dest)
-            return Continue(next_state="DISCOVER")
         if ctx.dry_run:
+            if dest.exists():
+                logger.info("[dry-run] would synchronize %s/%s at %s", ctx.org, item.repo, dest)
+                return Continue(next_state="DISCOVER")
             logger.info("[dry-run] would clone %s/%s to %s", ctx.org, item.repo, dest)
             return Continue(next_state="DISCOVER")
+
+        if dest.exists():
+            job = GitJob(
+                repo=item.repo,
+                op="sync_checkout",
+                timeout_s=GIT_JOB_TIMEOUT_S,
+                kwargs={"repo": f"{ctx.org}/{item.repo}", "dest": str(dest)},
+                descr=f"synchronize {ctx.org}/{item.repo}",
+            )
+            return JobRequest(job=job, on_done_state="DISCOVER")
 
         job = GitJob(
             repo=item.repo,
@@ -294,22 +306,22 @@ class RepoStage(Stage):
         return Continue(next_state="SEEDED")
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
-        """Record clone success/failure (state still CLONE_WAIT).
+        """Record checkout preparation success/failure (state still CLONE_WAIT).
 
         Args:
             item: The repo work item.
-            result: The clone job result.
+            result: The clone or checkout-synchronization job result.
             ctx: Stage context.
 
         """
         if item.state != "CLONE_WAIT":
             return
         if result.ok:
-            logger.info("repo:%s: clone completed", item.repo)
+            logger.info("repo:%s: checkout preparation completed", item.repo)
             return
         item.attempts["clone"] = item.attempts.get("clone", 0) + 1
         item.payload["clone_failed"] = True
-        logger.warning("repo:%s: clone failed: %s", item.repo, result.error)
+        logger.warning("repo:%s: checkout preparation failed: %s", item.repo, result.error)
 
 
 def product_to_work_item(repo: str, product: dict[str, Any]) -> WorkItem | None:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -637,18 +637,11 @@ class WorkerPool:
             ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=job.timeout_s
         ).stdout.strip()
         normalized_origin = origin.rstrip("/").removesuffix(".git")
-        expected_origins = {
-            f"https://github.com/{expected_repo}",
-            f"ssh://git@github.com/{expected_repo}",
-            f"git@github.com:{expected_repo}",
-        }
-        if normalized_origin not in expected_origins:
+        expected_origin = f"https://github.com/{expected_repo}"
+        if normalized_origin != expected_origin:
             return JobResult(
                 ok=False,
-                error=(
-                    f"checkout has unexpected origin; expected origin {expected_repo}, "
-                    f"found {origin}"
-                ),
+                error=f"checkout has unexpected origin; expected origin {expected_repo}",
             )
 
         status = git_utils.run(
@@ -684,7 +677,7 @@ class WorkerPool:
                 ),
             )
 
-        metadata_lock = checkout / "build" / ".worktrees" / ".git-metadata.lock"
+        metadata_lock = WorktreeManager.git_metadata_lock_path(checkout)
         with _interruptible_file_lock(
             metadata_lock,
             shutdown=self._shutdown,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -8,6 +8,7 @@ perform GitHub API mutations (enforced by test_pipeline_architecture.py).
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import threading
 import time
@@ -640,7 +641,6 @@ class WorkerPool:
             f"https://github.com/{expected_repo}",
             f"ssh://git@github.com/{expected_repo}",
             f"git@github.com:{expected_repo}",
-            f"git://github.com/{expected_repo}",
         }
         if normalized_origin not in expected_origins:
             return JobResult(
@@ -657,19 +657,24 @@ class WorkerPool:
         if status.stdout.strip():
             return JobResult(ok=False, error=f"checkout is dirty: {checkout}")
 
-        branch = git_utils.run(
+        branch_result = git_utils.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
             cwd=checkout,
+            check=False,
+            log_errors=False,
             timeout=job.timeout_s,
-        ).stdout.strip()
-        default_ref = git_utils.run(
-            ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        )
+        branch = branch_result.stdout.strip()
+        if branch_result.returncode != 0 or not branch:
+            return JobResult(ok=False, error=f"checkout is detached: {checkout}")
+
+        default_branch = git_utils.run(
+            ["gh", "api", f"repos/{expected_repo}", "--jq", ".default_branch"],
             cwd=checkout,
             timeout=job.timeout_s,
         ).stdout.strip()
-        if not default_ref.startswith("origin/"):
-            return JobResult(ok=False, error=f"checkout has no origin default branch: {checkout}")
-        default_branch = default_ref.removeprefix("origin/")
+        if not default_branch:
+            return JobResult(ok=False, error=f"repository has no default branch: {expected_repo}")
         if branch != default_branch:
             return JobResult(
                 ok=False,
@@ -679,20 +684,86 @@ class WorkerPool:
                 ),
             )
 
+        metadata_lock = checkout / "build" / ".worktrees" / ".git-metadata.lock"
+        with _interruptible_file_lock(
+            metadata_lock,
+            shutdown=self._shutdown,
+            timeout_s=job.timeout_s,
+        ):
+            return self._fast_forward_checkout(
+                checkout=checkout,
+                origin=origin,
+                default_branch=default_branch,
+                timeout_s=job.timeout_s,
+            )
+
+    @staticmethod
+    def _fast_forward_checkout(
+        *,
+        checkout: Path,
+        origin: str,
+        default_branch: str,
+        timeout_s: int,
+    ) -> JobResult:
+        """Fetch and fast-forward a validated checkout while its metadata is locked."""
+        hooks_disabled = f"core.hooksPath={os.devnull}"
         git_utils.run(
-            ["git", "fetch", "origin", default_branch], cwd=checkout, timeout=job.timeout_s
+            [
+                "git",
+                "-c",
+                hooks_disabled,
+                "fetch",
+                "--no-tags",
+                origin,
+                f"+refs/heads/{default_branch}:refs/remotes/origin/{default_branch}",
+            ],
+            cwd=checkout,
+            timeout=timeout_s,
         )
+        relation = git_utils.run(
+            [
+                "git",
+                "rev-list",
+                "--left-right",
+                "--count",
+                f"HEAD...origin/{default_branch}",
+            ],
+            cwd=checkout,
+            timeout=timeout_s,
+        ).stdout.split()
+        if len(relation) != 2:
+            return JobResult(ok=False, error=f"could not compare checkout history: {checkout}")
+        try:
+            ahead, _behind = (int(count) for count in relation)
+        except ValueError:
+            return JobResult(ok=False, error=f"could not compare checkout history: {checkout}")
+        if ahead:
+            return JobResult(
+                ok=False,
+                error=f"checkout has local commits beyond origin/{default_branch}: {checkout}",
+            )
+
         merge = git_utils.run(
-            ["git", "merge", "--ff-only", f"origin/{default_branch}"],
+            ["git", "-c", hooks_disabled, "merge", "--ff-only", f"origin/{default_branch}"],
             cwd=checkout,
             check=False,
             log_errors=False,
-            timeout=job.timeout_s,
+            timeout=timeout_s,
         )
         if merge.returncode != 0:
             return JobResult(
                 ok=False,
-                error=f"checkout cannot fast-forward {default_branch} to origin/{default_branch}",
+                error=(f"checkout cannot fast-forward {default_branch} to origin/{default_branch}"),
+            )
+        synced_heads = git_utils.run(
+            ["git", "rev-parse", "HEAD", f"origin/{default_branch}"],
+            cwd=checkout,
+            timeout=timeout_s,
+        ).stdout.split()
+        if len(synced_heads) != 2 or synced_heads[0] != synced_heads[1]:
+            return JobResult(
+                ok=False,
+                error=f"checkout did not reach origin/{default_branch}: {checkout}",
             )
         return JobResult(ok=True)
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -51,6 +51,26 @@ logger = logging.getLogger(__name__)
 _TAIL = 4000  # chars of stdout/stderr retained in a JobResult
 _ERR_MAX = 500  # chars of error detail retained in a JobResult
 _GIT_LOCK_WAIT_POLL_S = 0.1
+_FETCH_ENV_BLOCKLIST = frozenset(
+    {
+        "GIT_ASKPASS",
+        "GIT_SSH",
+        "GIT_SSH_COMMAND",
+        "SSH_ASKPASS",
+    }
+)
+
+
+def _controlled_fetch_env() -> dict[str, str]:
+    """Return a fetch environment that cannot inject local Git executables."""
+    env = os.environ.copy()
+    for key in _FETCH_ENV_BLOCKLIST:
+        env.pop(key, None)
+    for key in tuple(env):
+        if key == "GIT_CONFIG_COUNT" or key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            env.pop(key)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
 
 
 def _repo_lock_path(repo: str, lock_dir: Path | None = None) -> Path:
@@ -637,8 +657,12 @@ class WorkerPool:
             ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=job.timeout_s
         ).stdout.strip()
         normalized_origin = origin.rstrip("/").removesuffix(".git")
-        expected_origin = f"https://github.com/{expected_repo}"
-        if normalized_origin != expected_origin:
+        expected_origins = {
+            f"https://github.com/{expected_repo}",
+            f"ssh://git@github.com/{expected_repo}",
+            f"git@github.com:{expected_repo}",
+        }
+        if normalized_origin not in expected_origins:
             return JobResult(
                 ok=False,
                 error=f"checkout has unexpected origin; expected origin {expected_repo}",
@@ -700,11 +724,22 @@ class WorkerPool:
     ) -> JobResult:
         """Fetch and fast-forward a validated checkout while its metadata is locked."""
         hooks_disabled = f"core.hooksPath={os.devnull}"
+        fetch_config = [
+            "-c",
+            hooks_disabled,
+            "-c",
+            "core.sshCommand=ssh",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "credential.helper=!gh auth git-credential",
+            "-c",
+            "core.askPass=",
+        ]
         git_utils.run(
             [
                 "git",
-                "-c",
-                hooks_disabled,
+                *fetch_config,
                 "fetch",
                 "--no-tags",
                 origin,
@@ -712,6 +747,7 @@ class WorkerPool:
             ],
             cwd=checkout,
             timeout=timeout_s,
+            env=_controlled_fetch_env(),
         )
         relation = git_utils.run(
             [

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -611,9 +611,90 @@ class WorkerPool:
             git_utils.run(["gh", "repo", "clone", repo, dest], cwd=None, timeout=job.timeout_s)
             return JobResult(ok=True)
 
+        elif job.op == "sync_checkout":
+            return self._git_sync_checkout(job)
+
         else:
             # Should be impossible due to GitJob.__post_init__ validation
             return JobResult(ok=False, error=f"unknown op {job.op!r}")
+
+    def _git_sync_checkout(self, job: GitJob) -> JobResult:
+        """Validate and fast-forward a reusable checkout without discarding local work."""
+        expected_repo = str(job.kwargs.get("repo") or "")
+        dest = str(job.kwargs.get("dest") or "")
+        if not expected_repo or not dest:
+            return JobResult(
+                ok=False,
+                error="sync_checkout requires non-empty 'repo' and 'dest' kwargs",
+            )
+
+        checkout = Path(dest)
+        if not checkout.is_dir():
+            return JobResult(ok=False, error=f"checkout does not exist: {checkout}")
+
+        origin = git_utils.run(
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=job.timeout_s
+        ).stdout.strip()
+        normalized_origin = origin.rstrip("/").removesuffix(".git")
+        expected_origins = {
+            f"https://github.com/{expected_repo}",
+            f"ssh://git@github.com/{expected_repo}",
+            f"git@github.com:{expected_repo}",
+            f"git://github.com/{expected_repo}",
+        }
+        if normalized_origin not in expected_origins:
+            return JobResult(
+                ok=False,
+                error=(
+                    f"checkout has unexpected origin; expected origin {expected_repo}, "
+                    f"found {origin}"
+                ),
+            )
+
+        status = git_utils.run(
+            ["git", "status", "--porcelain"], cwd=checkout, timeout=job.timeout_s
+        )
+        if status.stdout.strip():
+            return JobResult(ok=False, error=f"checkout is dirty: {checkout}")
+
+        branch = git_utils.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            cwd=checkout,
+            timeout=job.timeout_s,
+        ).stdout.strip()
+        default_ref = git_utils.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+            cwd=checkout,
+            timeout=job.timeout_s,
+        ).stdout.strip()
+        if not default_ref.startswith("origin/"):
+            return JobResult(ok=False, error=f"checkout has no origin default branch: {checkout}")
+        default_branch = default_ref.removeprefix("origin/")
+        if branch != default_branch:
+            return JobResult(
+                ok=False,
+                error=(
+                    f"checkout is not on its default branch {default_branch}: "
+                    f"currently on {branch or 'detached HEAD'}"
+                ),
+            )
+
+        git_utils.run(
+            ["git", "fetch", "origin", default_branch], cwd=checkout, timeout=job.timeout_s
+        )
+        merge = git_utils.run(
+            ["git", "merge", "--ff-only", f"origin/{default_branch}"],
+            cwd=checkout,
+            check=False,
+            log_errors=False,
+            timeout=job.timeout_s,
+        )
+        if merge.returncode != 0:
+            return JobResult(
+                ok=False,
+                error=f"checkout cannot fast-forward {default_branch} to origin/{default_branch}",
+            )
+        return JobResult(ok=True)
 
     def _git_create_worktree(self, job: GitJob) -> JobResult:
         """Create a worktree and optionally sync an adopted PR branch."""

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -44,6 +44,7 @@ _AUTOMATION_PROMPT_PREFIXES = (
     ".claude-prompt-",
     ".claude-followup-",
 )
+_GIT_METADATA_LOCK_NAME = ".hephaestus-git-metadata.lock"
 
 
 def _timeout_kw(timeout: int | None) -> dict[str, Any]:
@@ -124,9 +125,18 @@ class WorktreeManager:
 
         logger.debug("Initialized WorktreeManager at %s", self.base_dir)
 
+    @staticmethod
+    def git_metadata_lock_path(repo_root: Path) -> Path:
+        """Return the cross-process lock guarding ``repo_root``'s Git metadata.
+
+        The sentinel belongs in ``.git`` so acquiring it never creates an
+        untracked file in a reusable checkout's worktree.
+        """
+        return repo_root / ".git" / _GIT_METADATA_LOCK_NAME
+
     def _git_metadata_lock_path(self) -> Path:
         """Return the cross-process lock guarding shared git worktree metadata."""
-        return self.base_dir / ".git-metadata.lock"
+        return self.git_metadata_lock_path(self.repo_root)
 
     @property
     def base_branch(self) -> str:

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -130,9 +130,30 @@ class WorktreeManager:
         """Return the cross-process lock guarding ``repo_root``'s Git metadata.
 
         The sentinel belongs in ``.git`` so acquiring it never creates an
-        untracked file in a reusable checkout's worktree.
+        untracked file in a reusable checkout's worktree.  Linked worktrees
+        use a ``.git`` *file*, so resolve their ``commondir`` and share the
+        sentinel with the primary checkout.
         """
-        return repo_root / ".git" / _GIT_METADATA_LOCK_NAME
+        git_entry = repo_root / ".git"
+        if not git_entry.is_file():
+            return git_entry / _GIT_METADATA_LOCK_NAME
+
+        gitdir_line = git_entry.read_text(encoding="utf-8").strip()
+        prefix = "gitdir: "
+        if not gitdir_line.startswith(prefix):
+            raise RuntimeError(f"Invalid Git directory reference: {git_entry}")
+        git_dir = Path(gitdir_line.removeprefix(prefix))
+        if not git_dir.is_absolute():
+            git_dir = repo_root / git_dir
+        git_dir = git_dir.resolve()
+
+        common_dir_file = git_dir / "commondir"
+        if common_dir_file.is_file():
+            common_dir = Path(common_dir_file.read_text(encoding="utf-8").strip())
+            if not common_dir.is_absolute():
+                common_dir = git_dir / common_dir
+            return common_dir.resolve() / _GIT_METADATA_LOCK_NAME
+        return git_dir / _GIT_METADATA_LOCK_NAME
 
     def _git_metadata_lock_path(self) -> Path:
         """Return the cross-process lock guarding shared git worktree metadata."""

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -8,6 +8,7 @@ is terminal (FINISH_PASS ``seeded:N``).
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -104,21 +105,28 @@ class TestOnEnterAndCloneStates:
         }
         assert result.on_done_state == "DISCOVER"
 
-    def test_clone_skipped_when_already_cloned(
+    def test_existing_checkout_submits_sync_job_before_discovery(
         self, repo_item: WorkItem, repo_ctx: Any, tmp_path: Path
     ) -> None:
+        """A pre-existing checkout is synchronized before its issues are read."""
         (tmp_path / "repo-a").mkdir()
         repo_item.state = "CLONE_WAIT"
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, Continue)
-        assert result.next_state == "DISCOVER"
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "sync_checkout"
+        assert result.job.kwargs == {
+            "repo": "test-org/repo-a",
+            "dest": str(tmp_path / "repo-a"),
+        }
+        assert result.on_done_state == "DISCOVER"
 
-    def test_clone_skipped_when_explicit_repo_root_is_existing_checkout(
+    def test_explicit_existing_repo_root_submits_sync_job(
         self, repo_item: WorkItem, tmp_path: Path, make_ctx: Callable[..., Any]
     ) -> None:
-        """An isolated checkout is used directly instead of ``projects_dir / repo``."""
+        """An isolated existing checkout is synchronized at its explicit path."""
         projects_dir = tmp_path / "projects"
         checkout = tmp_path / "isolated" / "repo-a-worktree"
         checkout.mkdir(parents=True)
@@ -127,8 +135,13 @@ class TestOnEnterAndCloneStates:
 
         result = RepoStage().step(repo_item, ctx)
 
-        assert isinstance(result, Continue)
-        assert result.next_state == "DISCOVER"
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "sync_checkout"
+        assert result.job.kwargs == {
+            "repo": "test-org/repo-a",
+            "dest": str(checkout),
+        }
 
     def test_clone_skipped_in_dry_run(
         self, repo_item: WorkItem, tmp_path: Path, make_ctx: Callable[..., Any]
@@ -141,6 +154,25 @@ class TestOnEnterAndCloneStates:
 
         assert isinstance(result, Continue)
         assert result.next_state == "DISCOVER"
+
+    def test_existing_checkout_is_not_synchronized_in_dry_run(
+        self,
+        repo_item: WorkItem,
+        tmp_path: Path,
+        make_ctx: Callable[..., Any],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Dry runs report a reusable checkout sync without submitting a GitJob."""
+        (tmp_path / "repo-a").mkdir()
+        ctx = make_ctx(dry_run=True, paths=_RepoPaths(tmp_path))
+        repo_item.state = "CLONE_WAIT"
+        caplog.set_level(logging.INFO, logger="hephaestus.automation.pipeline.stages.repo")
+
+        result = RepoStage().step(repo_item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DISCOVER"
+        assert "[dry-run] would synchronize test-org/repo-a" in caplog.text
 
     def test_clone_failure_retries_within_budget(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         """First failure (attempt 1 < budget 2) re-submits the clone."""

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -1389,6 +1389,14 @@ class TestGitOps:
                     "git",
                     "-c",
                     f"core.hooksPath={os.devnull}",
+                    "-c",
+                    "core.sshCommand=ssh",
+                    "-c",
+                    "credential.helper=",
+                    "-c",
+                    "credential.helper=!gh auth git-credential",
+                    "-c",
+                    "core.askPass=",
                     "fetch",
                     "--no-tags",
                     "https://github.com/owner/name.git",
@@ -1396,6 +1404,7 @@ class TestGitOps:
                 ],
                 cwd=checkout,
                 timeout=120,
+                env=ANY,
             ),
             call(
                 ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
@@ -1553,15 +1562,21 @@ class TestGitOps:
         assert result.ok is False
         assert "expected origin owner/name" in (result.error or "")
 
-    def test_sync_checkout_rejects_ssh_origin(
+    def test_sync_checkout_synchronizes_ssh_origin_with_controlled_transport(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Synchronization accepts only HTTPS remotes with controlled transport."""
+        """A valid SSH origin is fetched only with controlled Git configuration."""
         checkout = tmp_path / "checkout"
         checkout.mkdir()
+        monkeypatch.setenv("GIT_SSH_COMMAND", "/unsafe/ssh-wrapper")
+        monkeypatch.setenv("GIT_ASKPASS", "/unsafe/askpass")
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+        monkeypatch.setenv("GIT_CONFIG_KEY_0", "credential.helper")
+        monkeypatch.setenv("GIT_CONFIG_VALUE_0", "!/unsafe/credential-helper")
         job = GitJob(
             repo="test/repo",
             op="sync_checkout",
@@ -1569,17 +1584,48 @@ class TestGitOps:
             kwargs={"repo": "owner/name", "dest": str(checkout)},
         )
         with patch("hephaestus.automation.git_utils.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                [], 0, stdout="git@github.com:owner/name.git\n"
-            )
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="git@github.com:owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="new-head\nnew-head\n"),
+            ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
-        mock_run.assert_called_once_with(
-            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
-        )
-        assert result.ok is False
-        assert "expected origin owner/name" in (result.error or "")
+        fetch_call = mock_run.call_args_list[4]
+        assert fetch_call.args[0] == [
+            "git",
+            "-c",
+            f"core.hooksPath={os.devnull}",
+            "-c",
+            "core.sshCommand=ssh",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "credential.helper=!gh auth git-credential",
+            "-c",
+            "core.askPass=",
+            "fetch",
+            "--no-tags",
+            "git@github.com:owner/name.git",
+            "+refs/heads/main:refs/remotes/origin/main",
+        ]
+        fetch_env = fetch_call.kwargs["env"]
+        assert fetch_env["GIT_TERMINAL_PROMPT"] == "0"
+        for key in (
+            "GIT_SSH_COMMAND",
+            "GIT_ASKPASS",
+            "GIT_CONFIG_COUNT",
+            "GIT_CONFIG_KEY_0",
+            "GIT_CONFIG_VALUE_0",
+        ):
+            assert key not in fetch_env
+        assert result.ok is True
 
     def test_sync_checkout_rejects_spoofed_github_hostname(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -1339,6 +1339,185 @@ class TestGitOps:
             timeout=120,
         )
         assert result.ok is True
+
+    def test_sync_checkout_fast_forwards_clean_expected_default_branch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A reusable checkout is verified, fetched, then fast-forwarded before use."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="origin/main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_args_list == [
+            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
+            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                cwd=checkout,
+                timeout=120,
+            ),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+                cwd=checkout,
+                timeout=120,
+            ),
+            call(["git", "fetch", "origin", "main"], cwd=checkout, timeout=120),
+            call(
+                ["git", "merge", "--ff-only", "origin/main"],
+                cwd=checkout,
+                check=False,
+                log_errors=False,
+                timeout=120,
+            ),
+        ]
+        assert result.ok is True
+
+    def test_sync_checkout_rejects_dirty_worktree_before_fetching(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A reused checkout with local changes is never modified by the loop."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=" M changed.py\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_args_list == [
+            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
+            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+        ]
+        assert result.ok is False
+        assert "dirty" in (result.error or "")
+
+    def test_sync_checkout_rejects_unexpected_origin(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A directory for another repository cannot be mistaken for the target checkout."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout="https://github.com/other/project.git\n"
+            )
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_called_once_with(
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+        )
+        assert result.ok is False
+        assert "expected origin owner/name" in (result.error or "")
+
+    def test_sync_checkout_rejects_spoofed_github_hostname(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A hostname merely containing ``github.com`` cannot pass origin validation."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout="https://evilgithub.com/owner/name.git\n"
+            )
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_called_once_with(
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+        )
+        assert result.ok is False
+        assert "expected origin owner/name" in (result.error or "")
+
+    def test_sync_checkout_rejects_checkout_not_on_default_branch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A reusable feature branch is not silently advanced as though it were main."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="feature\n"),
+                subprocess.CompletedProcess([], 0, stdout="origin/main\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_args_list == [
+            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
+            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                cwd=checkout,
+                timeout=120,
+            ),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+                cwd=checkout,
+                timeout=120,
+            ),
+        ]
+        assert result.ok is False
+        assert "not on its default branch" in (result.error or "")
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -36,7 +36,7 @@ from hephaestus.automation.session_naming import (
 )
 from hephaestus.prompts import PromptCatalog
 from hephaestus.resilience import CircuitBreakerOpenError, get_circuit_breaker
-from hephaestus.utils.file_lock import LockUnavailableError
+from hephaestus.utils.file_lock import LockUnavailableError, file_lock
 from hephaestus.utils.helpers import get_repo_root
 
 _WP = "hephaestus.automation.pipeline.worker_pool"
@@ -1415,7 +1415,7 @@ class TestGitOps:
                 timeout=120,
             ),
         ]
-        assert (checkout / "build" / ".worktrees" / ".git-metadata.lock").is_file()
+        assert (checkout / ".git" / ".hephaestus-git-metadata.lock").is_file()
         assert result.ok is True
 
     def test_sync_checkout_rejects_dirty_worktree_before_fetching(
@@ -1476,6 +1476,33 @@ class TestGitOps:
         assert result.ok is False
         assert "expected origin owner/name" in (result.error or "")
 
+    def test_sync_checkout_does_not_disclose_an_unexpected_origin(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Credentials embedded in a rejected remote never reach pipeline evidence."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        origin = "https://token:secret@github.com/other/project.git"
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, stdout=f"{origin}\n")
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "expected origin owner/name" in (result.error or "")
+        assert "token" not in (result.error or "")
+        assert "secret" not in (result.error or "")
+        assert origin not in (result.error or "")
+
     def test_sync_checkout_rejects_missing_checkout(
         self,
         pool: WorkerPool,
@@ -1516,6 +1543,34 @@ class TestGitOps:
         with patch("hephaestus.automation.git_utils.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 [], 0, stdout="git://github.com/owner/name.git\n"
+            )
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_called_once_with(
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+        )
+        assert result.ok is False
+        assert "expected origin owner/name" in (result.error or "")
+
+    def test_sync_checkout_rejects_ssh_origin(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Synchronization accepts only HTTPS remotes with controlled transport."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout="git@github.com:owner/name.git\n"
             )
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1574,7 +1629,7 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="feature\n"),
-                subprocess.CompletedProcess([], 0, stdout="origin/main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1597,6 +1652,81 @@ class TestGitOps:
         ]
         assert result.ok is False
         assert "not on its default branch" in (result.error or "")
+
+    def test_sync_checkout_rejects_detached_head_before_fetching(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A detached reusable checkout is rejected before remote metadata or mutation."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 1, stdout=""),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_args_list == [
+            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
+            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                cwd=checkout,
+                check=False,
+                log_errors=False,
+                timeout=120,
+            ),
+        ]
+        assert result.ok is False
+        assert "detached" in (result.error or "")
+
+    def test_sync_checkout_waits_for_shared_git_metadata_lock(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Sync cannot fetch while a shared worktree-metadata operation is active."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        metadata_lock = checkout / ".git" / ".hephaestus-git-metadata.lock"
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=0,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with (
+            file_lock(metadata_lock),
+            patch("hephaestus.automation.git_utils.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "lock_timeout"
+        assert mock_run.call_args_list[-1] == call(
+            ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
+            cwd=checkout,
+            timeout=0,
+        )
 
     def test_sync_checkout_rejects_local_commits_ahead_of_remote(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1360,9 +1360,11 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
-                subprocess.CompletedProcess([], 0, stdout="origin/main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="new-head\nnew-head\n"),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1373,22 +1375,47 @@ class TestGitOps:
             call(
                 ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
                 cwd=checkout,
+                check=False,
+                log_errors=False,
                 timeout=120,
             ),
             call(
-                ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+                ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
                 cwd=checkout,
                 timeout=120,
             ),
-            call(["git", "fetch", "origin", "main"], cwd=checkout, timeout=120),
             call(
-                ["git", "merge", "--ff-only", "origin/main"],
+                [
+                    "git",
+                    "-c",
+                    f"core.hooksPath={os.devnull}",
+                    "fetch",
+                    "--no-tags",
+                    "https://github.com/owner/name.git",
+                    "+refs/heads/main:refs/remotes/origin/main",
+                ],
+                cwd=checkout,
+                timeout=120,
+            ),
+            call(
+                ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
+                cwd=checkout,
+                timeout=120,
+            ),
+            call(
+                ["git", "-c", f"core.hooksPath={os.devnull}", "merge", "--ff-only", "origin/main"],
                 cwd=checkout,
                 check=False,
                 log_errors=False,
                 timeout=120,
             ),
+            call(
+                ["git", "rev-parse", "HEAD", "origin/main"],
+                cwd=checkout,
+                timeout=120,
+            ),
         ]
+        assert (checkout / "build" / ".worktrees" / ".git-metadata.lock").is_file()
         assert result.ok is True
 
     def test_sync_checkout_rejects_dirty_worktree_before_fetching(
@@ -1439,6 +1466,56 @@ class TestGitOps:
         with patch("hephaestus.automation.git_utils.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 [], 0, stdout="https://github.com/other/project.git\n"
+            )
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_called_once_with(
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+        )
+        assert result.ok is False
+        assert "expected origin owner/name" in (result.error or "")
+
+    def test_sync_checkout_rejects_missing_checkout(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A vanished checkout path fails without running any Git command."""
+        checkout = tmp_path / "missing"
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_not_called()
+        assert result.ok is False
+        assert "does not exist" in (result.error or "")
+
+    def test_sync_checkout_rejects_plaintext_git_origin(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """The unauthenticated ``git://`` transport is never used for synchronization."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 0, stdout="git://github.com/owner/name.git\n"
             )
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1508,16 +1585,149 @@ class TestGitOps:
             call(
                 ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
                 cwd=checkout,
+                check=False,
+                log_errors=False,
                 timeout=120,
             ),
             call(
-                ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+                ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
                 cwd=checkout,
                 timeout=120,
             ),
         ]
         assert result.ok is False
         assert "not on its default branch" in (result.error or "")
+
+    def test_sync_checkout_rejects_local_commits_ahead_of_remote(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Clean local commits are not mistaken for a synchronized checkout."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="1\t0\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_args_list[-1] == call(
+            ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
+            cwd=checkout,
+            timeout=120,
+        )
+        assert result.ok is False
+        assert "local commits" in (result.error or "")
+
+    def test_sync_checkout_rejects_unknown_remote_default_branch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Missing GitHub default-branch metadata fails before a checkout mutation."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_args_list[-1] == call(
+            ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
+            cwd=checkout,
+            timeout=120,
+        )
+        assert result.ok is False
+        assert "default branch" in (result.error or "")
+
+    def test_sync_checkout_reports_failed_fast_forward(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A failed fast-forward cannot be treated as a ready checkout."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
+                subprocess.CompletedProcess([], 1),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "cannot fast-forward" in (result.error or "")
+
+    def test_sync_checkout_rejects_post_merge_head_mismatch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A successful merge still needs to leave HEAD at the fetched remote tip."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout="old-head\nnew-head\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "did not reach origin/main" in (result.error or "")
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from hephaestus.automation.worktree_manager import WorktreeDirtyError, WorktreeManager
+from hephaestus.utils.file_lock import file_lock
 
 
 @pytest.fixture(autouse=True)
@@ -20,6 +21,23 @@ def _clear_loop_trunk_githash(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestWorktreeManager:
     """Tests for WorktreeManager class."""
+
+    def test_git_metadata_lock_does_not_dirty_checkout(self, tmp_path: Path) -> None:
+        """The shared metadata sentinel remains invisible to ``git status``."""
+        checkout = tmp_path / "checkout"
+        subprocess.run(["git", "init", str(checkout)], check=True, capture_output=True, text=True)
+
+        with file_lock(WorktreeManager.git_metadata_lock_path(checkout)):
+            pass
+
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert status.stdout == ""
 
     def test_initialization_default_base_dir(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test initialization with default base directory."""
@@ -97,7 +115,7 @@ class TestWorktreeManager:
         ):
             manager.create_worktree(123, "123-feature")
 
-        assert lock_paths == [manager.base_dir / ".git-metadata.lock"]
+        assert lock_paths == [manager.repo_root / ".git" / ".hephaestus-git-metadata.lock"]
 
     def test_create_worktree_default_branch_name(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test worktree creation with default branch name."""

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -39,6 +39,54 @@ class TestWorktreeManager:
         )
         assert status.stdout == ""
 
+    def test_git_metadata_lock_uses_common_dir_for_linked_worktree(self, tmp_path: Path) -> None:
+        """Base and linked worktrees share a status-safe Git-metadata sentinel."""
+        checkout = tmp_path / "checkout"
+        linked = tmp_path / "linked"
+        subprocess.run(
+            ["git", "init", "--initial-branch", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for key, value in (("user.name", "Test User"), ("user.email", "test@example.com")):
+            subprocess.run(
+                ["git", "config", key, value],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "initial"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "linked", str(linked)],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        base_lock = WorktreeManager.git_metadata_lock_path(checkout)
+        assert WorktreeManager.git_metadata_lock_path(linked) == base_lock
+        with file_lock(base_lock):
+            pass
+
+        for worktree in (checkout, linked):
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=worktree,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            assert status.stdout == ""
+
     def test_initialization_default_base_dir(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test initialization with default base directory."""
         worktree_mocks.repo_root.return_value = tmp_path


### PR DESCRIPTION
## Summary

- synchronize reusable checkouts before repository discovery instead of trusting path existence
- verify the exact GitHub origin, a clean worktree, and the checked-out default branch
- fetch and fast-forward only; report safe failures for mismatches, dirtiness, branch drift, or divergence
- preserve dry-run read-only behavior

## Validation

- `uv run pytest tests/unit -q` — 6204 passed, 24 skipped, 85.08% coverage
- pre-push `uv run --all-extras --locked pytest -q` — 6595 passed, 6 skipped, 85.26% coverage
- `uv run pre-commit run --all-files`

Closes #2407