### PR TITLE
fix(release): add safe docs recovery mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      deployments: read
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       sha: ${{ steps.resolve.outputs.sha }}
+      release_exists: ${{ steps.resolve.outputs.release_exists }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -55,6 +57,7 @@ jobs:
           EVENT_REF: ${{ github.ref }}
           DOCS_ONLY: ${{ inputs.docs_only }}
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -78,13 +81,38 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "Resolved release tag ${TAG} to immutable commit ${SHA}"
 
+          RELEASE_EXISTS=false
+          DRAFT=""
+          if DRAFT="$(gh release view "$TAG" --json isDraft -q .isDraft)"; then
+            RELEASE_EXISTS=true
+          elif [ "$DOCS_ONLY" = "true" ]; then
+            echo "::error::Docs-only recovery requires an existing GitHub Release for ${TAG}" >&2
+            exit 1
+          fi
+
+          if [ "$RELEASE_EXISTS" = "true" ] && [ "$DRAFT" != "false" ]; then
+            echo "::error::Docs-only recovery requires a published GitHub Release for ${TAG}" >&2
+            exit 1
+          fi
+          echo "release_exists=${RELEASE_EXISTS}" >> "$GITHUB_OUTPUT"
+
           if [ "$DOCS_ONLY" = "true" ]; then
-            if ! DRAFT="$(gh release view "$TAG" --json isDraft -q .isDraft)"; then
-              echo "::error::Docs-only recovery requires an existing GitHub Release for ${TAG}" >&2
-              exit 1
-            fi
-            if [ "$DRAFT" != "false" ]; then
-              echo "::error::Docs-only recovery requires a published GitHub Release for ${TAG}" >&2
+            PUBLISHED_DEPLOYMENT=false
+            for DEPLOYMENT_ID in $(
+              gh api "repos/${REPOSITORY}/deployments?environment=pypi&sha=${SHA}" --jq '.[].id'
+            ); do
+              DEPLOYMENT_STATE="$({
+                gh api "repos/${REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses?per_page=1" \
+                  --jq '.[0].state'
+              })"
+              if [ "$DEPLOYMENT_STATE" = "success" ]; then
+                PUBLISHED_DEPLOYMENT=true
+                break
+              fi
+            done
+
+            if [ "$PUBLISHED_DEPLOYMENT" != "true" ]; then
+              echo "::error::Docs-only recovery requires a successful PyPI deployment for ${SHA}" >&2
               exit 1
             fi
           fi
@@ -92,7 +120,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     needs: resolve-release
-    if: ${{ !inputs.docs_only }}
+    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.release_exists != 'true' }}
     # Unit + integration suites run here; the uv env is cached and dev-install
     # already ran, so both finish well under this budget. 20 min (vs the prior
     # 15) is free insurance so a first-run integration slowdown never aborts a
@@ -133,7 +161,7 @@ jobs:
   type-check:
     runs-on: ubuntu-24.04
     needs: resolve-release
-    if: ${{ !inputs.docs_only }}
+    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.release_exists != 'true' }}
     timeout-minutes: 10
 
     steps:
@@ -159,7 +187,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [resolve-release, test, type-check]
-    if: ${{ !inputs.docs_only }}
+    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.release_exists != 'true' }}
     environment: pypi
     permissions:
       contents: write  # Create GitHub Release / upload assets
@@ -266,7 +294,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [resolve-release, test, type-check, build-and-publish]
-    if: ${{ always() && needs.resolve-release.result == 'success' && (inputs.docs_only || (needs.test.result == 'success' && needs.type-check.result == 'success' && needs.build-and-publish.result == 'success')) }}
+    if: ${{ always() && needs.resolve-release.result == 'success' && (inputs.docs_only || (needs.test.result == 'success' && needs.type-check.result == 'success' && needs.build-and-publish.result == 'success' && needs.resolve-release.outputs.release_exists != 'true')) }}
     # Publish the pdoc API reference to GitHub Pages only after the package
     # release succeeds, so the online docs always match a version on PyPI.
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (leave blank to use latest tag)"
+        description: "Tag to release"
+        required: true
+      docs_only:
+        description: "Deploy documentation for an existing published release without publishing."
         required: false
-        default: ""
+        default: false
+        type: boolean
 
 # Least-privilege permissions are declared per job below (zizmor
 # excessive-permissions, issue #2151): the workflow-level default is
@@ -19,12 +23,11 @@ permissions:
 
 # Serialize per-tag: this workflow builds, publishes to PyPI, and creates a
 # GitHub release — none idempotent. Two runs for the SAME tag must not race
-# (double-publish); different tags proceed independently. Key on the resolved
-# tag: dispatched runs group on the explicit `tag` input (previously they all
-# shared the branch ref's group), tag-push runs group on the tag ref. Never
-# cancel a publish in flight, hence cancel-in-progress: false.
+# (double-publish); different tags proceed independently. A tag push exposes
+# its short tag name through github.ref_name, matching the explicit dispatch
+# input. Never cancel a publish in flight, hence cancel-in-progress: false.
 concurrency:
