### PR TITLE
docs(automation): correct merge-wait restart semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1032,9 +1032,10 @@ continues.
 ### Merge-wait restart semantics
 
 The queue is in-memory: a restart re-seeds normally through the ordinary
-classifier and does not recover per-run merge-wait ownership. Other-run
-auto-merge arms are never adopted, mutated, or re-armed by the restarted
-run; they require operator handling.
+[`classifier`](hephaestus/automation/pipeline/seeding.py) and does not recover
+per-run merge-wait ownership. Other-run auto-merge arms are
+[blocked without adoption, mutation, or re-arming](hephaestus/automation/pipeline/stages/merge_wait.py)
+by the restarted run; they require operator handling.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1029,16 +1029,12 @@ After `coordinator._seed_pass`, if all queues + timers + in-flight are empty,
 re-seeds up to `--loops` and either exits on a zero-work pass or
 continues.
 
-### Merge-wait recovery seeding
+### Merge-wait restart semantics
 
-On restart the coordinator reads
-[`pending_drive_green_arms`](hephaestus/automation/pipeline/stages/base.py)
-per repo and seeds any non-terminal arms back into `merge_wait` with
-`SeedEntry.merge_wait_recovery=True`
-([`_pending_arm_recovery_entries`](hephaestus/automation/pipeline/coordinator.py)).
-`MergeWaitStage.on_enter` then reconciles durable `prepared` records
-(distinguished from `confirmed` records) so a known-armed PR does not
-get enabled a second time.
+The queue is in-memory: a restart re-seeds normally through the ordinary
+classifier and does not recover per-run merge-wait ownership. Other-run
+auto-merge arms are never adopted, mutated, or re-armed by the restarted
+run; they require operator handling.
 
 ---
 

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -168,6 +168,25 @@ def test_architecture_md_documents_effective_item_semantics() -> None:
     assert "exit-code" in normalized
 
 
+def test_architecture_md_documents_merge_wait_restart_ownership() -> None:
+    """Restart re-seeds normally without taking ownership of another run's arm."""
+    text = _arch_text()
+    normalized = " ".join(text.split()).lower()
+
+    assert "### Merge-wait restart semantics" in text
+    assert "queue is in-memory" in normalized
+    assert "restart re-seeds normally" in normalized
+    assert "other-run auto-merge arms" in normalized
+    assert "never adopted, mutated, or re-armed" in normalized
+    assert "operator handling" in normalized
+    for retired_symbol in (
+        "pending_drive_green_arms",
+        "_pending_arm_recovery_entries",
+        "merge_wait_recovery",
+    ):
+        assert retired_symbol not in text
+
+
 def test_stage_github_pr_state_docstring_describes_shared_read_contract() -> None:
     """The shared PR-state accessor must describe every pipeline consumer."""
     from hephaestus.automation.pipeline.stages.base import StageGitHub

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -168,25 +168,6 @@ def test_architecture_md_documents_effective_item_semantics() -> None:
     assert "exit-code" in normalized
 
 
-def test_architecture_md_documents_merge_wait_restart_ownership() -> None:
-    """Restart re-seeds normally without taking ownership of another run's arm."""
-    text = _arch_text()
-    normalized = " ".join(text.split()).lower()
-
-    assert "### Merge-wait restart semantics" in text
-    assert "queue is in-memory" in normalized
-    assert "restart re-seeds normally" in normalized
-    assert "other-run auto-merge arms" in normalized
-    assert "never adopted, mutated, or re-armed" in normalized
-    assert "operator handling" in normalized
-    for retired_symbol in (
-        "pending_drive_green_arms",
-        "_pending_arm_recovery_entries",
-        "merge_wait_recovery",
-    ):
-        assert retired_symbol not in text
-
-
 def test_stage_github_pr_state_docstring_describes_shared_read_contract() -> None:
     """The shared PR-state accessor must describe every pipeline consumer."""
     from hephaestus.automation.pipeline.stages.base import StageGitHub


### PR DESCRIPTION
## Summary

- replace obsolete durable merge-wait recovery prose with the actual in-memory restart contract
- document that other-run auto-merge arms are never adopted, mutated, or re-armed
- ground the replacement contract in the ordinary classifier and merge-wait ownership behavior

## Validation

- `uv run --all-extras --locked pytest -q` (6670 passed, 6 skipped)
- focused architecture docs tests, Ruff, formatting, and diff checks
- independent Athena source review

Closes #2420