### PR TITLE
fix(automation): preserve normal pipeline exit status

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1788,7 +1788,11 @@ class Coordinator:
             return
         self._pool_shut_down = True
         try:
-            self.pool.shutdown()
+            # ``self.shutdown`` belongs to the coordinator's signal path. A
+            # normal ``finally`` must reap worker resources without changing
+            # its exit outcome to an interruption (#2431), while a genuine
+            # signal preserves the pool's direct cancellation semantics.
+            self.pool.shutdown(mark_interrupted=self.shutdown.is_set())
         except Exception:  # pragma: no cover - defensive
             logger.exception("pool shutdown raised")
         for item in list(self.in_flight.values()):

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -377,17 +377,21 @@ class WorkerPool:
         future.add_done_callback(lambda f: self._on_future_done(handle, f))
         return handle
 
-    def shutdown(self) -> None:
+    def shutdown(self, *, mark_interrupted: bool = True) -> None:
         """Shut down the pool.
 
-        Sets the shutdown event, cancels pending futures, and SIGTERMs every
-        in-flight agent process group. ``executor.shutdown(cancel_futures=True)``
-        only cancels UN-STARTED futures; a job already blocked in a ``claude``
-        subprocess would keep running and pin its non-daemon worker thread
-        (holding the interpreter open at exit — the #2059 leak). Terminating the
-        tracked process groups frees those workers promptly.
+        When ``mark_interrupted`` is true, sets the shutdown event before
+        cancelling pending futures and SIGTERMing every in-flight agent process
+        group. Coordinators pass false for ordinary ``finally`` cleanup so
+        releasing pool resources cannot reclassify a completed run as a signal
+        interruption. ``executor.shutdown(cancel_futures=True)`` only cancels
+        UN-STARTED futures; a job already blocked in a ``claude`` subprocess
+        would keep running and pin its non-daemon worker thread (holding the
+        interpreter open at exit — the #2059 leak). Terminating tracked process
+        groups frees those workers promptly.
         """
-        self._shutdown.set()
+        if mark_interrupted:
+            self._shutdown.set()
         self._executor.shutdown(wait=False, cancel_futures=True)
         subprocess_registry.terminate_all()
 

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -134,10 +134,11 @@ class FakeWorkerPool:
             return JobResult(ok=True, value={"ready": True, "diff": "checkout diff"})
         return JobResult(ok=True)
 
-    def shutdown(self) -> None:
-        """Match the real pool's API (sets the shutdown event; nothing to cancel)."""
+    def shutdown(self, *, mark_interrupted: bool = True) -> None:
+        """Match real-pool cancellation and ordinary-teardown semantics."""
         self.shutdown_calls += 1
-        self.shutdown_event.set()
+        if mark_interrupted:
+            self.shutdown_event.set()
 
 
 class FakeGitHub:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -210,7 +210,7 @@ class TestInterruptSemantics:
         seed = [SeedEntry(kind="issue", identifier=3, stage=StageName.IMPLEMENTATION, reason="r")]
         _capture_signal_handlers(monkeypatch)
         coordinator = _coordinator(tmp_path, monkeypatch, seed=seed, install_signals=True)
-        pool = SecondSignalPool()
+        pool = SecondSignalPool(shutdown=coordinator.shutdown)
         coordinator.pool = pool
         coordinator.completion_q = pool.completion_q
         stage = JobRequestingStage()
@@ -219,6 +219,7 @@ class TestInterruptSemantics:
         exit_code = coordinator.run()
 
         assert exit_code == 130
+        assert coordinator.shutdown.is_set()
         assert len(pool.submitted) == 1
         assert pool.shutdown_event.is_set()
         assert stage.job_done_calls == 0
@@ -275,6 +276,42 @@ class TestInterruptSemantics:
         handler(signal_mod.SIGTERM, None)
         assert coordinator._immediate is True
         assert not coordinator.completion_q.empty()
+
+
+class TestNormalTeardownExitSemantics:
+    """Ordinary pool cleanup must not manufacture an interrupt outcome (#2431)."""
+
+    @staticmethod
+    def _default_pool_coordinator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Coordinator:
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        return Coordinator(
+            PipelineConfig(org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            install_signals=False,
+        )
+
+    def test_clean_real_pool_run_exits_zero_without_interruption(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A default WorkerPool cleanup cannot turn a clean run into exit 130."""
+        coordinator = self._default_pool_coordinator(tmp_path, monkeypatch)
+
+        assert coordinator.run() == 0
+        assert not coordinator.shutdown.is_set()
+
+    def test_fatal_real_pool_run_exits_failure_without_interruption(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fatal path remains a domain failure rather than a false interrupt."""
+        coordinator = self._default_pool_coordinator(tmp_path, monkeypatch)
+
+        def boom() -> None:
+            raise RuntimeError("expected test failure")
+
+        monkeypatch.setattr(coordinator, "_seed_pass", boom)
+
+        assert coordinator.run() == 1
+        assert not coordinator.shutdown.is_set()
 
 
 def _classify_from_fake(

--- a/tests/unit/automation/pipeline/test_fakes.py
+++ b/tests/unit/automation/pipeline/test_fakes.py
@@ -132,6 +132,12 @@ class TestFakeWorkerPool:
         fake.shutdown()
         assert fake.shutdown_event.is_set()
 
+    def test_shutdown_without_interrupt_keeps_event_clear(self) -> None:
+        """Explicit ordinary teardown matches the real pool's new API."""
+        fake = FakeWorkerPool()
+        fake.shutdown(mark_interrupted=False)
+        assert not fake.shutdown_event.is_set()
+
 
 class TestFakeGitHub:
     """FakeGitHub mirrors the real mutator surface and logs every mutation."""

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -100,6 +100,15 @@ def _agent_job(model: str = "opus-4-8", **overrides: object) -> AgentJob:
     return AgentJob(**defaults)  # type: ignore[arg-type]
 
 
+def test_shutdown_can_reap_without_marking_interrupted(
+    pool: WorkerPool, shutdown_event: threading.Event
+) -> None:
+    """Coordinator cleanup may release the pool without changing outcome state (#2431)."""
+    pool.shutdown(mark_interrupted=False)
+
+    assert not shutdown_event.is_set()
+
+
 class TestWorkerPoolSubmitComplete:
     """Tests for basic submit/complete workflow."""
 
@@ -2864,6 +2873,7 @@ class TestShutdownAndCancel:
             assert started.wait(timeout=10), "slow job never started"
             pool.submit(queued_job, StageName.PR_REVIEW)  # queued behind the busy worker
             pool.shutdown()  # sets shutdown event + cancel_futures=True
+            assert shutdown_event.is_set()
             release.set()
 
             handle, result = completion_q.get(timeout=10)


### PR DESCRIPTION
Closes #2431

## Summary

- separate normal worker-pool cleanup from the coordinator interruption outcome
- preserve direct pool cancellation and real-signal exit-130 behavior
- cover clean and fatal real-pool runs plus fake API parity

## Validation

- `just check`
- `uv run --all-extras --locked pytest -q --no-cov tests/unit/automation/pipeline` — 1,015 passed
- `uv run --all-extras --locked pytest -q` — 6,694 passed, 6 skipped; 85.22% coverage
- mandatory pre-push hook: same full suite passed