-  group: release-${{ inputs.tag || github.ref }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -50,23 +53,19 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           EVENT_REF: ${{ github.ref }}
+          DOCS_ONLY: ${{ inputs.docs_only }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$EVENT_REF" == refs/tags/* ]]; then
+          if [[ "$EVENT_REF" == refs/tags/* ]]; then
             TAG="${EVENT_REF#refs/tags/}"
           else
-            TAG="$(git for-each-ref \
-              --count=1 \
-              --sort=-version:refname \
-              --format='%(refname:short)' \
-              'refs/tags/v*')"
+            TAG="$INPUT_TAG"
           fi
 
           if [ -z "$TAG" ]; then
-            echo "::error::No release tag could be resolved" >&2
+            echo "::error::An explicit release tag is required" >&2
             exit 1
           fi
 
@@ -79,9 +78,21 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "Resolved release tag ${TAG} to immutable commit ${SHA}"
 
+          if [ "$DOCS_ONLY" = "true" ]; then
+            if ! DRAFT="$(gh release view "$TAG" --json isDraft -q .isDraft)"; then
+              echo "::error::Docs-only recovery requires an existing GitHub Release for ${TAG}" >&2
+              exit 1
+            fi
+            if [ "$DRAFT" != "false" ]; then
+              echo "::error::Docs-only recovery requires a published GitHub Release for ${TAG}" >&2
+              exit 1
+            fi
+          fi
+
   test:
     runs-on: ubuntu-24.04
     needs: resolve-release
+    if: ${{ !inputs.docs_only }}
     # Unit + integration suites run here; the uv env is cached and dev-install
     # already ran, so both finish well under this budget. 20 min (vs the prior
     # 15) is free insurance so a first-run integration slowdown never aborts a
@@ -122,6 +133,7 @@ jobs:
   type-check:
     runs-on: ubuntu-24.04
     needs: resolve-release
+    if: ${{ !inputs.docs_only }}
     timeout-minutes: 10
 
     steps:
@@ -147,6 +159,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [resolve-release, test, type-check]
+    if: ${{ !inputs.docs_only }}
     environment: pypi
     permissions:
       contents: write  # Create GitHub Release / upload assets
@@ -252,7 +265,8 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [resolve-release, build-and-publish]
+    needs: [resolve-release, test, type-check, build-and-publish]
+    if: ${{ always() && needs.resolve-release.result == 'success' && (inputs.docs_only || (needs.test.result == 'success' && needs.type-check.result == 'success' && needs.build-and-publish.result == 'success')) }}
     # Publish the pdoc API reference to GitHub Pages only after the package
     # release succeeds, so the online docs always match a version on PyPI.
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,9 @@ jobs:
             exit 1
           fi
 
-          if [ "$RELEASE_EXISTS" = "true" ] && [ "$DRAFT" != "false" ]; then
-            echo "::error::Release ${TAG} exists but is not published" >&2
+          if [ "$DOCS_ONLY" = "true" ] && [ "$RELEASE_EXISTS" = "true" ] \
+            && [ "$DRAFT" != "false" ]; then
+            echo "::error::Docs-only recovery requires a published GitHub Release for ${TAG}" >&2
             exit 1
           fi
 
@@ -124,15 +125,28 @@ jobs:
             fi
           fi
 
+          if [ "$DOCS_ONLY" != "true" ] && [ "$RELEASE_EXISTS" = "true" ] \
+            && [ "$DRAFT" = "false" ] && [ "$SOURCE_PROVENANCE_MATCHES" != "true" ]; then
+            echo "::error::Existing published release ${TAG} lacks immutable source provenance; refusing an unsafe retry" >&2
+            exit 1
+          fi
+
           COMPLETED_RELEASE_EXISTS=false
           if [ "$RELEASE_EXISTS" = "true" ] && [ "$SOURCE_PROVENANCE_MATCHES" = "true" ]; then
-            for DEPLOYMENT_ID in $(
+            if ! DEPLOYMENT_IDS="$(
               gh api "repos/${REPOSITORY}/deployments?environment=pypi&sha=${SHA}" --jq '.[].id'
-            ); do
-              DEPLOYMENT_STATUS="$({
+            )"; then
+              echo "::error::Could not inspect PyPI deployments for ${SHA}" >&2
+              exit 1
+            fi
+            for DEPLOYMENT_ID in $DEPLOYMENT_IDS; do
+              if ! DEPLOYMENT_STATUS="$({
                 gh api "repos/${REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses?per_page=1" \
                   --jq '[.[0].state, .[0].target_url] | @tsv'
-              })"
+              })"; then
+                echo "::error::Could not inspect PyPI deployment ${DEPLOYMENT_ID}" >&2
+                exit 1
+              fi
               IFS=$'\t' read -r DEPLOYMENT_STATE DEPLOYMENT_URL <<< "$DEPLOYMENT_STATUS"
               if [ "$DEPLOYMENT_STATE" = "success" ]; then
                 JOB_URL_PREFIX="https://github.com/${REPOSITORY}/actions/runs/"
@@ -141,27 +155,41 @@ jobs:
                     RUN_AND_JOB="${DEPLOYMENT_URL#"${JOB_URL_PREFIX}"}"
                     RUN_ID="${RUN_AND_JOB%%/job/*}"
                     JOB_ID="${RUN_AND_JOB#*/job/}"
-                    RUN_STATUS="$(
+                    if ! RUN_STATUS="$(
                       gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" \
-                        --jq '[.name, .head_sha] | @tsv'
-                    )"
-                    IFS=$'\t' read -r WORKFLOW_NAME RUN_HEAD_SHA <<< "$RUN_STATUS"
-                    if [ "$WORKFLOW_NAME" != "Release" ] || [ "$RUN_HEAD_SHA" != "$SHA" ]; then
+                        --jq '[.name, .path, .head_sha] | @tsv'
+                    )"; then
+                      echo "::error::Could not inspect release workflow run ${RUN_ID}" >&2
+                      exit 1
+                    fi
+                    IFS=$'\t' read -r WORKFLOW_NAME WORKFLOW_PATH RUN_HEAD_SHA <<< "$RUN_STATUS"
+                    if [ "$WORKFLOW_NAME" != "Release" ] \
+                      || [ "$WORKFLOW_PATH" != ".github/workflows/release.yml" ] \
+                      || [ "$RUN_HEAD_SHA" != "$SHA" ]; then
                       continue
                     fi
-                    JOB_STATUS="$(
+                    if ! JOB_STATUS="$(
                       gh api "repos/${REPOSITORY}/actions/jobs/${JOB_ID}" \
                         --jq '[
+                          .run_id,
+                          .head_sha,
                           .name,
                           ([.steps[] | select(.name == "Publish to PyPI") | .conclusion][0] // ""),
-                          ([.steps[] | select(.name == "Create GitHub Release") | .conclusion][0] // "")
+                          ([.steps[] | select(.name == "Create GitHub Release") | .conclusion][0] // ""),
+                          ([.steps[] | select(.name == "Publish existing draft release") | .conclusion][0] // "")
                         ] | @tsv'
-                    )"
-                    IFS=$'\t' read -r JOB_NAME PUBLISH_PYPI_CONCLUSION CREATE_RELEASE_CONCLUSION \
-                      <<< "$JOB_STATUS"
-                    if [ "$JOB_NAME" = "build-and-publish" ] \
+                    )"; then
+                      echo "::error::Could not inspect release job ${JOB_ID}" >&2
+                      exit 1
+                    fi
+                    IFS=$'\t' read -r JOB_RUN_ID JOB_HEAD_SHA JOB_NAME PUBLISH_PYPI_CONCLUSION \
+                      CREATE_RELEASE_CONCLUSION FINALIZE_DRAFT_CONCLUSION <<< "$JOB_STATUS"
+                    if [ "$JOB_RUN_ID" = "$RUN_ID" ] \
+                      && [ "$JOB_HEAD_SHA" = "$SHA" ] \
+                      && [ "$JOB_NAME" = "build-and-publish" ] \
                       && [ "$PUBLISH_PYPI_CONCLUSION" = "success" ] \
-                      && [ "$CREATE_RELEASE_CONCLUSION" = "success" ]; then
+                      && { [ "$CREATE_RELEASE_CONCLUSION" = "success" ] \
+                        || [ "$FINALIZE_DRAFT_CONCLUSION" = "success" ]; }; then
                       COMPLETED_RELEASE_EXISTS=true
                       break
                     fi
@@ -321,11 +349,17 @@ jobs:
           # workflow. GitHub marks releases immutable, and an immutable
           # release cannot be updated or have assets added — so the
           # create/update action below must be skipped when one exists.
-          if gh release view "$TAG" --json isImmutable -q .isImmutable >/dev/null 2>&1; then
+          if gh release view "$TAG" --json isImmutable,isDraft -q .isImmutable >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
+            if gh release view "$TAG" --json isDraft -q .isDraft | grep -qx true; then
+              echo "draft=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "draft=false" >> "$GITHUB_OUTPUT"
+            fi
             echo "Release $TAG already exists — skipping creation."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "draft=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
@@ -353,6 +387,24 @@ jobs:
             echo "Attached dist/* to release $TAG."
           else
             echo "::notice::Release $TAG is immutable — build artifacts not attached. The package is published to PyPI."
+          fi
+
+      - name: Publish existing draft release
+        if: steps.existing.outputs.exists == 'true' && steps.existing.outputs.draft == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ needs.resolve-release.outputs.sha }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          MARKER="<!-- hephaestus-source-sha:${SHA} -->"
+          RELEASE_BODY="$(gh release view "$TAG" --json body -q .body)"
+          if printf '%s\n' "$RELEASE_BODY" | grep -Fqx "$MARKER"; then
+            gh release edit "$TAG" --draft=false
+          else
+            gh release edit "$TAG" --draft=false --notes "${RELEASE_BODY}
+
+          ${MARKER}"
           fi
 
   deploy-docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
+      actions: read
       contents: read
       deployments: read
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       sha: ${{ steps.resolve.outputs.sha }}
-      release_exists: ${{ steps.resolve.outputs.release_exists }}
+      completed_release_exists: ${{ steps.resolve.outputs.completed_release_exists }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -83,44 +84,107 @@ jobs:
 
           RELEASE_EXISTS=false
           DRAFT=""
-          if DRAFT="$(gh release view "$TAG" --json isDraft -q .isDraft)"; then
+          RELEASE_RESPONSE=""
+          if RELEASE_RESPONSE="$(
+            gh api --include "repos/${REPOSITORY}/releases/tags/${TAG}" 2>&1
+          )"; then
             RELEASE_EXISTS=true
-          elif [ "$DOCS_ONLY" = "true" ]; then
-            echo "::error::Docs-only recovery requires an existing GitHub Release for ${TAG}" >&2
+            RELEASE_JSON="$(
+              printf '%s\n' "$RELEASE_RESPONSE" | awk '
+                /^[[:space:]]*$/ { body = 1; next }
+                body { print }
+              '
+            )"
+            DRAFT="$(printf '%s\n' "$RELEASE_JSON" | jq -r '.draft')"
+            IMMUTABLE="$(printf '%s\n' "$RELEASE_JSON" | jq -r '.immutable')"
+            RELEASE_BODY="$(printf '%s\n' "$RELEASE_JSON" | jq -r '.body')"
+          elif printf '%s\n' "$RELEASE_RESPONSE" | grep -qE '^HTTP/[0-9.]+ 404 '; then
+            echo "Release ${TAG} does not exist yet."
+          else
+            echo "::error::Could not inspect existing GitHub Release for ${TAG}" >&2
             exit 1
           fi
 
           if [ "$RELEASE_EXISTS" = "true" ] && [ "$DRAFT" != "false" ]; then
