### PR TITLE
fix(automation): complete checkout isolation hardening

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -76,24 +76,37 @@ def run(
         cmd[0] if cmd else "<empty>",
         max(len(cmd) - 1, 0),
     )
-    if cmd and cmd[0] == "git":
-        return _shared_run_git(
+    try:
+        if cmd and cmd[0] == "git":
+            return _shared_run_git(
+                cmd,
+                cwd=cwd,
+                timeout=timeout,
+                check=check,
+                log_on_error=False,
+                env=env,
+                retries=0,
+            )
+        return run_subprocess(
             cmd,
-            cwd=cwd,
+            cwd=str(cwd) if cwd else None,
             timeout=timeout,
             check=check,
-            log_on_error=log_errors,
+            log_on_error=False,
             env=env,
-            retries=0,
         )
-    return run_subprocess(
-        cmd,
-        cwd=str(cwd) if cwd else None,
-        timeout=timeout,
-        check=check,
-        log_on_error=log_errors,
-        env=env,
-    )
+    except subprocess.TimeoutExpired:
+        if log_errors:
+            logger.error("Command %s timed out after %ds", cmd[0] if cmd else "<empty>", timeout)
+        raise
+    except subprocess.CalledProcessError as error:
+        if log_errors:
+            logger.error(
+                "Command %s failed with exit code %s",
+                cmd[0] if cmd else "<empty>",
+                error.returncode,
+            )
+        raise
 
 
 _repo_info_cache: ThreadSafeCache[Path | None, tuple[str, str]] = ThreadSafeCache()

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -68,7 +68,14 @@ def run(
         subprocess.TimeoutExpired: If timeout is exceeded
 
     """
-    logger.debug("Running command: %s", " ".join(cmd))
+    # Command arguments may contain repository URLs or credential-helper
+    # configuration.  Preserve diagnostic value without ever serializing an
+    # argument value into application logs.
+    logger.debug(
+        "Running command %s with %d argument(s)",
+        cmd[0] if cmd else "<empty>",
+        max(len(cmd) - 1, 0),
+    )
     if cmd and cmd[0] == "git":
         return _shared_run_git(
             cmd,

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -68,14 +68,10 @@ def run(
         subprocess.TimeoutExpired: If timeout is exceeded
 
     """
-    # Command arguments may contain repository URLs or credential-helper
-    # configuration.  Preserve diagnostic value without ever serializing an
-    # argument value into application logs.
-    logger.debug(
-        "Running command %s with %d argument(s)",
-        cmd[0] if cmd else "<empty>",
-        max(len(cmd) - 1, 0),
-    )
+    # Command elements may contain repository URLs or credential-helper
+    # configuration.  Keep a stable lifecycle trace without serializing any
+    # value derived from the command into application logs.
+    logger.debug("Running subprocess")
     try:
         if cmd and cmd[0] == "git":
             return _shared_run_git(
@@ -97,15 +93,11 @@ def run(
         )
     except subprocess.TimeoutExpired:
         if log_errors:
-            logger.error("Command %s timed out after %ds", cmd[0] if cmd else "<empty>", timeout)
+            logger.error("Subprocess timed out")
         raise
     except subprocess.CalledProcessError as error:
         if log_errors:
-            logger.error(
-                "Command %s failed with exit code %s",
-                cmd[0] if cmd else "<empty>",
-                error.returncode,
-            )
+            logger.error("Subprocess failed with exit code %s", error.returncode)
         raise
 
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -156,6 +156,8 @@ def _unsafe_local_git_config_key(config: str) -> str | None:
             "uploadpack",
         }:
             return key
+        if normalized in {"fetch.recursesubmodules", "submodule.recurse"}:
+            return key
         if normalized.startswith(("include.", "includeif.")):
             return key
         if normalized.startswith("filter.") and normalized.rsplit(".", 1)[-1] in {
@@ -914,6 +916,7 @@ class WorkerPool:
                 *fetch_config,
                 "fetch",
                 "--no-tags",
+                "--no-recurse-submodules",
                 # The preflight validates origin before this point.  Fetch it
                 # by name so a remote URL never reaches command debug logs.
                 "origin",

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -70,7 +70,13 @@ _FETCH_ENV_BLOCKLIST = frozenset(
         "GIT_SSL_CAPATH",
         "GIT_SSL_NO_VERIFY",
         "GIT_WORK_TREE",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
         "SSH_ASKPASS",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
     }
 )
 
@@ -144,7 +150,11 @@ def _unsafe_local_git_config_key(config: str) -> str | None:
             normalized.startswith("credential.") and normalized.endswith(".helper")
         ):
             return key
-        if normalized.startswith("remote.") and normalized.endswith(".uploadpack"):
+        if normalized.startswith("remote.") and normalized.rsplit(".", 1)[-1] in {
+            "proxy",
+            "proxyauthmethod",
+            "uploadpack",
+        }:
             return key
         if normalized.startswith(("include.", "includeif.")):
             return key
@@ -162,6 +172,36 @@ def _unsafe_local_git_config_key(config: str) -> str | None:
         # verification/CA trust, including URL-scoped variants.
         if normalized.startswith(("http.", "url.")):
             return key
+    return None
+
+
+def _checkout_preflight_error(checkout: Path, timeout_s: int) -> str | None:
+    """Return a reusable-checkout metadata safety failure before synchronization."""
+    if not (checkout / ".git").exists():
+        return None
+    unsafe_config = _unsafe_local_git_config_key(
+        git_utils.run(
+            ["git", "config", "--null", "--list"],
+            cwd=checkout,
+            timeout=timeout_s,
+            env=_controlled_git_env(),
+        ).stdout
+    )
+    if unsafe_config is not None:
+        return "checkout has unsafe local Git configuration"
+    graft_value = git_utils.run(
+        ["git", "rev-parse", "--git-path", "info/grafts"],
+        cwd=checkout,
+        timeout=timeout_s,
+        env=_controlled_git_env(),
+    ).stdout.strip()
+    if not graft_value:
+        return None
+    graft_path = Path(graft_value)
+    if not graft_path.is_absolute():
+        graft_path = checkout / graft_path
+    if graft_path.is_file():
+        return "checkout has unsafe legacy Git grafts"
     return None
 
 
@@ -748,20 +788,8 @@ class WorkerPool:
         # ``git config --list`` uses the effective repository configuration,
         # including a linked worktree's ``config.worktree``.  It must precede
         # origin/status because either command can observe a poisoned setting.
-        if (checkout / ".git").exists():
-            unsafe_config = _unsafe_local_git_config_key(
-                git_utils.run(
-                    ["git", "config", "--null", "--list"],
-                    cwd=checkout,
-                    timeout=job.timeout_s,
-                    env=_controlled_git_env(),
-                ).stdout
-            )
-            if unsafe_config is not None:
-                return JobResult(
-                    ok=False,
-                    error="checkout has unsafe local Git configuration",
-                )
+        if preflight_error := _checkout_preflight_error(checkout, job.timeout_s):
+            return JobResult(ok=False, error=preflight_error)
 
         origin = git_utils.run(
             ["git", "remote", "get-url", "origin"],

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -57,6 +57,7 @@ _FETCH_ENV_BLOCKLIST = frozenset(
     {
         "GIT_ASKPASS",
         "GIT_COMMON_DIR",
+        "GIT_CONFIG",
         "GIT_CONFIG_PARAMETERS",
         "GIT_DIR",
         "GIT_EXEC_PATH",
@@ -96,6 +97,7 @@ def _controlled_git_env() -> dict[str, str]:
             env.pop(key)
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_NO_REPLACE_OBJECTS"] = "1"
     env["PATH"] = os.defpath
     env["GIT_PAGER"] = "cat"
     env["GIT_TERMINAL_PROMPT"] = "0"
@@ -136,8 +138,13 @@ def _unsafe_local_git_config_key(config: str) -> str | None:
             "core.gitproxy",
             "core.sshcommand",
             "core.worktree",
-            "credential.helper",
         }:
+            return key
+        if normalized == "credential.helper" or (
+            normalized.startswith("credential.") and normalized.endswith(".helper")
+        ):
+            return key
+        if normalized.startswith("remote.") and normalized.endswith(".uploadpack"):
             return key
         if normalized.startswith(("include.", "includeif.")):
             return key
@@ -830,7 +837,6 @@ class WorkerPool:
         ):
             return self._fast_forward_checkout(
                 checkout=checkout,
-                origin=origin,
                 default_branch=default_branch,
                 gh_command=gh_command,
                 timeout_s=job.timeout_s,
@@ -840,7 +846,6 @@ class WorkerPool:
     def _fast_forward_checkout(
         *,
         checkout: Path,
-        origin: str,
         default_branch: str,
         gh_command: str,
         timeout_s: int,
@@ -881,7 +886,9 @@ class WorkerPool:
                 *fetch_config,
                 "fetch",
                 "--no-tags",
-                origin,
+                # The preflight validates origin before this point.  Fetch it
+                # by name so a remote URL never reaches command debug logs.
+                "origin",
                 f"+refs/heads/{default_branch}:refs/remotes/origin/{default_branch}",
             ],
             cwd=checkout,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1374,6 +1374,7 @@ class TestGitOps:
         with patch("hephaestus.automation.git_utils.run") as mock_run:
             mock_run.side_effect = [
                 subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
@@ -1394,6 +1395,12 @@ class TestGitOps:
         assert mock_run.call_args_list == [
             call(
                 ["git", "config", "--null", "--list"],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "rev-parse", "--git-path", "info/grafts"],
                 cwd=checkout,
                 timeout=120,
                 env=ANY,
@@ -1675,6 +1682,15 @@ class TestGitOps:
         monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "credential.helper=!/unsafe/helper")
         monkeypatch.setenv("GIT_NO_REPLACE_OBJECTS", "0")
         monkeypatch.setenv("PATH", "/unsafe/path")
+        for key in (
+            "ALL_PROXY",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "all_proxy",
+            "http_proxy",
+            "https_proxy",
+        ):
+            monkeypatch.setenv(key, "http://unsafe-proxy")
         job = GitJob(
             repo="test/repo",
             op="sync_checkout",
@@ -1745,6 +1761,12 @@ class TestGitOps:
             "GIT_CONFIG_VALUE_0",
             "GIT_CONFIG",
             "GIT_CONFIG_PARAMETERS",
+            "ALL_PROXY",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "all_proxy",
+            "http_proxy",
+            "https_proxy",
         ):
             assert key not in fetch_env
         assert fetch_env["PATH"] == os.defpath
@@ -1807,6 +1829,8 @@ class TestGitOps:
             "url.file:///unsafe/.insteadOf\nhttps://github.com/owner/name\0",
             "credential.https://github.com.helper\n!/unsafe/helper\0",
             "remote.origin.uploadpack\n/unsafe/upload-pack\0",
+            "remote.origin.proxy\nhttp://unsafe-proxy\0",
+            "remote.origin.proxyAuthMethod\nanyauth\0",
             "core.worktree\n/unsafe/worktree\0",
         ),
         ids=(
@@ -1822,6 +1846,8 @@ class TestGitOps:
             "url-rewrite",
             "url-scoped-credential-helper",
             "remote-upload-pack",
+            "remote-proxy",
+            "remote-proxy-auth",
             "core-worktree",
         ),
     )
@@ -1903,6 +1929,79 @@ class TestGitOps:
         mock_run.assert_called_once()
         assert result.ok is False
         assert "unsafe local Git configuration" in (result.error or "")
+
+    def test_sync_checkout_rejects_grafts_in_linked_worktree(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Legacy grafts in linked-worktree metadata stop sync before ancestry checks."""
+        checkout = tmp_path / "checkout"
+        linked = tmp_path / "linked"
+        subprocess.run(
+            ["git", "init", "--initial-branch", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for key, value in (("user.name", "Test User"), ("user.email", "test@example.com")):
+            subprocess.run(
+                ["git", "config", key, value],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "initial"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "linked", str(linked)],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        graft_path = Path(
+            subprocess.run(
+                ["git", "rev-parse", "--git-path", "info/grafts"],
+                cwd=linked,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+        if not graft_path.is_absolute():
+            graft_path = linked / graft_path
+        graft_path.parent.mkdir(parents=True, exist_ok=True)
+        graft_path.write_text("# unsafe graft\n", encoding="utf-8")
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(linked)},
+        )
+        actual_run = git_utils.run
+
+        def run_preflight(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            assert command in (
+                ["git", "config", "--null", "--list"],
+                ["git", "rev-parse", "--git-path", "info/grafts"],
+            )
+            return actual_run(command, **kwargs)
+
+        with patch("hephaestus.automation.git_utils.run", side_effect=run_preflight) as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert mock_run.call_count == 2
+        assert result.ok is False
+        assert "unsafe legacy Git grafts" in (result.error or "")
 
     def test_sync_checkout_rejects_spoofed_github_hostname(
         self,
@@ -2072,6 +2171,7 @@ class TestGitOps:
             patch("hephaestus.automation.git_utils.run") as mock_run,
         ):
             mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
                 subprocess.CompletedProcess([], 0, stdout=""),

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1459,6 +1459,7 @@ class TestGitOps:
                     "http.sslVerify=true",
                     "fetch",
                     "--no-tags",
+                    "--no-recurse-submodules",
                     "origin",
                     "+refs/heads/main:refs/remotes/origin/main",
                 ],
@@ -1736,6 +1737,7 @@ class TestGitOps:
             "http.sslVerify=true",
             "fetch",
             "--no-tags",
+            "--no-recurse-submodules",
             "origin",
             "+refs/heads/main:refs/remotes/origin/main",
         ]
@@ -1831,6 +1833,8 @@ class TestGitOps:
             "remote.origin.uploadpack\n/unsafe/upload-pack\0",
             "remote.origin.proxy\nhttp://unsafe-proxy\0",
             "remote.origin.proxyAuthMethod\nanyauth\0",
+            "fetch.recurseSubmodules\ntrue\0",
+            "submodule.recurse\ntrue\0",
             "core.worktree\n/unsafe/worktree\0",
         ),
         ids=(
@@ -1848,6 +1852,8 @@ class TestGitOps:
             "remote-upload-pack",
             "remote-proxy",
             "remote-proxy-auth",
+            "fetch-recurses-submodules",
+            "submodule-recurses",
             "core-worktree",
         ),
     )

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1452,7 +1452,7 @@ class TestGitOps:
                     "http.sslVerify=true",
                     "fetch",
                     "--no-tags",
-                    "https://github.com/owner/name.git",
+                    "origin",
                     "+refs/heads/main:refs/remotes/origin/main",
                 ],
                 cwd=checkout,
@@ -1671,7 +1671,9 @@ class TestGitOps:
         monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
         monkeypatch.setenv("GIT_CONFIG_KEY_0", "credential.helper")
         monkeypatch.setenv("GIT_CONFIG_VALUE_0", "!/unsafe/credential-helper")
+        monkeypatch.setenv("GIT_CONFIG", "/unsafe/git-config")
         monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "credential.helper=!/unsafe/helper")
+        monkeypatch.setenv("GIT_NO_REPLACE_OBJECTS", "0")
         monkeypatch.setenv("PATH", "/unsafe/path")
         job = GitJob(
             repo="test/repo",
@@ -1718,7 +1720,7 @@ class TestGitOps:
             "http.sslVerify=true",
             "fetch",
             "--no-tags",
-            "git@github.com:owner/name.git",
+            "origin",
             "+refs/heads/main:refs/remotes/origin/main",
         ]
         fetch_env = fetch_call.kwargs["env"]
@@ -1741,12 +1743,14 @@ class TestGitOps:
             "GIT_CONFIG_COUNT",
             "GIT_CONFIG_KEY_0",
             "GIT_CONFIG_VALUE_0",
+            "GIT_CONFIG",
             "GIT_CONFIG_PARAMETERS",
         ):
             assert key not in fetch_env
         assert fetch_env["PATH"] == os.defpath
         assert fetch_env["GIT_CONFIG_GLOBAL"] == os.devnull
         assert fetch_env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert fetch_env["GIT_NO_REPLACE_OBJECTS"] == "1"
         assert mock_run.call_args_list[3] == call(
             [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
             cwd=checkout,
@@ -1756,6 +1760,7 @@ class TestGitOps:
         for git_call in (mock_run.call_args_list[index] for index in (0, 1, 2, 4, 5, 6, 7)):
             assert git_call.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
             assert "GIT_DIR" not in git_call.kwargs["env"]
+            assert git_call.kwargs["env"]["GIT_NO_REPLACE_OBJECTS"] == "1"
         assert result.ok is True
 
     def test_sync_checkout_rejects_executable_local_git_config(
@@ -1800,6 +1805,8 @@ class TestGitOps:
             "http.sslCAInfo\n/unsafe/ca.pem\0",
             "http.proxy\nhttp://unsafe-proxy\0",
             "url.file:///unsafe/.insteadOf\nhttps://github.com/owner/name\0",
+            "credential.https://github.com.helper\n!/unsafe/helper\0",
+            "remote.origin.uploadpack\n/unsafe/upload-pack\0",
             "core.worktree\n/unsafe/worktree\0",
         ),
         ids=(
@@ -1813,6 +1820,8 @@ class TestGitOps:
             "custom-ca",
             "http-proxy",
             "url-rewrite",
+            "url-scoped-credential-helper",
+            "remote-upload-pack",
             "core-worktree",
         ),
     )
@@ -1825,6 +1834,7 @@ class TestGitOps:
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Effective config scanning includes a linked worktree's config.worktree."""
         checkout = tmp_path / "checkout"
@@ -1871,6 +1881,9 @@ class TestGitOps:
             capture_output=True,
             text=True,
         )
+        benign_config = tmp_path / "benign-git-config"
+        benign_config.touch()
+        monkeypatch.setenv("GIT_CONFIG", str(benign_config))
         job = GitJob(
             repo="test/repo",
             op="sync_checkout",

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -57,32 +57,53 @@ class TestRun:
     def test_command_debug_log_does_not_disclose_arguments(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Command diagnostics identify the executable without logging sensitive argv values."""
+        """Command diagnostics do not log even a sensitive executable value."""
         sensitive_argument = "do-not-log-this-command-argument"
-        with caplog.at_level(logging.DEBUG, logger="hephaestus.automation.git_utils"):
-            run(["echo", sensitive_argument], check=True, capture_output=True)
+        completed = subprocess.CompletedProcess([sensitive_argument], 0, stdout="", stderr="")
+        with (
+            caplog.at_level(logging.DEBUG, logger="hephaestus.automation.git_utils"),
+            patch("hephaestus.automation.git_utils.run_subprocess", return_value=completed),
+        ):
+            result = run([sensitive_argument])
 
-        assert "Running command echo with 1 argument(s)" in caplog.messages
+        assert result is completed
+        assert "Running subprocess" in caplog.messages
         assert sensitive_argument not in caplog.text
 
-    def test_failed_git_command_log_does_not_disclose_arguments(
+    def test_failed_command_log_does_not_disclose_arguments(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Failure logs use the same redacted command summary as debug logs."""
         sensitive_argument = "do-not-log-this-failed-command-argument"
         failure = subprocess.CalledProcessError(
             1,
-            ["git", "fetch", sensitive_argument],
+            [sensitive_argument],
             stderr=sensitive_argument,
         )
         with (
             caplog.at_level(logging.ERROR, logger="hephaestus.automation.git_utils"),
-            patch("hephaestus.automation.git_utils._shared_run_git", side_effect=failure),
+            patch("hephaestus.automation.git_utils.run_subprocess", side_effect=failure),
             pytest.raises(subprocess.CalledProcessError),
         ):
-            run(["git", "fetch", sensitive_argument])
+            run([sensitive_argument])
 
-        assert "Command git failed with exit code 1" in caplog.messages
+        assert "Subprocess failed with exit code 1" in caplog.messages
+        assert sensitive_argument not in caplog.text
+
+    def test_timed_out_command_log_does_not_disclose_arguments(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Timeout logs do not disclose a sensitive executable value."""
+        sensitive_argument = "do-not-log-this-timed-out-command-argument"
+        timeout = subprocess.TimeoutExpired([sensitive_argument], 60)
+        with (
+            caplog.at_level(logging.ERROR, logger="hephaestus.automation.git_utils"),
+            patch("hephaestus.automation.git_utils.run_subprocess", side_effect=timeout),
+            pytest.raises(subprocess.TimeoutExpired),
+        ):
+            run([sensitive_argument], timeout=60)
+
+        assert "Subprocess timed out" in caplog.messages
         assert sensitive_argument not in caplog.text
 
     def test_failed_command_with_check(self) -> None:

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -1,5 +1,6 @@
 """Tests for git utility functions."""
 
+import logging
 import subprocess
 import sys
 from collections.abc import Generator
@@ -52,6 +53,17 @@ class TestRun:
 
         assert result.returncode == 0
         assert "hello" in result.stdout
+
+    def test_command_debug_log_does_not_disclose_arguments(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Command diagnostics identify the executable without logging sensitive argv values."""
+        sensitive_argument = "do-not-log-this-command-argument"
+        with caplog.at_level(logging.DEBUG, logger="hephaestus.automation.git_utils"):
+            run(["echo", sensitive_argument], check=True, capture_output=True)
+
+        assert "Running command echo with 1 argument(s)" in caplog.messages
+        assert sensitive_argument not in caplog.text
 
     def test_failed_command_with_check(self) -> None:
         """Test running a failed command with check=True."""

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -65,6 +65,26 @@ class TestRun:
         assert "Running command echo with 1 argument(s)" in caplog.messages
         assert sensitive_argument not in caplog.text
 
+    def test_failed_git_command_log_does_not_disclose_arguments(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Failure logs use the same redacted command summary as debug logs."""
+        sensitive_argument = "do-not-log-this-failed-command-argument"
+        failure = subprocess.CalledProcessError(
+            1,
+            ["git", "fetch", sensitive_argument],
+            stderr=sensitive_argument,
+        )
+        with (
+            caplog.at_level(logging.ERROR, logger="hephaestus.automation.git_utils"),
+            patch("hephaestus.automation.git_utils._shared_run_git", side_effect=failure),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            run(["git", "fetch", sensitive_argument])
+
+        assert "Command git failed with exit code 1" in caplog.messages
+        assert sensitive_argument not in caplog.text
+
     def test_failed_command_with_check(self) -> None:
         """Test running a failed command with check=True."""
         with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
Completes the final checkout-isolation protections that missed the concurrent merge of PR #2410: isolates Git configuration and replacement refs, rejects URL-scoped credential helpers, avoids logging raw origins, and redacts command arguments.

Closes #2411