### PR TITLE
fix(automation): isolate checkout Git execution

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1110,6 +1110,12 @@ git operation in two locks:
 Both locks are held for the entire operation because worktrees share
 `.git`.
 
+`sync_checkout` additionally takes the status-safe Git-metadata lock resolved
+by [`WorktreeManager.git_metadata_lock_path`](hephaestus/automation/worktree_manager.py).
+For linked worktrees this resolves Git's common directory, so the primary
+checkout and every linked worktree serialize synchronization and worktree
+metadata mutations without leaving an untracked sentinel in the worktree.
+
 ### Resilience wiring
 
 [`hephaestus.resilience.resilient_call`](hephaestus/resilience/__init__.py)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1115,6 +1115,10 @@ by [`WorktreeManager.git_metadata_lock_path`](hephaestus/automation/worktree_man
 For linked worktrees this resolves Git's common directory, so the primary
 checkout and every linked worktree serialize synchronization and worktree
 metadata mutations without leaving an untracked sentinel in the worktree.
+Before inspecting the origin or worktree status, it also reads the effective
+repository and worktree Git configuration with global/system configuration
+disabled, rejecting executable, transport-routing, and TLS-affecting settings
+from a reusable checkout.
 
 ### Resilience wiring
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
+import shutil
 import subprocess
 import threading
 import time
@@ -54,23 +56,77 @@ _GIT_LOCK_WAIT_POLL_S = 0.1
 _FETCH_ENV_BLOCKLIST = frozenset(
     {
         "GIT_ASKPASS",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_EXEC_PATH",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
         "GIT_SSH",
         "GIT_SSH_COMMAND",
+        "GIT_SSL_CAINFO",
+        "GIT_SSL_CAPATH",
+        "GIT_SSL_NO_VERIFY",
+        "GIT_WORK_TREE",
         "SSH_ASKPASS",
     }
 )
 
 
-def _controlled_fetch_env() -> dict[str, str]:
-    """Return a fetch environment that cannot inject local Git executables."""
+def _controlled_git_env() -> dict[str, str]:
+    """Return an environment that cannot redirect or extend Git execution."""
     env = os.environ.copy()
     for key in _FETCH_ENV_BLOCKLIST:
         env.pop(key, None)
     for key in tuple(env):
         if key == "GIT_CONFIG_COUNT" or key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
             env.pop(key)
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["PATH"] = os.defpath
     env["GIT_TERMINAL_PROMPT"] = "0"
     return env
+
+
+def _trusted_executable(name: str, *, path: str | None = None) -> str | None:
+    """Resolve a command to an absolute path before entering a controlled env."""
+    executable = shutil.which(name, path=path)
+    return str(Path(executable).resolve()) if executable is not None else None
+
+
+def _unsafe_local_git_config_key(config: str) -> str | None:
+    """Return an executable local-config key, if *config* contains one."""
+    for entry in config.split("\0"):
+        if not entry:
+            continue
+        key, _separator, value = entry.partition("\n")
+        normalized = key.lower()
+        if normalized in {
+            "core.askpass",
+            "core.attributesfile",
+            "core.fsmonitor",
+            "core.sshcommand",
+            "credential.helper",
+        }:
+            return key
+        if normalized.startswith(("include.", "includeif.")):
+            return key
+        if normalized.startswith("filter.") and normalized.rsplit(".", 1)[-1] in {
+            "clean",
+            "process",
+            "smudge",
+        }:
+            return key
+        if normalized.startswith("merge.") and normalized.endswith(".driver"):
+            return key
+        if normalized == "http.sslverify" and value.strip().lower() in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }:
+            return key
+    return None
 
 
 def _repo_lock_path(repo: str, lock_dir: Path | None = None) -> Path:
@@ -654,7 +710,10 @@ class WorkerPool:
             return JobResult(ok=False, error=f"checkout does not exist: {checkout}")
 
         origin = git_utils.run(
-            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=job.timeout_s
+            ["git", "remote", "get-url", "origin"],
+            cwd=checkout,
+            timeout=job.timeout_s,
+            env=_controlled_git_env(),
         ).stdout.strip()
         normalized_origin = origin.rstrip("/").removesuffix(".git")
         expected_origins = {
@@ -669,7 +728,10 @@ class WorkerPool:
             )
 
         status = git_utils.run(
-            ["git", "status", "--porcelain"], cwd=checkout, timeout=job.timeout_s
+            ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+            cwd=checkout,
+            timeout=job.timeout_s,
+            env=_controlled_git_env(),
         )
         if status.stdout.strip():
             return JobResult(ok=False, error=f"checkout is dirty: {checkout}")
