### PR TITLE
fix(release): align pdoc targets with API guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,7 @@ jobs:
         run: uv sync --all-groups --all-extras --locked
 
       - name: Generate API reference (pdoc -> docs/api/)
-        run: uv run pdoc ./hephaestus ./hephaestus/agents ./hephaestus/benchmarks ./hephaestus/ci ./hephaestus/cli ./hephaestus/config ./hephaestus/datasets ./hephaestus/discovery ./hephaestus/forensics ./hephaestus/github ./hephaestus/io ./hephaestus/logging ./hephaestus/markdown ./hephaestus/nats ./hephaestus/resilience ./hephaestus/scripts_lib ./hephaestus/system ./hephaestus/utils ./hephaestus/validation ./hephaestus/version --output-dir docs/api
+        run: uv run pdoc ./hephaestus ./hephaestus/agents ./hephaestus/benchmarks ./hephaestus/ci ./hephaestus/cli ./hephaestus/config ./hephaestus/datasets ./hephaestus/discovery ./hephaestus/forensics ./hephaestus/github ./hephaestus/io ./hephaestus/logging ./hephaestus/markdown ./hephaestus/nats ./hephaestus/observability ./hephaestus/prompts ./hephaestus/resilience ./hephaestus/scripts_lib ./hephaestus/system ./hephaestus/utils ./hephaestus/validation ./hephaestus/version --output-dir docs/api
 
       - name: Verify API reference coverage
         run: uv run hephaestus-check-api-reference --docs-dir docs/api

--- a/tests/unit/validation/test_api_reference_docs.py
+++ b/tests/unit/validation/test_api_reference_docs.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from hephaestus.validation.api_reference import (
     DEFAULT_REPO_ROOT,
@@ -55,12 +56,21 @@ class TestPdocTargets:
         assert expected in recipe
 
     def test_release_workflow_docs_recipe_matches_expected_targets(self) -> None:
-        workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        workflow = yaml.safe_load(
+            (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        )
         expected = (
             "uv run pdoc " + " ".join(expected_pdoc_targets(REPO_ROOT)) + " --output-dir docs/api"
         )
+        steps = workflow["jobs"]["deploy-docs"]["steps"]
+        pdoc_steps = [
+            step
+            for step in steps
+            if step.get("name") == "Generate API reference (pdoc -> docs/api/)"
+        ]
 
-        assert expected in workflow
+        assert len(pdoc_steps) == 1
+        assert pdoc_steps[0]["run"] == expected
 
 
 class TestFindViolations:

--- a/tests/unit/validation/test_api_reference_docs.py
+++ b/tests/unit/validation/test_api_reference_docs.py
@@ -54,6 +54,14 @@ class TestPdocTargets:
         )
         assert expected in recipe
 
+    def test_release_workflow_docs_recipe_matches_expected_targets(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        expected = (
+            "uv run pdoc " + " ".join(expected_pdoc_targets(REPO_ROOT)) + " --output-dir docs/api"
+        )
+
+        assert expected in workflow
+
 
 class TestFindViolations:
     """Tests for generated ``docs/api`` output validation."""


### PR DESCRIPTION
Closes #2413

The release workflow maintained a stale duplicated pdoc target list that omitted `hephaestus/observability` and `hephaestus/prompts`, causing the newly added API-reference coverage check to fail after the v0.10.0 release had already published. This aligns the workflow command with the canonical docs recipe and adds a structural regression test that prevents the executed release step from drifting.

Verification:
- `uv run --all-extras --locked pytest --no-cov -q tests/unit/validation/test_api_reference_docs.py tests/unit/ci/test_workflows.py`
- full pdoc generation plus `uv run hephaestus-check-api-reference`
- `uv run --all-extras --locked pre-commit run --all-files`
- pre-push full test suite