### PR TITLE
fix(automation): bound merge-wait polls

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -929,7 +929,7 @@ budgets. Every `routes.py` row and every doc row MUST agree.
 | `plan_review` | `IMPLEMENTATION` | `nogo` → `PLANNING`; `plan_cycles_exhausted` → `FINISHED`; `*` → `PLANNING` | `plan_review_iter = 3`, `plan_cycles = 2` |
 | `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `test_fix = 1` |
 | `pr_review` | `MERGE_WAIT` | `agent_error` → `IMPLEMENTATION`; `human_blocked` → `FINISHED`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
-| `merge_wait` | `FINISHED` | `not_implementation_go` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | (none) |
+| `merge_wait` | `FINISHED` | `not_implementation_go` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | `merge = DEFAULT_DRIVE_GREEN_LOOPS = 5` |
 | `finished` | `FINISHED` | — (terminal) | — |
 
 Budget provenance (cross-check):

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -256,10 +256,9 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=5,
         help=(
-            "Per-issue drive-green loop iterations before the issue is tagged "
-            "state:skip and the worker moves on (default: 5; replaces "
-            "--max-merge-attempts, whose default of 1 skip-parked issues on a "
-            "single transient failure)."
+            "Maximum pending polls of a current-run auto-merge arm per issue before "
+            "merge-wait stops the item without changing labels (default: 5; replaces "
+            "--max-merge-attempts)."
         ),
     )
     p.add_argument(

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -101,6 +101,17 @@ def _parse_repo_list(value: str) -> list[str]:
     return [s.strip() for s in value.split(",") if s.strip()]
 
 
+def _parse_positive_int(value: str) -> int:
+    """Parse one strictly positive integer for a bounded CLI setting."""
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}") from exc
+    if number <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {number}")
+    return number
+
+
 def _parse_positive_int_list(value: str, label: str) -> list[int]:
     """Split a comma-separated list into positive integers."""
     numbers: list[int] = []
@@ -186,9 +197,9 @@ class LoopConfig:
     # default is ``ALL_SELECTABLE`` (set in the parser), so an operator opts
     # into the blocking drive-green by default.
     phases: tuple[str, ...] = ALL_PHASES
-    # Bound on per-issue drive-green loop iterations before the issue is
-    # tagged ``state:skip`` (#2246, previously ``max_merge_attempts`` #1560).
-    # Defaults to 5 so one transient failure no longer parks an issue.
+    # Bound on pending polls of a current-run auto-merge arm per issue.
+    # Exhaustion stops the item with a non-success outcome and never mutates
+    # labels. The default of 5 tolerates transient pending merge state.
     drive_green_loops: int = 5
     # When True (default), never dispatch two issues whose plans touch the same
     # file concurrently — defer the later one (#1623).
@@ -253,7 +264,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
     p.add_argument(
         "--drive-green-loops",
-        type=int,
+        type=_parse_positive_int,
         default=5,
         help=(
             "Maximum pending polls of a current-run auto-merge arm per issue before "

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -138,7 +138,7 @@ ROUTES: dict[StageName, Route] = {
             "not_implementation_go": StageName.PR_REVIEW,
             "*": StageName.FINISHED,
         },
-        budgets={},
+        budgets={"merge": DEFAULT_DRIVE_GREEN_LOOPS},
     ),
     StageName.FINISHED: Route(next=StageName.FINISHED),
 }

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -5,7 +5,7 @@ loop-owned ``state:implementation-go`` label.  This stage consumes that
 label once, asks GitHub to arm auto-merge for the live head, and then polls
 only the arm it created.  It deliberately does not recover, confirm, retry,
 or take over an arm created by another process or run: those operational
-states are warned about and left for an operator.
+states are blocked and left for an operator.
 
 The implemented mini-state graph is:
 
@@ -118,7 +118,7 @@ class MergeWaitStage(Stage):
             logger.warning(
                 "merge_wait: PR #%d is already armed; leaving it to the operator", item.pr
             )
-            return StageOutcome(Disposition.FINISH_PASS, "auto_merge_already_armed")
+            return StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
         has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
         if not has_go:
             return StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
@@ -172,7 +172,19 @@ class MergeWaitStage(Stage):
             logger.warning(
                 "merge_wait: PR #%d was armed outside this run; leaving it to the operator", item.pr
             )
-            return StageOutcome(Disposition.FINISH_PASS, "auto_merge_already_armed")
+            return StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+        attempt = item.attempts.get("merge", 0) + 1
+        item.attempts["merge"] = attempt
+        budget = ctx.budget("merge")
+        if attempt >= budget:
+            logger.warning(
+                "merge_wait:%s: PR #%d remains pending after %d/%d own-arm polls; stopping",
+                item.issue,
+                item.pr,
+                attempt,
+                budget,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_wait_exhausted")
         item.payload["retry_delay_s"] = 30
         return StageOutcome(Disposition.RETRY, "merge_pending")
 

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -33,7 +33,7 @@ def test_loop_owned_implementation_go_arms_once_without_durable_recovery(
     assert item.armed is True
 
 
-def test_existing_auto_merge_is_warned_and_left_to_the_operator(
+def test_existing_auto_merge_is_blocked_and_left_to_the_operator(
     make_ctx: Any, make_work_item: Any, caplog: Any
 ) -> None:
     """An arm observed before this run never triggers recovery or re-arming."""
@@ -47,8 +47,9 @@ def test_existing_auto_merge_is_warned_and_left_to_the_operator(
 
     result = MergeWaitStage().step(item, make_ctx(github=github))
 
-    assert result == StageOutcome(Disposition.FINISH_PASS, "auto_merge_already_armed")
+    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
     assert not any(action == "arm_auto_merge" for action, _ in github.mutation_log)
+    assert item.attempts["merge"] == 0
     assert "already armed" in caplog.text
 
 
@@ -84,6 +85,105 @@ def test_lost_own_arm_is_warned_and_stops_without_retrying(
     assert result == StageOutcome(Disposition.FINISH_FAIL, "auto_merge_no_longer_armed")
     assert not any(action == "arm_auto_merge" for action, _ in github.mutation_log)
     assert "operator" in caplog.text
+
+
+def test_closed_pr_stops_without_mutating_or_consuming_merge_budget(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A closed-unmerged PR is terminal before merge-arm handling."""
+    github = _ArmingGitHub()
+    github._pr_state = {"state": "CLOSED"}
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+    item.armed = True
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "closed")
+    assert github.mutation_log == []
+    assert item.attempts["merge"] == 0
+
+
+def test_unavailable_pr_state_stops_without_mutating_or_consuming_merge_budget(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """An API/read failure is terminal before merge-arm handling."""
+    github = _ArmingGitHub()
+    github._pr_state = None
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+    item.armed = True
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
+    assert github.mutation_log == []
+    assert item.attempts["merge"] == 0
+
+
+def test_poll_external_auto_merge_is_blocked_without_consuming_merge_budget(
+    make_ctx: Any, make_work_item: Any, caplog: Any
+) -> None:
+    """A POLL restart never claims an arm it did not create."""
+    github = _ArmingGitHub()
+    github._pr_state = {
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "autoMergeRequest": {"enabledAt": "elsewhere"},
+    }
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+    assert github.mutation_log == []
+    assert item.attempts["merge"] == 0
+    assert "retry_delay_s" not in item.payload
+    assert "armed outside this run" in caplog.text
+
+
+def test_own_arm_poll_stops_at_the_configured_merge_budget(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """Only pending polls of this run's arm consume the merge budget."""
+    github = _ArmingGitHub()
+    github._pr_state = {
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "autoMergeRequest": {"enabledAt": "this-run"},
+    }
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+    item.armed = True
+    ctx = make_ctx(github=github, budget_fn=lambda name: 2 if name == "merge" else 1)
+
+    first = MergeWaitStage().step(item, ctx)
+
+    assert first == StageOutcome(Disposition.RETRY, "merge_pending")
+    assert item.attempts["merge"] == 1
+    assert item.payload.pop("retry_delay_s") == 30
+
+    second = MergeWaitStage().step(item, ctx)
+
+    assert second == StageOutcome(Disposition.FINISH_FAIL, "merge_wait_exhausted")
+    assert item.attempts["merge"] == 2
+    assert "retry_delay_s" not in item.payload
+
+
+def test_own_arm_poll_honors_a_single_poll_merge_budget(make_ctx: Any, make_work_item: Any) -> None:
+    """A one-poll override finishes after the first unresolved own-arm poll."""
+    github = _ArmingGitHub()
+    github._pr_state = {
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "autoMergeRequest": {"enabledAt": "this-run"},
+    }
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+    item.armed = True
+    ctx = make_ctx(github=github, budget_fn=lambda _name: 1)
+
+    result = MergeWaitStage().step(item, ctx)
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_wait_exhausted")
+    assert item.attempts["merge"] == 1
+    assert "retry_delay_s" not in item.payload
 
 
 def test_missing_implementation_go_returns_to_review(make_ctx: Any, make_work_item: Any) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -155,10 +155,11 @@ def test_own_arm_poll_stops_at_the_configured_merge_budget(
     ctx = make_ctx(github=github, budget_fn=lambda name: 2 if name == "merge" else 1)
 
     first = MergeWaitStage().step(item, ctx)
+    retry_delay_s = item.payload.pop("retry_delay_s")
 
     assert first == StageOutcome(Disposition.RETRY, "merge_pending")
     assert item.attempts["merge"] == 1
-    assert item.payload.pop("retry_delay_s") == 30
+    assert retry_delay_s == 30
 
     second = MergeWaitStage().step(item, ctx)
 

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -223,7 +223,7 @@ class TestROUTES:
                     "not_implementation_go": StageName.PR_REVIEW,
                     "*": StageName.FINISHED,
                 },
-                budgets={},
+                budgets={"merge": routing.DEFAULT_DRIVE_GREEN_LOOPS},
             ),
             StageName.FINISHED: Route(next=StageName.FINISHED),
         }

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -578,10 +578,9 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "_StoreAction",
             5,
             help_text=(
-                "Per-issue drive-green loop iterations before the issue is tagged "
-                "state:skip and the worker moves on (default: 5; replaces "
-                "--max-merge-attempts, whose default of 1 skip-parked issues on a "
-                "single transient failure)."
+                "Maximum pending polls of a current-run auto-merge arm per issue before "
+                "merge-wait stops the item without changing labels (default: 5; replaces "
+                "--max-merge-attempts)."
             ),
         ),
         _action_spec(

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -138,6 +138,14 @@ def test_parse_args_accepts_drive_green_loops() -> None:
     assert loop_runner._parse_args([]).drive_green_loops == 5
 
 
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_parse_args_rejects_non_positive_drive_green_loops(bad: str) -> None:
+    """The merge-poll budget must leave at least one current-run poll available."""
+    with pytest.raises(SystemExit) as excinfo:
+        loop_runner._parse_args(["--drive-green-loops", bad])
+    assert excinfo.value.code == 2
+
+
 def test_parse_args_accepts_issue_scope() -> None:
     """The loop runner can scope child phases to a comma-separated issue list."""
     args = loop_runner._parse_args(["--issues", "8, 13"])


### PR DESCRIPTION
## Summary

- bound merge-wait polling for auto-merge arms created by the current run with the configured `--drive-green-loops` budget
- report externally armed, still-open PRs as blocked without mutating the external arm
- align the routing table, CLI help, architecture contract, and direct lifecycle coverage

## Root cause

The queue passed the configured merge budget into the pipeline, but the merge-wait route did not declare that budget and the pending-poll path never consumed it. An open owned arm could therefore retry indefinitely.

## Validation

- `uv run --all-extras --locked pytest --no-cov -q tests/unit/automation/pipeline/stages/test_stage_merge_wait.py tests/unit/automation/pipeline/test_routing.py tests/unit/automation/pipeline/test_pipeline_flag.py tests/unit/automation/test_loop_runner.py tests/unit/automation/test_automation_parsers.py tests/unit/docs/test_automation_loop_architecture.py` (156 passed)
- Ruff, format check, mypy, and `git diff --check`
- Independent semantic and quality swarm reviews; their lifecycle coverage findings were addressed

Closes #2386