@@ -680,6 +742,7 @@ class WorkerPool:
             check=False,
             log_errors=False,
             timeout=job.timeout_s,
+            env=_controlled_git_env(),
         )
         branch = branch_result.stdout.strip()
         if branch_result.returncode != 0 or not branch:
@@ -700,6 +763,21 @@ class WorkerPool:
                     f"currently on {branch or 'detached HEAD'}"
                 ),
             )
+
+        if (checkout / ".git").exists():
+            unsafe_config = _unsafe_local_git_config_key(
+                git_utils.run(
+                    ["git", "config", "--local", "--null", "--list"],
+                    cwd=checkout,
+                    timeout=job.timeout_s,
+                    env=_controlled_git_env(),
+                ).stdout
+            )
+            if unsafe_config is not None:
+                return JobResult(
+                    ok=False,
+                    error="checkout has unsafe local Git configuration",
+                )
 
         metadata_lock = WorktreeManager.git_metadata_lock_path(checkout)
         with _interruptible_file_lock(
@@ -724,17 +802,34 @@ class WorkerPool:
     ) -> JobResult:
         """Fetch and fast-forward a validated checkout while its metadata is locked."""
         hooks_disabled = f"core.hooksPath={os.devnull}"
+        ssh_command = _trusted_executable("ssh", path=os.defpath)
+        gh_command = _trusted_executable("gh")
+        if ssh_command is None or gh_command is None:
+            return JobResult(ok=False, error="required fetch executable is unavailable")
+        ssh_config = " ".join(
+            (
+                shlex.quote(ssh_command),
+                "-F",
+                shlex.quote(os.devnull),
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "StrictHostKeyChecking=yes",
+            )
+        )
         fetch_config = [
             "-c",
             hooks_disabled,
             "-c",
-            "core.sshCommand=ssh",
+            f"core.sshCommand={ssh_config}",
             "-c",
             "credential.helper=",
             "-c",
-            "credential.helper=!gh auth git-credential",
+            f"credential.helper=!{shlex.quote(gh_command)} auth git-credential",
             "-c",
             "core.askPass=",
+            "-c",
+            "http.sslVerify=true",
         ]
         git_utils.run(
             [
@@ -747,7 +842,7 @@ class WorkerPool:
             ],
             cwd=checkout,
             timeout=timeout_s,
-            env=_controlled_fetch_env(),
+            env=_controlled_git_env(),
         )
         relation = git_utils.run(
             [
@@ -759,6 +854,7 @@ class WorkerPool:
             ],
             cwd=checkout,
             timeout=timeout_s,
+            env=_controlled_git_env(),
         ).stdout.split()
         if len(relation) != 2:
             return JobResult(ok=False, error=f"could not compare checkout history: {checkout}")