-            echo "::error::Docs-only recovery requires a published GitHub Release for ${TAG}" >&2
+            echo "::error::Release ${TAG} exists but is not published" >&2
             exit 1
           fi
-          echo "release_exists=${RELEASE_EXISTS}" >> "$GITHUB_OUTPUT"
 
-          if [ "$DOCS_ONLY" = "true" ]; then
-            PUBLISHED_DEPLOYMENT=false
+          SOURCE_PROVENANCE_MATCHES=false
+          SOURCE_PROVENANCE_MARKER="<!-- hephaestus-source-sha:${SHA} -->"
+          if [ "$RELEASE_EXISTS" = "true" ] && [ "$IMMUTABLE" = "true" ]; then
+            if printf '%s\n' "$RELEASE_BODY" | grep -Fqx "$SOURCE_PROVENANCE_MARKER"; then
+              SOURCE_PROVENANCE_MATCHES=true
+            # v0.10.0 predates the marker. Its immutable release, signed tag,
+            # successful PyPI deployment, and release job were independently
+            # audited when this one-time recovery path was added.
+            elif [ "$TAG" = "v0.10.0" ] \
+              && [ "$SHA" = "99a5437fc351fd7737fc85e7d4d76504d88a00d1" ]; then
+              SOURCE_PROVENANCE_MATCHES=true
+            fi
+          fi
+
+          COMPLETED_RELEASE_EXISTS=false
+          if [ "$RELEASE_EXISTS" = "true" ] && [ "$SOURCE_PROVENANCE_MATCHES" = "true" ]; then
             for DEPLOYMENT_ID in $(
               gh api "repos/${REPOSITORY}/deployments?environment=pypi&sha=${SHA}" --jq '.[].id'
             ); do
-              DEPLOYMENT_STATE="$({
+              DEPLOYMENT_STATUS="$({
                 gh api "repos/${REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses?per_page=1" \
-                  --jq '.[0].state'
+                  --jq '[.[0].state, .[0].target_url] | @tsv'
               })"
+              IFS=$'\t' read -r DEPLOYMENT_STATE DEPLOYMENT_URL <<< "$DEPLOYMENT_STATUS"
               if [ "$DEPLOYMENT_STATE" = "success" ]; then
-                PUBLISHED_DEPLOYMENT=true
-                break
+                JOB_URL_PREFIX="https://github.com/${REPOSITORY}/actions/runs/"
+                case "$DEPLOYMENT_URL" in
+                  "${JOB_URL_PREFIX}"*/job/*)
+                    RUN_AND_JOB="${DEPLOYMENT_URL#"${JOB_URL_PREFIX}"}"
+                    RUN_ID="${RUN_AND_JOB%%/job/*}"
+                    JOB_ID="${RUN_AND_JOB#*/job/}"
+                    RUN_STATUS="$(
+                      gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" \
+                        --jq '[.name, .head_sha] | @tsv'
+                    )"
+                    IFS=$'\t' read -r WORKFLOW_NAME RUN_HEAD_SHA <<< "$RUN_STATUS"
+                    if [ "$WORKFLOW_NAME" != "Release" ] || [ "$RUN_HEAD_SHA" != "$SHA" ]; then
+                      continue
+                    fi
+                    JOB_STATUS="$(
+                      gh api "repos/${REPOSITORY}/actions/jobs/${JOB_ID}" \
+                        --jq '[
+                          .name,
+                          ([.steps[] | select(.name == "Publish to PyPI") | .conclusion][0] // ""),
+                          ([.steps[] | select(.name == "Create GitHub Release") | .conclusion][0] // "")
+                        ] | @tsv'
+                    )"
+                    IFS=$'\t' read -r JOB_NAME PUBLISH_PYPI_CONCLUSION CREATE_RELEASE_CONCLUSION \
+                      <<< "$JOB_STATUS"
+                    if [ "$JOB_NAME" = "build-and-publish" ] \
+                      && [ "$PUBLISH_PYPI_CONCLUSION" = "success" ] \
+                      && [ "$CREATE_RELEASE_CONCLUSION" = "success" ]; then
+                      COMPLETED_RELEASE_EXISTS=true
+                      break
+                    fi
+                    ;;
+                esac
               fi
             done
+          fi
+          echo "completed_release_exists=${COMPLETED_RELEASE_EXISTS}" >> "$GITHUB_OUTPUT"
 
-            if [ "$PUBLISHED_DEPLOYMENT" != "true" ]; then
-              echo "::error::Docs-only recovery requires a successful PyPI deployment for ${SHA}" >&2
-              exit 1
-            fi
+          if [ "$DOCS_ONLY" = "true" ] && [ "$RELEASE_EXISTS" != "true" ]; then
+            echo "::error::Docs-only recovery requires an existing GitHub Release for ${TAG}" >&2
+            exit 1
+          fi
+          if [ "$DOCS_ONLY" = "true" ] && [ "$COMPLETED_RELEASE_EXISTS" != "true" ]; then
+            echo "::error::Docs-only recovery requires a successful PyPI publish and GitHub Release creation from the same release workflow run for ${SHA}" >&2
+            exit 1
           fi
 
   test:
     runs-on: ubuntu-24.04
     needs: resolve-release
-    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.release_exists != 'true' }}
+    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.completed_release_exists != 'true' }}
     # Unit + integration suites run here; the uv env is cached and dev-install
     # already ran, so both finish well under this budget. 20 min (vs the prior
     # 15) is free insurance so a first-run integration slowdown never aborts a
@@ -161,7 +225,7 @@ jobs:
   type-check:
     runs-on: ubuntu-24.04
     needs: resolve-release
-    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.release_exists != 'true' }}
+    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.completed_release_exists != 'true' }}
     timeout-minutes: 10
 
     steps:
@@ -187,7 +251,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [resolve-release, test, type-check]
-    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.release_exists != 'true' }}
+    if: ${{ !inputs.docs_only && needs.resolve-release.outputs.completed_release_exists != 'true' }}
     environment: pypi
     permissions:
       contents: write  # Create GitHub Release / upload assets
@@ -269,6 +333,7 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
         with:
           tag_name: ${{ needs.resolve-release.outputs.tag }}
