### PR TITLE
fix(automation): contain lost merge approval

### DIFF
--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -157,12 +157,6 @@ class MergeWaitStage(Stage):
                 "merge_wait: PR #%d state unavailable; operator action required", item.pr
             )
             return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
-        has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
-        if not has_go:
-            logger.warning(
-                "merge_wait: PR #%d approval disappeared; operator action required", item.pr
-            )
-            return StageOutcome(Disposition.FINISH_FAIL, "not_implementation_go")
         if not pr_state.get("autoMergeRequest"):
             logger.warning(
                 "merge_wait: PR #%d is no longer armed; operator action required", item.pr
@@ -173,6 +167,21 @@ class MergeWaitStage(Stage):
                 "merge_wait: PR #%d was armed outside this run; leaving it to the operator", item.pr
             )
             return StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+        has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
+        if not has_go:
+            try:
+                ctx.github.defer_auto_merge(item.pr)
+            except Exception as exc:
+                logger.warning(
+                    "merge_wait: could not defer PR #%d after approval disappeared (%s); "
+                    "operator action required",
+                    item.pr,
+                    exc,
+                )
+                return StageOutcome(Disposition.FINISH_FAIL, "auto_merge_defer_failed")
+            item.armed = False
+            logger.warning("merge_wait: PR #%d approval disappeared; returning to review", item.pr)
+            return StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
         attempt = item.attempts.get("merge", 0) + 1
         item.attempts["merge"] = attempt
         budget = ctx.budget("merge")

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -140,6 +140,26 @@ def test_poll_external_auto_merge_is_blocked_without_consuming_merge_budget(
     assert "armed outside this run" in caplog.text
 
 
+def test_poll_external_auto_merge_without_approval_remains_blocked(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """An external arm remains operator-owned even after its approval changes."""
+    github = _ArmingGitHub(labels=(False, False))
+    github._pr_state = {
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "autoMergeRequest": {"enabledAt": "elsewhere"},
+    }
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+    assert github.mutation_log == []
+    assert item.attempts["merge"] == 0
+    assert "retry_delay_s" not in item.payload
+
+
 def test_own_arm_poll_stops_at_the_configured_merge_budget(
     make_ctx: Any, make_work_item: Any
 ) -> None:
@@ -194,6 +214,54 @@ def test_missing_implementation_go_returns_to_review(make_ctx: Any, make_work_it
     result = MergeWaitStage().step(item, make_ctx(github=_ArmingGitHub(labels=(False, False))))
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
+
+
+def test_own_arm_without_approval_returns_to_review(make_ctx: Any, make_work_item: Any) -> None:
+    """A lost approval on this run's arm is remediated by a fresh PR review."""
+    github = _ArmingGitHub(labels=(False, False))
+    github._pr_state = {
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "autoMergeRequest": {"enabledAt": "this-run"},
+    }
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+    item.armed = True
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
+    assert github.mutation_log == [("defer_auto_merge", (12,))]
+    assert item.armed is False
+    assert item.attempts["merge"] == 0
+    assert "retry_delay_s" not in item.payload
+
+
+def test_own_arm_without_approval_stops_when_defer_fails(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """Review must not re-enter while this run's auto-merge arm remains live."""
+
+    class _FailingDeferGitHub(_ArmingGitHub):
+        def defer_auto_merge(self, pr_number: int) -> None:
+            self._log("defer_auto_merge", pr_number)
+            raise RuntimeError("transport failure")
+
+    github = _FailingDeferGitHub(labels=(False, False))
+    github._pr_state = {
+        "state": "OPEN",
+        "headRefOid": "a" * 40,
+        "autoMergeRequest": {"enabledAt": "this-run"},
+    }
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
+    item.armed = True
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "auto_merge_defer_failed")
+    assert github.mutation_log == [("defer_auto_merge", (12,))]
+    assert item.armed is True
+    assert item.attempts["merge"] == 0
+    assert "retry_delay_s" not in item.payload
 
 
 def test_orphan_pr_finishes_without_mutating_an_operator_owned_arm(

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -674,6 +674,101 @@ class TestDryRun:
 class TestFailBackRouting:
     """The Disposition->action table's FAIL_BACK rows."""
 
+    def test_owned_merge_wait_lost_approval_returns_to_pr_review(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Containment completes before the fresh PR-review context is entered."""
+        github = FakeStageGitHub(
+            pr_impl_state=(False, False),
+            pr_state={
+                "state": "OPEN",
+                "headRefOid": "a" * 40,
+                "autoMergeRequest": {"enabledAt": "this-run"},
+            },
+        )
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, github=github)
+
+        class ReviewAfterContainment(StubStage):
+            def on_enter(self, item: WorkItem, ctx: Any) -> Any:
+                assert github.mutation_log == [("defer_auto_merge", (12,))]
+                assert item.armed is False
+                return super().on_enter(item, ctx)
+
+        coordinator.stages[StageName.PR_REVIEW] = ReviewAfterContainment(
+            StageOutcome(Disposition.FINISH_FAIL, "stop")
+        )
+        item = _issue_item(3, StageName.MERGE_WAIT)
+        item.armed = True
+        item.pr = 12
+        item.state = "POLL"
+
+        coordinator._push_item(item, StageName.MERGE_WAIT, enter=False)
+        coordinator._drain_queues()
+
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None
+        assert item.result.reason == "stop"
+        assert github.mutation_log == [("defer_auto_merge", (12,))]
+
+    def test_external_auto_merge_block_does_not_enter_pr_review(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An external arm without approval is terminal, never review-rerouted."""
+        github = FakeStageGitHub(
+            pr_impl_state=(False, False),
+            pr_state={
+                "state": "OPEN",
+                "headRefOid": "a" * 40,
+                "autoMergeRequest": {"enabledAt": "elsewhere"},
+            },
+        )
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, github=github)
+        item = _issue_item(3, StageName.MERGE_WAIT)
+        item.pr = 12
+        item.state = "POLL"
+
+        coordinator._push_item(item, StageName.MERGE_WAIT, enter=False)
+        coordinator._drain_queues()
+
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None
+        assert item.result.reason == "blocked: auto_merge_already_armed"
+        assert not coordinator.queues[StageName.PR_REVIEW]
+        assert github.mutation_log == []
+
+    def test_owned_auto_merge_defer_failure_does_not_enter_pr_review(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A containment error is terminal rather than an unsafe fresh review."""
+
+        class FailingDeferGitHub(FakeStageGitHub):
+            def defer_auto_merge(self, pr_number: int) -> None:
+                self._log("defer_auto_merge", pr_number)
+                raise RuntimeError("transport failure")
+
+        github = FailingDeferGitHub(
+            pr_impl_state=(False, False),
+            pr_state={
+                "state": "OPEN",
+                "headRefOid": "a" * 40,
+                "autoMergeRequest": {"enabledAt": "this-run"},
+            },
+        )
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, github=github)
+        item = _issue_item(3, StageName.MERGE_WAIT)
+        item.armed = True
+        item.pr = 12
+        item.state = "POLL"
+
+        coordinator._push_item(item, StageName.MERGE_WAIT, enter=False)
+        coordinator._drain_queues()
+
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None
+        assert item.result.reason == "auto_merge_defer_failed"
+        assert not coordinator.queues[StageName.PR_REVIEW]
+        assert github.mutation_log == [("defer_auto_merge", (12,))]
+
     def test_named_reason_routes_to_mapped_stage(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- distinguish current-run and external auto-merge arms before acting on a missing implementation approval
- disable and verify the current-run arm before returning it to fresh PR review
- terminalize containment failures rather than allowing review to proceed with a live arm
- cover owned, external, and containment-failure paths at stage and coordinator levels

## Validation

- `uv run --all-extras --locked pytest -q` (6676 passed, 6 skipped)
- focused merge-wait, coordinator, routing, Ruff, formatting, mypy, and diff checks
- independent containment review

Closes #2417