@@ -773,11 +869,21 @@ class WorkerPool:
             )
 
         merge = git_utils.run(
-            ["git", "-c", hooks_disabled, "merge", "--ff-only", f"origin/{default_branch}"],
+            [
+                "git",
+                "-c",
+                hooks_disabled,
+                "-c",
+                "core.fsmonitor=false",
+                "merge",
+                "--ff-only",
+                f"origin/{default_branch}",
+            ],
             cwd=checkout,
             check=False,
             log_errors=False,
             timeout=timeout_s,
+            env=_controlled_git_env(),
         )
         if merge.returncode != 0:
             return JobResult(
@@ -788,6 +894,7 @@ class WorkerPool:
             ["git", "rev-parse", "HEAD", f"origin/{default_branch}"],
             cwd=checkout,
             timeout=timeout_s,
+            env=_controlled_git_env(),
         ).stdout.split()
         if len(synced_heads) != 2 or synced_heads[0] != synced_heads[1]:
             return JobResult(

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -57,6 +57,7 @@ _FETCH_ENV_BLOCKLIST = frozenset(
     {
         "GIT_ASKPASS",
         "GIT_COMMON_DIR",
+        "GIT_CONFIG_PARAMETERS",
         "GIT_DIR",
         "GIT_EXEC_PATH",
         "GIT_INDEX_FILE",
@@ -72,6 +73,18 @@ _FETCH_ENV_BLOCKLIST = frozenset(
     }
 )
 
+# ``gh`` must not be discovered through a caller-controlled ``PATH``: the
+# checkout synchronizer executes it as the GitHub credential helper.  These
+# are the system and package-manager locations we support for the automation
+# host.  Resolving candidates also rejects a symlink that escapes its trusted
+# installation root.
+_TRUSTED_GH_CANDIDATES = (
+    Path("/opt/homebrew/bin/gh"),
+    Path("/usr/local/bin/gh"),
+    Path("/usr/bin/gh"),
+)
+_TRUSTED_GH_ROOTS = (Path("/opt/homebrew"), Path("/usr/local"), Path("/usr"))
+
 
 def _controlled_git_env() -> dict[str, str]:
     """Return an environment that cannot redirect or extend Git execution."""
@@ -84,6 +97,7 @@ def _controlled_git_env() -> dict[str, str]:
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
     env["PATH"] = os.defpath
+    env["GIT_PAGER"] = "cat"
     env["GIT_TERMINAL_PROMPT"] = "0"
     return env
 
@@ -94,18 +108,34 @@ def _trusted_executable(name: str, *, path: str | None = None) -> str | None:
     return str(Path(executable).resolve()) if executable is not None else None
 
 
+def _trusted_gh_executable() -> str | None:
+    """Return a supported absolute ``gh`` binary without consulting ``PATH``."""
+    for candidate in _TRUSTED_GH_CANDIDATES:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if not resolved.is_file() or not os.access(resolved, os.X_OK):
+            continue
+        if any(resolved.is_relative_to(root) for root in _TRUSTED_GH_ROOTS):
+            return str(resolved)
+    return None
+
+
 def _unsafe_local_git_config_key(config: str) -> str | None:
-    """Return an executable local-config key, if *config* contains one."""
+    """Return an unsafe repository/worktree config key, if *config* contains one."""
     for entry in config.split("\0"):
         if not entry:
             continue
-        key, _separator, value = entry.partition("\n")
+        key, _separator, _value = entry.partition("\n")
         normalized = key.lower()
         if normalized in {
             "core.askpass",
             "core.attributesfile",
             "core.fsmonitor",
+            "core.gitproxy",
             "core.sshcommand",
+            "core.worktree",
             "credential.helper",
         }:
             return key
@@ -119,12 +149,11 @@ def _unsafe_local_git_config_key(config: str) -> str | None:
             return key
         if normalized.startswith("merge.") and normalized.endswith(".driver"):
             return key
-        if normalized == "http.sslverify" and value.strip().lower() in {
-            "0",
-            "false",
-            "no",
-            "off",
-        }:
+        # A checkout-specific URL rewrite can transform the validated literal
+        # GitHub origin when it is later passed to ``git fetch``.  Any local
+        # HTTP configuration can similarly proxy traffic or override TLS
+        # verification/CA trust, including URL-scoped variants.
+        if normalized.startswith(("http.", "url.")):
             return key
     return None
 
@@ -709,6 +738,24 @@ class WorkerPool:
         if not checkout.is_dir():
             return JobResult(ok=False, error=f"checkout does not exist: {checkout}")
 
+        # ``git config --list`` uses the effective repository configuration,
+        # including a linked worktree's ``config.worktree``.  It must precede
+        # origin/status because either command can observe a poisoned setting.
+        if (checkout / ".git").exists():
+            unsafe_config = _unsafe_local_git_config_key(
+                git_utils.run(
+                    ["git", "config", "--null", "--list"],
+                    cwd=checkout,
+                    timeout=job.timeout_s,
+                    env=_controlled_git_env(),
+                ).stdout
+            )
+            if unsafe_config is not None:
+                return JobResult(
+                    ok=False,
+                    error="checkout has unsafe local Git configuration",
+                )
+
         origin = git_utils.run(
             ["git", "remote", "get-url", "origin"],
             cwd=checkout,
@@ -728,7 +775,14 @@ class WorkerPool:
             )
 
         status = git_utils.run(
-            ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+            [
+                "git",
+                "-c",
+                "core.fsmonitor=false",
+                "status",
+                "--porcelain",
+                "--untracked-files=all",
+            ],
             cwd=checkout,
             timeout=job.timeout_s,
             env=_controlled_git_env(),
@@ -748,10 +802,14 @@ class WorkerPool:
         if branch_result.returncode != 0 or not branch:
             return JobResult(ok=False, error=f"checkout is detached: {checkout}")
 
+        gh_command = _trusted_gh_executable()
+        if gh_command is None:
+            return JobResult(ok=False, error="required GitHub executable is unavailable")
         default_branch = git_utils.run(
-            ["gh", "api", f"repos/{expected_repo}", "--jq", ".default_branch"],
+            [gh_command, "api", f"repos/{expected_repo}", "--jq", ".default_branch"],
             cwd=checkout,
             timeout=job.timeout_s,
+            env=_controlled_git_env(),
         ).stdout.strip()
         if not default_branch:
             return JobResult(ok=False, error=f"repository has no default branch: {expected_repo}")
@@ -764,21 +822,6 @@ class WorkerPool:
                 ),
             )
 
-        if (checkout / ".git").exists():
-            unsafe_config = _unsafe_local_git_config_key(
-                git_utils.run(
-                    ["git", "config", "--local", "--null", "--list"],
-                    cwd=checkout,
-                    timeout=job.timeout_s,
-                    env=_controlled_git_env(),
-                ).stdout
-            )
-            if unsafe_config is not None:
-                return JobResult(
-                    ok=False,
-                    error="checkout has unsafe local Git configuration",
-                )
-
         metadata_lock = WorktreeManager.git_metadata_lock_path(checkout)
         with _interruptible_file_lock(
             metadata_lock,
@@ -789,6 +832,7 @@ class WorkerPool:
                 checkout=checkout,
                 origin=origin,
                 default_branch=default_branch,
+                gh_command=gh_command,
                 timeout_s=job.timeout_s,
             )
 
@@ -798,13 +842,13 @@ class WorkerPool:
         checkout: Path,
         origin: str,
         default_branch: str,
+        gh_command: str,
         timeout_s: int,
     ) -> JobResult:
         """Fetch and fast-forward a validated checkout while its metadata is locked."""
         hooks_disabled = f"core.hooksPath={os.devnull}"
         ssh_command = _trusted_executable("ssh", path=os.defpath)