+          body: "<!-- hephaestus-source-sha:${{ needs.resolve-release.outputs.sha }} -->"
           generate_release_notes: true
           files: dist/*
         env:
@@ -294,7 +359,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [resolve-release, test, type-check, build-and-publish]
-    if: ${{ always() && needs.resolve-release.result == 'success' && (inputs.docs_only || (needs.test.result == 'success' && needs.type-check.result == 'success' && needs.build-and-publish.result == 'success' && needs.resolve-release.outputs.release_exists != 'true')) }}
+    if: ${{ always() && needs.resolve-release.result == 'success' && (inputs.docs_only || (needs.test.result == 'success' && needs.type-check.result == 'success' && needs.build-and-publish.result == 'success' && needs.resolve-release.outputs.completed_release_exists != 'true')) }}
     # Publish the pdoc API reference to GitHub Pages only after the package
     # release succeeds, so the online docs always match a version on PyPI.
     permissions:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -77,10 +77,10 @@ publish the same package again. After the workflow fix is merged, run the repair
 gh workflow run release.yml --ref main -f tag=vX.Y.Z -f docs_only=true
 ```
 
-The recovery checks that `vX.Y.Z` already has a published GitHub Release and a successful PyPI
-deployment recorded for the tag's immutable commit, checks out that commit to generate the API
-reference, and deploys only the Pages artifact. It performs no PyPI upload or GitHub Release
-write.
+The recovery verifies that `vX.Y.Z` already has a published GitHub Release created by the same
+successful PyPI release-workflow job for the tag's immutable commit, checks out that commit to
+generate the API reference, and deploys only the Pages artifact. It performs no PyPI upload or
+GitHub Release write.
 
 ## PyPI Trusted Publishing
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -77,9 +77,10 @@ publish the same package again. After the workflow fix is merged, run the repair
 gh workflow run release.yml --ref main -f tag=vX.Y.Z -f docs_only=true
 ```
 
-The recovery checks that `vX.Y.Z` already has a published GitHub Release, checks out that
-immutable tag to generate the API reference, and deploys only the Pages artifact. It performs no
-PyPI upload or GitHub Release write.
+The recovery checks that `vX.Y.Z` already has a published GitHub Release and a successful PyPI
+deployment recorded for the tag's immutable commit, checks out that commit to generate the API
+reference, and deploys only the Pages artifact. It performs no PyPI upload or GitHub Release
+write.
 
 ## PyPI Trusted Publishing
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,8 +45,8 @@ hatch-vcs dynamic versioning, so the package version is derived from the git tag
 ## Manual Tag + Release (escape hatch)
 
 If `auto-tag.yml` is skipped and a tag was pushed manually, the **Release** workflow also accepts
-a `workflow_dispatch` with an optional explicit `tag` input. Leave it blank to use the latest tag,
-or supply a tag name (e.g. `v0.8.0`) to release a specific ref.
+a `workflow_dispatch` with a required explicit `tag` input (for example, `v0.8.0`). Always name
+the tag: it serializes a manual dispatch with a tag-push release for that same version.
 
 ### Dispatch failed after tag push
 
@@ -66,9 +66,20 @@ Instead, dispatch the Release workflow directly with the stranded tag named expl
 gh workflow run release.yml -f tag=vX.Y.Z   # the exact tag auto-tag pushed
 ```
 
-Never dispatch with a blank `tag` input in this state. Blank means "latest tag", which is only
-correct until another tag lands between the failure and your recovery — always name the
-stranded tag.
+### Docs-only recovery after publication
+
+If PyPI publishing and GitHub Release creation succeed but the final API-doc deployment fails,
+do not re-run the normal release: PyPI versions are immutable and the workflow would try to
+publish the same package again. After the workflow fix is merged, run the repaired workflow from
+`main` in docs-only mode instead:
+
+```bash
+gh workflow run release.yml --ref main -f tag=vX.Y.Z -f docs_only=true
+```
+
+The recovery checks that `vX.Y.Z` already has a published GitHub Release, checks out that
+immutable tag to generate the API reference, and deploys only the Pages artifact. It performs no
+PyPI upload or GitHub Release write.
 
 ## PyPI Trusted Publishing
 

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -531,18 +531,73 @@ class TestAutoTagReleaseDispatch:
         assert "### Dispatch failed after tag push" in doc
         assert "gh workflow run release.yml -f tag=vX.Y.Z" in doc
 
+    def test_releasing_doc_has_docs_only_recovery_command(self) -> None:
+        """A published release with failed docs needs a no-republish recovery command."""
+        doc = (REPO_ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
+
+        assert "### Docs-only recovery after publication" in doc
+        assert "gh workflow run release.yml --ref main -f tag=vX.Y.Z -f docs_only=true" in doc
+
     def test_release_concurrency_keys_on_resolved_tag(self) -> None:
         """Dispatched and tag-push release runs must serialize per tag, not per branch.
 
-        With ``release-${{ github.ref }}`` every workflow_dispatch run grouped on
-        the branch ref, so two dispatched runs for DIFFERENT tags serialized while
-        a dispatched and a tag-push run of the SAME tag did not share a group.
-        Keying on ``inputs.tag`` first makes dispatched runs group per tag.
+        ``github.ref_name`` is the short tag name for a tag push, so it matches the
+        explicit ``tag`` dispatch input. ``github.ref`` includes ``refs/tags/`` and
+        would let a tag push and a manual dispatch for the same tag run together.
         """
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
         concurrency = workflow["concurrency"]
-        assert concurrency["group"] == "release-${{ inputs.tag || github.ref }}"
+        assert concurrency["group"] == "release-${{ inputs.tag || github.ref_name }}"
         assert concurrency["cancel-in-progress"] is False
+
+    def test_release_dispatch_requires_a_tag_and_supports_docs_only_recovery(self) -> None:
+        """Recovery must select an explicit tag and never republish its package."""
+        workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+        inputs = workflow[True]["workflow_dispatch"]["inputs"]
+
+        assert inputs["tag"]["required"] is True
+        assert inputs["docs_only"] == {
+            "description": (
+                "Deploy documentation for an existing published release without publishing."
+            ),
+            "required": False,
+            "default": False,
+            "type": "boolean",
+        }
+
+    def test_docs_only_recovery_skips_normal_release_jobs(self) -> None:
+        """Docs recovery keeps tag validation but skips test, publish, and release writes."""
+        workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+
+        assert jobs["test"]["if"] == "${{ !inputs.docs_only }}"
+        assert jobs["type-check"]["if"] == "${{ !inputs.docs_only }}"
+        assert jobs["build-and-publish"]["if"] == "${{ !inputs.docs_only }}"
+        assert jobs["deploy-docs"]["needs"] == [
+            "resolve-release",
+            "test",
+            "type-check",
+            "build-and-publish",
+        ]
+        assert jobs["deploy-docs"]["if"] == (
+            "${{ always() && needs.resolve-release.result == 'success' && "
+            "(inputs.docs_only || (needs.test.result == 'success' && "
+            "needs.type-check.result == 'success' && "
+            "needs.build-and-publish.result == 'success')) }}"
+        )
+
+    def test_docs_only_recovery_requires_an_existing_release(self) -> None:
+        """A docs-only dispatch is restricted to an already-published release tag."""
+        workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+        resolve_step = next(
+            step
+            for step in workflow["jobs"]["resolve-release"]["steps"]
+            if step.get("id") == "resolve"
+        )
+
+        assert resolve_step["env"]["DOCS_ONLY"] == "${{ inputs.docs_only }}"
+        assert resolve_step["env"]["GH_TOKEN"] == "${{ github.token }}"  # noqa: S105
+        assert 'gh release view "$TAG" --json isDraft -q .isDraft' in resolve_step["run"]
 
 
 class TestReleaseAttestations:

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -592,6 +593,89 @@ class TestAutoTagReleaseDispatch:
             "<!-- hephaestus-source-sha:${{ needs.resolve-release.outputs.sha }} -->"
         )
 
+    def _publish_draft_step(self) -> dict[str, Any]:
+        """Return the step that publishes a recovered draft release."""
+        workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+        return next(
+            step
+            for step in workflow["jobs"]["build-and-publish"]["steps"]
+            if step.get("name") == "Publish existing draft release"
+        )
+
+    def _run_draft_publisher(
+        self, tmp_path: Path, release_body: str
+    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+        """Run the draft-publishing shell step against a deterministic fake gh CLI."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        args_file = tmp_path / "gh-edit-args.json"
+        (bin_dir / "gh").write_text(
+            "#!/usr/bin/env python3\n"
+            "import json\n"
+            "import os\n"
+            "import sys\n"
+            "from pathlib import Path\n"
+            "args = sys.argv[1:]\n"
+            "if args[:2] == ['release', 'view']:\n"
+            "    print(os.environ['GH_RELEASE_BODY'])\n"
+            "elif args[:2] == ['release', 'edit']:\n"
+            "    Path(os.environ['GH_EDIT_ARGS_FILE']).write_text(\n"
+            "        json.dumps(args), encoding='utf-8'\n"
+            "    )\n"
+            "else:\n"
+            "    sys.exit(2)\n",
+            encoding="utf-8",
+        )
+        (bin_dir / "gh").chmod(0o755)
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "GH_EDIT_ARGS_FILE": str(args_file),
+            "GH_RELEASE_BODY": release_body,
+            "SHA": "0123456789012345678901234567890123456789",
+            "TAG": "v0.10.0",
+        }
+        result = subprocess.run(
+            ["bash", "-c", self._publish_draft_step()["run"]],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+        return result, json.loads(args_file.read_text(encoding="utf-8"))
+
+    def test_publish_existing_draft_release_finalizes_and_records_source_marker(
+        self, tmp_path: Path
+    ) -> None:
+        """An unmarked draft is published with exactly one source-provenance marker."""
+        step = self._publish_draft_step()
+        marker = "<!-- hephaestus-source-sha:0123456789012345678901234567890123456789 -->"
+        result, args = self._run_draft_publisher(tmp_path, "Existing draft notes")
+
+        assert step["if"] == (
+            "steps.existing.outputs.exists == 'true' && steps.existing.outputs.draft == 'true'"
+        )
+        assert result.returncode == 0
+        assert args == [
+            "release",
+            "edit",
+            "v0.10.0",
+            "--draft=false",
+            "--notes",
+            f"Existing draft notes\n\n{marker}",
+        ]
+        assert args[-1].count(marker) == 1
+
+    def test_publish_existing_draft_release_does_not_duplicate_source_marker(
+        self, tmp_path: Path
+    ) -> None:
+        """A marked draft is finalized without rewriting or duplicating its marker."""
+        marker = "<!-- hephaestus-source-sha:0123456789012345678901234567890123456789 -->"
+        result, args = self._run_draft_publisher(tmp_path, f"Existing draft notes\n{marker}")
+
+        assert result.returncode == 0
+        assert args == ["release", "edit", "v0.10.0", "--draft=false"]
+
     def _resolve_step(self) -> dict[str, Any]:
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
         return next(
@@ -610,6 +694,7 @@ class TestAutoTagReleaseDispatch:
         provenance_state: str = "linked",
         tag: str = "v0.10.0",
         source_sha: str = "0123456789012345678901234567890123456789",
+        api_failure: str = "",
     ) -> subprocess.CompletedProcess[str]:
         """Execute the resolver shell with deterministic local GitHub fixtures."""
         bin_dir = tmp_path / "bin"
@@ -643,11 +728,13 @@ class TestAutoTagReleaseDispatch:
             '        [ "$GH_DEPLOYMENT_STATE" = "error" ] && exit 1\n'
             '        [ "$GH_DEPLOYMENT_STATE" = "missing" ] || echo 42 ;;\n'
             "      *'/deployments/42/statuses?per_page=1')\n"
+            '        [ "$GH_API_FAILURE" = "deployment-status" ] && exit 1\n'
             '        [ "$GH_DEPLOYMENT_STATE" = "published" ] && '
             "echo 'success\\thttps://github.com/HomericIntelligence/Hephaestus"
             "/actions/runs/300/job/400' "
             "|| echo 'failure\\t' ;;\n"
             "      *'/actions/runs/300')\n"
+            '        [ "$GH_API_FAILURE" = "action-run" ] && exit 1\n'
             '        case "$GH_PROVENANCE_STATE" in\n'
             "          unlinked) echo 'Release\\t.github/workflows/release.yml\\t"
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ;;\n"
@@ -656,6 +743,7 @@ class TestAutoTagReleaseDispatch:
             '          *) echo "Release\\t.github/workflows/release.yml\\t$GH_SOURCE_SHA" ;;\n'
             "        esac ;;\n"
             "      *'/actions/jobs/400')\n"
+            '        [ "$GH_API_FAILURE" = "action-job" ] && exit 1\n'
             '        case "$GH_PROVENANCE_STATE" in\n'
             '          cross-run-job) echo "999\\t$GH_SOURCE_SHA\\tbuild-and-publish'
             '\\tsuccess\\tsuccess\\tskipped" ;;\n'
@@ -691,6 +779,7 @@ class TestAutoTagReleaseDispatch:
             "GH_DEPLOYMENT_STATE": deployment_state,
             "GH_PROVENANCE_STATE": provenance_state,
             "GH_SOURCE_SHA": source_sha,
+            "GH_API_FAILURE": api_failure,
         }
         return subprocess.run(
             ["bash", "-c", self._resolve_step()["run"]],
@@ -781,6 +870,30 @@ class TestAutoTagReleaseDispatch:
 
         assert result.returncode == 1
         assert "Could not inspect PyPI deployments" in result.stderr
+
+    @pytest.mark.parametrize("docs_only", [False, True])
+    @pytest.mark.parametrize(
+        ("api_failure", "error"),
+        [
+            ("deployment-status", "Could not inspect PyPI deployment 42"),
+            ("action-run", "Could not inspect release workflow run 300"),
+            ("action-job", "Could not inspect release job 400"),
+        ],
+    )
+    def test_provenance_api_failure_aborts_all_recovery_modes(
+        self, tmp_path: Path, docs_only: bool, api_failure: str, error: str
+    ) -> None:
+        """Every provenance API failure prevents docs deployment and duplicate publication."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=docs_only,
+            release_state="published",
+            deployment_state="published",
+            api_failure=api_failure,
+        )
+
+        assert result.returncode == 1
+        assert error in result.stderr
 
     def test_docs_only_recovery_accepts_the_audited_v010_legacy_tuple(self, tmp_path: Path) -> None:
         """The sole pre-marker release remains recoverable only at its audited tag and SHA."""

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -581,6 +581,17 @@ class TestAutoTagReleaseDispatch:
             "needs.resolve-release.outputs.completed_release_exists != 'true')) }}"
         )
 
+    def test_new_release_records_immutable_source_provenance(self) -> None:
+        """Every newly created release records the exact source SHA used to build it."""
+        workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["build-and-publish"]["steps"]
+        create = [step for step in steps if step.get("name") == "Create GitHub Release"]
+
+        assert len(create) == 1
+        assert create[0]["with"]["body"] == (
+            "<!-- hephaestus-source-sha:${{ needs.resolve-release.outputs.sha }} -->"
+        )
+
     def _resolve_step(self) -> dict[str, Any]:
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
         return next(
@@ -629,6 +640,7 @@ class TestAutoTagReleaseDispatch:
             "          *) printf 'HTTP/2.0 500 Server Error\\n\\n{}\\n'; exit 1 ;;\n"
             "        esac ;;\n"
             '      *"/deployments?environment=pypi&sha=${GH_SOURCE_SHA}")\n'
+            '        [ "$GH_DEPLOYMENT_STATE" = "error" ] && exit 1\n'
             '        [ "$GH_DEPLOYMENT_STATE" = "missing" ] || echo 42 ;;\n'
             "      *'/deployments/42/statuses?per_page=1')\n"
             '        [ "$GH_DEPLOYMENT_STATE" = "published" ] && '
@@ -637,16 +649,25 @@ class TestAutoTagReleaseDispatch:
             "|| echo 'failure\\t' ;;\n"
             "      *'/actions/runs/300')\n"
             '        case "$GH_PROVENANCE_STATE" in\n'
-            "          unlinked) echo 'Release\\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ;;\n"
-            '          wrong-workflow) echo "Other workflow\\t$GH_SOURCE_SHA" ;;\n'
-            '          *) echo "Release\\t$GH_SOURCE_SHA" ;;\n'
+            "          unlinked) echo 'Release\\t.github/workflows/release.yml\\t"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ;;\n"
+            '          wrong-workflow) echo "Other workflow\\t.github/workflows/release.yml'
+            '\\t$GH_SOURCE_SHA" ;;\n'
+            '          *) echo "Release\\t.github/workflows/release.yml\\t$GH_SOURCE_SHA" ;;\n'
             "        esac ;;\n"
             "      *'/actions/jobs/400')\n"
-            '        [ "$GH_PROVENANCE_STATE" = "no-release" ] '
-            "&& echo 'build-and-publish\\tsuccess\\tskipped' "
-            '|| [ "$GH_PROVENANCE_STATE" = "no-publish" ] '
-            "&& echo 'build-and-publish\\tskipped\\tsuccess' "
-            "|| echo 'build-and-publish\\tsuccess\\tsuccess' ;;\n"
+            '        case "$GH_PROVENANCE_STATE" in\n'
+            '          cross-run-job) echo "999\\t$GH_SOURCE_SHA\\tbuild-and-publish'
+            '\\tsuccess\\tsuccess\\tskipped" ;;\n'
+            '          no-release) echo "300\\t$GH_SOURCE_SHA\\tbuild-and-publish'
+            '\\tsuccess\\tskipped\\tskipped" ;;\n'
+            '          no-publish) echo "300\\t$GH_SOURCE_SHA\\tbuild-and-publish'
+            '\\tskipped\\tsuccess\\tskipped" ;;\n'
+            '          finalized) echo "300\\t$GH_SOURCE_SHA\\tbuild-and-publish'
+            '\\tsuccess\\tskipped\\tsuccess" ;;\n'
+            '          *) echo "300\\t$GH_SOURCE_SHA\\tbuild-and-publish'
+            '\\tsuccess\\tsuccess\\tskipped" ;;\n'
+            "        esac ;;\n"
             "    esac ;;\n"
             "  *) exit 2 ;;\n"
             "esac\n",
@@ -690,15 +711,28 @@ class TestAutoTagReleaseDispatch:
 
         assert result.returncode == 0
 
+    def test_docs_only_recovery_accepts_a_finalized_draft_release(self, tmp_path: Path) -> None:
+        """A normal run that publishes a pre-existing draft remains docs-recoverable."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=True,
+            release_state="published",
+            deployment_state="published",
+            provenance_state="finalized",
+        )
+
+        assert result.returncode == 0
+
     @pytest.mark.parametrize(
         ("release_state", "deployment_state", "provenance_state", "tag", "error"),
         [
             ("missing", "published", "linked", "v0.10.0", "existing GitHub Release"),
-            ("draft", "published", "linked", "v0.10.0", "not published"),
+            ("draft", "published", "linked", "v0.10.0", "published GitHub Release"),
             ("published", "missing", "linked", "v0.10.0", "same release workflow run"),
             ("published", "failed", "linked", "v0.10.0", "same release workflow run"),
             ("published", "published", "unlinked", "v0.10.0", "same release workflow run"),
             ("published", "published", "wrong-workflow", "v0.10.0", "same release workflow run"),
+            ("published", "published", "cross-run-job", "v0.10.0", "same release workflow run"),
             ("published", "published", "no-publish", "v0.10.0", "same release workflow run"),
             ("published", "published", "no-release", "v0.10.0", "same release workflow run"),
             ("published", "published", "unmarked", "v0.10.1", "same release workflow run"),
@@ -733,6 +767,21 @@ class TestAutoTagReleaseDispatch:
         assert result.returncode == 1
         assert error in result.stderr
 
+    @pytest.mark.parametrize("docs_only", [False, True])
+    def test_deployment_list_failure_aborts_all_recovery_modes(
+        self, tmp_path: Path, docs_only: bool
+    ) -> None:
+        """Deployment API errors must never allow a duplicate publication attempt."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=docs_only,
+            release_state="published",
+            deployment_state="error",
+        )
+
+        assert result.returncode == 1
+        assert "Could not inspect PyPI deployments" in result.stderr
+
     def test_docs_only_recovery_accepts_the_audited_v010_legacy_tuple(self, tmp_path: Path) -> None:
         """The sole pre-marker release remains recoverable only at its audited tag and SHA."""
         result = self._run_resolver(
@@ -756,6 +805,17 @@ class TestAutoTagReleaseDispatch:
         )
         assert wrong_source.returncode == 1
 
+        wrong_tag = self._run_resolver(
+            tmp_path / "wrong-tag",
+            docs_only=True,
+            release_state="published",
+            deployment_state="published",
+            provenance_state="unmarked",
+            tag="v0.10.1",
+            source_sha="99a5437fc351fd7737fc85e7d4d76504d88a00d1",
+        )
+        assert wrong_tag.returncode == 1
+
     def test_normal_release_continues_for_manual_partial_release(self, tmp_path: Path) -> None:
         """An existing manual release does not suppress a missing PyPI publication."""
         result = self._run_resolver(
@@ -769,6 +829,34 @@ class TestAutoTagReleaseDispatch:
         assert "completed_release_exists=false" in (tmp_path / "github-output").read_text(
             encoding="utf-8"
         )
+
+    def test_normal_release_allows_a_draft_to_be_completed(self, tmp_path: Path) -> None:
+        """A draft remains eligible for normal publish-and-finalize recovery."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=False,
+            release_state="draft",
+            deployment_state="missing",
+        )
+
+        assert result.returncode == 0
+        assert "completed_release_exists=false" in (tmp_path / "github-output").read_text(
+            encoding="utf-8"
+        )
+
+    def test_normal_release_rejects_unprovenanced_published_release(self, tmp_path: Path) -> None:
+        """A published immutable release without source provenance is not safely retryable."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=False,
+            release_state="published",
+            deployment_state="missing",
+            provenance_state="unmarked",
+            tag="v0.10.1",
+        )
+
+        assert result.returncode == 1
+        assert "lacks immutable source provenance" in result.stderr
 
     def test_normal_release_marks_linked_publication_as_duplicate(self, tmp_path: Path) -> None:
         """A queued duplicate release becomes a no-op only after the linked release completed."""

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -531,13 +533,6 @@ class TestAutoTagReleaseDispatch:
         assert "### Dispatch failed after tag push" in doc
         assert "gh workflow run release.yml -f tag=vX.Y.Z" in doc
 
-    def test_releasing_doc_has_docs_only_recovery_command(self) -> None:
-        """A published release with failed docs needs a no-republish recovery command."""
-        doc = (REPO_ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
-
-        assert "### Docs-only recovery after publication" in doc
-        assert "gh workflow run release.yml --ref main -f tag=vX.Y.Z -f docs_only=true" in doc
-
     def test_release_concurrency_keys_on_resolved_tag(self) -> None:
         """Dispatched and tag-push release runs must serialize per tag, not per branch.
 
@@ -556,23 +551,22 @@ class TestAutoTagReleaseDispatch:
         inputs = workflow[True]["workflow_dispatch"]["inputs"]
 
         assert inputs["tag"]["required"] is True
-        assert inputs["docs_only"] == {
-            "description": (
-                "Deploy documentation for an existing published release without publishing."
-            ),
-            "required": False,
-            "default": False,
-            "type": "boolean",
-        }
+        docs_only = inputs["docs_only"]
+        assert docs_only["required"] is False
+        assert docs_only["default"] is False
+        assert docs_only["type"] == "boolean"
 
     def test_docs_only_recovery_skips_normal_release_jobs(self) -> None:
         """Docs recovery keeps tag validation but skips test, publish, and release writes."""
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
         jobs = workflow["jobs"]
 
-        assert jobs["test"]["if"] == "${{ !inputs.docs_only }}"
-        assert jobs["type-check"]["if"] == "${{ !inputs.docs_only }}"
-        assert jobs["build-and-publish"]["if"] == "${{ !inputs.docs_only }}"
+        duplicate_guard = "needs.resolve-release.outputs.release_exists != 'true'"
+        assert jobs["test"]["if"] == f"${{{{ !inputs.docs_only && {duplicate_guard} }}}}"
+        assert jobs["type-check"]["if"] == f"${{{{ !inputs.docs_only && {duplicate_guard} }}}}"
+        assert (
+            jobs["build-and-publish"]["if"] == f"${{{{ !inputs.docs_only && {duplicate_guard} }}}}"
+        )
         assert jobs["deploy-docs"]["needs"] == [
             "resolve-release",
             "test",
@@ -583,21 +577,128 @@ class TestAutoTagReleaseDispatch:
             "${{ always() && needs.resolve-release.result == 'success' && "
             "(inputs.docs_only || (needs.test.result == 'success' && "
             "needs.type-check.result == 'success' && "
-            "needs.build-and-publish.result == 'success')) }}"
+            "needs.build-and-publish.result == 'success' && "
+            "needs.resolve-release.outputs.release_exists != 'true')) }}"
         )
 
-    def test_docs_only_recovery_requires_an_existing_release(self) -> None:
-        """A docs-only dispatch is restricted to an already-published release tag."""
+    def _resolve_step(self) -> dict[str, Any]:
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
-        resolve_step = next(
+        return next(
             step
             for step in workflow["jobs"]["resolve-release"]["steps"]
             if step.get("id") == "resolve"
         )
 
-        assert resolve_step["env"]["DOCS_ONLY"] == "${{ inputs.docs_only }}"
-        assert resolve_step["env"]["GH_TOKEN"] == "${{ github.token }}"  # noqa: S105
-        assert 'gh release view "$TAG" --json isDraft -q .isDraft' in resolve_step["run"]
+    def _run_resolver(
+        self,
+        tmp_path: Path,
+        *,
+        docs_only: bool,
+        release_state: str,
+        deployment_state: str,
+    ) -> subprocess.CompletedProcess[str]:
+        """Execute the resolver shell with deterministic local GitHub fixtures."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "git").write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "rev-parse" ]; then echo 0123456789012345678901234567890123456789; fi\n',
+            encoding="utf-8",
+        )
+        (bin_dir / "gh").write_text(
+            "#!/bin/sh\n"
+            'case "$1" in\n'
+            "  release)\n"
+            '    case "$GH_RELEASE_STATE" in\n'
+            "      published) echo false ;;\n"
+            "      draft) echo true ;;\n"
+            "      *) exit 1 ;;\n"
+            "    esac ;;\n"
+            "  api)\n"
+            '    case "$2" in\n'
+            "      *'/deployments?environment=pypi&sha=0123456789012345678901234567890123456789')\n"
+            '        [ "$GH_DEPLOYMENT_STATE" = "missing" ] || echo 42 ;;\n'
+            "      *'/deployments/42/statuses?per_page=1')\n"
+            '        [ "$GH_DEPLOYMENT_STATE" = "published" ] && echo success || echo failure ;;\n'
+            "    esac ;;\n"
+            "  *) exit 2 ;;\n"
+            "esac\n",
+            encoding="utf-8",
+        )
+        for command in (bin_dir / "git", bin_dir / "gh"):
+            command.chmod(0o755)
+
+        output = tmp_path / "github-output"
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "INPUT_TAG": "v0.10.0",
+            "EVENT_REF": "refs/heads/main",
+            "DOCS_ONLY": str(docs_only).lower(),
+            "GH_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "HomericIntelligence/Hephaestus",
+            "REPOSITORY": "HomericIntelligence/Hephaestus",
+            "GITHUB_OUTPUT": str(output),
+            "GH_RELEASE_STATE": release_state,
+            "GH_DEPLOYMENT_STATE": deployment_state,
+        }
+        return subprocess.run(
+            ["bash", "-c", self._resolve_step()["run"]],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+    def test_docs_only_recovery_accepts_published_release_source(self, tmp_path: Path) -> None:
+        """Docs-only recovery accepts only source already published through PyPI."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=True,
+            release_state="published",
+            deployment_state="published",
+        )
+
+        assert result.returncode == 0
+
+    @pytest.mark.parametrize(
+        ("release_state", "deployment_state", "error"),
+        [
+            ("missing", "published", "existing GitHub Release"),
+            ("draft", "published", "published GitHub Release"),
+            ("published", "missing", "successful PyPI deployment"),
+            ("published", "failed", "successful PyPI deployment"),
+        ],
+    )
+    def test_docs_only_recovery_rejects_unpublished_source(
+        self,
+        tmp_path: Path,
+        release_state: str,
+        deployment_state: str,
+        error: str,
+    ) -> None:
+        """Docs-only recovery must not deploy an unpublished or retargeted source."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=True,
+            release_state=release_state,
+            deployment_state=deployment_state,
+        )
+
+        assert result.returncode == 1
+        assert error in result.stderr
+
+    def test_normal_release_marks_existing_release_as_duplicate(self, tmp_path: Path) -> None:
+        """A queued duplicate normal release becomes a no-op before privileged jobs run."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=False,
+            release_state="published",
+            deployment_state="missing",
+        )
+
+        assert result.returncode == 0
+        assert "release_exists=true" in (tmp_path / "github-output").read_text(encoding="utf-8")
 
 
 class TestReleaseAttestations:

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -561,7 +561,7 @@ class TestAutoTagReleaseDispatch:
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
         jobs = workflow["jobs"]
 
-        duplicate_guard = "needs.resolve-release.outputs.release_exists != 'true'"
+        duplicate_guard = "needs.resolve-release.outputs.completed_release_exists != 'true'"
         assert jobs["test"]["if"] == f"${{{{ !inputs.docs_only && {duplicate_guard} }}}}"
         assert jobs["type-check"]["if"] == f"${{{{ !inputs.docs_only && {duplicate_guard} }}}}"
         assert (
@@ -578,7 +578,7 @@ class TestAutoTagReleaseDispatch:
             "(inputs.docs_only || (needs.test.result == 'success' && "
             "needs.type-check.result == 'success' && "
             "needs.build-and-publish.result == 'success' && "
-            "needs.resolve-release.outputs.release_exists != 'true')) }}"
+            "needs.resolve-release.outputs.completed_release_exists != 'true')) }}"
         )
 
     def _resolve_step(self) -> dict[str, Any]:
@@ -596,30 +596,57 @@ class TestAutoTagReleaseDispatch:
         docs_only: bool,
         release_state: str,
         deployment_state: str,
+        provenance_state: str = "linked",
+        tag: str = "v0.10.0",
+        source_sha: str = "0123456789012345678901234567890123456789",
     ) -> subprocess.CompletedProcess[str]:
         """Execute the resolver shell with deterministic local GitHub fixtures."""
         bin_dir = tmp_path / "bin"
-        bin_dir.mkdir()
+        bin_dir.mkdir(parents=True)
         (bin_dir / "git").write_text(
-            "#!/bin/sh\n"
-            'if [ "$1" = "rev-parse" ]; then echo 0123456789012345678901234567890123456789; fi\n',
+            '#!/bin/sh\nif [ "$1" = "rev-parse" ]; then echo "$GH_SOURCE_SHA"; fi\n',
             encoding="utf-8",
         )
         (bin_dir / "gh").write_text(
             "#!/bin/sh\n"
             'case "$1" in\n'
-            "  release)\n"
-            '    case "$GH_RELEASE_STATE" in\n'
-            "      published) echo false ;;\n"
-            "      draft) echo true ;;\n"
-            "      *) exit 1 ;;\n"
-            "    esac ;;\n"
             "  api)\n"
             '    case "$2" in\n'
-            "      *'/deployments?environment=pypi&sha=0123456789012345678901234567890123456789')\n"
+            "      --include)\n"
+            '        case "$GH_RELEASE_STATE" in\n'
+            "          published)\n"
+            '            if [ "$GH_PROVENANCE_STATE" = "unmarked" ]; then\n'
+            '              printf \'HTTP/2.0 200 OK\\n\\n{"draft":false,'
+            '"immutable":true,"body":""}\\n\'\n'
+            "            else\n"
+            '              printf \'HTTP/2.0 200 OK\\n\\n{"draft":false,'
+            '"immutable":true,"body":"<!-- hephaestus-source-sha:%s -->"}'
+            '\\n\' "$GH_SOURCE_SHA"\n'
+            "            fi ;;\n"
+            '          draft) printf \'HTTP/2.0 200 OK\\n\\n{"draft":true,'
+            '"immutable":true,"body":""}\\n\' ;;\n'
+            "          missing) printf 'HTTP/2.0 404 Not Found\\n\\n{}\\n'; exit 1 ;;\n"
+            "          *) printf 'HTTP/2.0 500 Server Error\\n\\n{}\\n'; exit 1 ;;\n"
+            "        esac ;;\n"
+            '      *"/deployments?environment=pypi&sha=${GH_SOURCE_SHA}")\n'
             '        [ "$GH_DEPLOYMENT_STATE" = "missing" ] || echo 42 ;;\n'
             "      *'/deployments/42/statuses?per_page=1')\n"
-            '        [ "$GH_DEPLOYMENT_STATE" = "published" ] && echo success || echo failure ;;\n'
+            '        [ "$GH_DEPLOYMENT_STATE" = "published" ] && '
+            "echo 'success\\thttps://github.com/HomericIntelligence/Hephaestus"
+            "/actions/runs/300/job/400' "
+            "|| echo 'failure\\t' ;;\n"
+            "      *'/actions/runs/300')\n"
+            '        case "$GH_PROVENANCE_STATE" in\n'
+            "          unlinked) echo 'Release\\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ;;\n"
+            '          wrong-workflow) echo "Other workflow\\t$GH_SOURCE_SHA" ;;\n'
+            '          *) echo "Release\\t$GH_SOURCE_SHA" ;;\n'
+            "        esac ;;\n"
+            "      *'/actions/jobs/400')\n"
+            '        [ "$GH_PROVENANCE_STATE" = "no-release" ] '
+            "&& echo 'build-and-publish\\tsuccess\\tskipped' "
+            '|| [ "$GH_PROVENANCE_STATE" = "no-publish" ] '
+            "&& echo 'build-and-publish\\tskipped\\tsuccess' "
+            "|| echo 'build-and-publish\\tsuccess\\tsuccess' ;;\n"
             "    esac ;;\n"
             "  *) exit 2 ;;\n"
             "esac\n",
@@ -632,7 +659,7 @@ class TestAutoTagReleaseDispatch:
         env = {
             **os.environ,
             "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-            "INPUT_TAG": "v0.10.0",
+            "INPUT_TAG": tag,
             "EVENT_REF": "refs/heads/main",
             "DOCS_ONLY": str(docs_only).lower(),
             "GH_TOKEN": "test-token",
@@ -641,6 +668,8 @@ class TestAutoTagReleaseDispatch:
             "GITHUB_OUTPUT": str(output),
             "GH_RELEASE_STATE": release_state,
             "GH_DEPLOYMENT_STATE": deployment_state,
+            "GH_PROVENANCE_STATE": provenance_state,
+            "GH_SOURCE_SHA": source_sha,
         }
         return subprocess.run(
             ["bash", "-c", self._resolve_step()["run"]],
@@ -650,8 +679,8 @@ class TestAutoTagReleaseDispatch:
             text=True,
         )
 
-    def test_docs_only_recovery_accepts_published_release_source(self, tmp_path: Path) -> None:
-        """Docs-only recovery accepts only source already published through PyPI."""
+    def test_docs_only_recovery_accepts_linked_published_release(self, tmp_path: Path) -> None:
+        """Docs-only recovery accepts only the release workflow that published this SHA."""
         result = self._run_resolver(
             tmp_path,
             docs_only=True,
@@ -662,12 +691,24 @@ class TestAutoTagReleaseDispatch:
         assert result.returncode == 0
 
     @pytest.mark.parametrize(
-        ("release_state", "deployment_state", "error"),
+        ("release_state", "deployment_state", "provenance_state", "tag", "error"),
         [
-            ("missing", "published", "existing GitHub Release"),
-            ("draft", "published", "published GitHub Release"),
-            ("published", "missing", "successful PyPI deployment"),
-            ("published", "failed", "successful PyPI deployment"),
+            ("missing", "published", "linked", "v0.10.0", "existing GitHub Release"),
+            ("draft", "published", "linked", "v0.10.0", "not published"),
+            ("published", "missing", "linked", "v0.10.0", "same release workflow run"),
+            ("published", "failed", "linked", "v0.10.0", "same release workflow run"),
+            ("published", "published", "unlinked", "v0.10.0", "same release workflow run"),
+            ("published", "published", "wrong-workflow", "v0.10.0", "same release workflow run"),
+            ("published", "published", "no-publish", "v0.10.0", "same release workflow run"),
+            ("published", "published", "no-release", "v0.10.0", "same release workflow run"),
+            ("published", "published", "unmarked", "v0.10.1", "same release workflow run"),
+            (
+                "error",
+                "published",
+                "linked",
+                "v0.10.0",
+                "Could not inspect existing GitHub Release",
+            ),
         ],
     )
     def test_docs_only_recovery_rejects_unpublished_source(
@@ -675,6 +716,8 @@ class TestAutoTagReleaseDispatch:
         tmp_path: Path,
         release_state: str,
         deployment_state: str,
+        provenance_state: str,
+        tag: str,
         error: str,
     ) -> None:
         """Docs-only recovery must not deploy an unpublished or retargeted source."""
@@ -683,13 +726,38 @@ class TestAutoTagReleaseDispatch:
             docs_only=True,
             release_state=release_state,
             deployment_state=deployment_state,
+            provenance_state=provenance_state,
+            tag=tag,
         )
 
         assert result.returncode == 1
         assert error in result.stderr
 
-    def test_normal_release_marks_existing_release_as_duplicate(self, tmp_path: Path) -> None:
-        """A queued duplicate normal release becomes a no-op before privileged jobs run."""
+    def test_docs_only_recovery_accepts_the_audited_v010_legacy_tuple(self, tmp_path: Path) -> None:
+        """The sole pre-marker release remains recoverable only at its audited tag and SHA."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=True,
+            release_state="published",
+            deployment_state="published",
+            provenance_state="unmarked",
+            source_sha="99a5437fc351fd7737fc85e7d4d76504d88a00d1",
+        )
+
+        assert result.returncode == 0
+
+        wrong_source = self._run_resolver(
+            tmp_path / "wrong-source",
+            docs_only=True,
+            release_state="published",
+            deployment_state="published",
+            provenance_state="unmarked",
+            source_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        assert wrong_source.returncode == 1
+
+    def test_normal_release_continues_for_manual_partial_release(self, tmp_path: Path) -> None:
+        """An existing manual release does not suppress a missing PyPI publication."""
         result = self._run_resolver(
             tmp_path,
             docs_only=False,
@@ -698,7 +766,23 @@ class TestAutoTagReleaseDispatch:
         )
 
         assert result.returncode == 0
-        assert "release_exists=true" in (tmp_path / "github-output").read_text(encoding="utf-8")
+        assert "completed_release_exists=false" in (tmp_path / "github-output").read_text(
+            encoding="utf-8"
+        )
+
+    def test_normal_release_marks_linked_publication_as_duplicate(self, tmp_path: Path) -> None:
+        """A queued duplicate release becomes a no-op only after the linked release completed."""
+        result = self._run_resolver(
+            tmp_path,
+            docs_only=False,
+            release_state="published",
+            deployment_state="published",
+        )
+
+        assert result.returncode == 0
+        assert "completed_release_exists=true" in (tmp_path / "github-output").read_text(
+            encoding="utf-8"
+        )
 
 
 class TestReleaseAttestations:


### PR DESCRIPTION
Closes #2415

Adds a guarded docs_only dispatch mode for an existing published release tag. It skips all PyPI and GitHub-release writes, reuses the immutable tagged source for pdoc, and deploys only Pages. Manual dispatches require an explicit tag, and tag pushes and dispatches share one per-tag concurrency key.

Recovery accepts a release only after proving that the same Release workflow run successfully published the exact tag SHA to PyPI and created or finalized the GitHub Release. All lookup failures stop safely. The sole legacy exception is the audited v0.10.0 tag and SHA.

Verification:
- 110 targeted workflow and API-reference tests passed
- full pre-commit suite passed
- full 6,668-test pre-push suite passed
- six independent final reviews approved the exact signed head