-        gh_command = _trusted_executable("gh")
-        if ssh_command is None or gh_command is None:
+        if ssh_command is None:
             return JobResult(ok=False, error="required fetch executable is unavailable")
         ssh_config = " ".join(
             (

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import queue
+import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -40,6 +42,13 @@ from hephaestus.utils.file_lock import LockUnavailableError, file_lock
 from hephaestus.utils.helpers import get_repo_root
 
 _WP = "hephaestus.automation.pipeline.worker_pool"
+
+
+def _executable_path(name: str, *, path: str | None = None) -> str:
+    """Resolve an executable expected to be available in this test environment."""
+    executable = shutil.which(name, path=path)
+    assert executable is not None
+    return str(Path(executable).resolve())
 
 
 @pytest.fixture
@@ -1369,15 +1378,31 @@ class TestGitOps:
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
+        ssh_command = _executable_path("ssh", path=os.defpath)
+        ssh_config = (
+            f"{shlex.quote(ssh_command)} -F {shlex.quote(os.devnull)} "
+            "-o BatchMode=yes -o StrictHostKeyChecking=yes"
+        )
         assert mock_run.call_args_list == [
-            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
-            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "remote", "get-url", "origin"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
             call(
                 ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
                 cwd=checkout,
                 check=False,
                 log_errors=False,
                 timeout=120,
+                env=ANY,
             ),
             call(
                 ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
@@ -1390,13 +1415,19 @@ class TestGitOps:
                     "-c",
                     f"core.hooksPath={os.devnull}",
                     "-c",
-                    "core.sshCommand=ssh",
+                    f"core.sshCommand={ssh_config}",
                     "-c",
                     "credential.helper=",
                     "-c",
-                    "credential.helper=!gh auth git-credential",
+                    (
+                        "credential.helper=!"
+                        f"{shlex.quote(_executable_path('gh'))} "
+                        "auth git-credential"
+                    ),
                     "-c",
                     "core.askPass=",
+                    "-c",
+                    "http.sslVerify=true",
                     "fetch",
                     "--no-tags",
                     "https://github.com/owner/name.git",
@@ -1410,18 +1441,30 @@ class TestGitOps:
                 ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
                 cwd=checkout,
                 timeout=120,
+                env=ANY,
             ),
             call(
-                ["git", "-c", f"core.hooksPath={os.devnull}", "merge", "--ff-only", "origin/main"],
+                [
+                    "git",
+                    "-c",
+                    f"core.hooksPath={os.devnull}",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "merge",
+                    "--ff-only",
+                    "origin/main",
+                ],
                 cwd=checkout,
                 check=False,
                 log_errors=False,
                 timeout=120,
+                env=ANY,
             ),
             call(
                 ["git", "rev-parse", "HEAD", "origin/main"],
                 cwd=checkout,
                 timeout=120,
+                env=ANY,
             ),
         ]
         assert (checkout / ".git" / ".hephaestus-git-metadata.lock").is_file()
@@ -1451,8 +1494,18 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert mock_run.call_args_list == [
-            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
-            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "remote", "get-url", "origin"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
         ]
         assert result.ok is False
         assert "dirty" in (result.error or "")
@@ -1480,7 +1533,7 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         mock_run.assert_called_once_with(
-            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120, env=ANY
         )
         assert result.ok is False
         assert "expected origin owner/name" in (result.error or "")
@@ -1557,7 +1610,7 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         mock_run.assert_called_once_with(
-            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120, env=ANY
         )
         assert result.ok is False
         assert "expected origin owner/name" in (result.error or "")
@@ -1572,8 +1625,19 @@ class TestGitOps:
         """A valid SSH origin is fetched only with controlled Git configuration."""
         checkout = tmp_path / "checkout"
         checkout.mkdir()
+        monkeypatch.setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/unsafe/objects")
+        monkeypatch.setenv("GIT_COMMON_DIR", "/unsafe/common-dir")
+        monkeypatch.setenv("GIT_DIR", "/unsafe/git-dir")
+        monkeypatch.setenv("GIT_EXEC_PATH", "/unsafe/git-exec-path")
+        monkeypatch.setenv("GIT_INDEX_FILE", "/unsafe/index")
+        monkeypatch.setenv("GIT_OBJECT_DIRECTORY", "/unsafe/object-dir")
+        monkeypatch.setenv("GIT_SSH", "/unsafe/ssh")
         monkeypatch.setenv("GIT_SSH_COMMAND", "/unsafe/ssh-wrapper")
         monkeypatch.setenv("GIT_ASKPASS", "/unsafe/askpass")
+        monkeypatch.setenv("SSH_ASKPASS", "/unsafe/ssh-askpass")
+        monkeypatch.setenv("GIT_SSL_NO_VERIFY", "1")
+        monkeypatch.setenv("GIT_SSL_CAINFO", "/unsafe/ca.pem")
+        monkeypatch.setenv("GIT_SSL_CAPATH", "/unsafe/ca-dir")
         monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
         monkeypatch.setenv("GIT_CONFIG_KEY_0", "credential.helper")
         monkeypatch.setenv("GIT_CONFIG_VALUE_0", "!/unsafe/credential-helper")
@@ -1598,18 +1662,25 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         fetch_call = mock_run.call_args_list[4]
+        ssh_command = _executable_path("ssh", path=os.defpath)
+        ssh_config = (
+            f"{shlex.quote(ssh_command)} -F {shlex.quote(os.devnull)} "
+            "-o BatchMode=yes -o StrictHostKeyChecking=yes"
+        )
         assert fetch_call.args[0] == [
             "git",
             "-c",
             f"core.hooksPath={os.devnull}",
             "-c",
-            "core.sshCommand=ssh",
+            f"core.sshCommand={ssh_config}",
             "-c",
             "credential.helper=",
             "-c",
-            "credential.helper=!gh auth git-credential",
+            (f"credential.helper=!{shlex.quote(_executable_path('gh'))} auth git-credential"),
             "-c",
             "core.askPass=",
+            "-c",
+            "http.sslVerify=true",
             "fetch",
             "--no-tags",
             "git@github.com:owner/name.git",
@@ -1618,14 +1689,62 @@ class TestGitOps:
         fetch_env = fetch_call.kwargs["env"]
         assert fetch_env["GIT_TERMINAL_PROMPT"] == "0"
         for key in (
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_COMMON_DIR",
+            "GIT_DIR",
+            "GIT_SSH",
             "GIT_SSH_COMMAND",
             "GIT_ASKPASS",
+            "GIT_EXEC_PATH",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "SSH_ASKPASS",
+            "GIT_SSL_NO_VERIFY",
+            "GIT_SSL_CAINFO",
+            "GIT_SSL_CAPATH",
             "GIT_CONFIG_COUNT",
             "GIT_CONFIG_KEY_0",
             "GIT_CONFIG_VALUE_0",
         ):
             assert key not in fetch_env
+        assert fetch_env["PATH"] == os.defpath
+        for git_call in (mock_run.call_args_list[index] for index in (0, 1, 2, 4, 5, 6, 7)):
+            assert git_call.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+            assert "GIT_DIR" not in git_call.kwargs["env"]
         assert result.ok is True
+
+    def test_sync_checkout_rejects_executable_local_git_config(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Executable checkout-local Git config is rejected before any fetch or merge."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        (checkout / ".git").mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess(
+                    [], 0, stdout="filter.payload.process\n/unsafe/filter\0"
+                ),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "unsafe local Git configuration" in (result.error or "")
+        assert all("fetch" not in call.args[0] for call in mock_run.call_args_list)
 
     def test_sync_checkout_rejects_spoofed_github_hostname(
         self,
@@ -1650,7 +1769,7 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         mock_run.assert_called_once_with(
-            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120
+            ["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120, env=ANY
         )
         assert result.ok is False
         assert "expected origin owner/name" in (result.error or "")
@@ -1681,14 +1800,25 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert mock_run.call_args_list == [
-            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
-            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "remote", "get-url", "origin"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
             call(
                 ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
                 cwd=checkout,
                 check=False,
                 log_errors=False,
                 timeout=120,
+                env=ANY,
             ),
             call(
                 ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
@@ -1724,14 +1854,25 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert mock_run.call_args_list == [
-            call(["git", "remote", "get-url", "origin"], cwd=checkout, timeout=120),
-            call(["git", "status", "--porcelain"], cwd=checkout, timeout=120),
+            call(
+                ["git", "remote", "get-url", "origin"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
             call(
                 ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
                 cwd=checkout,
                 check=False,
                 log_errors=False,
                 timeout=120,
+                env=ANY,
             ),
         ]
         assert result.ok is False
@@ -1762,6 +1903,7 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1769,9 +1911,10 @@ class TestGitOps:
         assert result.ok is False
         assert result.error == "lock_timeout"
         assert mock_run.call_args_list[-1] == call(
-            ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
+            ["git", "config", "--local", "--null", "--list"],
             cwd=checkout,
             timeout=0,
+            env=ANY,
         )
 
     def test_sync_checkout_rejects_local_commits_ahead_of_remote(
@@ -1805,6 +1948,7 @@ class TestGitOps:
             ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
             cwd=checkout,
             timeout=120,
+            env=ANY,
         )
         assert result.ok is False
         assert "local commits" in (result.error or "")

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -19,6 +19,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
+from hephaestus.automation import git_utils
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
@@ -31,7 +32,12 @@ from hephaestus.automation.pipeline.jobs import (
 )
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
-from hephaestus.automation.pipeline.worker_pool import WorkerPool, _repo_lock_path
+from hephaestus.automation.pipeline.worker_pool import (
+    WorkerPool,
+    _repo_lock_path,
+    _trusted_gh_executable,
+    _unsafe_local_git_config_key,
+)
 from hephaestus.automation.session_naming import (
     AGENT_IMPLEMENTER,
     AGENT_PR_REVIEWER,
@@ -1358,6 +1364,7 @@ class TestGitOps:
         """A reusable checkout is verified, fetched, then fast-forwarded before use."""
         checkout = tmp_path / "checkout"
         checkout.mkdir()
+        (checkout / ".git").mkdir()
         job = GitJob(
             repo="test/repo",
             op="sync_checkout",
@@ -1366,6 +1373,7 @@ class TestGitOps:
         )
         with patch("hephaestus.automation.git_utils.run") as mock_run:
             mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
@@ -1385,13 +1393,26 @@ class TestGitOps:
         )
         assert mock_run.call_args_list == [
             call(
+                ["git", "config", "--null", "--list"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
                 ["git", "remote", "get-url", "origin"],
                 cwd=checkout,
                 timeout=120,
                 env=ANY,
             ),
             call(
-                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                [
+                    "git",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                ],
                 cwd=checkout,
                 timeout=120,
                 env=ANY,
@@ -1405,9 +1426,10 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
-                ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
+                [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
                 cwd=checkout,
                 timeout=120,
+                env=ANY,
             ),
             call(
                 [
@@ -1421,7 +1443,7 @@ class TestGitOps:
                     "-c",
                     (
                         "credential.helper=!"
-                        f"{shlex.quote(_executable_path('gh'))} "
+                        f"{shlex.quote(_trusted_gh_executable() or '')} "
                         "auth git-credential"
                     ),
                     "-c",
@@ -1501,7 +1523,14 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
-                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                [
+                    "git",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                ],
                 cwd=checkout,
                 timeout=120,
                 env=ANY,
@@ -1638,9 +1667,12 @@ class TestGitOps:
         monkeypatch.setenv("GIT_SSL_NO_VERIFY", "1")
         monkeypatch.setenv("GIT_SSL_CAINFO", "/unsafe/ca.pem")
         monkeypatch.setenv("GIT_SSL_CAPATH", "/unsafe/ca-dir")
+        monkeypatch.setenv("GIT_WORK_TREE", "/unsafe/worktree")
         monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
         monkeypatch.setenv("GIT_CONFIG_KEY_0", "credential.helper")
         monkeypatch.setenv("GIT_CONFIG_VALUE_0", "!/unsafe/credential-helper")
+        monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "credential.helper=!/unsafe/helper")
+        monkeypatch.setenv("PATH", "/unsafe/path")
         job = GitJob(
             repo="test/repo",
             op="sync_checkout",
@@ -1676,7 +1708,10 @@ class TestGitOps:
             "-c",
             "credential.helper=",
             "-c",
-            (f"credential.helper=!{shlex.quote(_executable_path('gh'))} auth git-credential"),
+            (
+                "credential.helper=!"
+                f"{shlex.quote(_trusted_gh_executable() or '')} auth git-credential"
+            ),
             "-c",
             "core.askPass=",
             "-c",
@@ -1702,12 +1737,22 @@ class TestGitOps:
             "GIT_SSL_NO_VERIFY",
             "GIT_SSL_CAINFO",
             "GIT_SSL_CAPATH",
+            "GIT_WORK_TREE",
             "GIT_CONFIG_COUNT",
             "GIT_CONFIG_KEY_0",
             "GIT_CONFIG_VALUE_0",
+            "GIT_CONFIG_PARAMETERS",
         ):
             assert key not in fetch_env
         assert fetch_env["PATH"] == os.defpath
+        assert fetch_env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert fetch_env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert mock_run.call_args_list[3] == call(
+            [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
+            cwd=checkout,
+            timeout=120,
+            env=ANY,
+        )
         for git_call in (mock_run.call_args_list[index] for index in (0, 1, 2, 4, 5, 6, 7)):
             assert git_call.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
             assert "GIT_DIR" not in git_call.kwargs["env"]
@@ -1731,10 +1776,6 @@ class TestGitOps:
         )
         with patch("hephaestus.automation.git_utils.run") as mock_run:
             mock_run.side_effect = [
-                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
-                subprocess.CompletedProcess([], 0, stdout=""),
-                subprocess.CompletedProcess([], 0, stdout="main\n"),
-                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess(
                     [], 0, stdout="filter.payload.process\n/unsafe/filter\0"
                 ),
@@ -1745,6 +1786,110 @@ class TestGitOps:
         assert result.ok is False
         assert "unsafe local Git configuration" in (result.error or "")
         assert all("fetch" not in call.args[0] for call in mock_run.call_args_list)
+
+    @pytest.mark.parametrize(
+        "entry",
+        (
+            "core.sshCommand\n/unsafe/ssh\0",
+            "credential.helper\n!/unsafe/credential-helper\0",
+            "include.path\n/unsafe/include\0",
+            "includeIf.gitdir:/unsafe/.path\n/unsafe/include\0",
+            "merge.payload.driver\n/unsafe/merge\0",
+            "http.sslVerify\nfalse\0",
+            "http.https://github.com/.sslVerify\nfalse\0",
+            "http.sslCAInfo\n/unsafe/ca.pem\0",
+            "http.proxy\nhttp://unsafe-proxy\0",
+            "url.file:///unsafe/.insteadOf\nhttps://github.com/owner/name\0",
+            "core.worktree\n/unsafe/worktree\0",
+        ),
+        ids=(
+            "ssh-command",
+            "credential-helper",
+            "include",
+            "conditional-include",
+            "merge-driver",
+            "disabled-tls",
+            "url-scoped-tls",
+            "custom-ca",
+            "http-proxy",
+            "url-rewrite",
+            "core-worktree",
+        ),
+    )
+    def test_checkout_config_parser_rejects_unsafe_settings(self, entry: str) -> None:
+        """Executable, routing, and TLS-affecting checkout config cannot survive scanning."""
+        assert _unsafe_local_git_config_key(entry) is not None
+
+    def test_sync_checkout_rejects_unsafe_linked_worktree_config(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Effective config scanning includes a linked worktree's config.worktree."""
+        checkout = tmp_path / "checkout"
+        linked = tmp_path / "linked"
+        subprocess.run(
+            ["git", "init", "--initial-branch", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for key, value in (("user.name", "Test User"), ("user.email", "test@example.com")):
+            subprocess.run(
+                ["git", "config", key, value],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "initial"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "linked", str(linked)],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "extensions.worktreeConfig", "true"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "--worktree", "filter.payload.process", "/unsafe/filter"],
+            cwd=linked,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(linked)},
+        )
+        actual_run = git_utils.run
+
+        def run_config_only(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            assert command == ["git", "config", "--null", "--list"]
+            return actual_run(command, **kwargs)
+
+        with patch("hephaestus.automation.git_utils.run", side_effect=run_config_only) as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_called_once()
+        assert result.ok is False
+        assert "unsafe local Git configuration" in (result.error or "")
 
     def test_sync_checkout_rejects_spoofed_github_hostname(
         self,
@@ -1807,7 +1952,14 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
-                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                [
+                    "git",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                ],
                 cwd=checkout,
                 timeout=120,
                 env=ANY,
@@ -1821,9 +1973,10 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
-                ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
+                [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
                 cwd=checkout,
                 timeout=120,
+                env=ANY,
             ),
         ]
         assert result.ok is False
@@ -1861,7 +2014,14 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
-                ["git", "-c", "core.fsmonitor=false", "status", "--porcelain"],
+                [
+                    "git",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                ],
                 cwd=checkout,
                 timeout=120,
                 env=ANY,
@@ -1899,11 +2059,12 @@ class TestGitOps:
             patch("hephaestus.automation.git_utils.run") as mock_run,
         ):
             mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
-                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1911,7 +2072,7 @@ class TestGitOps:
         assert result.ok is False
         assert result.error == "lock_timeout"
         assert mock_run.call_args_list[-1] == call(
-            ["git", "config", "--local", "--null", "--list"],
+            [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
             cwd=checkout,
             timeout=0,
             env=ANY,
@@ -1979,9 +2140,10 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert mock_run.call_args_list[-1] == call(
-            ["gh", "api", "repos/owner/name", "--jq", ".default_branch"],
+            [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
             cwd=checkout,
             timeout=120,
+            env=ANY,
         )
         assert result.ok is False
         assert "default branch" in (result.error or "")


### PR DESCRIPTION
Summary: isolate every reusable-checkout Git invocation from inherited execution, location, helper, TLS, and askpass state; reject executable checkout-local Git configuration; document common Git-directory locking.

Verification: complete unit suite, pre-commit hooks, and mandatory all-extras pre-push suite.

Closes #2409