### PR TITLE
Add bounded backpressure to pipeline stage and completion queues

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,6 +281,12 @@ synthesizes interrupted results for remaining in-flight jobs.
 Completion publication rejection starts the same grace-bounded shutdown after
 the coordinator parks the exact rejected item. If the bounded rejection
 mailbox overflows, immediate teardown parks every remaining in-flight item.
+Stage-queue saturation follows the same recovery rule for existing work. A
+genuinely new seed rejected by a full stage queue is first added to the
+coordinator ledger, parked RESUMABLE, and then starts a non-successful graceful
+shutdown; it is never omitted from the run's effective items. Every production
+entrypoint supplies the durable JSONL event-log path, including when metrics
+are disabled.
 Items touched by an interrupt report
 `ItemResult(passed=False, reason="resumable at <stage>", …)` — **never** FAILED. The
 end-of-run summary lists them under `RESUMABLE at <stage>`. Resume is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,8 +173,14 @@ thread lock, outer) **and**
 operations on the same checkout would race.
 The only cross-thread channel is
 [`CompletionQueue`](hephaestus/automation/pipeline/queues.py)
-(`queue.Queue[(JobHandle, JobResult)]`); its blocking
-`get(timeout=…)` is the loop's idle sleep
+(`queue.Queue[(JobHandle, JobResult)]`). Let
+`C = max(1, parallel_repos × max_workers)`: every stage queue and the result
+queue has capacity `C`, and global admission keeps at most `C` handles in
+flight. A completion publication never blocks a worker. When the result queue
+is full, the rejected `(JobHandle, JobResult)` enters a separate bounded
+mailbox of capacity `C` for coordinator-owned terminalization. Signal wakes
+use a coalesced out-of-band latch and consume no result capacity. The
+coordinator's bounded poll is the loop's idle sleep
 ([`_wait_for_completion`](hephaestus/automation/pipeline/coordinator.py)).
 Poll interval = [`_IDLE_POLL_S = 1.0`](hephaestus/automation/pipeline/coordinator.py).
 Pool size = `parallel_repos × max_workers`
@@ -272,6 +278,9 @@ A first signal sets `shutdown` and starts a graceful drain window
 The coordinator stops admitting new work, drains in-flight to RESUMABLE and parks touched items at their current stage. A second signal or an
 expired grace window, tears the pool down immediately and the coordinator
 synthesizes interrupted results for remaining in-flight jobs.
+Completion publication rejection starts the same grace-bounded shutdown after
+the coordinator parks the exact rejected item. If the bounded rejection
+mailbox overflows, immediate teardown parks every remaining in-flight item.
 Items touched by an interrupt report
 `ItemResult(passed=False, reason="resumable at <stage>", …)` — **never** FAILED. The
 end-of-run summary lists them under `RESUMABLE at <stage>`. Resume is
@@ -1105,8 +1114,13 @@ log; error message truncated to 500 chars.
 
 ### Completion contract
 
-Every non-cancelled `submit()` produces EXACTLY ONE
-`(JobHandle, JobResult)` tuple on the completion queue
+Every non-cancelled `submit()` produces one completion outcome: a successful
+publication places exactly one `(JobHandle, JobResult)` tuple on the bounded
+completion queue; a full queue places that tuple in the bounded rejection
+mailbox. The coordinator consumes rejected outcomes before normal results,
+records a durable `queue_saturated` event, removes the exact handle from
+`in_flight`, and parks its item RESUMABLE. If the rejection mailbox is also
+full, the coordinator parks all remaining live work immediately.
 ([`_on_future_done`](hephaestus/automation/pipeline/worker_pool.py)).
 Normal job failures are converted to error results in `_run`; anything
 that escapes `future.result()` (exception + process-control escapes
@@ -1233,6 +1247,10 @@ state-transition is rendered as zero, not as stale active work.
 | Gauge | Type | Labels | Default | Semantics |
 |-------------------------------------------|--------|-----------|---------|-----------|
 | `hephaestus_pipeline_queue_depth` | Gauge | `stage` | `0` | Item count per pipeline stage. Useful for detecting back-pressure. |
+| `hephaestus_pipeline_queue_capacity` | Gauge | `stage` | `C` | Configured capacity for each stage queue. |
+| `hephaestus_pipeline_completion_depth` | Gauge | — | `0` | Completion results waiting for the coordinator. |
+| `hephaestus_pipeline_completion_capacity` | Gauge | — | `C` | Configured result-queue capacity. |
+| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Rejected stage or completion publications. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo` | `0` | In-flight jobs by repo, capped by `max_workers`. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`,`state` | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |
@@ -1255,9 +1273,9 @@ Emitted events drive `hephaestus_pipeline_alert_active` and a durable
 
 - **Default trigger**: queue-depth threshold is read from
  [`PipelineConfig.alert_queue_depth_threshold`](hephaestus/automation/pipeline/coordinator.py)
- (int, non-negative; the CLI tool validates this in `[tool.coverage]`-style
- pre-flight before it ever reaches the coordinator). The constructor
- fails fast on a negative input.
+ (a percentage in `[0, 100]`; the constructor fails fast outside that range).
+ It is compared with each stage's measured capacity, so the default `100`
+ fires when a non-empty stage is full.
 - **Default value**: 100. Operators tune via `--alert-queue-depth-threshold N`
  on `hephaestus-automation-loop`.
 - **Resolution events**: an alert transitions to `resolved` when the depth

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,13 +174,15 @@ operations on the same checkout would race.
 The only cross-thread channel is
 [`CompletionQueue`](hephaestus/automation/pipeline/queues.py)
 (`queue.Queue[(JobHandle, JobResult)]`). Let
-`C = max(1, parallel_repos × max_workers)`: every stage queue and the result
-queue has capacity `C`, and global admission keeps at most `C` handles in
-flight. A completion publication never blocks a worker. When the result queue
-is full, the rejected `(JobHandle, JobResult)` enters a separate bounded
-mailbox of capacity `C` for coordinator-owned terminalization. Signal wakes
-use a coalesced out-of-band latch and consume no result capacity. The
-coordinator's bounded poll is the loop's idle sleep
+`C = max(1, parallel_repos × max_workers)`: the result queue has capacity `C`,
+and global admission keeps at most `C` handles in flight. Each stage queue has
+the independent `PipelineConfig.stage_queue_capacity` bound; a full stage
+queue defers admission into the coordinator-owned spool until the next drain.
+A completion publication never blocks a worker. When the result queue is full,
+the rejected `(JobHandle, JobResult)` enters a separate bounded mailbox of
+capacity `C` for coordinator-owned terminalization. Signal wakes use a
+coalesced out-of-band latch and consume no result capacity. The coordinator's
+bounded poll is the loop's idle sleep
 ([`_wait_for_completion`](hephaestus/automation/pipeline/coordinator.py)).
 Poll interval = [`_IDLE_POLL_S = 1.0`](hephaestus/automation/pipeline/coordinator.py).
 Pool size = `parallel_repos × max_workers`
@@ -281,12 +283,13 @@ synthesizes interrupted results for remaining in-flight jobs.
 Completion publication rejection starts the same grace-bounded shutdown after
 the coordinator parks the exact rejected item. If the bounded rejection
 mailbox overflows, immediate teardown parks every remaining in-flight item.
-Stage-queue saturation follows the same recovery rule for existing work. A
-genuinely new seed rejected by a full stage queue is first added to the
-coordinator ledger, parked RESUMABLE, and then starts a non-successful graceful
-shutdown; it is never omitted from the run's effective items. Every production
-entrypoint supplies the durable JSONL event-log path, including when metrics
-are disabled.
+Stage-queue backlogs are deferred rather than treated as saturation: the
+coordinator retains the item in its admission spool and retries it after queue
+slots open, so a normal `C+1` seed burst does not shut down the run. Completion
+publication saturation still starts the same recovery rule after the exact
+rejected item is parked. Every production entrypoint supplies the durable JSONL
+event-log path, including when metrics are disabled; if that journal cannot
+record a saturation event, the coordinator fails closed with exit code `1`.
 Items touched by an interrupt report
 `ItemResult(passed=False, reason="resumable at <stage>", …)` — **never** FAILED. The
 end-of-run summary lists them under `RESUMABLE at <stage>`. Resume is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,6 +178,9 @@ The only cross-thread channel is
 and global admission keeps at most `C` handles in flight. Each stage queue has
 the independent `PipelineConfig.stage_queue_capacity` bound; a full stage
 queue defers admission into the coordinator-owned spool until the next drain.
+That spool has capacity `number of stages × stage_queue_capacity`, providing
+one additional full batch per stage. If it fills, the exact rejected item is
+journaled and parked RESUMABLE, and the run stops admitting source work.
 A completion publication never blocks a worker. When the result queue is full,
 the rejected `(JobHandle, JobResult)` enters a separate bounded mailbox of
 capacity `C` for coordinator-owned terminalization. Signal wakes use a
@@ -285,11 +288,14 @@ the coordinator parks the exact rejected item. If the bounded rejection
 mailbox overflows, immediate teardown parks every remaining in-flight item.
 Stage-queue backlogs are deferred rather than treated as saturation: the
 coordinator retains the item in its admission spool and retries it after queue
-slots open, so a normal `C+1` seed burst does not shut down the run. Completion
-publication saturation still starts the same recovery rule after the exact
-rejected item is parked. Every production entrypoint supplies the durable JSONL
-event-log path, including when metrics are disabled; if that journal cannot
-record a saturation event, the coordinator fails closed with exit code `1`.
+slots open, so a normal `C+1` seed burst does not shut down the run. If the
+bounded spool fills, admission saturation journals and parks the boundary item
+before shutdown; source reconstruction on the next run recovers the unadmitted
+remainder. Completion publication saturation uses the same recovery rule after
+the exact rejected item is parked. Every production entrypoint supplies the
+durable JSONL event-log path, including when metrics are disabled; if that
+journal cannot record a saturation event, the coordinator fails closed with
+exit code `1`.
 Items touched by an interrupt report
 `ItemResult(passed=False, reason="resumable at <stage>", …)` — **never** FAILED. The
 end-of-run summary lists them under `RESUMABLE at <stage>`. Resume is
@@ -1259,6 +1265,8 @@ state-transition is rendered as zero, not as stale active work.
 | `hephaestus_pipeline_queue_capacity` | Gauge | `stage` | `C` | Configured capacity for each stage queue. |
 | `hephaestus_pipeline_completion_depth` | Gauge | — | `0` | Completion results waiting for the coordinator. |
 | `hephaestus_pipeline_completion_capacity` | Gauge | — | `C` | Configured result-queue capacity. |
+| `hephaestus_pipeline_admission_depth` | Gauge | — | `0` | Deferred items waiting for a stage-queue slot. |
+| `hephaestus_pipeline_admission_capacity` | Gauge | — | `stages × stage capacity` | Configured admission-spool capacity. |
 | `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Rejected stage or completion publications. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo` | `0` | In-flight jobs by repo, capped by `max_workers`. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,7 +176,8 @@ The only cross-thread channel is
 (`queue.Queue[(JobHandle, JobResult)]`). Let
 `C = max(1, parallel_repos × max_workers)`: the result queue has capacity `C`,
 and global admission keeps at most `C` handles in flight. Each stage queue has
-the independent `PipelineConfig.stage_queue_capacity` bound; a full stage
+the independent `PipelineConfig.stage_queue_capacity` bound (default `64`), not
+the worker-window capacity `C`; a full stage
 queue defers admission into the coordinator-owned spool until the next drain.
 That spool has capacity `number of stages × stage_queue_capacity`, providing
 one additional full batch per stage. If it fills, the exact rejected item is
@@ -1267,7 +1268,7 @@ state-transition is rendered as zero, not as stale active work.
 | `hephaestus_pipeline_completion_capacity` | Gauge | — | `C` | Configured result-queue capacity. |
 | `hephaestus_pipeline_admission_depth` | Gauge | — | `0` | Deferred items waiting for a stage-queue slot. |
 | `hephaestus_pipeline_admission_capacity` | Gauge | — | `stages × stage capacity` | Configured admission-spool capacity. |
-| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Completion-publication rejections plus admission-spool and completion-rejection-mailbox saturation events; normal stage-queue deferrals are excluded. |
+| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Irrecoverable admission-spool saturation plus completion-publication and completion-rejection-mailbox rejections; ordinary full-stage deferrals are retried and excluded. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo` | `0` | In-flight jobs by repo, capped by `max_workers`. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`,`state` | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,12 +315,17 @@ errors: a signal means the run did not complete.
 
 ### Effective-item rule
 
-The summary uses `latest_logical_items(self.items)` from
-[`summary.py`](hephaestus/automation/pipeline/summary.py) so a re-seeded
+The summary uses `latest_logical_items([*self.item_summaries, *self.items])`
+from [`summary.py`](hephaestus/automation/pipeline/summary.py) so a re-seeded
 item's superseded attempts are collapsed before per-row / exit-code /
-preserved-worktree calculation. The current item's own failed, skipped or blocked result still counts; an old failed attempt that was superseded
-by a later passing attempt does not. Pull requests already merged/closed are
-terminalized before summary collapse so stale attempts cannot re-enter the queue.
+preserved-worktree calculation. `self.items` owns only bounded live
+`WorkItem`s; the finished sink retires each completed item into an immutable
+scalar-only `WorkItemSummary`, releasing issue/PR bodies, plans, histories,
+and session caches immediately. The current item's own failed, skipped or
+blocked result still counts; an old failed attempt that was superseded by a
+later passing attempt does not. Pull requests already merged/closed are
+terminalized before summary collapse so stale attempts cannot re-enter the
+queue.
 
 ### Rate-budget gate
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1262,12 +1262,12 @@ state-transition is rendered as zero, not as stale active work.
 | Gauge | Type | Labels | Default | Semantics |
 |-------------------------------------------|--------|-----------|---------|-----------|
 | `hephaestus_pipeline_queue_depth` | Gauge | `stage` | `0` | Item count per pipeline stage. Useful for detecting back-pressure. |
-| `hephaestus_pipeline_queue_capacity` | Gauge | `stage` | `C` | Configured capacity for each stage queue. |
+| `hephaestus_pipeline_queue_capacity` | Gauge | `stage` | `stage_queue_capacity` (64) | Configured capacity for each stage queue. |
 | `hephaestus_pipeline_completion_depth` | Gauge | — | `0` | Completion results waiting for the coordinator. |
 | `hephaestus_pipeline_completion_capacity` | Gauge | — | `C` | Configured result-queue capacity. |
 | `hephaestus_pipeline_admission_depth` | Gauge | — | `0` | Deferred items waiting for a stage-queue slot. |
 | `hephaestus_pipeline_admission_capacity` | Gauge | — | `stages × stage capacity` | Configured admission-spool capacity. |
-| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Rejected stage or completion publications. |
+| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Rejected completion publications plus admission-spool and completion-rejection-mailbox saturation events. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo` | `0` | In-flight jobs by repo, capped by `max_workers`. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`,`state` | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1267,7 +1267,7 @@ state-transition is rendered as zero, not as stale active work.
 | `hephaestus_pipeline_completion_capacity` | Gauge | — | `C` | Configured result-queue capacity. |
 | `hephaestus_pipeline_admission_depth` | Gauge | — | `0` | Deferred items waiting for a stage-queue slot. |
 | `hephaestus_pipeline_admission_capacity` | Gauge | — | `stages × stage capacity` | Configured admission-spool capacity. |
-| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Rejected completion publications plus admission-spool and completion-rejection-mailbox saturation events. |
+| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Completion-publication rejections plus admission-spool and completion-rejection-mailbox saturation events; normal stage-queue deferrals are excluded. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo` | `0` | In-flight jobs by repo, capped by `max_workers`. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`,`state` | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,10 +175,10 @@ The only cross-thread channel is
 [`CompletionQueue`](hephaestus/automation/pipeline/queues.py)
 (`queue.Queue[(JobHandle, JobResult)]`). Let
 `C = max(1, parallel_repos × max_workers)`: the result queue has capacity `C`,
-and global admission keeps at most `C` handles in flight. Each stage queue has
-the independent `PipelineConfig.stage_queue_capacity` bound (default `64`), not
-the worker-window capacity `C`; a full stage
-queue defers admission into the coordinator-owned spool until the next drain.
+and global admission keeps at most `C` handles in flight. Each stage queue
+instead uses the independent `PipelineConfig.stage_queue_capacity` bound. Its
+default is `64` and does not vary with the worker-window capacity `C`; a full
+stage queue defers admission into the coordinator-owned spool until the next drain.
 That spool has capacity `number of stages × stage_queue_capacity`, providing
 one additional full batch per stage. If it fills, the exact rejected item is
 journaled and parked RESUMABLE, and the run stops admitting source work.
@@ -1268,7 +1268,7 @@ state-transition is rendered as zero, not as stale active work.
 | `hephaestus_pipeline_completion_capacity` | Gauge | — | `C` | Configured result-queue capacity. |
 | `hephaestus_pipeline_admission_depth` | Gauge | — | `0` | Deferred items waiting for a stage-queue slot. |
 | `hephaestus_pipeline_admission_capacity` | Gauge | — | `stages × stage capacity` | Configured admission-spool capacity. |
-| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Irrecoverable admission-spool saturation plus completion-publication and completion-rejection-mailbox rejections; ordinary full-stage deferrals are retried and excluded. |
+| `hephaestus_pipeline_queue_rejections_total` | Counter | `queue` | `0` | Rejections at the bounded admission spool, completion-result channel, or completion-rejection mailbox. A full stage queue only emits `queue_deferred`; that retryable deferral is not counted as a rejection. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo` | `0` | In-flight jobs by repo, capped by `max_workers`. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`,`state` | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -43,10 +43,13 @@ are constructed only when a metrics port is configured.
 The alert queue-depth threshold is configurable as a percentage via
 `PipelineConfig.alert_queue_depth_threshold` (default `100`). It is evaluated
 against each stage's measured capacity, so a full queue is a backlog warning;
-it does not imply rejected work. The critical `queue_saturated` alert fires
-only after an enqueue or completion publication is rejected. Saturation is
-also written as a `queue_saturated` JSONL event through the coordinator event
-log even when `metrics_port=0`. The stall threshold defaults to `3`, matching the coordinator's own
+it does not imply rejected work. Deferred stage admissions are retried by the
+coordinator as slots open. The critical `queue_saturated` alert fires only
+after a completion publication or rejection-mailbox publication is rejected.
+Saturation is also written as a `queue_saturated` JSONL event through the
+coordinator event log even when `metrics_port=0`; an append failure fails the
+run closed rather than disabling saturation journaling. The stall threshold
+defaults to `3`, matching the coordinator's own
 `_STALL_TICKS_BEFORE_FORCE`.
 
 ## Metrics
@@ -61,7 +64,7 @@ points at the emission chokepoint in `coordinator.py`.
 | `hephaestus_pipeline_queue_capacity` | gauge | `stage` | Configured capacity for each stage queue. |
 | `hephaestus_pipeline_completion_depth` | gauge | — | Completion results waiting for the coordinator. |
 | `hephaestus_pipeline_completion_capacity` | gauge | — | Configured completion result capacity. |
-| `hephaestus_pipeline_queue_rejections_total` | counter | `queue` | Rejected stage or completion publications. |
+| `hephaestus_pipeline_queue_rejections_total` | counter | `queue` | Rejected completion publications or rejection-mailbox entries. |
 | `hephaestus_pipeline_inflight_jobs` | gauge | — | Jobs currently owned by the worker pool. |
 | `hephaestus_pipeline_inflight_per_repo` | gauge | `repo` | In-flight jobs partitioned by repository. |
 | `hephaestus_pipeline_loops_total` | gauge | — | Reseed passes run by this coordinator process. |
@@ -84,7 +87,7 @@ persistent degradation never produces repeated event spam.
 | --- | --- | --- | --- | --- |
 | `circuit_breaker_open` | critical | Any circuit breaker in the snapshot reports `state == "open"`. | repository maintainer | [`docs/runbooks/automation-loop-crash.md`](runbooks/automation-loop-crash.md) |
 | `queue_depth_exceeds` | warning | Any non-empty stage reaches `alert_queue_depth_threshold` percent of capacity (default `100`); backlog does not prove rejection. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
-| `queue_saturated` | critical | A stage or completion publication is rejected. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
+| `queue_saturated` | critical | A completion or rejection-mailbox publication is rejected. | repository maintainer | [`docs/runbooks/queue-saturation.md`](runbooks/queue-saturation.md) |
 | `pipeline_stalled` | warning | `stalled_ticks` reaches the stall threshold (default `3`) — drain ticks with no progress. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
 
 ## SLOs

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,9 +40,13 @@ are constructed only when a metrics port is configured.
   `alert_fired` or `alert_resolved` record carrying the alert `name`,
   `severity`, and `message`. These are the lines to cite when escalating.
 
-The alert queue-depth threshold is configurable via
-`PipelineConfig.alert_queue_depth_threshold` (default `100`); the stall
-threshold defaults to `3`, matching the coordinator's own
+The alert queue-depth threshold is configurable as a percentage via
+`PipelineConfig.alert_queue_depth_threshold` (default `100`). It is evaluated
+against each stage's measured capacity, so a full queue is a backlog warning;
+it does not imply rejected work. The critical `queue_saturated` alert fires
+only after an enqueue or completion publication is rejected. Saturation is
+also written as a `queue_saturated` JSONL event through the coordinator event
+log even when `metrics_port=0`. The stall threshold defaults to `3`, matching the coordinator's own
 `_STALL_TICKS_BEFORE_FORCE`.
 
 ## Metrics
@@ -54,6 +58,10 @@ points at the emission chokepoint in `coordinator.py`.
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
 | `hephaestus_pipeline_queue_depth` | gauge | `stage` | Queued work items waiting in each stage queue. |
+| `hephaestus_pipeline_queue_capacity` | gauge | `stage` | Configured capacity for each stage queue. |
+| `hephaestus_pipeline_completion_depth` | gauge | — | Completion results waiting for the coordinator. |
+| `hephaestus_pipeline_completion_capacity` | gauge | — | Configured completion result capacity. |
+| `hephaestus_pipeline_queue_rejections_total` | counter | `queue` | Rejected stage or completion publications. |
 | `hephaestus_pipeline_inflight_jobs` | gauge | — | Jobs currently owned by the worker pool. |
 | `hephaestus_pipeline_inflight_per_repo` | gauge | `repo` | In-flight jobs partitioned by repository. |
 | `hephaestus_pipeline_loops_total` | gauge | — | Reseed passes run by this coordinator process. |
@@ -75,7 +83,8 @@ persistent degradation never produces repeated event spam.
 | Alert | Severity | Condition | Owner | Runbook |
 | --- | --- | --- | --- | --- |
 | `circuit_breaker_open` | critical | Any circuit breaker in the snapshot reports `state == "open"`. | repository maintainer | [`docs/runbooks/automation-loop-crash.md`](runbooks/automation-loop-crash.md) |
-| `queue_depth_exceeds` | warning | Any stage queue depth exceeds `alert_queue_depth_threshold` (default `100`). | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
+| `queue_depth_exceeds` | warning | Any non-empty stage reaches `alert_queue_depth_threshold` percent of capacity (default `100`); backlog does not prove rejection. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
+| `queue_saturated` | critical | A stage or completion publication is rejected. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
 | `pipeline_stalled` | warning | `stalled_ticks` reaches the stall threshold (default `3`) — drain ticks with no progress. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
 
 ## SLOs

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -44,8 +44,9 @@ The alert queue-depth threshold is configurable as a percentage via
 `PipelineConfig.alert_queue_depth_threshold` (default `100`). It is evaluated
 against each stage's measured capacity, so a full queue is a backlog warning;
 it does not imply rejected work. Deferred stage admissions are retried by the
-coordinator as slots open. The critical `queue_saturated` alert fires only
-after a completion publication or rejection-mailbox publication is rejected.
+coordinator as slots open, and their bounded spool has separate depth and
+capacity gauges. The critical `queue_saturated` alert fires after an admission,
+completion, or rejection-mailbox publication is rejected.
 Saturation is also written as a `queue_saturated` JSONL event through the
 coordinator event log even when `metrics_port=0`; an append failure fails the
 run closed rather than disabling saturation journaling. The stall threshold
@@ -64,6 +65,8 @@ points at the emission chokepoint in `coordinator.py`.
 | `hephaestus_pipeline_queue_capacity` | gauge | `stage` | Configured capacity for each stage queue. |
 | `hephaestus_pipeline_completion_depth` | gauge | — | Completion results waiting for the coordinator. |
 | `hephaestus_pipeline_completion_capacity` | gauge | — | Configured completion result capacity. |
+| `hephaestus_pipeline_admission_depth` | gauge | — | Deferred items waiting for a stage-queue slot. |
+| `hephaestus_pipeline_admission_capacity` | gauge | — | Bounded admission-spool capacity (one extra full batch per stage). |
 | `hephaestus_pipeline_queue_rejections_total` | counter | `queue` | Rejected completion publications or rejection-mailbox entries. |
 | `hephaestus_pipeline_inflight_jobs` | gauge | — | Jobs currently owned by the worker pool. |
 | `hephaestus_pipeline_inflight_per_repo` | gauge | `repo` | In-flight jobs partitioned by repository. |
@@ -87,7 +90,7 @@ persistent degradation never produces repeated event spam.
 | --- | --- | --- | --- | --- |
 | `circuit_breaker_open` | critical | Any circuit breaker in the snapshot reports `state == "open"`. | repository maintainer | [`docs/runbooks/automation-loop-crash.md`](runbooks/automation-loop-crash.md) |
 | `queue_depth_exceeds` | warning | Any non-empty stage reaches `alert_queue_depth_threshold` percent of capacity (default `100`); backlog does not prove rejection. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
-| `queue_saturated` | critical | A completion or rejection-mailbox publication is rejected. | repository maintainer | [`docs/runbooks/queue-saturation.md`](runbooks/queue-saturation.md) |
+| `queue_saturated` | critical | An admission, completion, or rejection-mailbox publication is rejected. | repository maintainer | [`docs/runbooks/queue-saturation.md`](runbooks/queue-saturation.md) |
 | `pipeline_stalled` | warning | `stalled_ticks` reaches the stall threshold (default `3`) — drain ticks with no progress. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
 
 ## SLOs

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -34,7 +34,7 @@ are constructed only when a metrics port is configured.
   top-level `status` of `ok` (running) or `stopping` (shutdown requested).
 - **Structured event log (JSONL).** When a loop runs, the coordinator writes a
   durable JSONL event log (default:
-  `build/.issue_implementer/pipeline-events-<timestamp>-<pid>.jsonl`, set via
+  `build/.issue_implementer/pipeline-events-<timestamp>-<nanoseconds>.jsonl`, set via
   `PipelineConfig.event_log_path`). Each metrics tick appends a
   `metrics_snapshot` record, and every alert transition appends an
   `alert_fired` or `alert_resolved` record carrying the alert `name`,

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -40,6 +40,14 @@ from normal pytest collection:
 uv run pytest tests/performance --override-ini="addopts=" -v --strict-markers --load-duration-s=30 --load-max-jobs=50000 --load-workers=8 --load-max-in-flight=64 --load-service-ms=5 --load-p95-budget-ms=500 --load-report=build/performance/worker-pool.json
 ```
 
+The stalled-consumer recovery regression is performance-marked and is not
+covered by the default unit-suite command (`pyproject.toml` deselects
+`performance`). Re-execute it explicitly when validating that behavior:
+
+```bash
+uv run pytest tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers --override-ini="addopts=" -m performance --strict-markers -v
+```
+
 ## Runtime evidence
 
 The generated JSON report records schema version, profile, Python/platform and

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -42,7 +42,9 @@ uv run pytest tests/performance --override-ini="addopts=" -v --strict-markers --
 
 The stalled-consumer recovery regression is performance-marked and is not
 covered by the default unit-suite command (`pyproject.toml` deselects
-`performance`). Re-execute it explicitly when validating that behavior:
+`performance`). A successful unit-suite run therefore does not validate this
+regression and must not be reported as evidence for it. Re-execute the test
+explicitly when validating that behavior:
 
 ```bash
 uv run pytest tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers --override-ini="addopts=" -m performance --strict-markers -v

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -60,26 +60,3 @@ when a threshold fails.
 
 Measurements are runtime evidence only. Do not commit or hand-author report
 values; inspect the generated CI artifact instead.
-
-## Locally captured verification evidence
-
-The following commands were independently run on the reviewed head on
-2026-07-31. Their exit status was 0 in each case. The unit-suite result is
-reported separately from the performance-marked regression because the latter
-is excluded by the default unit-suite selection.
-
-Unit suite (the repository's stated unit-suite command):
-
-```text
-$ uv run pytest tests/unit -v
-Required test coverage of 83.0% reached. Total coverage: 85.01%
-================= 6380 passed, 6 skipped in 136.10s (0:02:16) ==================
-```
-
-Stalled-consumer recovery regression (the explicit command above):
-
-```text
-$ uv run pytest tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers --override-ini="addopts=" -m performance --strict-markers -v
-tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers PASSED [100%]
-============================== 1 passed in 0.30s ===============================
-```

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -40,11 +40,10 @@ from normal pytest collection:
 uv run pytest tests/performance --override-ini="addopts=" -v --strict-markers --load-duration-s=30 --load-max-jobs=50000 --load-workers=8 --load-max-in-flight=64 --load-service-ms=5 --load-p95-budget-ms=500 --load-report=build/performance/worker-pool.json
 ```
 
-The stalled-consumer recovery regression is performance-marked and is not
-covered by the default unit-suite command (`pyproject.toml` deselects
+The stalled-consumer recovery regression is performance-marked and is
+deselected by the default unit-suite command (`pyproject.toml` excludes
 `performance`). A successful unit-suite run therefore does not validate this
-regression and must not be reported as evidence for it. Re-execute the test
-explicitly when validating that behavior:
+regression; run the test explicitly when reporting evidence for that behavior:
 
 ```bash
 uv run pytest tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers --override-ini="addopts=" -m performance --strict-markers -v

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -60,3 +60,26 @@ when a threshold fails.
 
 Measurements are runtime evidence only. Do not commit or hand-author report
 values; inspect the generated CI artifact instead.
+
+## Locally captured verification evidence
+
+The following commands were independently run on the reviewed head on
+2026-07-31. Their exit status was 0 in each case. The unit-suite result is
+reported separately from the performance-marked regression because the latter
+is excluded by the default unit-suite selection.
+
+Unit suite (the repository's stated unit-suite command):
+
+```text
+$ uv run pytest tests/unit -v
+Required test coverage of 83.0% reached. Total coverage: 85.01%
+================= 6380 passed, 6 skipped in 136.10s (0:02:16) ==================
+```
+
+Stalled-consumer recovery regression (the explicit command above):
+
+```text
+$ uv run pytest tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers --override-ini="addopts=" -m performance --strict-markers -v
+tests/performance/test_worker_pool_load.py::test_worker_pool_stalled_consumer_preserves_and_recovers PASSED [100%]
+============================== 1 passed in 0.30s ===============================
+```

--- a/docs/runbooks/index.md
+++ b/docs/runbooks/index.md
@@ -11,6 +11,7 @@ needs hands-on recovery.
 | [Automation loop crashed mid-issue](automation-loop-crash.md) | The `hephaestus-automation-loop` process died or a phase timed out and you need to resume safely. |
 | [Recover a corrupted worktree state](corrupted-worktree.md) | An issue's `build/.worktrees/issue-<N>` worktree is dirty, abandoned, or blocking a clean re-run. |
 | [Drive-green stall](ci-driver-stall.md) | A PR with loop-owned `state:implementation-go` remains blocked. |
+| [Queue saturation](queue-saturation.md) | A completion channel or rejection mailbox is full and the pipeline parks work for recovery. |
 | [Claude quota exhausted (429)](claude-quota-exhausted.md) | A stage emits `Verdict: ERROR` and the issue is left unlabeled because the Claude API quota / session limit was hit. |
 | [Reviving a state:skip-labeled issue](state-skip-revival.md) | An issue was labeled `state:skip` after automation already started work on it (planned or opened a PR) and you want to resume driving it. |
 | [No silent failures](no-silent-failures.md) | Policy reference: why `\|\| true`, `continue-on-error`, and advisory `::warning::` are forbidden, and how to fix a tripped hook. |

--- a/docs/runbooks/queue-saturation.md
+++ b/docs/runbooks/queue-saturation.md
@@ -1,0 +1,49 @@
+# Runbook: Pipeline Queue Saturation
+
+Use this when the coordinator emits the critical `queue_saturated` alert or a
+run ends with resumable work after a completion publication was rejected.
+Normal stage backlogs emit `queue_deferred` and drain automatically; they are
+not saturation incidents.
+
+## Diagnose
+
+1. Locate the run's JSONL event log under `build/.issue_implementer/` and find
+   the `queue_saturated` record. Its `queue`, `capacity`, `source`, and `item`
+   fields identify the rejected channel and exact work item:
+
+   ```bash
+   rg '"event": "queue_saturated"' build/.issue_implementer/pipeline-events-*.jsonl
+   ```
+
+2. Compare the event with the live snapshot or metrics. A stage queue at its
+   configured capacity is only a backlog; `queue_saturated` means a completion
+   publication or the bounded rejection mailbox could not accept a result.
+
+3. Check the run summary for `RESUMABLE at <stage>`. The coordinator parks the
+   exact rejected item before graceful shutdown, and parks all remaining live
+   work if the rejection mailbox itself overflows.
+
+## Recover
+
+Re-run the same scoped command after confirming that the event-log directory is
+writable and the worker pool is healthy:
+
+```bash
+uv run hephaestus-automation-loop --issues <N> --repos <REPO> --loops 1
+```
+
+The queue snapshot is in memory only. Recovery reconstructs admission from
+GitHub labels, PR state, and local worktrees; the same seed is safe to retry.
+Use `--dry-run --loops 1 -v` first when the source state needs inspection.
+
+## Journal failure
+
+If a saturation event cannot be appended, the coordinator fails closed with
+exit code `1` and does not continue as though the recovery record existed.
+Repair the path or disk-full condition before rerunning. Do not delete the
+JSONL log until the incident has been attached to the recovery issue.
+
+## See also
+
+- [Automation loop crashed mid-issue](automation-loop-crash.md)
+- [Operations runbooks index](index.md)

--- a/docs/runbooks/queue-saturation.md
+++ b/docs/runbooks/queue-saturation.md
@@ -1,9 +1,10 @@
 # Runbook: Pipeline Queue Saturation
 
 Use this when the coordinator emits the critical `queue_saturated` alert or a
-run ends with resumable work after a completion publication was rejected.
-Normal stage backlogs emit `queue_deferred` and drain automatically; they are
-not saturation incidents.
+run ends with resumable work after an admission or completion publication was
+rejected. Normal stage backlogs emit `queue_deferred` and drain automatically;
+they are not saturation incidents unless the bounded admission spool also
+fills.
 
 ## Diagnose
 
@@ -16,8 +17,9 @@ not saturation incidents.
    ```
 
 2. Compare the event with the live snapshot or metrics. A stage queue at its
-   configured capacity is only a backlog; `queue_saturated` means a completion
-   publication or the bounded rejection mailbox could not accept a result.
+   configured capacity is only a backlog; `queue_saturated` means the bounded
+   admission spool, completion channel, or rejection mailbox could not accept
+   more work.
 
 3. Check the run summary for `RESUMABLE at <stage>`. The coordinator parks the
    exact rejected item before graceful shutdown, and parks all remaining live

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -212,7 +212,7 @@ def main() -> int:
     # the CLI actually runs.
     from hephaestus.utils.terminal import install_sigtstp_only
 
-    from .pipeline.coordinator import PipelineConfig, run_pipeline
+    from .pipeline.coordinator import PipelineConfig, default_event_log_path, run_pipeline
 
     install_sigtstp_only()
     args = _parse_args()
@@ -242,6 +242,7 @@ def main() -> int:
         # drive_green_all. A scoped run (issues or PRs given) stays narrow (POLA).
         drive_green_all = not issues and not prs
 
+        projects_dir = resolve_projects_dir(None, prefer_cwd_parent=True)
         config = PipelineConfig(
             org=org,
             repos=[repo],
@@ -258,7 +259,8 @@ def main() -> int:
             drive_green_all=drive_green_all,
             include_bot_prs=args.include_bot_prs,
             include_all_authors=args.include_all_authors,
-            projects_dir=resolve_projects_dir(None, prefer_cwd_parent=True),
+            event_log_path=default_event_log_path(projects_dir, [repo]),
+            projects_dir=projects_dir,
             json_out=args.json,
             scope=PipelineScope(_CI_DRIVER_SCOPE_STAGES),
         )

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -466,7 +466,7 @@ def main() -> int:
     # the CLI actually runs.
     from hephaestus.utils.terminal import install_sigtstp_only
 
-    from .pipeline.coordinator import PipelineConfig, run_pipeline
+    from .pipeline.coordinator import PipelineConfig, default_event_log_path, run_pipeline
     from .pipeline.routing import PipelineScope, StageName
 
     install_sigtstp_only()
@@ -523,6 +523,7 @@ def main() -> int:
     issues = list(dict.fromkeys(issues))
     log.info("Issues to implement: %s", issues)
 
+    projects_dir = resolve_projects_dir(None, prefer_cwd_parent=True)
     config = PipelineConfig(
         org=org,
         repos=[repo],
@@ -537,7 +538,8 @@ def main() -> int:
         agent=agent,
         no_advise=args.no_advise,
         nitpick=args.nitpick,
-        projects_dir=resolve_projects_dir(None, prefer_cwd_parent=True),
+        event_log_path=default_event_log_path(projects_dir, [repo]),
+        projects_dir=projects_dir,
         json_out=args.json,
         scope=PipelineScope(
             frozenset({StageName.IMPLEMENTATION, StageName.PR_REVIEW, StageName.MERGE_WAIT})

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -279,6 +279,67 @@ def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
     return sorted(pulls, key=lambda pr: pr["number"])
 
 
+def _iter_open_pr_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
+    """Yield normalized open-PR metadata one GitHub page at a time.
+
+    This is the bounded counterpart to :func:`_list_open_pr_meta`: callers can
+    stop advancing the cursor while downstream admission is full, so neither
+    the repository stage nor ``gh`` materializes every open pull request.
+
+    Raises:
+        RuntimeError: On a network, JSON, or malformed-response failure.
+
+    """
+    page = 1
+    while True:
+        try:
+            out = gh_call(
+                [
+                    "api",
+                    f"/repos/{org}/{repo}/pulls?state=open&per_page=100"
+                    f"&sort=created&direction=asc&page={page}",
+                ],
+                timeout=NETWORK_TIMEOUT,
+            )
+            entries = json.loads(out.stdout or "[]")
+            if not isinstance(entries, list):
+                raise ValueError("expected a pull-list page")
+        except (
+            subprocess.SubprocessError,
+            RuntimeError,
+            OSError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as exc:
+            raise RuntimeError(f"failed to list open PRs for {org}/{repo}: {exc}") from exc
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"failed to list open PRs for {org}/{repo}: malformed pull row")
+            number = entry.get("number")
+            if not isinstance(number, int) or number <= 0:
+                raise RuntimeError(
+                    f"failed to list open PRs for {org}/{repo}: malformed pull number"
+                )
+            raw_user = entry.get("user")
+            user = raw_user if isinstance(raw_user, dict) else {}
+            raw_state = entry.get("state")
+            state = raw_state if isinstance(raw_state, str) else "open"
+            yield {
+                "number": number,
+                "state": state.upper(),
+                "isDraft": bool(entry.get("draft", False)),
+                "user": {
+                    "login": user.get("login"),
+                    "type": user.get("type"),
+                },
+            }
+
+        if len(entries) < 100:
+            return
+        page += 1
+
+
 def _list_open_issue_numbers(org: str, repo: str, *, dry_run: bool = False) -> list[int]:
     """Return open NON-epic issue numbers in ``org/repo``, sorted ascending.
 

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -156,6 +157,73 @@ def _list_open_issue_meta(org: str, repo: str) -> list[dict[str, Any]]:
         for e in entries
         if isinstance(e, dict) and "number" in e
     ]
+
+
+def _iter_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
+    """Yield normalized open-issue metadata one GitHub page at a time.
+
+    The REST endpoint is requested page-by-page so repository discovery never
+    materializes every open issue before coordinator admission can apply
+    backpressure. GitHub's issues endpoint also returns pull requests; those
+    rows are skipped to preserve the historical ``gh issue list`` contract.
+
+    Raises:
+        RuntimeError: On a network, JSON, or malformed-response failure.
+
+    """
+    page = 1
+    while True:
+        try:
+            out = gh_call(
+                [
+                    "api",
+                    f"/repos/{org}/{repo}/issues?state=open&per_page=100"
+                    f"&sort=created&direction=asc&page={page}",
+                ],
+                timeout=NETWORK_TIMEOUT,
+            )
+            entries = json.loads(out.stdout or "[]")
+            if not isinstance(entries, list):
+                raise ValueError("expected an issue-list page")
+        except (
+            subprocess.SubprocessError,
+            RuntimeError,
+            OSError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as exc:
+            raise RuntimeError(f"failed to list open issues for {org}/{repo}: {exc}") from exc
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(
+                    f"failed to list open issues for {org}/{repo}: malformed issue row"
+                )
+            if "pull_request" in entry:
+                continue
+            number = entry.get("number")
+            title = entry.get("title", "")
+            labels = entry.get("labels", [])
+            if not isinstance(number, int) or number <= 0:
+                raise RuntimeError(
+                    f"failed to list open issues for {org}/{repo}: malformed issue number"
+                )
+            if not isinstance(title, str) or not isinstance(labels, list):
+                raise RuntimeError(
+                    f"failed to list open issues for {org}/{repo}: malformed issue metadata"
+                )
+            label_names: list[str] = []
+            for label in labels:
+                if not isinstance(label, dict) or not isinstance(label.get("name"), str):
+                    raise RuntimeError(
+                        f"failed to list open issues for {org}/{repo}: malformed issue label"
+                    )
+                label_names.append(label["name"])
+            yield {"number": number, "labels": label_names, "title": title}
+
+        if len(entries) < 100:
+            return
+        page += 1
 
 
 def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -34,7 +34,6 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -51,7 +50,6 @@ from hephaestus.automation.loop_repo_manager import (
     _resolve_repo_dir as _resolve_repo_dir,
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
-from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.cli.utils import (
     configure_cli_logging,
     configure_github_throttle_from_args,
@@ -516,8 +514,9 @@ def _pipeline_event_log_path(projects_dir: Path, repos: list[str]) -> Path | Non
     """
     if not repos:
         return None
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    return Path(DEFAULT_STATE_DIR) / f"pipeline-events-{stamp}-{os.getpid()}.jsonl"
+    from hephaestus.automation.pipeline.coordinator import default_event_log_path
+
+    return default_event_log_path(projects_dir, repos)
 
 
 # ---------------------------------------------------------------------------

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -152,6 +152,19 @@ def _parse_metrics_port(value: str) -> int:
     return port
 
 
+def _parse_alert_queue_depth_threshold(value: str) -> int:
+    """Parse an inclusive queue-capacity percentage for alerting."""
+    try:
+        threshold = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"alert queue depth threshold must be an integer, got {value!r}"
+        ) from exc
+    if not 0 <= threshold <= 100:
+        raise argparse.ArgumentTypeError("alert queue depth threshold must be in 0..100")
+    return threshold
+
+
 def _default_phase_timeout_s() -> float:
     """Return the default per-agent-job timeout in seconds.
 
@@ -237,6 +250,8 @@ class LoopConfig:
     # listener rather than selecting an ephemeral port, so the CLI remains
     # opt-in and operators know which port is exposed.
     metrics_port: int = 0
+    # Queue-capacity percentage that triggers a measured backlog alert.
+    alert_queue_depth_threshold: int = 100
 
 
 # ---------------------------------------------------------------------------
@@ -428,6 +443,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Loopback-only port for the local Prometheus /metrics and /health server "
             "(0 disables it)."
+        ),
+    )
+    p.add_argument(
+        "--alert-queue-depth-threshold",
+        type=_parse_alert_queue_depth_threshold,
+        default=100,
+        metavar="PERCENT",
+        help=(
+            "Queue-capacity percentage that triggers a backlog alert when local metrics "
+            "are enabled (0-100, default: 100)."
         ),
     )
     p.add_argument(
@@ -688,6 +713,7 @@ def _build_pipeline_config(
         budget_overrides={"merge": cfg.drive_green_loops},
         serialize_file_overlap=cfg.serialize_file_overlap,
         metrics_port=cfg.metrics_port,
+        alert_queue_depth_threshold=cfg.alert_queue_depth_threshold,
         circuit_breaker_snapshot_provider=circuit_breaker_snapshot_provider,
         event_log_path=_pipeline_event_log_path(cfg.projects_dir, repos),
         projects_dir=cfg.projects_dir,
@@ -837,6 +863,7 @@ def main(argv: list[str] | None = None) -> int:
             args.phase_timeout if args.phase_timeout and args.phase_timeout > 0 else None
         ),
         metrics_port=args.metrics_port,
+        alert_queue_depth_threshold=args.alert_queue_depth_threshold,
     )
 
     if not repos:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -155,8 +155,6 @@ _MAX_STEPS_PER_TICK = 100
 #: cycles terminate even if a stage's own bookkeeping has a bug.
 _FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
 
-_WAKE_HANDLE = object()
-
 _PROMPT_PREFLIGHT_TEMPLATE = "shared/untrusted_notice.j2"
 _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — reinstall: `uv sync`."
 
@@ -249,7 +247,7 @@ class PipelineConfig:
     # validated at the CLI boundary and again by MetricsHTTPServer on use.
     metrics_port: int = 0
     # Alerts are emitted only from measured queue depths and circuit-breaker
-    # snapshots. Keep the threshold explicit and non-negative.
+    # snapshots. The queue threshold is a capacity percentage in [0, 100].
     alert_queue_depth_threshold: int = 100
     # A product-layer caller supplies the library breaker snapshot reader. The
     # coordinator remains a zero-I/O pipeline module and never imports the
@@ -349,7 +347,8 @@ class Coordinator:
         self.github = github
         self._github_factory = github_factory
         self.shutdown = threading.Event()
-        self.completion_q: CompletionQueue = queue_mod.Queue()
+        self._work_window = max(1, config.parallel_repos * config.max_workers)
+        self.completion_q = CompletionQueue(capacity=self._work_window)
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
             # I/O-capable module and tests never need it.
@@ -362,11 +361,19 @@ class Coordinator:
             )
         else:
             # Share channels with an injected pool when it exposes them.
-            if getattr(pool, "completion_q", None) is not None:
-                self.completion_q = pool.completion_q
+            injected_queue = getattr(pool, "completion_q", None)
+            if injected_queue is None:
+                raise TypeError("injected worker pool must expose completion_q")
+            if getattr(injected_queue, "capacity", None) != self._work_window:
+                raise ValueError(
+                    "injected completion queue capacity must match coordinator work window"
+                )
+            self.completion_q = injected_queue
         self.pool: Any = pool
 
-        self.queues: dict[StageName, StageQueue] = {name: StageQueue() for name in StageName}
+        self.queues: dict[StageName, StageQueue] = {
+            name: StageQueue(capacity=self._work_window) for name in StageName
+        }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
         self.inflight_per_repo: Counter[str] = Counter()
@@ -375,6 +382,10 @@ class Coordinator:
         self.items: list[WorkItem] = []
         self.event_log: list[tuple[Any, ...]] = []
         self._event_log_disabled = False
+        self._completion_wake = threading.Event()
+        self._saturated_queues: set[str] = set()
+        self._saturation_totals: Counter[str] = Counter()
+        self._exported_saturation_totals: Counter[str] = Counter()
         # Observability is opt-in.  Keep imports and all socket setup out of
         # the default construction path so the product layer retains its
         # zero-I/O import contract.
@@ -531,6 +542,30 @@ class Coordinator:
             logger.warning("failed to write pipeline event log %s: %s", path, exc)
             self._event_log_disabled = True
 
+    def _record_queue_saturation(
+        self,
+        *,
+        queue: str,
+        capacity: int,
+        item: WorkItem | None = None,
+        source: str,
+        fatal: bool = False,
+    ) -> None:
+        """Record a bounded queue rejection in memory and the optional journal."""
+        self._saturation_totals[queue] += 1
+        self._saturated_queues.add(queue)
+        fields: dict[str, Any] = {
+            "queue": queue,
+            "capacity": capacity,
+            "source": source,
+            "rejections": self._saturation_totals[queue],
+        }
+        if item is not None:
+            fields["item"] = self._item_key(item)
+        if fatal:
+            fields["fatal"] = True
+        self._record_event("queue_saturated", fields)
+
     def _observability_snapshot(self) -> dict[str, Any]:
         """Read the coordinator lifecycle values that observability exposes."""
         circuit_breakers: dict[str, dict[str, Any]] = {}
@@ -545,6 +580,13 @@ class Coordinator:
 
         return {
             "queue_depths": {name.value: len(queue) for name, queue in self.queues.items()},
+            "queue_capacities": {
+                name.value: queue.capacity for name, queue in self.queues.items()
+            },
+            "completion_depth": self.completion_q.qsize(),
+            "completion_capacity": self.completion_q.capacity,
+            "queue_rejection_totals": dict(self._saturation_totals),
+            "saturated_queues": sorted(self._saturated_queues),
             "inflight_per_repo": dict(self.inflight_per_repo),
             "inflight_jobs": len(self.in_flight),
             "circuit_breakers": circuit_breakers,
@@ -563,6 +605,7 @@ class Coordinator:
         registry = self._metrics_registry
         tracker = self._alert_tracker
         if registry is None or tracker is None:
+            self._saturated_queues.clear()
             return
         snapshot = self._observability_snapshot()
         for stage, depth in snapshot["queue_depths"].items():
@@ -570,6 +613,29 @@ class Coordinator:
                 "hephaestus_pipeline_queue_depth",
                 "Queued pipeline work items by stage.",
             ).set(depth, labels={"stage": stage})
+        for stage, capacity in snapshot["queue_capacities"].items():
+            registry.gauge(
+                "hephaestus_pipeline_queue_capacity",
+                "Configured pipeline queue capacity by stage.",
+            ).set(capacity, labels={"stage": stage})
+        registry.gauge(
+            "hephaestus_pipeline_completion_depth",
+            "Completion results waiting for the coordinator.",
+        ).set(snapshot["completion_depth"])
+        registry.gauge(
+            "hephaestus_pipeline_completion_capacity",
+            "Configured completion queue capacity.",
+        ).set(snapshot["completion_capacity"])
+        rejection_totals = registry.counter(
+            "hephaestus_pipeline_queue_rejections_total",
+            "Rejected stage or completion queue publications by queue.",
+        )
+        for queue_name, total in snapshot["queue_rejection_totals"].items():
+            # Counter samples are cumulative, so only add the delta since the
+            # last snapshot rather than re-emitting the process total.
+            previous = self._exported_saturation_totals.get(queue_name, 0)
+            rejection_totals.inc(total - previous, labels={"queue": queue_name})
+            self._exported_saturation_totals[queue_name] = total
         registry.gauge(
             "hephaestus_pipeline_inflight_jobs",
             "Pipeline jobs currently owned by the worker pool.",
@@ -628,10 +694,11 @@ class Coordinator:
                     "message": event.message,
                 },
             )
+        self._saturated_queues.clear()
 
     def _wake_completion_wait(self) -> None:
-        """Wake the coordinator if it is blocked in completion_q.get()."""
-        self.completion_q.put((_WAKE_HANDLE, JobResult(ok=False, interrupted=True, error="wake")))
+        """Wake the coordinator without consuming a completion queue slot."""
+        self._completion_wake.set()
 
     # -- run loop ---------------------------------------------------------------
 
@@ -664,6 +731,8 @@ class Coordinator:
                 self._drain_completions()
                 self._emit_observability_tick()
                 if self.shutdown.is_set():
+                    if self._grace_deadline is None:
+                        self._begin_graceful_shutdown("external shutdown request")
                     # Graceful: stop admitting; drain in-flight to RESUMABLE.
                     if not self.in_flight:
                         break
@@ -824,26 +893,87 @@ class Coordinator:
 
     def _drain_completions(self) -> None:
         """Drain ALL ready completions without blocking."""
+        if self._drain_completion_rejections():
+            return
+        if self._completion_wake.is_set():
+            self._completion_wake.clear()
+            self._record_event("wake", "completion_q")
         while True:
+            if self._drain_completion_rejections():
+                return
             try:
                 handle, result = self.completion_q.get_nowait()
             except queue_mod.Empty:
                 return
-            if handle is _WAKE_HANDLE:
-                self._record_event("wake", "completion_q")
-                continue
             self._handle_completion(handle, result)
 
     def _wait_for_completion(self, timeout: float) -> None:
         """Block up to *timeout* for one completion; handle it if one arrives."""
-        try:
-            handle, result = self.completion_q.get(timeout=timeout)
-        except queue_mod.Empty:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            if self._drain_completion_rejections():
+                return
+            if self._completion_wake.is_set():
+                self._completion_wake.clear()
+                self._record_event("wake", "completion_q")
+                return
+            try:
+                handle, result = self.completion_q.get_nowait()
+            except queue_mod.Empty:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return
+                # Queue.get() cannot observe the out-of-band wake latch. A
+                # short Event wait keeps signal shutdown responsive while the
+                # non-blocking queue poll handles worker completions.
+                self._completion_wake.wait(timeout=min(remaining, 0.05))
+                continue
+            self._handle_completion(handle, result)
             return
-        if handle is _WAKE_HANDLE:
-            self._record_event("wake", "completion_q")
-            return
-        self._handle_completion(handle, result)
+
+    def _drain_completion_rejections(self) -> bool:
+        """Terminalize rejected completions before normal result processing."""
+        rejected, mailbox_overflowed = self.completion_q.take_rejections()
+        for rejection in rejected:
+            item = self.in_flight.pop(rejection.handle, None)
+            if item is None:
+                continue
+            self._release_inflight(item)
+            self._record_queue_saturation(
+                queue="completion",
+                capacity=self.completion_q.capacity,
+                item=item,
+                source="completion_publish_rejected",
+            )
+            self._park_resumable(item, reason="completion publication rejected")
+        if mailbox_overflowed:
+            self._record_queue_saturation(
+                queue="completion",
+                capacity=self.completion_q.capacity,
+                source="completion_rejection_mailbox_overflow",
+                fatal=True,
+            )
+            self._teardown_immediate()
+            return True
+        if rejected:
+            self._begin_graceful_shutdown("completion queue saturation")
+        return False
+
+    def _begin_graceful_shutdown(self, reason: str) -> None:
+        """Start a grace-bounded shutdown for any externally requested stop."""
+        self.shutdown.set()
+        if self._grace_deadline is None:
+            self._grace_deadline = time.monotonic() + max(0.0, self.config.grace_s)
+            self._record_event(
+                "shutdown_requested",
+                {"reason": reason, "grace_s": max(0.0, self.config.grace_s)},
+            )
+
+    def _release_inflight(self, item: WorkItem) -> None:
+        """Release one item from the coordinator's in-flight counters."""
+        self.inflight_per_repo[item.repo] -= 1
+        if self.inflight_per_repo[item.repo] <= 0:
+            del self.inflight_per_repo[item.repo]
 
     def _handle_completion(self, handle: JobHandle, result: JobResult) -> None:
         """Route one completed job back to its item.
@@ -873,9 +1003,7 @@ class Coordinator:
                 **self._job_result_event_fields(result),
             },
         )
-        self.inflight_per_repo[item.repo] -= 1
-        if self.inflight_per_repo[item.repo] <= 0:
-            del self.inflight_per_repo[item.repo]
+        self._release_inflight(item)
         if isinstance(handle.job, AgentJob):
             self._agent_job_count += 1
             self._agent_job_time_s += result.duration_s
@@ -927,19 +1055,22 @@ class Coordinator:
             return
         self._run_item(item)
 
-    def _park_resumable(self, item: WorkItem) -> None:
+    def _park_resumable(self, item: WorkItem, *, reason: str | None = None) -> None:
         """Park *item* as RESUMABLE at its current stage (interrupt semantics).
 
         Never FAILED: durable writes precede queue pushes, so a restart's
         seeding reconstruction resumes exactly here with no shutdown
         bookkeeping.
         """
+        resumable_reason = f"resumable at {item.stage.value}"
+        if reason:
+            resumable_reason = f"{resumable_reason}: {reason}"
         item.result = ItemResult(
             passed=False,
-            reason=f"resumable at {item.stage.value}",
+            reason=resumable_reason,
             final_stage=item.stage,
         )
-        item.add_history_event(item.stage, item.state, note="interrupted; resumable")
+        item.add_history_event(item.stage, item.state, note=reason or "interrupted; resumable")
         self._record_event("resumable", self._item_key(item), item.stage.value, item.state)
         logger.info(
             "interrupt: item %s RESUMABLE at %s (never failed)",
@@ -987,7 +1118,7 @@ class Coordinator:
                     return
                 item = q.pop()
                 if not self._admit(item):
-                    q.push(item)
+                    self._push_item(item, stage_name, enter=False)
                     continue
                 self._record_event("drain", stage_name.value, self._item_key(item))
                 self._run_item(item)
@@ -1051,7 +1182,7 @@ class Coordinator:
         # Preserve original queue order for deferred / non-admitted / non-issue items.
         for it in items:
             if id(it) not in ran:
-                q.push(it)
+                self._push_item(it, StageName.IMPLEMENTATION, enter=False)
 
     def _dedup_implementation_items(self, items: list[WorkItem]) -> list[WorkItem]:
         """Drop transient duplicate work items, keyed by ``(repo, issue)`` (#2057).
@@ -1114,8 +1245,11 @@ class Coordinator:
         return issue_items, ambiguous
 
     def _admit(self, item: WorkItem) -> bool:
-        """Admission control: per-repo in-flight cap (O(1) Counter lookup)."""
-        return self.inflight_per_repo[item.repo] < max(1, self.config.max_workers)
+        """Admission control: global work window plus per-repo cap."""
+        return (
+            len(self.in_flight) < self._work_window
+            and self.inflight_per_repo[item.repo] < max(1, self.config.max_workers)
+        )
 
     # -- item execution -----------------------------------------------------
 
@@ -1361,9 +1495,12 @@ class Coordinator:
                     reason=product.get("reason", "already finished"),
                     final_stage=StageName.FINISHED,
                 )
+                self._push_item(new_item, new_item.stage, enter=True)
             elif new_item.stage is not StageName.REPO:
-                self._pass_work_count += 1
-            self._push_item(new_item, new_item.stage, enter=True)
+                if self._push_item(new_item, new_item.stage, enter=True):
+                    self._pass_work_count += 1
+            else:
+                self._push_item(new_item, new_item.stage, enter=True)
 
     def _live_issue_keys(self) -> set[tuple[str, int]]:
         """Return ``(repo, issue)`` keys currently queued (any stage) or in-flight.
@@ -1382,7 +1519,7 @@ class Coordinator:
                 keys.add((it.repo, it.issue))
         return keys
 
-    def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> None:
+    def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> bool:
         """Push *item* into *stage*'s queue (the single push chokepoint).
 
         Every durable GitHub mutation for this transition already happened
@@ -1402,18 +1539,31 @@ class Coordinator:
             and (item.repo, item.issue) in self._live_issue_keys()
         ):
             logger.info("seed skipped: #%s already queued/in-flight in %s", item.issue, item.repo)
-            return
+            return False
+        is_new = id(item) not in self._seen_item_ids
+        queue = self.queues[stage]
+        if not queue.push(item):
+            self._record_queue_saturation(
+                queue=stage.value,
+                capacity=queue.capacity,
+                item=item,
+                source="stage_enqueue_rejected",
+            )
+            if not is_new:
+                item.stage = stage
+                self._park_resumable(item, reason="stage enqueue rejected")
+            return False
         item.stage = stage
         if enter:
             item.state = "ENTER"
             item.payload["_enter_pending"] = True
             item.add_history_event(stage, item.state, note="enqueued")
-        if id(item) not in self._seen_item_ids:
+        if is_new:
             self._seen_item_ids.add(id(item))
             self.items.append(item)
             item.payload.setdefault("entry_stage", stage.value)
-        self.queues[stage].push(item)
         self._record_event("push", stage.value, self._item_key(item))
+        return True
 
     @staticmethod
     def _item_key(item: WorkItem) -> str:
@@ -1450,14 +1600,14 @@ class Coordinator:
                 logger.info("seed excluded: %s", entry.reason)
                 continue
             item = self._entry_to_item(entry, self.config.repos[0] if self.config.repos else "")
-            if item.stage not in (StageName.REPO, StageName.FINISHED):
-                self._pass_work_count += 1
             if item.stage is StageName.FINISHED and item.result is None:
                 item.result = ItemResult(
                     passed=entry.passed, reason=entry.reason, final_stage=StageName.FINISHED
                 )
-            self._push_item(item, item.stage, enter=True)
-            pushed += 1
+            if self._push_item(item, item.stage, enter=True):
+                if item.stage not in (StageName.REPO, StageName.FINISHED):
+                    self._pass_work_count += 1
+                pushed += 1
         return pushed
 
     def _clamp_seed_stage_to_scope(
@@ -1756,8 +1906,7 @@ class Coordinator:
                     signum,
                     self.config.grace_s,
                 )
-                self.shutdown.set()
-                self._grace_deadline = time.monotonic() + self.config.grace_s
+                self._begin_graceful_shutdown(f"signal {signum}")
                 self._wake_completion_wait()
 
         sigs = [signal.SIGINT, signal.SIGTERM]

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -82,12 +82,13 @@ import time
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypeAlias
 
 from jinja2 import TemplateNotFound
 
-from hephaestus.automation.models import IssueInfo
+from hephaestus.automation.models import DEFAULT_STATE_DIR, IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
 from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
@@ -205,6 +206,18 @@ def _json_safe(value: Any) -> Any:
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     return str(value)
+
+
+def default_event_log_path(projects_dir: Path, repos: list[str]) -> Path:
+    """Return the process-local durable journal path for a pipeline run.
+
+    ``projects_dir`` is accepted so every production entrypoint can derive its
+    journal from the same configuration seam. The journal intentionally lives
+    in the automation state directory rather than inside a repository checkout.
+    """
+    del projects_dir, repos
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path(DEFAULT_STATE_DIR) / f"pipeline-events-{stamp}-{time.time_ns()}.jsonl"
 
 
 @dataclass(frozen=True)
@@ -580,9 +593,7 @@ class Coordinator:
 
         return {
             "queue_depths": {name.value: len(queue) for name, queue in self.queues.items()},
-            "queue_capacities": {
-                name.value: queue.capacity for name, queue in self.queues.items()
-            },
+            "queue_capacities": {name.value: queue.capacity for name, queue in self.queues.items()},
             "completion_depth": self.completion_q.qsize(),
             "completion_capacity": self.completion_q.capacity,
             "queue_rejection_totals": dict(self._saturation_totals),
@@ -1246,9 +1257,8 @@ class Coordinator:
 
     def _admit(self, item: WorkItem) -> bool:
         """Admission control: global work window plus per-repo cap."""
-        return (
-            len(self.in_flight) < self._work_window
-            and self.inflight_per_repo[item.repo] < max(1, self.config.max_workers)
+        return len(self.in_flight) < self._work_window and self.inflight_per_repo[item.repo] < max(
+            1, self.config.max_workers
         )
 
     # -- item execution -----------------------------------------------------
@@ -1549,9 +1559,17 @@ class Coordinator:
                 item=item,
                 source="stage_enqueue_rejected",
             )
-            if not is_new:
-                item.stage = stage
-                self._park_resumable(item, reason="stage enqueue rejected")
+            item.stage = stage
+            if is_new:
+                self._seen_item_ids.add(id(item))
+                self.items.append(item)
+                item.payload.setdefault("entry_stage", stage.value)
+            self._park_resumable(item, reason="stage enqueue rejected")
+            if is_new:
+                # A rejected seed is otherwise absent from every coordinator
+                # collection. Stop with a resumable status so callers cannot
+                # mistake an incomplete admission pass for a clean run.
+                self._begin_graceful_shutdown("stage queue saturation")
             return False
         item.stage = stage
         if enter:
@@ -1978,6 +1996,11 @@ def run_pipeline(config: PipelineConfig) -> int:
 
     """
     _preflight_prompt_catalog()
+    if config.event_log_path is None:
+        config = replace(
+            config,
+            event_log_path=default_event_log_path(config.projects_dir, config.repos),
+        )
 
     # Imported here: pipeline_github maps the accessor onto the real gh
     # helpers and must stay out of the pure pipeline import surface.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -79,7 +79,7 @@ import queue as queue_mod
 import signal
 import threading
 import time
-from collections import Counter
+from collections import Counter, deque
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -142,6 +142,10 @@ _DEFAULT_GRACE_S = 30.0
 
 #: Coordinator idle poll interval while waiting for completions (seconds).
 _IDLE_POLL_S = 1.0
+
+#: Default in-memory stage backlog bound. This is intentionally independent of
+#: the worker/completion window; excess seed products use admission spooling.
+_DEFAULT_STAGE_QUEUE_CAPACITY = 64
 
 #: Number of fully stalled idle ticks before the coordinator force-runs work.
 _STALL_TICKS_BEFORE_FORCE = 3
@@ -231,6 +235,7 @@ class PipelineConfig:
     loops: int = 1
     max_workers: int = 1
     parallel_repos: int = 1
+    stage_queue_capacity: int = _DEFAULT_STAGE_QUEUE_CAPACITY
     dry_run: bool = False
     grace_s: float = _DEFAULT_GRACE_S
     phase_timeout_s: float | None = None
@@ -361,6 +366,8 @@ class Coordinator:
         self._github_factory = github_factory
         self.shutdown = threading.Event()
         self._work_window = max(1, config.parallel_repos * config.max_workers)
+        if config.stage_queue_capacity < 1:
+            raise ValueError("stage queue capacity must be positive")
         self.completion_q = CompletionQueue(capacity=self._work_window)
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
@@ -385,7 +392,7 @@ class Coordinator:
         self.pool: Any = pool
 
         self.queues: dict[StageName, StageQueue] = {
-            name: StageQueue(capacity=self._work_window) for name in StageName
+            name: StageQueue(capacity=config.stage_queue_capacity) for name in StageName
         }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
@@ -395,7 +402,9 @@ class Coordinator:
         self.items: list[WorkItem] = []
         self.event_log: list[tuple[Any, ...]] = []
         self._event_log_disabled = False
+        self._journal_failure = False
         self._completion_wake = threading.Event()
+        self._pending_admissions: deque[tuple[WorkItem, StageName, bool]] = deque()
         self._saturated_queues: set[str] = set()
         self._saturation_totals: Counter[str] = Counter()
         self._exported_saturation_totals: Counter[str] = Counter()
@@ -534,14 +543,14 @@ class Coordinator:
         event_name, fields = encode_stage_event(event)
         self._record_event(event_name, fields)
 
-    def _record_event(self, event: str, *fields: Any) -> None:
-        """Append an event to memory and, when configured, to JSONL on disk."""
+    def _record_event(self, event: str, *fields: Any) -> bool:
+        """Append an event to memory and report whether disk journaling worked."""
         self.event_log.append((event, *fields))
         if self._event_log_disabled:
-            return
+            return False
         path = self.config.event_log_path
         if path is None:
-            return
+            return True
         record = {
             "ts": time.time(),
             "event": event,
@@ -554,6 +563,8 @@ class Coordinator:
         except OSError as exc:
             logger.warning("failed to write pipeline event log %s: %s", path, exc)
             self._event_log_disabled = True
+            return False
+        return True
 
     def _record_queue_saturation(
         self,
@@ -577,7 +588,15 @@ class Coordinator:
             fields["item"] = self._item_key(item)
         if fatal:
             fields["fatal"] = True
-        self._record_event("queue_saturated", fields)
+        if (
+            not self._record_event("queue_saturated", fields)
+            and self.config.event_log_path is not None
+        ):
+            # Saturation is a recovery boundary. Continuing without the
+            # journal would turn resumable work into an unaccounted loss.
+            self._journal_failure = True
+            self._fatal = True
+            self._begin_graceful_shutdown("saturation journal unavailable")
 
     def _observability_snapshot(self) -> dict[str, Any]:
         """Read the coordinator lifecycle values that observability exposes."""
@@ -750,6 +769,7 @@ class Coordinator:
                     self._wait_for_completion(timeout=0.2)
                     continue
                 self._drain_queues()
+                self._drain_pending_admissions()
                 if self._all_idle():
                     if not self._reseed_if_converged():
                         break
@@ -815,6 +835,8 @@ class Coordinator:
 
     def _exit_code(self) -> int:
         """130 on interrupt; 1 on any effective fail/skip/blocked; 0 clean."""
+        if self._journal_failure:
+            return 1
         if self.shutdown.is_set():
             # Interrupt deliberately takes priority over non-passing ledger
             # entries and fatal coordinator errors: a signal means the run did
@@ -833,6 +855,7 @@ class Coordinator:
             all(len(q) == 0 for q in self.queues.values())
             and not self.timers
             and not self.in_flight
+            and not self._pending_admissions
         )
 
     def _grace_exceeded(self) -> bool:
@@ -1133,6 +1156,29 @@ class Coordinator:
                     continue
                 self._record_event("drain", stage_name.value, self._item_key(item))
                 self._run_item(item)
+
+    def _drain_pending_admissions(self) -> None:
+        """Admit deferred items as stage queue slots become available.
+
+        Stage queues are bounded independently of the worker window. A seed
+        burst may therefore have more ready items than a queue can hold in one
+        tick; those items remain in this coordinator-owned admission spool and
+        are retried after the normal downstream-first drain.
+        """
+        if self.shutdown.is_set() or not self._pending_admissions:
+            return
+        for _ in range(len(self._pending_admissions)):
+            item, stage, enter = self._pending_admissions.popleft()
+            queue = self.queues[stage]
+            if not queue.push(item):
+                self._pending_admissions.append((item, stage, enter))
+                continue
+            if enter:
+                item.state = "ENTER"
+                item.payload["_enter_pending"] = True
+                item.add_history_event(stage, item.state, note="enqueued")
+            self._record_event("push", stage.value, self._item_key(item))
+            self._progress = True
 
     def _drain_implementation(self) -> None:
         """Drain the implementation queue under topo order + file-overlap gating.
@@ -1527,6 +1573,9 @@ class Coordinator:
         for it in self.in_flight.values():
             if it.kind is ItemKind.ISSUE and it.issue is not None:
                 keys.add((it.repo, it.issue))
+        for it, _stage, _enter in self._pending_admissions:
+            if it.kind is ItemKind.ISSUE and it.issue is not None:
+                keys.add((it.repo, it.issue))
         return keys
 
     def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> bool:
@@ -1553,24 +1602,23 @@ class Coordinator:
         is_new = id(item) not in self._seen_item_ids
         queue = self.queues[stage]
         if not queue.push(item):
-            self._record_queue_saturation(
-                queue=stage.value,
-                capacity=queue.capacity,
-                item=item,
-                source="stage_enqueue_rejected",
-            )
             item.stage = stage
+            if enter:
+                item.state = "ENTER"
+                item.payload["_enter_pending"] = True
             if is_new:
                 self._seen_item_ids.add(id(item))
                 self.items.append(item)
                 item.payload.setdefault("entry_stage", stage.value)
-            self._park_resumable(item, reason="stage enqueue rejected")
-            if is_new:
-                # A rejected seed is otherwise absent from every coordinator
-                # collection. Stop with a resumable status so callers cannot
-                # mistake an incomplete admission pass for a clean run.
-                self._begin_graceful_shutdown("stage queue saturation")
-            return False
+            self._pending_admissions.append((item, stage, enter))
+            item.add_history_event(stage, item.state, note="queue deferred")
+            self._record_event(
+                "queue_deferred",
+                stage.value,
+                self._item_key(item),
+                {"capacity": queue.capacity},
+            )
+            return True
         item.stage = stage
         if enter:
             item.state = "ENTER"
@@ -1977,6 +2025,7 @@ class Coordinator:
                 continue
             leftovers.extend(q.snapshot())
         leftovers.extend(self.in_flight.values())
+        leftovers.extend(item for item, _stage, _enter in self._pending_admissions)
         for item in leftovers:
             if item.result is None:
                 self._park_resumable(item)

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -147,6 +147,10 @@ _IDLE_POLL_S = 1.0
 #: the worker/completion window; excess seed products use admission spooling.
 _DEFAULT_STAGE_QUEUE_CAPACITY = 64
 
+#: Maximum number of recent coordinator events kept for in-process diagnostics.
+#: The optional JSONL journal remains the durable complete event history.
+_DEFAULT_EVENT_LOG_CAPACITY = 1_024
+
 #: Number of fully stalled idle ticks before the coordinator force-runs work.
 _STALL_TICKS_BEFORE_FORCE = 3
 
@@ -271,6 +275,9 @@ class PipelineConfig:
     # coordinator remains a zero-I/O pipeline module and never imports the
     # resilience capability directly.
     circuit_breaker_snapshot_provider: Callable[[], dict[str, dict[str, Any]]] | None = None
+    # A bounded diagnostic view only; ``event_log_path`` is the durable event
+    # history and is not truncated by this setting.
+    event_log_capacity: int = _DEFAULT_EVENT_LOG_CAPACITY
     event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
     # Optional exceptions to the normal ``projects_dir / repo`` checkout
@@ -368,6 +375,8 @@ class Coordinator:
         self._work_window = max(1, config.parallel_repos * config.max_workers)
         if config.stage_queue_capacity < 1:
             raise ValueError("stage queue capacity must be positive")
+        if config.event_log_capacity < 1:
+            raise ValueError("event log capacity must be positive")
         self.completion_q = CompletionQueue(capacity=self._work_window)
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
@@ -400,11 +409,19 @@ class Coordinator:
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
-        self.event_log: list[tuple[Any, ...]] = []
+        self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
         self._event_log_disabled = False
         self._journal_failure = False
         self._completion_wake = threading.Event()
-        self._pending_admissions: deque[tuple[WorkItem, StageName, bool]] = deque()
+        # A single global spool serves every bounded stage queue.  Reserving one
+        # additional full batch per stage gives each stage equal overflow room
+        # while proving a hard resident-work bound of 2 * stages * capacity
+        # (plus the independently bounded worker window).
+        self._admission_spool_capacity = len(StageName) * config.stage_queue_capacity
+        self._pending_admissions: deque[tuple[WorkItem, StageName, bool]] = deque(
+            maxlen=self._admission_spool_capacity
+        )
+        self._admission_saturated = False
         self._saturated_queues: set[str] = set()
         self._saturation_totals: Counter[str] = Counter()
         self._exported_saturation_totals: Counter[str] = Counter()
@@ -454,6 +471,10 @@ class Coordinator:
         self._seq = 0
         self._grace_deadline: float | None = None
         self._immediate = False
+        # The worker pool and internal recovery paths share ``shutdown`` with
+        # signal handling, so the Event alone cannot identify an operator
+        # interrupt. Exit 130 is reserved for a handler-observed signal.
+        self._signal_received = False
         self._agent_job_count = 0
         self._agent_job_time_s = 0.0
         self._loops_run = 0
@@ -574,6 +595,7 @@ class Coordinator:
         item: WorkItem | None = None,
         source: str,
         fatal: bool = False,
+        details: dict[str, Any] | None = None,
     ) -> None:
         """Record a bounded queue rejection in memory and the optional journal."""
         self._saturation_totals[queue] += 1
@@ -588,6 +610,8 @@ class Coordinator:
             fields["item"] = self._item_key(item)
         if fatal:
             fields["fatal"] = True
+        if details:
+            fields["details"] = details
         if (
             not self._record_event("queue_saturated", fields)
             and self.config.event_log_path is not None
@@ -615,6 +639,8 @@ class Coordinator:
             "queue_capacities": {name.value: queue.capacity for name, queue in self.queues.items()},
             "completion_depth": self.completion_q.qsize(),
             "completion_capacity": self.completion_q.capacity,
+            "admission_depth": len(self._pending_admissions),
+            "admission_capacity": self._admission_spool_capacity,
             "queue_rejection_totals": dict(self._saturation_totals),
             "saturated_queues": sorted(self._saturated_queues),
             "inflight_per_repo": dict(self.inflight_per_repo),
@@ -656,6 +682,14 @@ class Coordinator:
             "hephaestus_pipeline_completion_capacity",
             "Configured completion queue capacity.",
         ).set(snapshot["completion_capacity"])
+        registry.gauge(
+            "hephaestus_pipeline_admission_depth",
+            "Pipeline work waiting for a bounded stage-queue slot.",
+        ).set(snapshot["admission_depth"])
+        registry.gauge(
+            "hephaestus_pipeline_admission_capacity",
+            "Configured pending-admission spool capacity.",
+        ).set(snapshot["admission_capacity"])
         rejection_totals = registry.counter(
             "hephaestus_pipeline_queue_rejections_total",
             "Rejected stage or completion queue publications by queue.",
@@ -834,10 +868,10 @@ class Coordinator:
         return active
 
     def _exit_code(self) -> int:
-        """130 on interrupt; 1 on any effective fail/skip/blocked; 0 clean."""
+        """130 on a signal; 1 on internal stop/fail/skip/blocked; 0 clean."""
         if self._journal_failure:
             return 1
-        if self.shutdown.is_set():
+        if self._signal_received:
             # Interrupt deliberately takes priority over non-passing ledger
             # entries and fatal coordinator errors: a signal means the run did
             # not complete, so wrappers must classify it as cancellation even
@@ -845,7 +879,7 @@ class Coordinator:
             return 130
         effective_results = [item.result for item in self._effective_items() if item.result]
         results = effective_results or self.ledger
-        if self._fatal or any(not result.passed for result in results):
+        if self.shutdown.is_set() or self._fatal or any(not result.passed for result in results):
             return 1
         return 0
 
@@ -1539,6 +1573,8 @@ class Coordinator:
         if item.kind is not ItemKind.REPO:
             return
         for product in item.payload.pop("products", []):
+            if self._admission_saturated:
+                break
             if product.get("stage") is None:
                 logger.info("[%s] excluded: %s", item.repo, product.get("reason", ""))
                 continue
@@ -1591,25 +1627,54 @@ class Coordinator:
         from an already-tracked item re-pushing itself on timer/retry/fail-back/
         advance, which must always be allowed through.
         """
+        is_new = id(item) not in self._seen_item_ids
+        if self._admission_saturated:
+            # The first rejected item is retained below as the exact durable
+            # recovery boundary.  Refuse later source products without
+            # retaining them so a caller that has not observed shutdown yet
+            # cannot defeat the resident-work bound.
+            return False
         if (
-            id(item) not in self._seen_item_ids
+            is_new
             and item.kind is ItemKind.ISSUE
             and item.issue is not None
             and (item.repo, item.issue) in self._live_issue_keys()
         ):
             logger.info("seed skipped: #%s already queued/in-flight in %s", item.issue, item.repo)
             return False
-        is_new = id(item) not in self._seen_item_ids
+        # Register a novel item before attempting bounded admission. This makes
+        # ``items`` the accounting source of truth for every seed that reaches
+        # the queue-capacity decision: it is present whether admitted directly,
+        # deferred to the bounded spool, or parked at the saturation boundary.
+        if is_new:
+            self._seen_item_ids.add(id(item))
+            self.items.append(item)
+            item.payload.setdefault("entry_stage", stage.value)
         queue = self.queues[stage]
         if not queue.push(item):
             item.stage = stage
             if enter:
                 item.state = "ENTER"
                 item.payload["_enter_pending"] = True
-            if is_new:
-                self._seen_item_ids.add(id(item))
-                self.items.append(item)
-                item.payload.setdefault("entry_stage", stage.value)
+            if len(self._pending_admissions) >= self._admission_spool_capacity:
+                self._admission_saturated = True
+                self._fatal = True
+                self._record_queue_saturation(
+                    queue="admission",
+                    capacity=self._admission_spool_capacity,
+                    item=item,
+                    source=f"{stage.value}_stage_queue_overflow",
+                    fatal=True,
+                    details={
+                        "admission_depth": len(self._pending_admissions),
+                        "blocked_stage": stage.value,
+                        "stage_capacity": queue.capacity,
+                        "stage_depth": len(queue),
+                    },
+                )
+                self._park_resumable(item, reason="admission spool saturated")
+                self._begin_graceful_shutdown("admission spool saturation")
+                return False
             self._pending_admissions.append((item, stage, enter))
             item.add_history_event(stage, item.state, note="queue deferred")
             self._record_event(
@@ -1624,10 +1689,6 @@ class Coordinator:
             item.state = "ENTER"
             item.payload["_enter_pending"] = True
             item.add_history_event(stage, item.state, note="enqueued")
-        if is_new:
-            self._seen_item_ids.add(id(item))
-            self.items.append(item)
-            item.payload.setdefault("entry_stage", stage.value)
         self._record_event("push", stage.value, self._item_key(item))
         return True
 
@@ -1657,6 +1718,8 @@ class Coordinator:
             entries.extend(self._seed_direct_scope(default_repo))
         pushed = 0
         for entry in entries:
+            if self._admission_saturated:
+                break
             if entry.stage is None:
                 # Epic tagging is the ONE sanctioned seeding write, executed
                 # here through the skip_epics chokepoint BEFORE the exclusion
@@ -1962,11 +2025,13 @@ class Coordinator:
         """SIGINT/SIGTERM/SIGHUP -> one shutdown Event (first graceful, second immediate)."""
 
         def _handler(signum: int, frame: object) -> None:
-            if self.shutdown.is_set():
+            del frame
+            if self._signal_received:
                 logger.warning("second signal %d: immediate shutdown", signum)
                 self._immediate = True
                 self._wake_completion_wait()
             else:
+                self._signal_received = True
                 logger.warning(
                     "signal %d: graceful shutdown (grace %.0fs; press again to force)",
                     signum,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -118,7 +118,11 @@ from hephaestus.automation.pipeline.stages import (
     StageGitHub,
 )
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
-from hephaestus.automation.pipeline.stages.repo import RepoIssueSource, product_to_work_item
+from hephaestus.automation.pipeline.stages.repo import (
+    RepoIssueSource,
+    _drive_green_pr_is_in_scope,
+    product_to_work_item,
+)
 from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
 from hephaestus.automation.pipeline.work_item import (
     ItemKind,
@@ -1436,14 +1440,16 @@ class Coordinator:
         """Consume source rows until one is admitted, deferred, or exhausted."""
         source = active.source
         ctx = self._ctx_for_repo(active.repo)
+        if source.issues_exhausted:
+            return self._drain_repo_pr_source(active)
         while True:
             metadata = source.pending
             if metadata is None:
                 try:
                     metadata = next(source.metadata)
                 except StopIteration:
-                    self._record_event("repo_source_complete", active.repo, source.seeded_count)
-                    return False
+                    source.issues_exhausted = True
+                    return self._drain_repo_pr_source(active)
                 except Exception as exc:
                     self._record_repo_source_failure(active.repo, f"discovery failed: {exc}")
                     return False
@@ -1519,6 +1525,86 @@ class Coordinator:
                     self._pass_work_count += 1
             self._progress = True
             return True
+
+    def _drain_repo_pr_source(  # noqa: C901 - source lifecycle is intentionally linear
+        self, active: _ActiveRepoIssueSource
+    ) -> bool:
+        """Admit one eligible drive-green PR through the bounded source path."""
+        source = active.source
+        metadata_iter = source.pr_metadata
+        if metadata_iter is None:
+            self._record_event("repo_source_complete", active.repo, source.seeded_count)
+            return False
+
+        metadata = source.pending_pr
+        if metadata is None:
+            try:
+                metadata = next(metadata_iter)
+            except StopIteration:
+                self._record_event("repo_source_complete", active.repo, source.seeded_count)
+                return False
+            except Exception as exc:
+                self._record_repo_source_failure(active.repo, f"PR discovery failed: {exc}")
+                return False
+
+        include_bot_prs = bool(getattr(self.config, "include_bot_prs", True))
+        if not _drive_green_pr_is_in_scope(
+            metadata,
+            include_bot_prs=include_bot_prs,
+            viewer_login=source.viewer_login,
+        ):
+            source.pending_pr = None
+            self._progress = True
+            return True
+        try:
+            pr_number = int(metadata["number"])
+        except (KeyError, TypeError, ValueError) as exc:
+            self._record_repo_source_failure(
+                active.repo, f"PR discovery failed: malformed metadata: {exc}"
+            )
+            return False
+
+        # Issue discovery runs first. Its WorkItems remain in ``items`` after
+        # terminalization, so this constant-space lookup prevents the PR cursor
+        # from producing a second item for an already-covered pull request.
+        if any(item.repo == active.repo and item.pr == pr_number for item in self.items):
+            source.pending_pr = None
+            self._record_event("repo_pr_source_covered", active.repo, pr_number)
+            self._progress = True
+            return True
+        if not self._repo_source_can_admit():
+            source.pending_pr = metadata
+            return True
+
+        ctx = self._ctx_for_repo(active.repo)
+        try:
+            entry = self._seed_entry_for_pr(pr_number, ctx.github, fail_unlinked=False)
+        except Exception as exc:
+            self._record_repo_source_failure(active.repo, f"PR discovery failed: {exc}")
+            return False
+        source.pending_pr = None
+        if entry is None:
+            logger.info(
+                "repo:%s: skipping PR #%d; no linked issue supplies requirements",
+                active.repo,
+                pr_number,
+            )
+            self._progress = True
+            return True
+
+        new_item = self._entry_to_item(entry, active.repo)
+        if new_item.stage is StageName.FINISHED and new_item.result is None:
+            new_item.result = ItemResult(
+                passed=entry.passed,
+                reason=entry.reason,
+                final_stage=StageName.FINISHED,
+            )
+        if self._push_item(new_item, new_item.stage, enter=True):
+            source.seeded_count += 1
+            if new_item.stage not in (StageName.REPO, StageName.FINISHED):
+                self._pass_work_count += 1
+        self._progress = True
+        return True
 
     def _record_repo_source_failure(self, repo: str, reason: str) -> None:
         """Record a bounded terminal failure when a discovery cursor aborts."""
@@ -2236,102 +2322,106 @@ class Coordinator:
             stage, reason, passed = self._scope_seed_decision(issue, stage, reason, scope_stages)
             yield replace(entry, stage=stage, reason=reason, passed=passed)
         for pr in self.config.prs:
-            issue_number = github.find_issue_for_pr(pr)
-            if issue_number is None:
-                yield _seeding.SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=StageName.FINISHED,
-                    reason=(
-                        f"PR #{pr} has no linked issue; refusing review without "
-                        "requirements context"
-                    ),
-                    pr_number=pr,
-                    passed=False,
-                )
-                continue
-            scope_identifier = issue_number if issue_number is not None else pr
-            pr_state = github.gh_pr_state(pr)
-            pr_state_name = ((pr_state or {}).get("state") or "").upper()
-            if pr_state_name == "MERGED":
-                yield _seeding.SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=StageName.FINISHED,
-                    reason=f"PR #{pr} already merged",
-                    pr_number=pr,
-                    issue_number=issue_number,
-                    passed=True,
-                )
-                continue
-            if pr_state_name == "CLOSED":
-                yield _seeding.SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=StageName.FINISHED,
-                    reason=f"PR #{pr} already closed without merging",
-                    pr_number=pr,
-                    issue_number=issue_number,
-                    passed=False,
-                )
-                continue
-            has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
-            if has_go:
-                stage, reason, passed = self._scope_seed_decision(
-                    scope_identifier,
-                    StageName.MERGE_WAIT,
-                    f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
-                    scope_stages,
-                )
-                yield _seeding.SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=stage,
-                    reason=reason,
-                    pr_number=pr,
-                    issue_number=issue_number,
-                    passed=passed,
-                )
-            else:
-                issue_facts: _seeding.IssueFacts | None
-                review_context: dict[str, str] | None
-                try:
-                    issue_facts = _seeding.seed_issue_from_github(issue_number, github)
-                    review_context = github.pr_review_context(pr)
-                except Exception as exc:
-                    logger.warning("PR #%d: review context read failed: %s", pr, exc)
-                    review_context = None
-                    issue_facts = None
-                if issue_facts is None or review_context is None:
-                    yield _seeding.SeedEntry(
-                        kind="pr",
-                        identifier=pr,
-                        stage=StageName.FINISHED,
-                        reason=f"PR #{pr} review context could not be read",
-                        pr_number=pr,
-                        issue_number=issue_number,
-                        passed=False,
-                    )
-                    continue
-                stage, reason, passed = self._scope_seed_decision(
-                    scope_identifier,
-                    StageName.PR_REVIEW,
-                    f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
-                    scope_stages,
-                )
-                yield _seeding.SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=stage,
-                    reason=reason,
-                    pr_number=pr,
-                    issue_number=issue_number,
-                    issue_title=issue_facts.title,
-                    issue_body=issue_facts.body,
-                    pr_diff=review_context["pr_diff"],
-                    pr_description=review_context["pr_description"],
-                    passed=passed,
-                )
+            pr_entry = self._seed_entry_for_pr(pr, github, fail_unlinked=True)
+            assert pr_entry is not None  # noqa: S101 - fail_unlinked guarantees an entry
+            yield pr_entry
+
+    def _seed_entry_for_pr(
+        self,
+        pr: int,
+        github: Any,
+        *,
+        fail_unlinked: bool,
+    ) -> _seeding.SeedEntry | None:
+        """Hydrate one linked PR without weakening requirements-context fencing."""
+        issue_number = github.find_issue_for_pr(pr)
+        if issue_number is None:
+            if not fail_unlinked:
+                return None
+            return _seeding.SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.FINISHED,
+                reason=(
+                    f"PR #{pr} has no linked issue; refusing review without requirements context"
+                ),
+                pr_number=pr,
+                passed=False,
+            )
+        scope_stages = self.config.scope.stages if self.config.scope is not None else None
+        pr_state = github.gh_pr_state(pr)
+        pr_state_name = ((pr_state or {}).get("state") or "").upper()
+        if pr_state_name == "MERGED":
+            return _seeding.SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.FINISHED,
+                reason=f"PR #{pr} already merged",
+                pr_number=pr,
+                issue_number=issue_number,
+                passed=True,
+            )
+        if pr_state_name == "CLOSED":
+            return _seeding.SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.FINISHED,
+                reason=f"PR #{pr} already closed without merging",
+                pr_number=pr,
+                issue_number=issue_number,
+                passed=False,
+            )
+        has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
+        if has_go:
+            stage, reason, passed = self._scope_seed_decision(
+                issue_number,
+                StageName.MERGE_WAIT,
+                f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                scope_stages,
+            )
+            return _seeding.SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=stage,
+                reason=reason,
+                pr_number=pr,
+                issue_number=issue_number,
+                passed=passed,
+            )
+
+        try:
+            issue_facts = _seeding.seed_issue_from_github(issue_number, github)
+            review_context = github.pr_review_context(pr)
+        except Exception as exc:
+            logger.warning("PR #%d: review context read failed: %s", pr, exc)
+            return _seeding.SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.FINISHED,
+                reason=f"PR #{pr} review context could not be read",
+                pr_number=pr,
+                issue_number=issue_number,
+                passed=False,
+            )
+        stage, reason, passed = self._scope_seed_decision(
+            issue_number,
+            StageName.PR_REVIEW,
+            f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
+            scope_stages,
+        )
+        return _seeding.SeedEntry(
+            kind="pr",
+            identifier=pr,
+            stage=stage,
+            reason=reason,
+            pr_number=pr,
+            issue_number=issue_number,
+            issue_title=issue_facts.title,
+            issue_body=issue_facts.body,
+            pr_diff=review_context["pr_diff"],
+            pr_description=review_context["pr_description"],
+            passed=passed,
+        )
 
     @staticmethod
     def _entry_to_item(entry: _seeding.SeedEntry, default_repo: str) -> WorkItem:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -81,6 +81,7 @@ import threading
 import time
 from collections import Counter, deque
 from collections.abc import Callable, Iterator
+from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -92,7 +93,7 @@ from hephaestus.automation.models import DEFAULT_STATE_DIR, IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
 from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
-from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue
+from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue, StageQueueLease
 from hephaestus.automation.pipeline.routing import (
     PIPELINE_ORDER,
     ROUTES,
@@ -117,7 +118,7 @@ from hephaestus.automation.pipeline.stages import (
     StageGitHub,
 )
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
-from hephaestus.automation.pipeline.stages.repo import product_to_work_item
+from hephaestus.automation.pipeline.stages.repo import RepoIssueSource, product_to_work_item
 from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
 from hephaestus.automation.pipeline.work_item import (
     ItemKind,
@@ -125,7 +126,11 @@ from hephaestus.automation.pipeline.work_item import (
     PreservedWorktree,
     WorkItem,
 )
-from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO, STATE_PLAN_BLOCKED
+from hephaestus.automation.state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_PLAN_BLOCKED,
+    is_epic,
+)
 from hephaestus.prompts import PromptCatalog
 
 logger = logging.getLogger(__name__)
@@ -331,6 +336,28 @@ class _Paths:
     projects_dir: Path
 
 
+@dataclass
+class _ActiveRepoIssueSource:
+    """One bounded repository metadata cursor detached from setup work."""
+
+    repo: str
+    source: RepoIssueSource
+
+
+@dataclass(frozen=True)
+class _PendingHandoff:
+    """A completed route retained by its source-stage lease.
+
+    Only the transition intent is retained. The item stays owned by its source
+    lease until the destination accepts it, so this map is bounded by the
+    coordinator's global live-work permits and cannot become a spill queue.
+    """
+
+    target: StageName
+    enter: bool
+    result: ItemResult | None = None
+
+
 def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
     """Resolve *repo* to its explicit checkout or conventional projects path."""
     return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
@@ -405,6 +432,10 @@ class Coordinator:
         }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
+        self._leases: dict[int, StageQueueLease] = {}
+        self._pending_handoffs: dict[int, _PendingHandoff] = {}
+        self._live_work_permit_ids: set[int] = set()
+        self._seed_entries: Iterator[_seeding.SeedEntry] | None = None
         self.inflight_per_repo: Counter[str] = Counter()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
@@ -421,6 +452,10 @@ class Coordinator:
         self._pending_admissions: deque[tuple[WorkItem, StageName, bool]] = deque(
             maxlen=self._admission_spool_capacity
         )
+        # At most C repositories retain one page cursor plus one pending
+        # metadata row each. This is the bounded replacement for the former
+        # repo WorkItem ``payload["products"]`` list.
+        self._repo_issue_sources: deque[_ActiveRepoIssueSource] = deque()
         self._admission_saturated = False
         self._saturated_queues: set[str] = set()
         self._saturation_totals: Counter[str] = Counter()
@@ -635,7 +670,7 @@ class Coordinator:
                 logger.exception("circuit-breaker snapshot provider failed")
 
         return {
-            "queue_depths": {name.value: len(queue) for name, queue in self.queues.items()},
+            "queue_depths": {name.value: queue.occupancy for name, queue in self.queues.items()},
             "queue_capacities": {name.value: queue.capacity for name, queue in self.queues.items()},
             "completion_depth": self.completion_q.qsize(),
             "completion_capacity": self.completion_q.capacity,
@@ -804,6 +839,8 @@ class Coordinator:
                     continue
                 self._drain_queues()
                 self._drain_pending_admissions()
+                self._drain_repo_issue_sources()
+                self._drain_seed_entries()
                 if self._all_idle():
                     if not self._reseed_if_converged():
                         break
@@ -889,7 +926,11 @@ class Coordinator:
             all(len(q) == 0 for q in self.queues.values())
             and not self.timers
             and not self.in_flight
+            and not self._leases
+            and not self._pending_handoffs
             and not self._pending_admissions
+            and not self._repo_issue_sources
+            and self._seed_entries is None
         )
 
     def _grace_exceeded(self) -> bool:
@@ -928,7 +969,9 @@ class Coordinator:
         for stage_name in _DRAIN_ORDER:
             q = self.queues[stage_name]
             if len(q):
-                item = q.pop()
+                item = self._claim_item(stage_name)
+                if item is None:  # pragma: no cover - coordinator-thread invariant
+                    continue
                 logger.error(
                     "pipeline stalled with no in-flight work; "
                     "force-running %s item %s; inflight_per_repo=%s",
@@ -943,6 +986,7 @@ class Coordinator:
 
     def _timer_park(self, item: WorkItem, delay_s: float) -> None:
         """Park *item* on the timer heap for ``delay_s`` seconds."""
+        self._release_source_lease(item)
         wake = time.monotonic() + max(0.0, delay_s)
         heapq.heappush(self.timers, (wake, self._seq, item))
         self._seq += 1
@@ -1028,7 +1072,7 @@ class Coordinator:
         return False
 
     def _begin_graceful_shutdown(self, reason: str) -> None:
-        """Start a grace-bounded shutdown for any externally requested stop."""
+        """Start a grace-bounded shutdown without classifying it as a signal."""
         self.shutdown.set()
         if self._grace_deadline is None:
             self._grace_deadline = time.monotonic() + max(0.0, self.config.grace_s)
@@ -1042,6 +1086,131 @@ class Coordinator:
         self.inflight_per_repo[item.repo] -= 1
         if self.inflight_per_repo[item.repo] <= 0:
             del self.inflight_per_repo[item.repo]
+
+    @property
+    def live_work_count(self) -> int:
+        """Return the number of globally permitted nonterminal work items."""
+        return len(self._live_work_permit_ids)
+
+    def _try_acquire_work_permit(self, item: WorkItem) -> bool:
+        """Reserve one of the coordinator's C global live-work slots."""
+        item_id = id(item)
+        if item_id in self._live_work_permit_ids:
+            return True
+        if self.live_work_count >= self._work_window:
+            return False
+        self._live_work_permit_ids.add(item_id)
+        return True
+
+    def _release_work_permit(self, item: WorkItem) -> None:
+        """Release an item's global permit after terminal ownership ends."""
+        self._live_work_permit_ids.discard(id(item))
+
+    def _claim_item(self, stage_name: StageName, *, index: int = 0) -> WorkItem | None:
+        """Claim ready work while retaining its source-stage capacity."""
+        lease = self.queues[stage_name].claim_at(index)
+        if lease is None:
+            return None
+        item = lease.item
+        item_id = id(item)
+        if item_id in self._leases:  # pragma: no cover - internal invariant
+            lease.restore()
+            raise RuntimeError(f"duplicate active lease for {self._item_key(item)}")
+        self._leases[item_id] = lease
+        return item
+
+    def _restore_source_lease(self, item: WorkItem) -> bool:
+        """Restore an active item lease to its exact source FIFO position."""
+        self._pending_handoffs.pop(id(item), None)
+        lease = self._leases.pop(id(item), None)
+        if lease is None:
+            return False
+        lease.restore()
+        return True
+
+    def _release_source_lease(self, item: WorkItem) -> bool:
+        """Release a source reservation when a non-queue owner takes the item."""
+        self._pending_handoffs.pop(id(item), None)
+        lease = self._leases.pop(id(item), None)
+        if lease is None:
+            return False
+        lease.release()
+        return True
+
+    def _activate_handoff(
+        self,
+        item: WorkItem,
+        target: StageName,
+        *,
+        enter: bool,
+        result: ItemResult | None,
+    ) -> None:
+        """Publish a transition only after destination admission succeeds."""
+        item.stage = target
+        if enter:
+            item.state = "ENTER"
+            item.payload["_enter_pending"] = True
+            item.add_history_event(target, item.state, note="enqueued")
+        if result is not None:
+            item.result = result
+        self._record_event("push", target.value, self._item_key(item))
+
+    def _handoff_item(
+        self,
+        item: WorkItem,
+        target: StageName,
+        *,
+        enter: bool,
+        result: ItemResult | None = None,
+    ) -> bool:
+        """Route destination-first, retaining a bounded intent if target is full."""
+        lease = self._leases.get(id(item))
+        if lease is None:
+            if result is not None:
+                item.result = result
+            return self._push_item(item, target, enter=enter)
+        if target is item.stage:
+            if result is not None:  # pragma: no cover - terminal target differs
+                raise RuntimeError("terminal result cannot route to its source stage")
+            return self._restore_source_lease(item)
+        if lease.handoff(self.queues[target]):
+            self._leases.pop(id(item), None)
+            self._pending_handoffs.pop(id(item), None)
+            self._activate_handoff(item, target, enter=enter, result=result)
+            self._progress = True
+            return True
+        pending = _PendingHandoff(target=target, enter=enter, result=result)
+        existing = self._pending_handoffs.setdefault(id(item), pending)
+        if existing != pending:  # pragma: no cover - one route per active lease
+            raise RuntimeError(f"conflicting pending handoff for {self._item_key(item)}")
+        self._record_event(
+            "handoff_pending",
+            item.stage.value,
+            target.value,
+            self._item_key(item),
+        )
+        return False
+
+    def _drain_pending_handoffs(self) -> None:
+        """Retry retained routes after downstream queues may have opened."""
+        for item_id, pending in list(self._pending_handoffs.items()):
+            lease = self._leases.get(item_id)
+            if lease is None:  # pragma: no cover - defensive repair
+                self._pending_handoffs.pop(item_id, None)
+                continue
+            item = lease.item
+            if not lease.handoff(self.queues[pending.target]):
+                continue
+            self._leases.pop(item_id, None)
+            self._pending_handoffs.pop(item_id, None)
+            self._activate_handoff(
+                item,
+                pending.target,
+                enter=pending.enter,
+                result=pending.result,
+            )
+            self._record_event("handoff_retry", item.stage.value, self._item_key(item))
+            self._progress = True
 
     def _handle_completion(self, handle: JobHandle, result: JobResult) -> None:
         """Route one completed job back to its item.
@@ -1130,6 +1299,8 @@ class Coordinator:
         seeding reconstruction resumes exactly here with no shutdown
         bookkeeping.
         """
+        self._release_source_lease(item)
+        self._release_work_permit(item)
         resumable_reason = f"resumable at {item.stage.value}"
         if reason:
             resumable_reason = f"{resumable_reason}: {reason}"
@@ -1174,22 +1345,27 @@ class Coordinator:
 
     def _drain_queues(self) -> None:
         """Drain queues downstream-first with admission control."""
+        self._drain_pending_handoffs()
         for stage_name in _DRAIN_ORDER:
             if self.shutdown.is_set():
                 return
             if stage_name is StageName.IMPLEMENTATION:
                 self._drain_implementation()
+                self._drain_pending_handoffs()
                 continue
             q = self.queues[stage_name]
             for _ in range(len(q)):
                 if self.shutdown.is_set():
                     return
-                item = q.pop()
+                item = self._claim_item(stage_name)
+                if item is None:  # pragma: no cover - coordinator-thread invariant
+                    break
                 if not self._admit(item):
-                    self._push_item(item, stage_name, enter=False)
+                    self._restore_source_lease(item)
                     continue
                 self._record_event("drain", stage_name.value, self._item_key(item))
                 self._run_item(item)
+            self._drain_pending_handoffs()
 
     def _drain_pending_admissions(self) -> None:
         """Admit deferred items as stage queue slots become available.
@@ -1204,7 +1380,7 @@ class Coordinator:
         for _ in range(len(self._pending_admissions)):
             item, stage, enter = self._pending_admissions.popleft()
             queue = self.queues[stage]
-            if not queue.push(item):
+            if not queue.offer(item):
                 self._pending_admissions.append((item, stage, enter))
                 continue
             if enter:
@@ -1213,6 +1389,130 @@ class Coordinator:
                 item.add_history_event(stage, item.state, note="enqueued")
             self._record_event("push", stage.value, self._item_key(item))
             self._progress = True
+
+    def _externalize_repo_issue_source(self, item: WorkItem, source: RepoIssueSource) -> bool:
+        """Move completed repo setup into the C-bounded discovery registry."""
+        if len(self._repo_issue_sources) >= self._work_window:
+            return False
+        item.payload.pop("_repo_issue_source", None)
+        self._repo_issue_sources.append(_ActiveRepoIssueSource(item.repo, source))
+        self._release_source_lease(item)
+        self._release_work_permit(item)
+        self._seen_item_ids.discard(id(item))
+        with suppress(ValueError):
+            self.items.remove(item)
+        self._record_event("repo_source_activate", item.repo, len(self._repo_issue_sources))
+        return True
+
+    def _repo_source_can_admit(self) -> bool:
+        """Return whether one not-yet-classified issue has bounded ownership."""
+        if self.live_work_count >= self._work_window:
+            return False
+        if len(self._pending_admissions) < self._admission_spool_capacity:
+            return True
+        # With no spool slot, classification is safe only when every possible
+        # destination can accept the resulting item directly.
+        return all(
+            queue.can_offer() for stage, queue in self.queues.items() if stage is not StageName.REPO
+        )
+
+    def _drain_repo_issue_sources(self) -> None:
+        """Run one fair admission attempt for each active repository cursor."""
+        for _ in range(len(self._repo_issue_sources)):
+            active = self._repo_issue_sources.popleft()
+            if self._drain_repo_issue_source(active):
+                self._repo_issue_sources.append(active)
+
+    def _drain_repo_issue_source(  # noqa: C901 - source lifecycle is intentionally linear
+        self, active: _ActiveRepoIssueSource
+    ) -> bool:
+        """Consume source rows until one is admitted, deferred, or exhausted."""
+        source = active.source
+        ctx = self._ctx_for_repo(active.repo)
+        while True:
+            metadata = source.pending
+            if metadata is None:
+                try:
+                    metadata = next(source.metadata)
+                except StopIteration:
+                    self._record_event("repo_source_complete", active.repo, source.seeded_count)
+                    return False
+                except Exception as exc:
+                    self._record_repo_source_failure(active.repo, f"discovery failed: {exc}")
+                    return False
+
+            try:
+                number = int(metadata["number"])
+                labels = list(metadata.get("labels") or [])
+                title = str(metadata.get("title") or "")
+            except (KeyError, TypeError, ValueError) as exc:
+                self._record_repo_source_failure(
+                    active.repo, f"discovery failed: malformed metadata: {exc}"
+                )
+                return False
+
+            if is_epic(labels, title):
+                try:
+                    ctx.github.skip_epics({number: labels})
+                except Exception as exc:
+                    self._record_repo_source_failure(active.repo, f"epic skip tag failed: {exc}")
+                    return False
+                source.pending = None
+                self._progress = True
+                return True
+
+            if not self._repo_source_can_admit():
+                source.pending = metadata
+                return True
+
+            try:
+                facts = _seeding.seed_issue_from_github(number, ctx.github)
+                if STATE_PLAN_BLOCKED in facts.labels:
+                    ctx.github.ensure_blocked_audit(number)
+                entry = _seeding.seed_entry_from_facts(facts)
+                scope_stages = self.config.scope.stages if self.config.scope is not None else None
+                stage, reason, passed = self._scope_seed_decision(
+                    number, entry.stage, entry.reason, scope_stages
+                )
+                entry = replace(entry, stage=stage, reason=reason, passed=passed)
+            except Exception as exc:
+                self._record_repo_source_failure(active.repo, f"discovery failed: {exc}")
+                return False
+
+            if entry.stage is None:
+                try:
+                    if entry.skip_tag_obligation is not None:
+                        ctx.github.skip_epics({entry.skip_tag_obligation.issue: []})
+                except Exception as exc:
+                    self._record_repo_source_failure(active.repo, f"epic skip tag failed: {exc}")
+                    return False
+                source.pending = None
+                self._progress = True
+                return True
+
+            new_item = self._entry_to_item(entry, active.repo)
+            if new_item.stage is StageName.FINISHED and new_item.result is None:
+                new_item.result = ItemResult(
+                    passed=entry.passed,
+                    reason=entry.reason,
+                    final_stage=StageName.FINISHED,
+                )
+            source.pending = None
+            if self._push_item(new_item, new_item.stage, enter=True):
+                source.seeded_count += 1
+                if new_item.stage not in (StageName.REPO, StageName.FINISHED):
+                    self._pass_work_count += 1
+            self._progress = True
+            return True
+
+    def _record_repo_source_failure(self, repo: str, reason: str) -> None:
+        """Record a bounded terminal failure when a discovery cursor aborts."""
+        item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.FINISHED)
+        item.result = ItemResult(passed=False, reason=reason, final_stage=StageName.REPO)
+        item.payload["entry_stage"] = StageName.REPO.value
+        self.items.append(item)
+        self.ledger.append(item.result)
+        self._fatal = True
 
     def _drain_implementation(self) -> None:
         """Drain the implementation queue under topo order + file-overlap gating.
@@ -1236,7 +1536,23 @@ class Coordinator:
         q = self.queues[StageName.IMPLEMENTATION]
         if not len(q):
             return
-        items = self._dedup_implementation_items([q.pop() for _ in range(len(q))])
+        for duplicate in self._implementation_duplicates(q.snapshot()):
+            if not self._claim_selected_implementation_item(duplicate):
+                return
+            logger.warning(
+                "implementation %s#%s already queued; dropping duplicate work item",
+                duplicate.repo,
+                duplicate.issue,
+            )
+            self._finish(
+                duplicate,
+                passed=True,
+                reason=f"{duplicate.repo}#{duplicate.issue} superseded by queued duplicate",
+            )
+            if id(duplicate) in self._leases:
+                return
+
+        items = q.snapshot()
         issue_items, ambiguous = self._index_issue_items(items)
         infos = [
             IssueInfo(
@@ -1259,21 +1575,41 @@ class Coordinator:
             dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
             for number in deferred:
                 logger.info("implementation #%s deferred (file overlap)", number)
-        ran: set[int] = set()
         # Cross-repo same-number items bypass the number-keyed gates and dispatch
         # directly — they are distinct work that the ordering model cannot rank.
         dispatch_items = [issue_items[number] for number in dispatch]
         dispatch_items.extend(it for group in ambiguous.values() for it in group)
         for item in dispatch_items:
             if self.shutdown.is_set() or not self._admit(item):
-                continue  # stays queued (re-pushed below)
-            ran.add(id(item))
+                continue
+            if not self._claim_selected_implementation_item(item):
+                continue
             self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
             self._run_item(item)
-        # Preserve original queue order for deferred / non-admitted / non-issue items.
-        for it in items:
-            if id(it) not in ran:
-                self._push_item(it, StageName.IMPLEMENTATION, enter=False)
+
+    @staticmethod
+    def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
+        """Return non-first duplicates keyed by ``(repo, issue)``."""
+        seen: set[tuple[str, int]] = set()
+        duplicates: list[WorkItem] = []
+        for item in items:
+            if item.issue is None:
+                continue
+            key = (item.repo, item.issue)
+            if key in seen:
+                duplicates.append(item)
+            else:
+                seen.add(key)
+        return duplicates
+
+    def _claim_selected_implementation_item(self, item: WorkItem) -> bool:
+        """Claim a selected implementation item by identity."""
+        ready = self.queues[StageName.IMPLEMENTATION].snapshot()
+        try:
+            index = next(index for index, candidate in enumerate(ready) if candidate is item)
+        except StopIteration:
+            return False
+        return self._claim_item(StageName.IMPLEMENTATION, index=index) is item
 
     def _dedup_implementation_items(self, items: list[WorkItem]) -> list[WorkItem]:
         """Drop transient duplicate work items, keyed by ``(repo, issue)`` (#2057).
@@ -1363,6 +1699,19 @@ class Coordinator:
                 if isinstance(result, Continue):
                     item.state = result.next_state
                     item.add_history_event(item.stage, item.state)
+                    if (
+                        item.kind is ItemKind.REPO
+                        and item.state == "SOURCE"
+                        and isinstance(item.payload.get("_repo_issue_source"), RepoIssueSource)
+                    ):
+                        source = item.payload["_repo_issue_source"]
+                        if self._externalize_repo_issue_source(item, source):
+                            return
+                        # The registry is bounded. Retain the setup item in
+                        # the existing bounded admission path until a cursor
+                        # slot becomes available.
+                        self._restore_source_lease(item)
+                        return
                     continue
                 if isinstance(result, JobRequest):
                     if self.config.dry_run:
@@ -1479,6 +1828,8 @@ class Coordinator:
         if item.stage is StageName.FINISHED:
             # Sink outcomes are terminal: the result is already recorded.
             self._record_event("done", self._item_key(item), outcome.note)
+            self._release_source_lease(item)
+            self._release_work_permit(item)
             return
 
         if disposition is Disposition.ADVANCE:
@@ -1487,7 +1838,7 @@ class Coordinator:
             if target is StageName.FINISHED:
                 self._finish(item, passed=True, reason=outcome.note or "advance")
             else:
-                self._push_item(item, target, enter=True)
+                self._handoff_item(item, target, enter=True)
             return
 
         if disposition is Disposition.RETRY:
@@ -1522,7 +1873,7 @@ class Coordinator:
         """
         delay = item.payload.pop("retry_delay_s", None)
         if delay is None:
-            self._push_item(item, item.stage, enter=False)
+            self._handoff_item(item, item.stage, enter=False)
         elif self.config.dry_run:
             self._finish(
                 item, passed=False, reason=f"[dry-run] would wait {delay}s: {outcome.note}"
@@ -1555,24 +1906,35 @@ class Coordinator:
         if target is StageName.FINISHED:
             self._finish(item, passed=False, reason=outcome.note or "fail_back")
         else:
-            self._push_item(item, target, enter=True)
+            self._handoff_item(item, target, enter=True)
 
     def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
         """Set the item's result and hand it to the finished sink."""
-        item.result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
+        result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
         if item.stage is StageName.FINISHED:
             # Poisoned inside the sink: record directly, never re-queue.
             if not item.payload.get("_recorded", False):
-                self.ledger.append(item.result)
+                item.result = result
+                self.ledger.append(result)
                 item.payload["_recorded"] = True
+            self._release_source_lease(item)
+            self._release_work_permit(item)
             return
-        self._push_item(item, StageName.FINISHED, enter=True)
+        self._handoff_item(item, StageName.FINISHED, enter=True, result=result)
 
     def _seed_products(self, item: WorkItem) -> None:
         """Push a terminal repo item's discovered products into entry queues."""
         if item.kind is not ItemKind.REPO:
             return
-        for product in item.payload.pop("products", []):
+        products = item.payload.pop("products", [])
+        actionable = [product for product in products if product.get("stage") is not None]
+        available = self._work_window - self.live_work_count
+        if len(actionable) > available:
+            raise RuntimeError(
+                "eager repository products exceed the global work window; "
+                "RepoStage must stream discovery through RepoIssueSource"
+            )
+        for product in products:
             if self._admission_saturated:
                 break
             if product.get("stage") is None:
@@ -1609,6 +1971,13 @@ class Coordinator:
         for it in self.in_flight.values():
             if it.kind is ItemKind.ISSUE and it.issue is not None:
                 keys.add((it.repo, it.issue))
+        for _wake, _sequence, it in self.timers:
+            if it.kind is ItemKind.ISSUE and it.issue is not None:
+                keys.add((it.repo, it.issue))
+        for lease in self._leases.values():
+            it = lease.item
+            if it.kind is ItemKind.ISSUE and it.issue is not None:
+                keys.add((it.repo, it.issue))
         for it, _stage, _enter in self._pending_admissions:
             if it.kind is ItemKind.ISSUE and it.issue is not None:
                 keys.add((it.repo, it.issue))
@@ -1642,6 +2011,8 @@ class Coordinator:
         ):
             logger.info("seed skipped: #%s already queued/in-flight in %s", item.issue, item.repo)
             return False
+        if is_new and not self._try_acquire_work_permit(item):
+            return False
         # Register a novel item before attempting bounded admission. This makes
         # ``items`` the accounting source of truth for every seed that reaches
         # the queue-capacity decision: it is present whether admitted directly,
@@ -1651,7 +2022,7 @@ class Coordinator:
             self.items.append(item)
             item.payload.setdefault("entry_stage", stage.value)
         queue = self.queues[stage]
-        if not queue.push(item):
+        if not queue.offer(item):
             item.stage = stage
             if enter:
                 item.state = "ENTER"
@@ -1711,13 +2082,28 @@ class Coordinator:
 
         """
         self._pass_work_count = 0
+        if self._seed_entries is not None:
+            raise RuntimeError("cannot start a seed pass while its source is active")
         default_repo = self.config.repos[0] if self.config.repos else ""
         if self.config.issues or self.config.prs:
             entries = self._seed_direct_scope(default_repo)
         else:
             entries = _seeding.seed_from_cli(self.config.repos, [], [])
+        self._seed_entries = iter(entries)
+        return self._drain_seed_entries()
+
+    def _drain_seed_entries(self) -> int:
+        """Lazily admit source entries while global work permits remain."""
+        entries = self._seed_entries
+        if entries is None or self.shutdown.is_set():
+            return 0
         pushed = 0
-        for entry in entries:
+        while self.live_work_count < self._work_window:
+            try:
+                entry = next(entries)
+            except StopIteration:
+                self._seed_entries = None
+                break
             if entry.stage is None:
                 # Epic tagging is the ONE sanctioned seeding write, executed
                 # here through the skip_epics chokepoint BEFORE the exclusion
@@ -2069,16 +2455,22 @@ class Coordinator:
         """Mark every still-live item RESUMABLE at its stage (never FAILED)."""
         if not self.shutdown.is_set() and not self._fatal:
             return
-        leftovers: list[WorkItem] = [item for _, _, item in self.timers]
-        for stage_name, q in self.queues.items():
-            if stage_name is StageName.FINISHED:
-                continue
-            leftovers.extend(q.snapshot())
-        leftovers.extend(self.in_flight.values())
-        leftovers.extend(item for item, _stage, _enter in self._pending_admissions)
-        for item in leftovers:
+        candidates: dict[int, WorkItem] = {id(item): item for _, _, item in self.timers}
+        for q in self.queues.values():
+            for item in q.snapshot():
+                candidates[id(item)] = item
+        for item in self.in_flight.values():
+            candidates[id(item)] = item
+        for item, _stage, _enter in self._pending_admissions:
+            candidates[id(item)] = item
+        for lease in self._leases.values():
+            candidates[id(lease.item)] = lease.item
+        for item in candidates.values():
             if item.result is None:
                 self._park_resumable(item)
+            else:
+                self._release_source_lease(item)
+                self._release_work_permit(item)
 
 
 def run_pipeline(config: PipelineConfig) -> int:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -123,12 +123,18 @@ from hephaestus.automation.pipeline.stages.repo import (
     _drive_green_pr_is_in_scope,
     product_to_work_item,
 )
-from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
+from hephaestus.automation.pipeline.summary import (
+    RunStats,
+    SummaryItem,
+    latest_logical_items,
+    print_summary,
+)
 from hephaestus.automation.pipeline.work_item import (
     ItemKind,
     ItemResult,
     PreservedWorktree,
     WorkItem,
+    WorkItemSummary,
 )
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
@@ -471,7 +477,12 @@ class Coordinator:
         self.inflight_per_repo: Counter[str] = Counter()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
+        # ``items`` owns only live, payload-bearing work. Terminal items are
+        # retired immediately into compact scalar summaries so streamed runs
+        # never retain O(total discovered work) issue bodies/plans/reviews.
         self.items: list[WorkItem] = []
+        self.item_summaries: list[WorkItemSummary] = []
+        self._terminal_pr_keys: set[tuple[str, int]] = set()
         self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
         self._event_log_disabled = False
         self._journal_failure = False
@@ -915,9 +926,25 @@ class Coordinator:
                     self._metrics_server.stop()
         return exit_code
 
-    def _effective_items(self) -> list[WorkItem]:
-        """Return latest logical items, collapsing superseded re-seed attempts."""
-        return latest_logical_items(self.items)
+    def _effective_items(self) -> list[SummaryItem]:
+        """Return latest logical active/terminal items for reporting."""
+        return latest_logical_items([*self.item_summaries, *self.items])
+
+    def _retire_terminal_item(self, item: WorkItem) -> None:
+        """Drop a completed payload-bearing item after saving its compact summary."""
+        item_id = id(item)
+        tracked_index = next(
+            (index for index, candidate in enumerate(self.items) if candidate is item),
+            None,
+        )
+        if tracked_index is None and item_id not in self._seen_item_ids:
+            return
+        self.item_summaries.append(WorkItemSummary.from_item(item))
+        if item.pr is not None:
+            self._terminal_pr_keys.add((item.repo, item.pr))
+        if tracked_index is not None:
+            del self.items[tracked_index]
+        self._seen_item_ids.discard(item_id)
 
     def _active_preserved_worktrees(self) -> list[PreservedWorktree]:
         """Return preserved worktrees for latest failed items that still exist."""
@@ -1615,10 +1642,12 @@ class Coordinator:
             )
             return False
 
-        # Issue discovery runs first. Its WorkItems remain in ``items`` after
-        # terminalization, so this constant-space lookup prevents the PR cursor
-        # from producing a second item for an already-covered pull request.
-        if any(item.repo == active.repo and item.pr == pr_number for item in self.items):
+        # Issue discovery runs first. Check both bounded live ownership and the
+        # compact terminal-key index so the PR cursor cannot produce a second
+        # item for an already-covered pull request.
+        if (active.repo, pr_number) in self._terminal_pr_keys or any(
+            item.repo == active.repo and item.pr == pr_number for item in self.items
+        ):
             source.pending_pr = None
             self._record_event("repo_pr_source_covered", active.repo, pr_number)
             self._progress = True
@@ -1662,7 +1691,7 @@ class Coordinator:
         item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.FINISHED)
         item.result = ItemResult(passed=False, reason=reason, final_stage=StageName.REPO)
         item.payload["entry_stage"] = StageName.REPO.value
-        self.items.append(item)
+        self.item_summaries.append(WorkItemSummary.from_item(item))
         self.ledger.append(item.result)
         self._fatal = True
 
@@ -1990,6 +2019,7 @@ class Coordinator:
             self._record_event("done", self._item_key(item), outcome.note)
             self._release_source_lease(item)
             self._release_work_permit(item)
+            self._retire_terminal_item(item)
             return
 
         if disposition is Disposition.ADVANCE:
@@ -2079,6 +2109,7 @@ class Coordinator:
                 item.payload["_recorded"] = True
             self._release_source_lease(item)
             self._release_work_permit(item)
+            self._retire_terminal_item(item)
             return
         self._handoff_item(item, StageName.FINISHED, enter=True, result=result)
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -413,6 +413,8 @@ class Coordinator:
         self._work_window = max(1, config.parallel_repos * config.max_workers)
         if config.stage_queue_capacity < 1:
             raise ValueError("stage queue capacity must be positive")
+        if not 0 <= config.alert_queue_depth_threshold <= 100:
+            raise ValueError("alert queue depth threshold must be between 0 and 100")
         if config.event_log_capacity < 1:
             raise ValueError("event log capacity must be positive")
         self.completion_q = CompletionQueue(capacity=self._work_window)
@@ -427,7 +429,17 @@ class Coordinator:
                 completion_q=self.completion_q,
             )
         else:
-            # Share channels with an injected pool when it exposes them.
+            # Share channels and cancellation with an injected pool.  The
+            # coordinator owns the event because signals and admission
+            # saturation both set it; workers must observe that same object.
+            injected_shutdown = getattr(pool, "shutdown_event", None)
+            if not isinstance(injected_shutdown, type(self.shutdown)):
+                raise TypeError("injected worker pool must expose shutdown_event")
+            pool.shutdown_event = self.shutdown
+            # WorkerPool keeps its internal alias for hot worker paths.  Keep
+            # compatible injected implementations bound when they expose it.
+            if hasattr(pool, "_shutdown"):
+                pool._shutdown = self.shutdown
             injected_queue = getattr(pool, "completion_q", None)
             if injected_queue is None:
                 raise TypeError("injected worker pool must expose completion_q")
@@ -1010,7 +1022,11 @@ class Coordinator:
         while self.timers and self.timers[0][0] <= now:
             _, _, item = heapq.heappop(self.timers)
             self._progress = True
-            self._push_item(item, item.stage, enter=False)
+            if not self._push_item(item, item.stage, enter=False):
+                # The timer was already removed, so a saturated admission
+                # boundary must park the tracked item before it disappears
+                # from every collection that finalization can recover.
+                self._park_resumable(item, reason="timer wake rejected by admission saturation")
 
     # -- completions ----------------------------------------------------------
 
@@ -1428,11 +1444,21 @@ class Coordinator:
         )
 
     def _drain_repo_issue_sources(self) -> None:
-        """Run one fair admission attempt for each active repository cursor."""
+        """Run one fair admission attempt for each active repository cursor.
+
+        Admission saturation is a recovery boundary.  Once a cursor reaches
+        it, do not let later cursors fetch rows that cannot enter a queue or a
+        durable recovery path; leave those cursors (and their pending rows) in
+        the registry for the next run.
+        """
         for _ in range(len(self._repo_issue_sources)):
+            if self.shutdown.is_set() or self._admission_saturated:
+                return
             active = self._repo_issue_sources.popleft()
             if self._drain_repo_issue_source(active):
                 self._repo_issue_sources.append(active)
+            if self.shutdown.is_set() or self._admission_saturated:
+                return
 
     def _drain_repo_issue_source(  # noqa: C901 - source lifecycle is intentionally linear
         self, active: _ActiveRepoIssueSource

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -79,7 +79,7 @@ import queue as queue_mod
 import signal
 import threading
 import time
-from collections import Counter, deque
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
@@ -527,8 +527,11 @@ class Coordinator:
         self._terminal_per_stage: Counter[str] = Counter()
         # Aggregates represent the latest terminal attempt for each logical
         # item, rather than every retired reseed attempt.  This keeps a
-        # fail->pass reseed from leaving the run failed after collapse.
-        self._terminal_latest: dict[tuple[object, ...], tuple[str, str]] = {}
+        # fail->pass reseed from leaving the run failed after collapse.  The
+        # cache is deliberately bounded: once a terminal row has fallen out
+        # of the retained summary window, its identity is no longer needed to
+        # reconcile the bounded diagnostic view.
+        self._terminal_latest: OrderedDict[tuple[object, ...], tuple[str, str]] = OrderedDict()
         self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
         self._event_log_disabled = False
         self._journal_failure = False
@@ -1014,6 +1017,9 @@ class Coordinator:
             if self._terminal_per_stage[old_stage] == 0:
                 del self._terminal_per_stage[old_stage]
         self._terminal_latest[key] = (disposition, summary.stage.value)
+        self._terminal_latest.move_to_end(key)
+        while len(self._terminal_latest) > self.config.terminal_retention_capacity:
+            self._terminal_latest.popitem(last=False)
         self._terminal_dispositions[disposition] += 1
         self._terminal_per_stage[summary.stage.value] += 1
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -338,10 +338,17 @@ class _Paths:
 
 @dataclass
 class _ActiveRepoIssueSource:
-    """One bounded repository metadata cursor detached from setup work."""
+    """One bounded repository metadata cursor detached from setup work.
+
+    GitHub issue numbers increase with creation time, and the source requests
+    metadata in ascending creation order. ``seen_through_issue`` therefore
+    provides constant-space deduplication: a repeated or stale row cannot
+    re-enter the pipeline after its first work item releases its live permit.
+    """
 
     repo: str
     source: RepoIssueSource
+    seen_through_issue: int | None = None
 
 
 @dataclass(frozen=True)
@@ -906,14 +913,14 @@ class Coordinator:
 
     def _exit_code(self) -> int:
         """130 on a signal; 1 on internal stop/fail/skip/blocked; 0 clean."""
-        if self._journal_failure:
-            return 1
         if self._signal_received:
             # Interrupt deliberately takes priority over non-passing ledger
             # entries and fatal coordinator errors: a signal means the run did
             # not complete, so wrappers must classify it as cancellation even
             # if earlier work had already failed.
             return 130
+        if self._journal_failure:
+            return 1
         effective_results = [item.result for item in self._effective_items() if item.result]
         results = effective_results or self.ledger
         if self.shutdown.is_set() or self._fatal or any(not result.passed for result in results):
@@ -1451,12 +1458,19 @@ class Coordinator:
                 )
                 return False
 
+            if active.seen_through_issue is not None and number <= active.seen_through_issue:
+                source.pending = None
+                self._record_event("repo_source_duplicate", active.repo, number)
+                self._progress = True
+                return True
+
             if is_epic(labels, title):
                 try:
                     ctx.github.skip_epics({number: labels})
                 except Exception as exc:
                     self._record_repo_source_failure(active.repo, f"epic skip tag failed: {exc}")
                     return False
+                active.seen_through_issue = number
                 source.pending = None
                 self._progress = True
                 return True
@@ -1478,6 +1492,7 @@ class Coordinator:
             except Exception as exc:
                 self._record_repo_source_failure(active.repo, f"discovery failed: {exc}")
                 return False
+            active.seen_through_issue = number
 
             if entry.stage is None:
                 try:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1917,6 +1917,14 @@ class Coordinator:
         sanctioned fallback).
         """
         assert not self.config.dry_run, "dry-run must never submit jobs"  # noqa: S101
+        if self.shutdown.is_set():
+            # Completion/admission saturation begins graceful shutdown while
+            # accepted completions may still be drained for durability.  The
+            # submit chokepoint must therefore fail closed even if a caller
+            # reaches it after shutdown was requested.
+            self._record_event("submit_rejected", self._item_key(item), item.stage.value)
+            self._park_resumable(item, reason="submission rejected during shutdown")
+            return
         job = request.job
         if isinstance(job, AgentJob):
             ok, delay = self._rate_budget_ok()

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -374,6 +374,22 @@ def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
     return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
 
 
+def _bind_injected_pool_shutdown(pool: Any, shutdown: threading.Event) -> None:
+    """Bind every injected-pool shutdown alias to the coordinator event."""
+    injected_shutdown = getattr(pool, "shutdown_event", None)
+    if not isinstance(injected_shutdown, type(shutdown)):
+        raise TypeError("injected worker pool must expose shutdown_event")
+    pool.shutdown_event = shutdown
+    if pool.shutdown_event is not shutdown:
+        raise TypeError("injected worker pool shutdown_event must be coordinator-owned")
+    # WorkerPool keeps its internal alias for hot worker paths.  Keep
+    # compatible injected implementations bound when they expose it.
+    if hasattr(pool, "_shutdown"):
+        pool._shutdown = shutdown
+        if pool._shutdown is not shutdown:
+            raise TypeError("injected worker pool _shutdown must be coordinator-owned")
+
+
 class Coordinator:
     """The single-threaded pipeline event loop.
 
@@ -432,14 +448,7 @@ class Coordinator:
             # Share channels and cancellation with an injected pool.  The
             # coordinator owns the event because signals and admission
             # saturation both set it; workers must observe that same object.
-            injected_shutdown = getattr(pool, "shutdown_event", None)
-            if not isinstance(injected_shutdown, type(self.shutdown)):
-                raise TypeError("injected worker pool must expose shutdown_event")
-            pool.shutdown_event = self.shutdown
-            # WorkerPool keeps its internal alias for hot worker paths.  Keep
-            # compatible injected implementations bound when they expose it.
-            if hasattr(pool, "_shutdown"):
-                pool._shutdown = self.shutdown
+            _bind_injected_pool_shutdown(pool, self.shutdown)
             injected_queue = getattr(pool, "completion_q", None)
             if injected_queue is None:
                 raise TypeError("injected worker pool must expose completion_q")
@@ -1118,6 +1127,22 @@ class Coordinator:
     def live_work_count(self) -> int:
         """Return the number of globally permitted nonterminal work items."""
         return len(self._live_work_permit_ids)
+
+    @property
+    def repo_source_owner_count(self) -> int:
+        """Return repo setup items plus active cursors owning source slots.
+
+        Repo setup and its detached discovery cursor are two states of the
+        same C-bounded ownership.  Counting both prevents a later setup item
+        from taking the last live-work permit while every cursor slot is
+        already occupied: at C=1 that would leave the setup waiting for the
+        cursor and the cursor waiting for the permit forever.
+        """
+        setup_owners = sum(
+            item.kind is ItemKind.REPO and id(item) in self._live_work_permit_ids
+            for item in self.items
+        )
+        return len(self._repo_issue_sources) + setup_owners
 
     def _try_acquire_work_permit(self, item: WorkItem) -> bool:
         """Reserve one of the coordinator's C global live-work slots."""
@@ -2220,12 +2245,15 @@ class Coordinator:
         return self._drain_seed_entries()
 
     def _drain_seed_entries(self) -> int:
-        """Lazily admit source entries while global work permits remain."""
+        """Lazily admit source entries while their ownership slots remain."""
         entries = self._seed_entries
         if entries is None or self.shutdown.is_set():
             return 0
         pushed = 0
-        while self.live_work_count < self._work_window:
+        direct_scope = bool(self.config.issues or self.config.prs)
+        while self.live_work_count < self._work_window and (
+            direct_scope or self.repo_source_owner_count < self._work_window
+        ):
             try:
                 entry = next(entries)
             except StopIteration:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -525,6 +525,10 @@ class Coordinator:
         self._terminal_item_count = 0
         self._terminal_dispositions: Counter[str] = Counter()
         self._terminal_per_stage: Counter[str] = Counter()
+        # Aggregates represent the latest terminal attempt for each logical
+        # item, rather than every retired reseed attempt.  This keeps a
+        # fail->pass reseed from leaving the run failed after collapse.
+        self._terminal_latest: dict[tuple[object, ...], tuple[str, str]] = {}
         self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
         self._event_log_disabled = False
         self._journal_failure = False
@@ -996,9 +1000,33 @@ class Coordinator:
         """Retain one bounded terminal row and update complete aggregates."""
         summary = WorkItemSummary.from_item(item)
         self.item_summaries.append(summary)
-        self._terminal_item_count += 1
-        self._terminal_dispositions[self._terminal_disposition_bucket(summary.result)] += 1
+        key = self._logical_item_key(summary)
+        disposition = self._terminal_disposition_bucket(summary.result)
+        previous = self._terminal_latest.get(key)
+        if previous is None:
+            self._terminal_item_count += 1
+        else:
+            old_disposition, old_stage = previous
+            self._terminal_dispositions[old_disposition] -= 1
+            self._terminal_per_stage[old_stage] -= 1
+            if self._terminal_dispositions[old_disposition] == 0:
+                del self._terminal_dispositions[old_disposition]
+            if self._terminal_per_stage[old_stage] == 0:
+                del self._terminal_per_stage[old_stage]
+        self._terminal_latest[key] = (disposition, summary.stage.value)
+        self._terminal_dispositions[disposition] += 1
         self._terminal_per_stage[summary.stage.value] += 1
+
+    @staticmethod
+    def _logical_item_key(item: SummaryItem) -> tuple[object, ...]:
+        """Return the stable identity used to collapse reseeded attempts."""
+        if item.kind is ItemKind.REPO:
+            return (item.repo, "repo")
+        if item.kind is ItemKind.ISSUE:
+            return (item.repo, "issue", item.issue)
+        if item.kind is ItemKind.PR:
+            return (item.repo, "pr", item.pr)
+        return (item.repo, item.kind.value, item.issue, item.pr)
 
     @staticmethod
     def _terminal_disposition_bucket(result: ItemResult) -> str:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -85,7 +85,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, TypeVar
 
 from jinja2 import TemplateNotFound
 
@@ -166,6 +166,12 @@ _DEFAULT_STAGE_QUEUE_CAPACITY = 64
 #: The optional JSONL journal remains the durable complete event history.
 _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 
+#: Maximum number of recent terminal rows retained in memory for diagnostics
+#: and end-of-run detail output. Aggregate accounting is maintained separately,
+#: so completed runs larger than this cap do not retain O(total work) terminal
+#: ``WorkItemSummary`` or ledger entries.
+_DEFAULT_TERMINAL_RETENTION_CAPACITY = 1_024
+
 #: Number of fully stalled idle ticks before the coordinator force-runs work.
 _STALL_TICKS_BEFORE_FORCE = 3
 
@@ -196,6 +202,7 @@ _DRAIN_ORDER: tuple[StageName, ...] = (
 )
 
 StageStepResult: TypeAlias = Continue | JobRequest | StageOutcome
+_T = TypeVar("_T")
 
 
 def _budget_lookup(name: str) -> int:
@@ -293,6 +300,9 @@ class PipelineConfig:
     # A bounded diagnostic view only; ``event_log_path`` is the durable event
     # history and is not truncated by this setting.
     event_log_capacity: int = _DEFAULT_EVENT_LOG_CAPACITY
+    # Bounded diagnostic terminal rows only. Aggregate accounting is retained
+    # separately and remains complete for the run.
+    terminal_retention_capacity: int = _DEFAULT_TERMINAL_RETENTION_CAPACITY
     event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
     # Optional exceptions to the normal ``projects_dir / repo`` checkout
@@ -375,6 +385,30 @@ class _PendingHandoff:
     result: ItemResult | None = None
 
 
+class _BoundedAppendList(list[_T]):
+    """List-compatible append-only ring used by coordinator-owned sinks.
+
+    ``FinishedStage`` receives the ledger through constructor injection and
+    calls ``append`` directly. Keeping this type list-compatible avoids pushing
+    retention policy into stage code while still enforcing a hard coordinator
+    memory bound.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        """Create an empty list retaining at most *capacity* recent entries."""
+        if capacity < 1:
+            raise ValueError("capacity must be positive")
+        super().__init__()
+        self.capacity = capacity
+
+    def append(self, item: _T) -> None:
+        """Append *item*, evicting the oldest rows past the retention cap."""
+        super().append(item)
+        overflow = len(self) - self.capacity
+        if overflow > 0:
+            del self[:overflow]
+
+
 def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
     """Resolve *repo* to its explicit checkout or conventional projects path."""
     return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
@@ -439,6 +473,8 @@ class Coordinator:
             raise ValueError("alert queue depth threshold must be between 0 and 100")
         if config.event_log_capacity < 1:
             raise ValueError("event log capacity must be positive")
+        if config.terminal_retention_capacity < 1:
+            raise ValueError("terminal retention capacity must be positive")
         self.completion_q = CompletionQueue(capacity=self._work_window)
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
@@ -475,14 +511,20 @@ class Coordinator:
         self._live_work_permit_ids: set[int] = set()
         self._seed_entries: Iterator[_seeding.SeedEntry] | None = None
         self.inflight_per_repo: Counter[str] = Counter()
-        self.ledger: list[ItemResult] = []
-        self.preserved: list[PreservedWorktree] = []
+        self.ledger: list[ItemResult] = _BoundedAppendList(config.terminal_retention_capacity)
+        self.preserved: list[PreservedWorktree] = _BoundedAppendList(
+            config.terminal_retention_capacity
+        )
         # ``items`` owns only live, payload-bearing work. Terminal items are
         # retired immediately into compact scalar summaries so streamed runs
         # never retain O(total discovered work) issue bodies/plans/reviews.
         self.items: list[WorkItem] = []
-        self.item_summaries: list[WorkItemSummary] = []
-        self._terminal_pr_keys: set[tuple[str, int]] = set()
+        self.item_summaries: list[WorkItemSummary] = _BoundedAppendList(
+            config.terminal_retention_capacity
+        )
+        self._terminal_item_count = 0
+        self._terminal_dispositions: Counter[str] = Counter()
+        self._terminal_per_stage: Counter[str] = Counter()
         self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
         self._event_log_disabled = False
         self._journal_failure = False
@@ -906,8 +948,14 @@ class Coordinator:
                 agent_job_count=self._agent_job_count,
                 agent_job_time_s=self._agent_job_time_s,
                 wall_s=time.monotonic() - started,
+                terminal_item_count=self._terminal_item_count,
+                terminal_dispositions=dict(self._terminal_dispositions),
+                terminal_per_stage=dict(self._terminal_per_stage),
             )
             summary_items = self._effective_items()
+            summary_item_count = self._terminal_item_count + sum(
+                1 for item in summary_items if not isinstance(item, WorkItemSummary)
+            )
             preserved = self._active_preserved_worktrees()
             try:
                 self._record_event(
@@ -915,7 +963,7 @@ class Coordinator:
                     {
                         "exit_code": exit_code,
                         "interrupted": stats.interrupted,
-                        "items": len(summary_items),
+                        "items": summary_item_count,
                         "agent_jobs": self._agent_job_count,
                         "wall_s": stats.wall_s,
                     },
@@ -939,12 +987,31 @@ class Coordinator:
         )
         if tracked_index is None and item_id not in self._seen_item_ids:
             return
-        self.item_summaries.append(WorkItemSummary.from_item(item))
-        if item.pr is not None:
-            self._terminal_pr_keys.add((item.repo, item.pr))
+        self._record_terminal_summary(item)
         if tracked_index is not None:
             del self.items[tracked_index]
         self._seen_item_ids.discard(item_id)
+
+    def _record_terminal_summary(self, item: WorkItem) -> None:
+        """Retain one bounded terminal row and update complete aggregates."""
+        summary = WorkItemSummary.from_item(item)
+        self.item_summaries.append(summary)
+        self._terminal_item_count += 1
+        self._terminal_dispositions[self._terminal_disposition_bucket(summary.result)] += 1
+        self._terminal_per_stage[summary.stage.value] += 1
+
+    @staticmethod
+    def _terminal_disposition_bucket(result: ItemResult) -> str:
+        """Return the aggregate disposition bucket used by summary output."""
+        if result.reason.startswith("resumable"):
+            return "resumable"
+        if result.passed:
+            return "pass"
+        if result.reason.startswith("skip"):
+            return "skip"
+        if result.reason.startswith("blocked"):
+            return "blocked"
+        return "fail"
 
     def _active_preserved_worktrees(self) -> list[PreservedWorktree]:
         """Return preserved worktrees for latest failed items that still exist."""
@@ -974,8 +1041,16 @@ class Coordinator:
         if self._journal_failure:
             return 1
         effective_results = [item.result for item in self._effective_items() if item.result]
-        results = effective_results or self.ledger
-        if self.shutdown.is_set() or self._fatal or any(not result.passed for result in results):
+        retained_results = effective_results or self.ledger
+        has_nonpassing_terminal = any(
+            count for bucket, count in self._terminal_dispositions.items() if bucket != "pass"
+        )
+        if (
+            self.shutdown.is_set()
+            or self._fatal
+            or has_nonpassing_terminal
+            or any(not result.passed for result in retained_results)
+        ):
             return 1
         return 0
 
@@ -1642,12 +1717,11 @@ class Coordinator:
             )
             return False
 
-        # Issue discovery runs first. Check both bounded live ownership and the
-        # compact terminal-key index so the PR cursor cannot produce a second
-        # item for an already-covered pull request.
-        if (active.repo, pr_number) in self._terminal_pr_keys or any(
-            item.repo == active.repo and item.pr == pr_number for item in self.items
-        ):
+        # Issue discovery runs first. Check bounded live ownership before
+        # doing the more expensive PR hydration; terminal duplicate coverage
+        # is decided after PR→issue lookup using the source cursor's bounded
+        # ``seen_through_issue`` progress marker.
+        if any(item.repo == active.repo and item.pr == pr_number for item in self.items):
             source.pending_pr = None
             self._record_event("repo_pr_source_covered", active.repo, pr_number)
             self._progress = True
@@ -1671,6 +1745,14 @@ class Coordinator:
             )
             self._progress = True
             return True
+        if (
+            entry.issue_number is not None
+            and active.seen_through_issue is not None
+            and entry.issue_number <= active.seen_through_issue
+        ):
+            self._record_event("repo_pr_source_covered", active.repo, pr_number)
+            self._progress = True
+            return True
 
         new_item = self._entry_to_item(entry, active.repo)
         if new_item.stage is StageName.FINISHED and new_item.result is None:
@@ -1691,8 +1773,8 @@ class Coordinator:
         item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.FINISHED)
         item.result = ItemResult(passed=False, reason=reason, final_stage=StageName.REPO)
         item.payload["entry_stage"] = StageName.REPO.value
-        self.item_summaries.append(WorkItemSummary.from_item(item))
         self.ledger.append(item.result)
+        self._record_terminal_summary(item)
         self._fatal = True
 
     def _drain_implementation(self) -> None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -80,7 +80,7 @@ import signal
 import threading
 import time
 from collections import Counter, deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1711,15 +1711,13 @@ class Coordinator:
 
         """
         self._pass_work_count = 0
-        discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
-        entries = _seeding.seed_from_cli(discovery_repos, [], [])
         default_repo = self.config.repos[0] if self.config.repos else ""
         if self.config.issues or self.config.prs:
-            entries.extend(self._seed_direct_scope(default_repo))
+            entries = self._seed_direct_scope(default_repo)
+        else:
+            entries = _seeding.seed_from_cli(self.config.repos, [], [])
         pushed = 0
         for entry in entries:
-            if self._admission_saturated:
-                break
             if entry.stage is None:
                 # Epic tagging is the ONE sanctioned seeding write, executed
                 # here through the skip_epics chokepoint BEFORE the exclusion
@@ -1737,6 +1735,8 @@ class Coordinator:
                 if item.stage not in (StageName.REPO, StageName.FINISHED):
                     self._pass_work_count += 1
                 pushed += 1
+            if self._admission_saturated:
+                break
         return pushed
 
     def _clamp_seed_stage_to_scope(
@@ -1819,13 +1819,11 @@ class Coordinator:
             return StageName.FINISHED, f"#{issue} already past selected scope ({reason})", True
         return stage, reason, True
 
-    def _seed_direct_scope(self, repo: str) -> list[_seeding.SeedEntry]:
+    def _seed_direct_scope(self, repo: str) -> Iterator[_seeding.SeedEntry]:
         """Seed explicit ``--issues`` / ``--prs`` through the target repo accessor."""
         github = self._ctx_for_repo(repo).github if repo else self.github
-        entries: list[_seeding.SeedEntry] = []
         scope_stages = self.config.scope.stages if self.config.scope is not None else None
-        requested_issues = list(self.config.issues)
-        issue_numbers = requested_issues
+        issue_numbers = self.config.issues
         if issue_numbers:
             issue_numbers = _admission._filter_open_issues(repo, issue_numbers)
         for issue in issue_numbers:
@@ -1835,51 +1833,45 @@ class Coordinator:
             entry = _seeding.seed_entry_from_facts(facts)
             stage, reason = entry.stage, entry.reason
             stage, reason, passed = self._scope_seed_decision(issue, stage, reason, scope_stages)
-            entries.append(replace(entry, stage=stage, reason=reason, passed=passed))
+            yield replace(entry, stage=stage, reason=reason, passed=passed)
         for pr in self.config.prs:
             issue_number = github.find_issue_for_pr(pr)
             if issue_number is None:
-                entries.append(
-                    _seeding.SeedEntry(
-                        kind="pr",
-                        identifier=pr,
-                        stage=StageName.FINISHED,
-                        reason=(
-                            f"PR #{pr} has no linked issue; refusing review without "
-                            "requirements context"
-                        ),
-                        pr_number=pr,
-                        passed=False,
-                    )
+                yield _seeding.SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=StageName.FINISHED,
+                    reason=(
+                        f"PR #{pr} has no linked issue; refusing review without "
+                        "requirements context"
+                    ),
+                    pr_number=pr,
+                    passed=False,
                 )
                 continue
             scope_identifier = issue_number if issue_number is not None else pr
             pr_state = github.gh_pr_state(pr)
             pr_state_name = ((pr_state or {}).get("state") or "").upper()
             if pr_state_name == "MERGED":
-                entries.append(
-                    _seeding.SeedEntry(
-                        kind="pr",
-                        identifier=pr,
-                        stage=StageName.FINISHED,
-                        reason=f"PR #{pr} already merged",
-                        pr_number=pr,
-                        issue_number=issue_number,
-                        passed=True,
-                    )
+                yield _seeding.SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=StageName.FINISHED,
+                    reason=f"PR #{pr} already merged",
+                    pr_number=pr,
+                    issue_number=issue_number,
+                    passed=True,
                 )
                 continue
             if pr_state_name == "CLOSED":
-                entries.append(
-                    _seeding.SeedEntry(
-                        kind="pr",
-                        identifier=pr,
-                        stage=StageName.FINISHED,
-                        reason=f"PR #{pr} already closed without merging",
-                        pr_number=pr,
-                        issue_number=issue_number,
-                        passed=False,
-                    )
+                yield _seeding.SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=StageName.FINISHED,
+                    reason=f"PR #{pr} already closed without merging",
+                    pr_number=pr,
+                    issue_number=issue_number,
+                    passed=False,
                 )
                 continue
             has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
@@ -1890,16 +1882,14 @@ class Coordinator:
                     f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
                     scope_stages,
                 )
-                entries.append(
-                    _seeding.SeedEntry(
-                        kind="pr",
-                        identifier=pr,
-                        stage=stage,
-                        reason=reason,
-                        pr_number=pr,
-                        issue_number=issue_number,
-                        passed=passed,
-                    )
+                yield _seeding.SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=stage,
+                    reason=reason,
+                    pr_number=pr,
+                    issue_number=issue_number,
+                    passed=passed,
                 )
             else:
                 issue_facts: _seeding.IssueFacts | None
@@ -1912,16 +1902,14 @@ class Coordinator:
                     review_context = None
                     issue_facts = None
                 if issue_facts is None or review_context is None:
-                    entries.append(
-                        _seeding.SeedEntry(
-                            kind="pr",
-                            identifier=pr,
-                            stage=StageName.FINISHED,
-                            reason=f"PR #{pr} review context could not be read",
-                            pr_number=pr,
-                            issue_number=issue_number,
-                            passed=False,
-                        )
+                    yield _seeding.SeedEntry(
+                        kind="pr",
+                        identifier=pr,
+                        stage=StageName.FINISHED,
+                        reason=f"PR #{pr} review context could not be read",
+                        pr_number=pr,
+                        issue_number=issue_number,
+                        passed=False,
                     )
                     continue
                 stage, reason, passed = self._scope_seed_decision(
@@ -1930,22 +1918,19 @@ class Coordinator:
                     f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
                     scope_stages,
                 )
-                entries.append(
-                    _seeding.SeedEntry(
-                        kind="pr",
-                        identifier=pr,
-                        stage=stage,
-                        reason=reason,
-                        pr_number=pr,
-                        issue_number=issue_number,
-                        issue_title=issue_facts.title,
-                        issue_body=issue_facts.body,
-                        pr_diff=review_context["pr_diff"],
-                        pr_description=review_context["pr_description"],
-                        passed=passed,
-                    )
+                yield _seeding.SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=stage,
+                    reason=reason,
+                    pr_number=pr,
+                    issue_number=issue_number,
+                    issue_title=issue_facts.title,
+                    issue_body=issue_facts.body,
+                    pr_diff=review_context["pr_diff"],
+                    pr_description=review_context["pr_description"],
+                    passed=passed,
                 )
-        return entries
 
     @staticmethod
     def _entry_to_item(entry: _seeding.SeedEntry, default_repo: str) -> WorkItem:

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -6,17 +6,61 @@ the coordinator thread. The CompletionQueue is the only cross-thread channel.
 
 from __future__ import annotations
 
+import threading
 from collections import deque
-from queue import Queue
+from dataclasses import dataclass
+from queue import Empty, Full, Queue
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .work_item import WorkItem
 
-# Payload is (JobHandle, JobResult) per docs/architecture.md §8;
-# both types land with the worker pool (epic #1809 worker-pool slice), so the
-# alias stays shape-only until then.
-CompletionQueue = Queue[tuple[Any, Any]]
+@dataclass(frozen=True)
+class CompletionRejection:
+    """A completion that could not fit in the result channel."""
+
+    handle: Any
+    result: Any
+
+
+class CompletionQueue(Queue[tuple[Any, Any]]):
+    """Bounded completion channel with a bounded coordinator-owned fallback."""
+
+    def __init__(self, *, capacity: int) -> None:
+        """Create a queue with result and rejection-mailbox capacity."""
+        if capacity < 1:
+            raise ValueError("completion queue capacity must be positive")
+        super().__init__(maxsize=capacity)
+        self.capacity = capacity
+        self._rejections: Queue[CompletionRejection] = Queue(maxsize=capacity)
+        self._rejection_overflowed = False
+        self._rejection_lock = threading.Lock()
+
+    def offer(self, value: tuple[Any, Any]) -> bool:
+        """Publish without blocking, retaining rejected work for the coordinator."""
+        try:
+            self.put_nowait(value)
+        except Full:
+            try:
+                self._rejections.put_nowait(CompletionRejection(*value))
+            except Full:
+                with self._rejection_lock:
+                    self._rejection_overflowed = True
+            return False
+        return True
+
+    def take_rejections(self) -> tuple[list[CompletionRejection], bool]:
+        """Drain rejected completions and return whether the mailbox overflowed."""
+        rejected: list[CompletionRejection] = []
+        while True:
+            try:
+                rejected.append(self._rejections.get_nowait())
+            except Empty:
+                break
+        with self._rejection_lock:
+            overflowed = self._rejection_overflowed
+            self._rejection_overflowed = False
+        return rejected, overflowed
 
 
 class StageQueue:
@@ -26,13 +70,19 @@ class StageQueue:
     Used to route items through the pipeline stage by stage.
     """
 
-    def __init__(self) -> None:
-        """Initialize an empty queue."""
+    def __init__(self, *, capacity: int) -> None:
+        """Initialize an empty queue with a positive item capacity."""
+        if capacity < 1:
+            raise ValueError("stage queue capacity must be positive")
+        self.capacity = capacity
         self._items: deque[WorkItem] = deque()
 
-    def push(self, item: WorkItem) -> None:
-        """Append an item to the queue."""
+    def push(self, item: WorkItem) -> bool:
+        """Append an item, returning false when the queue is already full."""
+        if len(self._items) >= self.capacity:
+            return False
         self._items.append(item)
+        return True
 
     def pop(self) -> WorkItem:
         """Remove and return the front item. Raises IndexError if empty."""

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .work_item import WorkItem
 
+
 @dataclass(frozen=True)
 class CompletionRejection:
     """A completion that could not fit in the result channel."""

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -15,6 +15,13 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .work_item import WorkItem
 
+__all__ = [
+    "CompletionQueue",
+    "CompletionRejection",
+    "StageQueue",
+    "StageQueueLease",
+]
+
 
 @dataclass(frozen=True)
 class CompletionRejection:

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -64,30 +64,188 @@ class CompletionQueue(Queue[tuple[Any, Any]]):
         return rejected, overflowed
 
 
+class StageQueueLease:
+    """A temporary, capacity-reserving claim on one stage-queue item.
+
+    Leases are coordinator-thread objects: they are not thread-safe and their
+    lifetime is bounded by one successful :meth:`handoff` or :meth:`restore`.
+    A failed handoff intentionally leaves the lease active so the caller can
+    retry after the destination makes capacity available.
+    """
+
+    def __init__(self, source: StageQueue, item: WorkItem, ticket: int) -> None:
+        """Create an active lease owned by *source* for *item*."""
+        self._source = source
+        self.item = item
+        self._ticket = ticket
+        self._active = True
+
+    def restore(self) -> None:
+        """Return this active lease's item to its original FIFO position.
+
+        A released lease is a harmless no-op. This makes cleanup paths safe
+        to repeat while preserving the item's exact-once queue ownership.
+        """
+        if not self._active:
+            return
+
+        self._source._restore_lease(self.item, self._ticket)
+        self._active = False
+
+    def handoff(self, destination: StageQueue) -> bool:
+        """Move this active lease to *destination* when it has capacity.
+
+        Destination admission happens before the source reservation is
+        released. Therefore a full destination leaves the item held by this
+        lease and does not create a spill buffer or lose work.
+        """
+        if not self._active or not destination.offer(self.item):
+            return False
+
+        self._source._release_lease(self.item, self._ticket)
+        self._active = False
+        return True
+
+    def release(self) -> None:
+        """Release a lease when an external owner takes the item.
+
+        Timers and the terminal ledger are neither source restores nor stage
+        handoffs. Their coordinator-owned containers take responsibility for
+        the item after this method returns, while the source slot becomes
+        available without disturbing another ready item's FIFO position.
+        """
+        if not self._active:
+            return
+
+        self._source._release_lease(self.item, self._ticket)
+        self._active = False
+
+
 class StageQueue:
     """FIFO queue of work items for a stage.
 
     Owned exclusively by the coordinator thread; not thread-safe.
-    Used to route items through the pipeline stage by stage.
+    Used to route items through the pipeline stage by stage. Every queue has
+    an explicit, positive capacity. Callers that can defer admission should
+    use :meth:`offer`, which reports a full queue without changing it.
     """
 
-    def __init__(self, *, capacity: int) -> None:
-        """Initialize an empty queue with a positive item capacity."""
-        if capacity < 1:
-            raise ValueError("stage queue capacity must be positive")
-        self.capacity = capacity
-        self._items: deque[WorkItem] = deque()
+    def __init__(self, capacity: int) -> None:
+        """Initialize an empty queue with a positive item capacity.
 
-    def push(self, item: WorkItem) -> bool:
-        """Append an item, returning false when the queue is already full."""
-        if len(self._items) >= self.capacity:
+        Args:
+            capacity: Maximum number of work items the queue may hold.
+
+        Raises:
+            ValueError: If ``capacity`` is not positive.
+
+        """
+        if capacity <= 0:
+            raise ValueError("StageQueue capacity must be positive")
+
+        self._capacity = capacity
+        self._items: deque[tuple[int, WorkItem]] = deque()
+        self._leased: dict[int, int] = {}
+        self._next_ticket = 0
+
+    @property
+    def capacity(self) -> int:
+        """Return the maximum number of items the queue can hold."""
+        return self._capacity
+
+    @property
+    def occupancy(self) -> int:
+        """Return all ready and leased items currently held by the queue."""
+        return len(self._items) + len(self._leased)
+
+    def push(self, item: WorkItem) -> None:
+        """Append an item or raise if the queue is full.
+
+        Callers that need to retain an item for a later retry should use
+        :meth:`offer` instead.
+
+        Raises:
+            OverflowError: If the queue has reached its capacity.
+
+        """
+        if not self.offer(item):
+            raise OverflowError("StageQueue is full")
+
+    def can_offer(self) -> bool:
+        """Return whether :meth:`offer` can append one new item now.
+
+        A claimed item retains its source capacity until it is restored or
+        handed off, while an immutable FIFO ticket lets other ready work use
+        remaining capacity without allowing a retry to overtake it.
+        """
+        return self.occupancy < self._capacity
+
+    def offer(self, item: WorkItem) -> bool:
+        """Append an item when capacity is available.
+
+        Returns:
+            ``True`` when ``item`` was appended, otherwise ``False``. A
+            rejected offer leaves the queue unchanged so the caller retains
+            ownership of the work item and can retry it later.
+
+        """
+        if not self.can_offer():
             return False
-        self._items.append(item)
+
+        self._items.append((self._next_ticket, item))
+        self._next_ticket += 1
         return True
 
     def pop(self) -> WorkItem:
         """Remove and return the front item. Raises IndexError if empty."""
-        return self._items.popleft()
+        _ticket, item = self._items.popleft()
+        return item
+
+    def claim(self) -> StageQueueLease | None:
+        """Claim the FIFO-ready item without releasing this queue's capacity.
+
+        The returned lease owns the item until it is restored or handed off.
+        Several claims may be active concurrently up to :attr:`capacity`.
+        Their immutable tickets retain the original FIFO order whenever any
+        retry restores, while ready work inspection remains available through
+        :meth:`snapshot`.
+        """
+        return self.claim_at(0)
+
+    def claim_at(self, index: int) -> StageQueueLease | None:
+        """Claim one ready item at *index* while preserving its retry position.
+
+        Implementation's topological scheduler may need to execute a
+        dependency that is ready behind the FIFO head. A selected lease keeps
+        its immutable ticket, so restoring it returns the item to the exact
+        order it occupied when claimed even while other work is active.
+        """
+        if not 0 <= index < len(self._items):
+            return None
+
+        ticket, item = self._items[index]
+        del self._items[index]
+        self._leased[id(item)] = ticket
+        return StageQueueLease(self, item, ticket=ticket)
+
+    def _restore_lease(self, item: WorkItem, ticket: int) -> None:
+        """Restore one active lease in original FIFO order without opening capacity."""
+        if self._leased.pop(id(item), None) != ticket:
+            raise RuntimeError("StageQueue lease ticket mismatch")
+        index = next(
+            (
+                position
+                for position, (ready_ticket, _ready) in enumerate(self._items)
+                if ticket < ready_ticket
+            ),
+            len(self._items),
+        )
+        self._items.insert(index, (ticket, item))
+
+    def _release_lease(self, item: WorkItem, ticket: int) -> None:
+        """Release one active lease after its item was admitted elsewhere."""
+        if self._leased.pop(id(item), None) != ticket:
+            raise RuntimeError("StageQueue lease ticket mismatch")
 
     def __len__(self) -> int:
         """Return the number of items in the queue."""
@@ -95,4 +253,4 @@ class StageQueue:
 
     def snapshot(self) -> list[WorkItem]:
         """Return a copy of all items in queue order (for inspection/debugging)."""
-        return list(self._items)
+        return [item for _ticket, item in self._items]

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -33,7 +33,7 @@ GitHub mutations in this module, so seeding returns an explicit
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -482,7 +482,7 @@ def seed_from_cli(
     issues: Sequence[int],
     prs: Sequence[int],
     github: Any | None = None,
-) -> list[SeedEntry]:
+) -> Iterator[SeedEntry]:
     """Map CLI scope args (``--repos`` / ``--issues`` / ``--prs``) to queue pushes.
 
     Pure planning plus thin fetch — no mutations:
@@ -516,42 +516,38 @@ def seed_from_cli(
             :func:`~hephaestus.automation.github_api.gh_pr_state` /
             :func:`~hephaestus.automation.github_api.gh_pr_label_names`.
 
-    Returns:
-        Planned queue pushes, in the given order (repos, issues, prs).
+    Yields:
+        Planned queue pushes, in the given order (repos, issues, prs). Entries
+        are classified lazily so the coordinator can stop reading the source
+        as soon as its bounded admission path reaches saturation.
 
     """
-    entries: list[SeedEntry] = [
-        SeedEntry(
+    for repo in repos:
+        yield SeedEntry(
             kind="repo", identifier=repo, stage=StageName.REPO, reason=f"{repo} CLI repo seed"
         )
-        for repo in repos
-    ]
     for issue in issues:
         facts = seed_issue(issue)
-        entries.append(seed_entry_from_facts(facts))
+        yield seed_entry_from_facts(facts)
     for pr in prs:
         pr_state = github.gh_pr_state(pr) if github is not None else gh_pr_state(pr)
         state = str((pr_state or {}).get("state") or "").upper()
         if state == "MERGED" or (pr_state or {}).get("mergedAt"):
-            entries.append(
-                SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=StageName.FINISHED,
-                    reason=f"PR #{pr} merged (idempotent)",
-                    pr_number=pr,
-                )
+            yield SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.FINISHED,
+                reason=f"PR #{pr} merged (idempotent)",
+                pr_number=pr,
             )
             continue
         if state == "CLOSED":
-            entries.append(
-                SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=None,
-                    reason=f"PR #{pr} closed (not merged) — excluded",
-                    pr_number=pr,
-                )
+            yield SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=None,
+                reason=f"PR #{pr} closed (not merged) — excluded",
+                pr_number=pr,
             )
             continue
 
@@ -560,26 +556,21 @@ def seed_from_cli(
         else:
             has_go = is_implementation_go(gh_pr_label_names(pr))
         if has_go:
-            entries.append(
-                SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=StageName.MERGE_WAIT,
-                    reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
-                    pr_number=pr,
-                )
+            yield SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.MERGE_WAIT,
+                reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                pr_number=pr,
             )
         else:
-            entries.append(
-                SeedEntry(
-                    kind="pr",
-                    identifier=pr,
-                    stage=StageName.PR_REVIEW,
-                    reason=f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
-                    pr_number=pr,
-                )
+            yield SeedEntry(
+                kind="pr",
+                identifier=pr,
+                stage=StageName.PR_REVIEW,
+                reason=f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
+                pr_number=pr,
             )
-    return entries
 
 
 __all__ = [

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -6,9 +6,9 @@ The universal sink. States: ENTER -> RECORD -> CLEANUP -> DONE.
 
 Steps:
 
-1. [M] RECORD: append the item's :class:`~..work_item.ItemResult` to the run
-   ledger (the coordinator injects its ledger list at construction — queue
-   and ledger ownership stay with the coordinator).
+1. [M] RECORD: append the item's :class:`~..work_item.ItemResult` to the
+   coordinator-owned recent ledger window. Complete aggregate accounting stays
+   with the coordinator when the terminal item is retired.
 2. [W:G] CLEANUP: remove the implementation worktree on pass; on fail, preserve that writer
    worktree for debugging and record it in the preserved list the end-of-run
    summary prints.
@@ -45,7 +45,7 @@ class FinishedStage(Stage):
     """Sink stage: record :class:`ItemResult` and clean up worktrees.
 
     Args:
-        ledger: The coordinator's run ledger; RECORD appends here.
+        ledger: The coordinator's bounded recent ledger; RECORD appends here.
         preserved: The coordinator's preserved-worktree list
             (``(repo, item_number, worktree_path)`` tuples) the summary prints.
             Failed issue items use the issue number; PR-only items use the PR

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -14,10 +14,13 @@ Steps:
    checkout. Both operations are logged-skipped under dry-run — the
    coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
-3. [M] DISCOVER: initialize one page-at-a-time metadata cursor. It never
-   materializes a list of classified products.
-4. [M] SOURCE: the coordinator owns the bounded cursor and admits one metadata
-   row only when its bounded stage/admission path has room.
+3. [M] DISCOVER: initialize one page-at-a-time issue cursor and, for
+   ``--drive-green-all``, a one-page-at-a-time PR cursor. Neither materializes
+   a list of classified products.
+4. [M] SOURCE: the coordinator owns the bounded cursors and admits one metadata
+   row only when its bounded stage/admission path has room. Issue discovery
+   drains first; eligible PRs not already represented by an issue product then
+   enter the same capacity-controlled path.
 
 Discovery seams (``_repo_manager`` / ``_seeding`` module attributes) mirror
 the ``loop_runner._admission`` seam pattern so unit tests patch the reads
@@ -57,16 +60,21 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class RepoIssueSource:
-    """Bounded repository-discovery cursor handed to the coordinator.
+    """Bounded repository issue/PR discovery cursors handed to the coordinator.
 
-    ``pending`` retains at most the one metadata row waiting for downstream
-    admission. The iterator itself holds at most one fetched GitHub page.
-    Classified ``WorkItem`` products are never accumulated here.
+    ``pending`` and ``pending_pr`` retain at most one row for their respective
+    source while downstream admission is unavailable. Each iterator holds at
+    most one fetched GitHub page. Classified ``WorkItem`` products are never
+    accumulated here.
     """
 
     metadata: Iterator[dict[str, Any]]
     pending: dict[str, Any] | None = None
     seeded_count: int = 0
+    pr_metadata: Iterator[dict[str, Any]] | None = None
+    pending_pr: dict[str, Any] | None = None
+    issues_exhausted: bool = False
+    viewer_login: str = ""
 
 
 def _drive_green_pr_is_in_scope(
@@ -225,6 +233,12 @@ class RepoStage(Stage):
         """[M] Initialize a bounded metadata source without eager classification."""
         try:
             source = RepoIssueSource(_repo_manager._iter_open_issue_meta(ctx.org, item.repo))
+            if getattr(ctx.config, "drive_green_all", False):
+                include_all_authors = bool(getattr(ctx.config, "include_all_authors", False))
+                source.viewer_login = (
+                    "" if include_all_authors else _pr_discovery._resolve_viewer_login()
+                )
+                source.pr_metadata = _repo_manager._iter_open_pr_meta(ctx.org, item.repo)
         except Exception as exc:
             logger.warning("repo:%s: discovery failed: %s", item.repo, exc)
             return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -2,7 +2,7 @@
 
 Binding contract: docs/architecture.md §5.1 "repo".
 
-States: ENTER -> CLONE_WAIT -> DISCOVER -> SEEDED.
+States: ENTER -> CLONE_WAIT -> DISCOVER -> SOURCE.
 
 Steps:
 
@@ -14,16 +14,10 @@ Steps:
    checkout. Both operations are logged-skipped under dry-run — the
    coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
-3. [M] DISCOVER: list issues (read-only ``_list_open_issue_meta``), dedup,
-   ``partition_epics`` -> tag epics ``state:skip`` via
-   ``ctx.github.skip_epics`` [durable, BEFORE excluding], classify each kept
-   issue via the REUSED :func:`~..seeding.seed_issue` /
-   :func:`~..seeding.classify_issue`, and (``--drive-green-all``) route
-   open PRs with a linked tracked issue to PR review.
-4. [M] SEEDED: expose the classified products in
-   ``item.payload["products"]`` — the coordinator (queue owner) performs the
-   actual queue pushes when routing the repo item — and finish
-   ``FINISH_PASS(seeded:N)``. The repo item is terminal.
+3. [M] DISCOVER: initialize one page-at-a-time metadata cursor. It never
+   materializes a list of classified products.
+4. [M] SOURCE: the coordinator owns the bounded cursor and admits one metadata
+   row only when its bounded stage/admission path has room.
 
 Discovery seams (``_repo_manager`` / ``_seeding`` module attributes) mirror
 the ``loop_runner._admission`` seam pattern so unit tests patch the reads
@@ -33,6 +27,8 @@ without network I/O.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -57,6 +53,20 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RepoIssueSource:
+    """Bounded repository-discovery cursor handed to the coordinator.
+
+    ``pending`` retains at most the one metadata row waiting for downstream
+    admission. The iterator itself holds at most one fetched GitHub page.
+    Classified ``WorkItem`` products are never accumulated here.
+    """
+
+    metadata: Iterator[dict[str, Any]]
+    pending: dict[str, Any] | None = None
+    seeded_count: int = 0
 
 
 def _drive_green_pr_is_in_scope(
@@ -120,12 +130,7 @@ def _repair_blocked_audit(facts: _seeding.IssueFacts, ctx: StageContext) -> None
 
 
 class RepoStage(Stage):
-    """Repo discovery and classification stage (the pipeline's sole producer).
-
-    Products are ``(kind, identifier, stage, reason, facts)`` tuples staged
-    in ``item.payload["products"]``; the coordinator turns them into
-    :class:`WorkItem` pushes because stage code never touches queues.
-    """
+    """Repository setup stage that initializes a bounded discovery source."""
 
     kind = StageName.REPO
 
@@ -163,14 +168,10 @@ class RepoStage(Stage):
         if item.state == "DISCOVER":
             return self._discover(item, ctx)
 
-        if item.state == "SEEDED":
-            seeded_count = item.payload.get("seeded_count")
-            if seeded_count is None:
-                seeded_count = sum(
-                    1 for p in item.payload.get("products", []) if p.get("stage") is not None
-                )
-            seeded = int(seeded_count)
-            return StageOutcome(Disposition.FINISH_PASS, note=f"seeded:{seeded}")
+        if item.state == "SOURCE":
+            # Coordinator._run_item externalizes the cursor as soon as the
+            # DISCOVER -> SOURCE transition is observed.
+            return Continue(next_state="SOURCE")
 
         return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
 
@@ -221,89 +222,14 @@ class RepoStage(Stage):
         return JobRequest(job=job, on_done_state="DISCOVER")
 
     def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """[M] List, dedup, tag-then-exclude epics, classify, stage products."""
+        """[M] Initialize a bounded metadata source without eager classification."""
         try:
-            meta = _repo_manager._list_open_issue_meta(ctx.org, item.repo)
+            source = RepoIssueSource(_repo_manager._iter_open_issue_meta(ctx.org, item.repo))
         except Exception as exc:
             logger.warning("repo:%s: discovery failed: %s", item.repo, exc)
             return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
-
-        # Dedup while preserving listing order.
-        seen: set[int] = set()
-        deduped: list[dict[str, Any]] = []
-        for entry in meta:
-            number = int(entry["number"])
-            if number in seen:
-                continue
-            seen.add(number)
-            deduped.append(entry)
-
-        # Epic tagging: the ONE sanctioned seeding write, durable and BEFORE
-        # the exclusion is final (doc row "Epic tagging is the one seeding
-        # write; done BEFORE excluding").
-        try:
-            kept, epics = _partition_and_tag_epics(item.repo, ctx, deduped)
-        except Exception as exc:
-            logger.warning("repo:%s: could not tag excluded epics state:skip: %s", item.repo, exc)
-            return StageOutcome(Disposition.FINISH_FAIL, note=f"epic skip tag failed: {exc}")
-
-        products: list[dict[str, Any]] = [
-            {
-                "kind": "issue",
-                "number": num,
-                "stage": None,
-                "reason": f"epic #{num} excluded",
-            }
-            for num in epics
-        ]
-        covered_prs: set[int] = set()
-        for num in kept:
-            facts = _seeding.seed_issue_from_github(num, ctx.github)
-            _repair_blocked_audit(facts, ctx)
-            stage, reason = _seeding.classify_issue(facts)
-            if facts.pr_number is not None:
-                covered_prs.add(facts.pr_number)
-            products.append(
-                {
-                    "kind": "issue",
-                    "number": num,
-                    "stage": stage,
-                    "reason": reason,
-                    "pr": facts.pr_number if facts.pr_is_open else None,
-                    "labels": sorted(facts.labels),
-                    "title": facts.title,
-                    "body": facts.body,
-                }
-            )
-
-        # --drive-green-all: only linked PRs can be reviewed. Orphans have no
-        # requirements context and must remain outside the automation loop.
-        if getattr(ctx.config, "drive_green_all", False):
-            include_bot_prs = bool(getattr(ctx.config, "include_bot_prs", True))
-            include_all_authors = bool(getattr(ctx.config, "include_all_authors", False))
-            try:
-                open_prs = _repo_manager._list_open_pr_meta(ctx.org, item.repo)
-                viewer_login = "" if include_all_authors else _pr_discovery._resolve_viewer_login()
-            except Exception as exc:
-                logger.warning("repo:%s: PR discovery failed: %s", item.repo, exc)
-                return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
-            for pr in open_prs:
-                pr_number = int(pr["number"])
-                if pr_number in covered_prs:
-                    continue
-                if not _drive_green_pr_is_in_scope(
-                    pr, include_bot_prs=include_bot_prs, viewer_login=viewer_login
-                ):
-                    continue
-                logger.info(
-                    "repo:%s: skipping orphan PR #%d; no linked issue supplies requirements",
-                    item.repo,
-                    pr_number,
-                )
-
-        item.payload["products"] = products
-        item.payload["seeded_count"] = sum(1 for p in products if p.get("stage") is not None)
-        return Continue(next_state="SEEDED")
+        item.payload["_repo_issue_source"] = source
+        return Continue(next_state="SOURCE")
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Record checkout preparation success/failure (state still CLONE_WAIT).

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -16,11 +16,20 @@ import logging
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TypeAlias, TypeVar
 
-from hephaestus.automation.pipeline.work_item import ItemKind, PreservedWorktree, WorkItem
+from hephaestus.automation.pipeline.work_item import (
+    ItemKind,
+    PreservedWorktree,
+    WorkItem,
+    WorkItemSummary,
+)
 from hephaestus.cli.utils import emit_json_status
 
 logger = logging.getLogger(__name__)
+
+SummaryItem: TypeAlias = WorkItem | WorkItemSummary
+_SummaryItemT = TypeVar("_SummaryItemT", bound=SummaryItem)
 
 
 @dataclass(frozen=True)
@@ -71,7 +80,7 @@ def format_preserved_worktrees(preserved: Sequence[PreservedWorktree], script: s
     return lines
 
 
-def _logical_item_key(item: WorkItem) -> tuple[object, ...]:
+def _logical_item_key(item: SummaryItem) -> tuple[object, ...]:
     """Return the stable logical identity for a potentially re-seeded item."""
     if item.kind is ItemKind.REPO:
         return (item.repo, "repo")
@@ -82,9 +91,9 @@ def _logical_item_key(item: WorkItem) -> tuple[object, ...]:
     return (item.repo, item.kind.value, id(item))
 
 
-def latest_logical_items(items: Sequence[WorkItem]) -> list[WorkItem]:
+def latest_logical_items(items: Sequence[_SummaryItemT]) -> list[_SummaryItemT]:
     """Return only the latest queued item for each logical issue/PR/repo."""
-    latest: dict[tuple[object, ...], WorkItem] = {}
+    latest: dict[tuple[object, ...], _SummaryItemT] = {}
     for item in items:
         key = _logical_item_key(item)
         latest.pop(key, None)
@@ -92,7 +101,7 @@ def latest_logical_items(items: Sequence[WorkItem]) -> list[WorkItem]:
     return list(latest.values())
 
 
-def _disposition(item: WorkItem) -> str:
+def _disposition(item: SummaryItem) -> str:
     """Classify one item's summary disposition cell."""
     result = item.result
     if result is None:
@@ -108,7 +117,7 @@ def _disposition(item: WorkItem) -> str:
     return f"FAIL:{result.reason}"
 
 
-def _disposition_bucket(item: WorkItem) -> str:
+def _disposition_bucket(item: SummaryItem) -> str:
     """Aggregate-count bucket for one item (pass/fail/skip/blocked/resumable)."""
     cell = _disposition(item)
     return cell.split(":")[0].split(" ")[0].lower()
@@ -123,12 +132,17 @@ def _json_message(exit_code: int) -> str:
     return "pipeline failed"
 
 
-def _item_row(item: WorkItem) -> str:
+def _item_row(item: SummaryItem) -> str:
     """Format one per-item summary row."""
     issue = f"#{item.issue}" if item.issue else "-"
     pr = f"!{item.pr}" if item.pr else "-"
-    entry = str(item.payload.get("entry_stage", item.stage.value))
-    attempts = ",".join(f"{k}={v}" for k, v in sorted(item.attempts.items()) if v) or "-"
+    if isinstance(item, WorkItemSummary):
+        entry = item.entry_stage
+        attempt_items = item.attempts
+    else:
+        entry = str(item.payload.get("entry_stage", item.stage.value))
+        attempt_items = tuple(sorted((key, value) for key, value in item.attempts.items() if value))
+    attempts = ",".join(f"{key}={value}" for key, value in attempt_items) or "-"
     elapsed_s = (item.updated_at - item.created_at).total_seconds()
     return (
         f"  {item.repo:<28} {issue:>7} {pr:>7} {entry:<15} "
@@ -137,7 +151,7 @@ def _item_row(item: WorkItem) -> str:
 
 
 def print_summary(
-    items: list[WorkItem],
+    items: Sequence[SummaryItem],
     stats: RunStats,
     preserved: list[PreservedWorktree],
     *,
@@ -146,7 +160,7 @@ def print_summary(
     """Log the end-of-run summary; emit the JSON envelope when requested.
 
     Args:
-        items: Every work item the run ever queued (results attached).
+        items: Effective active items and compact terminal summaries.
         stats: Aggregate run statistics (exit code, loops, agent time, wall).
         preserved: ``(repo, issue_number, worktree_path)`` tuples for failed items.
         json_out: Emit the machine-readable ``emit_json_status`` envelope.

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypeAlias, TypeVar
 
 from hephaestus.automation.pipeline.work_item import (
@@ -41,6 +41,9 @@ class RunStats:
     agent_job_count: int
     agent_job_time_s: float
     wall_s: float
+    terminal_item_count: int = 0
+    terminal_dispositions: dict[str, int] = field(default_factory=dict)
+    terminal_per_stage: dict[str, int] = field(default_factory=dict)
 
     @property
     def interrupted(self) -> bool:
@@ -179,15 +182,38 @@ def print_summary(
     for item in items:
         logger.info("%s", _item_row(item))
 
-    dispositions: dict[str, int] = {}
-    per_stage: dict[str, int] = {}
-    for item in items:
-        dispositions[_disposition_bucket(item)] = dispositions.get(_disposition_bucket(item), 0) + 1
-        per_stage[item.stage.value] = per_stage.get(item.stage.value, 0) + 1
+    if stats.terminal_item_count or stats.terminal_dispositions or stats.terminal_per_stage:
+        dispositions = dict(stats.terminal_dispositions)
+        per_stage = dict(stats.terminal_per_stage)
+        aggregate_items = stats.terminal_item_count
+        # Terminal WorkItemSummary rows are a bounded recent sample already
+        # represented in the terminal aggregates. Active WorkItems still need
+        # to contribute to the end-of-run counts.
+        for item in items:
+            if isinstance(item, WorkItemSummary):
+                continue
+            dispositions[_disposition_bucket(item)] = (
+                dispositions.get(_disposition_bucket(item), 0) + 1
+            )
+            per_stage[item.stage.value] = per_stage.get(item.stage.value, 0) + 1
+            aggregate_items += 1
+    else:
+        dispositions = {}
+        per_stage = {}
+        for item in items:
+            dispositions[_disposition_bucket(item)] = (
+                dispositions.get(_disposition_bucket(item), 0) + 1
+            )
+            per_stage[item.stage.value] = per_stage.get(item.stage.value, 0) + 1
+        aggregate_items = len(items)
 
     logger.info("")
     logger.info("=== Aggregates ===")
-    logger.info("  items: %d  dispositions: %s", len(items), dict(sorted(dispositions.items())))
+    logger.info(
+        "  items: %d  dispositions: %s",
+        aggregate_items,
+        dict(sorted(dispositions.items())),
+    )
     logger.info("  per-stage: %s", dict(sorted(per_stage.items())))
     logger.info(
         "  agent jobs: %d (%.1fs total)  loops: %d  wall: %.1fs  interrupted: %s",

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -58,6 +58,45 @@ class ItemResult:
     final_stage: StageName
 
 
+@dataclass(frozen=True)
+class WorkItemSummary:
+    """Compact terminal projection used for accounting and end-of-run output.
+
+    The coordinator must not retain completed :class:`WorkItem` instances:
+    their payloads can contain issue/PR bodies, plans, review text, and session
+    caches. This projection keeps only the scalar fields the summary needs.
+    """
+
+    repo: str
+    kind: ItemKind
+    issue: int | None
+    pr: int | None
+    stage: StageName
+    entry_stage: str
+    attempts: tuple[tuple[str, int], ...]
+    created_at: datetime
+    updated_at: datetime
+    result: ItemResult
+
+    @classmethod
+    def from_item(cls, item: WorkItem) -> WorkItemSummary:
+        """Capture the summary-relevant terminal state of *item*."""
+        if item.result is None:
+            raise ValueError("cannot summarize a work item without a terminal result")
+        return cls(
+            repo=item.repo,
+            kind=item.kind,
+            issue=item.issue,
+            pr=item.pr,
+            stage=item.stage,
+            entry_stage=str(item.payload.get("entry_stage", item.stage.value)),
+            attempts=tuple(sorted((key, value) for key, value in item.attempts.items() if value)),
+            created_at=item.created_at,
+            updated_at=item.updated_at,
+            result=item.result,
+        )
+
+
 @dataclass
 class WorkItem:
     """A unit of work flowing through the pipeline.

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1,8 +1,8 @@
 """Worker pool: the only place agent, build/test, git, and session work runs.
 
 The coordinator submits frozen jobs and drains ``(handle, result)`` tuples from
-the completion queue. Workers never touch WorkItems or stage queues and never
-perform GitHub API mutations (enforced by test_pipeline_architecture.py).
+the bounded completion queue. Workers never touch WorkItems or stage queues and
+never perform GitHub API mutations (enforced by test_pipeline_architecture.py).
 """
 
 from __future__ import annotations
@@ -323,6 +323,9 @@ class WorkerPool:
         )
         self._shutdown = shutdown
         self._completion_q = completion_q
+        # Public for coordinator wiring and test doubles; the private alias is
+        # retained for the worker callback's internal channel use.
+        self.completion_q = completion_q
         self._repo_locks: dict[str, _RepoLockEntry] = {}
         self._repo_locks_guard = threading.Lock()
         self._lock_dir = lock_dir
@@ -399,13 +402,15 @@ class WorkerPool:
         """Drain result to completion queue when a job future completes.
 
         If the future was cancelled, do not emit a completion (the coordinator
-        synthesizes one later). For every OTHER outcome a completion MUST be
-        queued: ``_run`` already converts normal job failures into error
+        synthesizes one later). For every OTHER outcome the callback attempts a
+        non-blocking completion publication: ``_run`` already converts normal
+        job failures into error
         results, and anything that still escapes ``future.result()`` -- any
         ``Exception`` plus the process-control escapes ``KeyboardInterrupt``,
         ``SystemExit``, and ``GeneratorExit`` -- is converted here to a
-        ``worker_crash`` result so a non-cancelled submit never silently loses
-        its completion. Process-control escapes are logged without traceback at
+        ``worker_crash`` result. A full completion queue retains a rejected
+        result in its bounded coordinator mailbox and requests shutdown without
+        blocking this worker. Process-control escapes are logged without traceback at
         warning/info severity; genuine ``Exception`` crashes keep
         ``logger.exception``. ``KeyboardInterrupt`` is intentionally NOT
         re-raised after queuing: this callback runs on an executor worker
@@ -438,7 +443,12 @@ class WorkerPool:
                 error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
                 worker_id=worker_id,
             )
-        self._completion_q.put((handle, result))
+        if not self._completion_q.offer((handle, result)):
+            logger.critical(
+                "completion queue rejected result for %s; coordinator will park resumable work",
+                handle,
+            )
+            self._shutdown.set()
 
     def _run(
         self,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 _TAIL = 4000  # chars of stdout/stderr retained in a JobResult
 _ERR_MAX = 500  # chars of error detail retained in a JobResult
+_JOB_LOG_FIELD_MAX = 160  # chars of non-secret job identity retained in incident logs
 _GIT_LOCK_WAIT_POLL_S = 0.1
 _FETCH_ENV_BLOCKLIST = frozenset(
     {
@@ -91,6 +92,31 @@ _TRUSTED_GH_CANDIDATES = (
     Path("/usr/bin/gh"),
 )
 _TRUSTED_GH_ROOTS = (Path("/opt/homebrew"), Path("/usr/local"), Path("/usr"))
+
+
+def _bounded_job_log_field(value: object) -> str:
+    """Return a bounded, single-line scalar suitable for incident logging."""
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, int) and not isinstance(value, bool):
+        text = str(value)
+    else:
+        return ""
+    text = text.replace("\r", "\\r").replace("\n", "\\n")
+    if len(text) <= _JOB_LOG_FIELD_MAX:
+        return text
+    return f"{text[: _JOB_LOG_FIELD_MAX - 1]}…"
+
+
+def _completion_rejection_log_fields(handle: JobHandle) -> tuple[str, str, str, str]:
+    """Return bounded identifiers without rendering untrusted job payloads."""
+    job = handle.job
+    return (
+        type(job).__name__,
+        _bounded_job_log_field(job.repo),
+        _bounded_job_log_field(getattr(job, "issue", "")),
+        _bounded_job_log_field(job.descr),
+    )
 
 
 def _controlled_git_env() -> dict[str, str]:
@@ -444,9 +470,14 @@ class WorkerPool:
                 worker_id=worker_id,
             )
         if not self._completion_q.offer((handle, result)):
+            job_type, repo, issue, description = _completion_rejection_log_fields(handle)
             logger.critical(
-                "completion queue rejected result for %s; coordinator will park resumable work",
-                handle,
+                "completion queue rejected result; coordinator will park resumable work "
+                "job_type=%s repo=%s issue=%s description=%s",
+                job_type,
+                repo,
+                issue,
+                description,
             )
             self._shutdown.set()
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -109,10 +109,15 @@ def _bounded_job_log_field(value: object) -> str:
 
 
 def _completion_rejection_log_fields(handle: JobHandle) -> tuple[str, str, str, str]:
-    """Return bounded identifiers without rendering untrusted job payloads."""
+    """Return bounded identifiers without rendering a job or handle wholesale.
+
+    In particular, never call ``str`` or ``repr`` on ``handle``/``job`` here:
+    agent jobs carry prompt kwargs and session identifiers that can contain
+    untrusted, sensitive, and arbitrarily large review content.
+    """
     job = handle.job
     return (
-        type(job).__name__,
+        _bounded_job_log_field(type(job).__name__),
         _bounded_job_log_field(job.repo),
         _bounded_job_log_field(getattr(job, "issue", "")),
         _bounded_job_log_field(job.descr),

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -353,6 +353,9 @@ class WorkerPool:
             thread_name_prefix="hephaestus-pipeline-worker",
         )
         self._shutdown = shutdown
+        # Public for coordinator wiring and test doubles; worker paths use the
+        # private alias to keep their hot-path access unchanged.
+        self.shutdown_event = shutdown
         self._completion_q = completion_q
         # Public for coordinator wiring and test doubles; the private alias is
         # retained for the worker callback's internal channel use.

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -170,7 +170,7 @@ def main() -> int:
     # the CLI actually runs.
     from hephaestus.utils.terminal import install_sigtstp_only
 
-    from .pipeline.coordinator import PipelineConfig, run_pipeline
+    from .pipeline.coordinator import PipelineConfig, default_event_log_path, run_pipeline
 
     install_sigtstp_only()
     args = _parse_args()
@@ -207,6 +207,7 @@ def main() -> int:
     issues = list(dict.fromkeys(issues))
     log.info("Issues to plan: %s", issues)
 
+    projects_dir = resolve_projects_dir(None, prefer_cwd_parent=True)
     config = PipelineConfig(
         org=org,
         repos=[repo],
@@ -220,7 +221,8 @@ def main() -> int:
         dry_run=args.dry_run,
         agent=agent,
         no_advise=args.no_advise,
-        projects_dir=resolve_projects_dir(None, prefer_cwd_parent=True),
+        event_log_path=default_event_log_path(projects_dir, [repo]),
+        projects_dir=projects_dir,
         json_out=args.json,
         scope=PipelineScope(_PLANNER_SCOPE_STAGES),
         # --force re-plans issues already at-or-past state:plan-go (seeding

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -157,7 +157,7 @@ def main() -> int:
     # the CLI actually runs.
     from hephaestus.utils.terminal import install_sigtstp_only
 
-    from .pipeline.coordinator import PipelineConfig, run_pipeline
+    from .pipeline.coordinator import PipelineConfig, default_event_log_path, run_pipeline
 
     install_sigtstp_only()
     args = _parse_args()
@@ -176,6 +176,7 @@ def main() -> int:
         # the same issue twice.
         issues = list(dict.fromkeys(args.issues))
 
+        projects_dir = resolve_projects_dir(None, prefer_cwd_parent=True)
         config = PipelineConfig(
             org=org,
             repos=[repo],
@@ -188,7 +189,8 @@ def main() -> int:
             max_workers=args.max_workers,
             dry_run=args.dry_run,
             agent=agent,
-            projects_dir=resolve_projects_dir(None, prefer_cwd_parent=True),
+            event_log_path=default_event_log_path(projects_dir, [repo]),
+            projects_dir=projects_dir,
             json_out=args.json,
             scope=PipelineScope(_PR_REVIEWER_SCOPE_STAGES),
         )

--- a/hephaestus/observability/alerts.py
+++ b/hephaestus/observability/alerts.py
@@ -31,8 +31,8 @@ def evaluate_alerts(
     coordinator. Returned events describe active conditions;
     :class:`AlertTracker` turns those into fire/resolve transitions.
     """
-    if queue_depth_threshold < 0:
-        raise ValueError("queue depth threshold must be non-negative")
+    if not 0 <= queue_depth_threshold <= 100:
+        raise ValueError("queue depth threshold must be between 0 and 100")
     if stalled_ticks_threshold < 0:
         raise ValueError("stalled ticks threshold must be non-negative")
     events: list[AlertEvent] = []
@@ -54,13 +54,19 @@ def evaluate_alerts(
             )
 
     raw_depths = snapshot.get("queue_depths", {})
+    raw_capacities = snapshot.get("queue_capacities", {})
     if isinstance(raw_depths, Mapping):
         exceeded: list[str] = []
         for stage, depth in raw_depths.items():
+            capacity = raw_capacities.get(stage) if isinstance(raw_capacities, Mapping) else None
             if (
                 isinstance(depth, (int, float))
                 and not isinstance(depth, bool)
-                and depth > queue_depth_threshold
+                and isinstance(capacity, int)
+                and not isinstance(capacity, bool)
+                and capacity > 0
+                and depth > 0
+                and depth * 100 >= capacity * queue_depth_threshold
             ):
                 exceeded.append(str(stage))
         if exceeded:
@@ -69,10 +75,22 @@ def evaluate_alerts(
                     name="queue_depth_exceeds",
                     severity="warning",
                     status="fired",
-                    message=f"queue depth exceeds {queue_depth_threshold}: "
+                    message=f"queue depth reaches {queue_depth_threshold}% of capacity: "
                     f"{', '.join(sorted(exceeded))}",
                 )
             )
+
+    raw_saturated = snapshot.get("saturated_queues", [])
+    if isinstance(raw_saturated, (list, tuple, set, frozenset)) and raw_saturated:
+        saturated = sorted(str(queue_name) for queue_name in raw_saturated)
+        events.append(
+            AlertEvent(
+                name="queue_saturated",
+                severity="critical",
+                status="fired",
+                message=f"queue rejections observed: {', '.join(saturated)}",
+            )
+        )
 
     raw_stalled = snapshot.get("stalled_ticks")
     if (
@@ -98,8 +116,8 @@ class AlertTracker:
         self, *, queue_depth_threshold: int = 100, stalled_ticks_threshold: int = 3
     ) -> None:
         """Create a tracker with the coordinator's alert thresholds."""
-        if queue_depth_threshold < 0:
-            raise ValueError("queue depth threshold must be non-negative")
+        if not 0 <= queue_depth_threshold <= 100:
+            raise ValueError("queue depth threshold must be between 0 and 100")
         if stalled_ticks_threshold < 0:
             raise ValueError("stalled ticks threshold must be non-negative")
         self._queue_depth_threshold = queue_depth_threshold

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -383,6 +383,112 @@ def _run_load(
 
 
 @pytest.mark.performance
+def test_worker_pool_stalled_consumer_saturates_and_recovers() -> None:
+    """Concurrent completions stay bounded and all resumable work recovers.
+
+    The consumer is deliberately paused while every real worker completes at
+    once. One result fits the completion queue, one enters its bounded
+    rejection mailbox, and the remaining result triggers the bounded overflow
+    shutdown path. A fresh real pool then recovers the completion-rejected and
+    overflowed work.
+    """
+    capacity = 1
+    workers = 3
+    completion_q = CompletionQueue(capacity=capacity)
+    shutdown = threading.Event()
+    all_started = threading.Event()
+    release = threading.Event()
+    state_lock = threading.Lock()
+    started = 0
+    finished = 0
+
+    jobs = [
+        BuildTestJob(
+            repo="performance/worker-pool",
+            cwd=Path.cwd(),
+            argv=("synthetic", f"saturation-{index}"),
+            timeout_s=2,
+            descr=f"saturation-{index}",
+        )
+        for index in range(workers)
+    ]
+    pool = WorkerPool(size=workers, shutdown=shutdown, completion_q=completion_q)
+
+    def stalled_handler(_pool: WorkerPool, job: BuildTestJob) -> JobResult:
+        """Hold all workers until the test has filled the completion path."""
+        nonlocal started, finished
+        with state_lock:
+            started += 1
+            if started == workers:
+                all_started.set()
+        assert release.wait(timeout=2.0)
+        with state_lock:
+            finished += 1
+        return JobResult(ok=True, value=job.descr)
+
+    try:
+        with patch.object(WorkerPool, "_run_build_test", stalled_handler):
+            handles = [pool.submit(job, StageName.MERGE_WAIT) for job in jobs]
+            assert all_started.wait(timeout=2.0)
+            # Pause consumption until all workers publish concurrently.
+            release.set()
+            assert shutdown.wait(timeout=2.0)
+            deadline = time.monotonic() + 2.0
+            while True:
+                with state_lock:
+                    if finished == workers:
+                        break
+                assert time.monotonic() < deadline
+                time.sleep(0.005)
+
+            queued: list[tuple[JobHandle, JobResult]] = []
+            while True:
+                try:
+                    queued.append(completion_q.get_nowait())
+                except queue.Empty:
+                    break
+            rejected, overflowed = completion_q.take_rejections()
+
+            assert len(queued) == capacity
+            assert len(rejected) == capacity
+            assert overflowed is True
+            assert completion_q.qsize() <= capacity
+            assert completion_q._rejections.qsize() <= capacity
+            assert shutdown.is_set()
+
+            queued_handles = {handle for handle, _result in queued}
+            resumable_handles = set(handles) - queued_handles
+            assert len(resumable_handles) == workers - capacity
+
+        recovery_shutdown = threading.Event()
+        recovery_q = CompletionQueue(capacity=len(resumable_handles))
+        recovery_pool = WorkerPool(
+            size=len(resumable_handles),
+            shutdown=recovery_shutdown,
+            completion_q=recovery_q,
+        )
+        try:
+            with patch.object(
+                WorkerPool,
+                "_run_build_test",
+                lambda _pool, job: JobResult(ok=True, value=job.descr),
+            ):
+                recovery_handles = [
+                    recovery_pool.submit(handle.job, StageName.MERGE_WAIT)
+                    for handle in resumable_handles
+                ]
+                recovered: set[JobHandle] = set()
+                for _ in recovery_handles:
+                    recovered.add(recovery_q.get(timeout=2.0)[0])
+                assert len(recovered) == len(resumable_handles)
+                assert recovery_q.qsize() <= recovery_q.capacity
+        finally:
+            recovery_pool.shutdown(mark_interrupted=False)
+    finally:
+        pool.shutdown(mark_interrupted=True)
+
+
+@pytest.mark.performance
 def test_worker_pool_capacity_scales(load_config: LoadConfig) -> None:
     """Four workers complete fixed-delay jobs at least twice as fast as one."""
     job_count = min(_CAPACITY_JOBS, load_config.max_jobs)

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -10,13 +10,17 @@ import threading
 import time
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
 from hephaestus.automation.pipeline.jobs import BuildTestJob, JobHandle, JobResult
 from hephaestus.automation.pipeline.queues import CompletionQueue
-from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from hephaestus.automation.pipeline.worker_pool import WorkerPool
 from tests.performance.conftest import LoadConfig
 
@@ -383,109 +387,109 @@ def _run_load(
 
 
 @pytest.mark.performance
-def test_worker_pool_stalled_consumer_saturates_and_recovers() -> None:
-    """Concurrent completions stay bounded and all resumable work recovers.
-
-    The consumer is deliberately paused while every real worker completes at
-    once. One result fits the completion queue, one enters its bounded
-    rejection mailbox, and the remaining result triggers the bounded overflow
-    shutdown path. A fresh real pool then recovers the completion-rejected and
-    overflowed work.
-    """
-    capacity = 1
+def test_worker_pool_stalled_consumer_preserves_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A production-wired coordinator bounds completions and resumes a seed burst."""
     workers = 3
-    completion_q = CompletionQueue(capacity=capacity)
-    shutdown = threading.Event()
-    all_started = threading.Event()
-    release = threading.Event()
-    state_lock = threading.Lock()
+    seed_count = workers + 1
+
+    class SyntheticStage:
+        """One real worker-pool job followed by a terminal success."""
+
+        def on_enter(self, item: WorkItem, ctx: Any) -> None:
+            del item, ctx
+
+        def step(self, item: WorkItem, ctx: Any) -> JobRequest | StageOutcome:
+            del ctx
+            if item.payload.get("completed"):
+                return StageOutcome(Disposition.FINISH_PASS, "synthetic complete")
+            job = BuildTestJob(
+                repo=item.repo,
+                cwd=Path.cwd(),
+                argv=("synthetic", f"recovery-{item.issue}"),
+                timeout_s=2,
+                descr=f"recovery-{item.issue}",
+            )
+            return JobRequest(job, on_done_state=StageName.PLANNING)
+
+        def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+            del ctx
+            if result.ok:
+                item.payload["completed"] = True
+
+    def make_coordinator() -> Coordinator:
+        """Build the same C-sized coordinator/pool topology used in production."""
+        completion_q = CompletionQueue(capacity=workers)
+        pool = WorkerPool(size=workers, shutdown=threading.Event(), completion_q=completion_q)
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["performance/worker-pool"],
+                loops=1,
+                max_workers=workers,
+                parallel_repos=1,
+                stage_queue_capacity=workers,
+                projects_dir=Path.cwd(),
+            ),
+            github=cast(Any, object()),
+            pool=pool,
+            install_signals=False,
+        )
+        coordinator.stages[StageName.PLANNING] = SyntheticStage()
+        monkeypatch.setattr(coordinator, "_seed_pass", lambda: 0)
+        for issue in range(seed_count):
+            item = WorkItem(
+                repo="performance/worker-pool",
+                kind=ItemKind.ISSUE,
+                issue=issue,
+                stage=StageName.PLANNING,
+            )
+            assert coordinator._push_item(item, StageName.PLANNING, enter=True)
+        return coordinator
+
+    stalled = make_coordinator()
     started = 0
     finished = 0
-
-    jobs = [
-        BuildTestJob(
-            repo="performance/worker-pool",
-            cwd=Path.cwd(),
-            argv=("synthetic", f"saturation-{index}"),
-            timeout_s=2,
-            descr=f"saturation-{index}",
-        )
-        for index in range(workers)
-    ]
-    pool = WorkerPool(size=workers, shutdown=shutdown, completion_q=completion_q)
+    state_lock = threading.Lock()
+    release = threading.Event()
 
     def stalled_handler(_pool: WorkerPool, job: BuildTestJob) -> JobResult:
-        """Hold all workers until the test has filled the completion path."""
+        """Release all C workers together, then request graceful shutdown."""
         nonlocal started, finished
         with state_lock:
             started += 1
             if started == workers:
-                all_started.set()
+                stalled.shutdown.set()
+                release.set()
         assert release.wait(timeout=2.0)
         with state_lock:
             finished += 1
         return JobResult(ok=True, value=job.descr)
 
-    try:
-        with patch.object(WorkerPool, "_run_build_test", stalled_handler):
-            handles = [pool.submit(job, StageName.MERGE_WAIT) for job in jobs]
-            assert all_started.wait(timeout=2.0)
-            # Pause consumption until all workers publish concurrently.
-            release.set()
-            assert shutdown.wait(timeout=2.0)
-            deadline = time.monotonic() + 2.0
-            while True:
-                with state_lock:
-                    if finished == workers:
-                        break
-                assert time.monotonic() < deadline
-                time.sleep(0.005)
+    with patch.object(WorkerPool, "_run_build_test", stalled_handler):
+        assert stalled.run() == 130
 
-            queued: list[tuple[JobHandle, JobResult]] = []
-            while True:
-                try:
-                    queued.append(completion_q.get_nowait())
-                except queue.Empty:
-                    break
-            rejected, overflowed = completion_q.take_rejections()
+    assert stalled._work_window == workers
+    assert stalled.completion_q.capacity == stalled._work_window
+    assert stalled.completion_q.qsize() <= stalled.completion_q.capacity
+    assert finished == workers
+    assert len(stalled.items) == seed_count
+    assert all(
+        item.result is not None and item.result.reason.startswith("resumable at")
+        for item in stalled.items
+    )
 
-            assert len(queued) == capacity
-            assert len(rejected) == capacity
-            assert overflowed is True
-            assert completion_q.qsize() <= capacity
-            assert completion_q._rejections.qsize() <= capacity
-            assert shutdown.is_set()
+    recovered = make_coordinator()
+    with patch.object(
+        WorkerPool,
+        "_run_build_test",
+        lambda _pool, job: JobResult(ok=True, value=job.descr),
+    ):
+        assert recovered.run() == 0
 
-            queued_handles = {handle for handle, _result in queued}
-            resumable_handles = set(handles) - queued_handles
-            assert len(resumable_handles) == workers - capacity
-
-        recovery_shutdown = threading.Event()
-        recovery_q = CompletionQueue(capacity=len(resumable_handles))
-        recovery_pool = WorkerPool(
-            size=len(resumable_handles),
-            shutdown=recovery_shutdown,
-            completion_q=recovery_q,
-        )
-        try:
-            with patch.object(
-                WorkerPool,
-                "_run_build_test",
-                lambda _pool, job: JobResult(ok=True, value=job.descr),
-            ):
-                recovery_handles = [
-                    recovery_pool.submit(handle.job, StageName.MERGE_WAIT)
-                    for handle in resumable_handles
-                ]
-                recovered: set[JobHandle] = set()
-                for _ in recovery_handles:
-                    recovered.add(recovery_q.get(timeout=2.0)[0])
-                assert len(recovered) == len(resumable_handles)
-                assert recovery_q.qsize() <= recovery_q.capacity
-        finally:
-            recovery_pool.shutdown(mark_interrupted=False)
-    finally:
-        pool.shutdown(mark_interrupted=True)
+    assert len(recovered.items) == seed_count
+    assert all(item.result is not None and item.result.passed for item in recovered.items)
 
 
 @pytest.mark.performance

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -173,6 +173,157 @@ class _LoadReport:
         }
 
 
+class _SyntheticRecoveryStage:
+    """Run one real worker-pool job, then finish after its completion."""
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        """Perform no enter-time transition."""
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> JobRequest | StageOutcome:
+        """Submit once and finish after the recovered completion."""
+        del ctx
+        if item.payload.get("completed"):
+            return StageOutcome(Disposition.FINISH_PASS, "synthetic complete")
+        job = BuildTestJob(
+            repo=item.repo,
+            cwd=Path.cwd(),
+            argv=("synthetic", f"recovery-{item.issue}"),
+            timeout_s=2,
+            descr=f"recovery-{item.issue}",
+        )
+        return JobRequest(job, on_done_state=StageName.PLANNING)
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        """Record successful completion for the next stage step."""
+        del ctx
+        if result.ok:
+            item.payload["completed"] = True
+
+
+class _ObservedCompletionQueue(CompletionQueue):
+    """Completion queue with a synchronization-only publication counter."""
+
+    def __init__(self, *, capacity: int) -> None:
+        super().__init__(capacity=capacity)
+        self._offer_condition = threading.Condition()
+        self.offer_count = 0
+        self.accepted_count = 0
+        self.rejected_count = 0
+        self.result_high_water = 0
+        self.rejection_high_water = 0
+        self.overflow_observed = False
+        self.publication_outcomes: list[tuple[str, bool]] = []
+
+    def offer(self, value: tuple[Any, Any]) -> bool:
+        """Publish normally and capture exact paused-consumer high-water state."""
+        accepted = super().offer(value)
+        with self._offer_condition:
+            self.offer_count += 1
+            if accepted:
+                self.accepted_count += 1
+            else:
+                self.rejected_count += 1
+            self.result_high_water = max(self.result_high_water, self.qsize())
+            self.rejection_high_water = max(
+                self.rejection_high_water,
+                self._rejections.qsize(),
+            )
+            self.overflow_observed = self.overflow_observed or self._rejection_overflowed
+            handle = value[0]
+            description = str(getattr(getattr(handle, "job", None), "descr", ""))
+            self.publication_outcomes.append((description, accepted))
+            self._offer_condition.notify_all()
+        return accepted
+
+    def wait_for_offers(self, expected: int, *, timeout: float) -> None:
+        """Wait until exactly observed worker callbacks reach *expected*."""
+        deadline = time.monotonic() + timeout
+        with self._offer_condition:
+            while self.offer_count < expected:
+                remaining = deadline - time.monotonic()
+                assert remaining > 0, (
+                    f"observed {self.offer_count}/{expected} completion publications"
+                )
+                self._offer_condition.wait(timeout=remaining)
+
+
+class _StalledConsumerHarness:
+    """Synchronize two complete worker waves without relying on sleeps."""
+
+    def __init__(self, workers: int) -> None:
+        self.workers = workers
+        self.legitimate_started = 0
+        self.overflow_started = 0
+        self.state_lock = threading.Lock()
+        self.legitimate_ready = threading.Event()
+        self.overflow_ready = threading.Event()
+        self.release_legitimate = threading.Event()
+        self.release_overflow = threading.Event()
+
+    def run_job(self, _pool: WorkerPool, job: BuildTestJob) -> JobResult:
+        """Hold two worker waves while the coordinator cannot consume."""
+        is_overflow = job.descr.startswith("overflow-")
+        with self.state_lock:
+            if is_overflow:
+                self.overflow_started += 1
+                if self.overflow_started == self.workers:
+                    self.overflow_ready.set()
+            else:
+                self.legitimate_started += 1
+                if self.legitimate_started == self.workers:
+                    self.legitimate_ready.set()
+        release = self.release_overflow if is_overflow else self.release_legitimate
+        assert release.wait(timeout=5.0)
+        return JobResult(ok=True, value=job.descr)
+
+
+def _make_recovery_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    workers: int,
+    *,
+    observed: bool = False,
+) -> Coordinator:
+    """Build the same C-sized coordinator/pool topology used in production."""
+    config = PipelineConfig(
+        org="org",
+        repos=["performance/worker-pool"],
+        loops=1,
+        max_workers=workers,
+        parallel_repos=1,
+        stage_queue_capacity=workers,
+        projects_dir=Path.cwd(),
+    )
+    work_window = max(1, config.parallel_repos * config.max_workers)
+    completion_q: CompletionQueue
+    if observed:
+        completion_q = _ObservedCompletionQueue(capacity=work_window)
+    else:
+        completion_q = CompletionQueue(capacity=work_window)
+    shared_shutdown = threading.Event()
+    pool = WorkerPool(size=work_window, shutdown=shared_shutdown, completion_q=completion_q)
+    coordinator = Coordinator(
+        config,
+        github=cast(Any, object()),
+        pool=pool,
+        install_signals=False,
+    )
+    # Injected pools expose their queue but not their private shutdown event.
+    # Use the same event on both sides, as production Coordinator does.
+    coordinator.shutdown = shared_shutdown
+    coordinator.stages[StageName.PLANNING] = _SyntheticRecoveryStage()
+    monkeypatch.setattr(coordinator, "_seed_pass", lambda: 0)
+    for issue in range(workers):
+        item = WorkItem(
+            repo="performance/worker-pool",
+            kind=ItemKind.ISSUE,
+            issue=issue,
+            stage=StageName.PLANNING,
+        )
+        assert coordinator._push_item(item, StageName.PLANNING, enter=True)
+    return coordinator
+
+
 def _percentile(samples: list[float], percentile: float) -> float:
     """Return the linearly interpolated percentile (tail-inclusive) in ms.
 
@@ -390,97 +541,95 @@ def _run_load(
 def test_worker_pool_stalled_consumer_preserves_and_recovers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A production-wired coordinator bounds completions and resumes a seed burst."""
+    """A stalled coordinator bounds concurrent publication and recovers its seeds."""
     workers = 3
-    seed_count = workers + 1
+    stalled = _make_recovery_coordinator(monkeypatch, workers, observed=True)
+    assert isinstance(stalled.completion_q, _ObservedCompletionQueue)
+    assert stalled._work_window == stalled.config.parallel_repos * stalled.config.max_workers
+    assert stalled.completion_q.capacity == stalled._work_window == workers
+    harness = _StalledConsumerHarness(workers)
+    consumer_paused = threading.Event()
+    resume_consumer = threading.Event()
 
-    class SyntheticStage:
-        """One real worker-pool job followed by a terminal success."""
+    original_wait = stalled._wait_for_completion
 
-        def on_enter(self, item: WorkItem, ctx: Any) -> None:
-            del item, ctx
+    def paused_wait(timeout: float) -> None:
+        """Stop the only completion-consumer path once all C seeds are live."""
+        if len(stalled.in_flight) == workers and not resume_consumer.is_set():
+            consumer_paused.set()
+            assert resume_consumer.wait(timeout=5.0)
+        original_wait(timeout)
 
-        def step(self, item: WorkItem, ctx: Any) -> JobRequest | StageOutcome:
-            del ctx
-            if item.payload.get("completed"):
-                return StageOutcome(Disposition.FINISH_PASS, "synthetic complete")
-            job = BuildTestJob(
-                repo=item.repo,
-                cwd=Path.cwd(),
-                argv=("synthetic", f"recovery-{item.issue}"),
-                timeout_s=2,
-                descr=f"recovery-{item.issue}",
+    monkeypatch.setattr(stalled, "_wait_for_completion", paused_wait)
+    run_codes: list[int] = []
+    run_thread = threading.Thread(target=lambda: run_codes.append(stalled.run()), daemon=True)
+
+    with patch.object(
+        WorkerPool,
+        "_run_build_test",
+        lambda pool, job: harness.run_job(pool, job),
+    ):
+        run_thread.start()
+        assert harness.legitimate_ready.wait(timeout=5.0)
+        assert consumer_paused.wait(timeout=5.0)
+
+        # The coordinator owns C legitimate handles. Queue a separate C+1
+        # publication burst through the same real pool while all workers are
+        # occupied, then release each wave under the stalled consumer.
+        for index in range(workers + 1):
+            stalled.pool.submit(
+                BuildTestJob(
+                    repo="performance/worker-pool",
+                    cwd=Path.cwd(),
+                    argv=("synthetic", f"overflow-{index}"),
+                    timeout_s=2,
+                    descr=f"overflow-{index}",
+                ),
+                StageName.PLANNING,
             )
-            return JobRequest(job, on_done_state=StageName.PLANNING)
 
-        def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
-            del ctx
-            if result.ok:
-                item.payload["completed"] = True
+        harness.release_legitimate.set()
+        stalled.completion_q.wait_for_offers(workers, timeout=5.0)
+        assert harness.overflow_ready.wait(timeout=5.0)
+        assert stalled.completion_q.qsize() == workers
 
-    def make_coordinator() -> Coordinator:
-        """Build the same C-sized coordinator/pool topology used in production."""
-        completion_q = CompletionQueue(capacity=workers)
-        pool = WorkerPool(size=workers, shutdown=threading.Event(), completion_q=completion_q)
-        coordinator = Coordinator(
-            PipelineConfig(
-                org="org",
-                repos=["performance/worker-pool"],
-                loops=1,
-                max_workers=workers,
-                parallel_repos=1,
-                stage_queue_capacity=workers,
-                projects_dir=Path.cwd(),
-            ),
-            github=cast(Any, object()),
-            pool=pool,
-            install_signals=False,
-        )
-        coordinator.stages[StageName.PLANNING] = SyntheticStage()
-        monkeypatch.setattr(coordinator, "_seed_pass", lambda: 0)
-        for issue in range(seed_count):
-            item = WorkItem(
-                repo="performance/worker-pool",
-                kind=ItemKind.ISSUE,
-                issue=issue,
-                stage=StageName.PLANNING,
-            )
-            assert coordinator._push_item(item, StageName.PLANNING, enter=True)
-        return coordinator
+        harness.release_overflow.set()
+        stalled.completion_q.wait_for_offers((2 * workers) + 1, timeout=5.0)
 
-    stalled = make_coordinator()
-    started = 0
-    finished = 0
-    state_lock = threading.Lock()
-    release = threading.Event()
+        # C results occupy the channel, C rejected results occupy its bounded
+        # mailbox, and the final publication records overflow. Nothing grows
+        # while consumption is paused, and the worker callback requests stop.
+        assert run_thread.is_alive()
+        assert not resume_consumer.is_set()
+        assert harness.legitimate_started == workers
+        assert stalled.completion_q.offer_count == (2 * workers) + 1
+        assert stalled.completion_q.accepted_count == workers
+        assert stalled.completion_q.rejected_count == workers + 1
+        assert set(stalled.completion_q.publication_outcomes) == {
+            *((f"recovery-{issue}", True) for issue in range(workers)),
+            *((f"overflow-{issue}", False) for issue in range(workers + 1)),
+        }
+        assert stalled.completion_q.result_high_water == workers
+        assert stalled.completion_q.rejection_high_water == workers
+        assert stalled.completion_q.overflow_observed is True
+        assert stalled.completion_q.qsize() == stalled.completion_q.capacity == workers
+        assert stalled.shutdown.is_set()
 
-    def stalled_handler(_pool: WorkerPool, job: BuildTestJob) -> JobResult:
-        """Release all C workers together, then request graceful shutdown."""
-        nonlocal started, finished
-        with state_lock:
-            started += 1
-            if started == workers:
-                stalled.shutdown.set()
-                release.set()
-        assert release.wait(timeout=2.0)
-        with state_lock:
-            finished += 1
-        return JobResult(ok=True, value=job.descr)
+        resume_consumer.set()
+        run_thread.join(timeout=5.0)
 
-    with patch.object(WorkerPool, "_run_build_test", stalled_handler):
-        assert stalled.run() == 130
-
-    assert stalled._work_window == workers
-    assert stalled.completion_q.capacity == stalled._work_window
-    assert stalled.completion_q.qsize() <= stalled.completion_q.capacity
-    assert finished == workers
-    assert len(stalled.items) == seed_count
+    assert not run_thread.is_alive()
+    assert run_codes and run_codes[0] != 0
+    assert len(stalled.items) == workers
+    expected_issues = set(range(workers))
+    assert {item.issue for item in stalled.items} == expected_issues
     assert all(
         item.result is not None and item.result.reason.startswith("resumable at")
         for item in stalled.items
     )
 
-    recovered = make_coordinator()
+    recovered = _make_recovery_coordinator(monkeypatch, workers)
+    assert recovered.completion_q.capacity == recovered._work_window
     with patch.object(
         WorkerPool,
         "_run_build_test",
@@ -488,7 +637,8 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     ):
         assert recovered.run() == 0
 
-    assert len(recovered.items) == seed_count
+    assert len(recovered.items) == workers
+    assert {item.issue for item in recovered.items} == expected_issues
     assert all(item.result is not None and item.result.passed for item in recovered.items)
 
 

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -307,7 +307,7 @@ def _run_load(
     duration_s: float | None,
 ) -> _LoadReport:
     """Exercise the real worker-pool completion path with bounded synthetic work."""
-    completion_q: CompletionQueue = queue.Queue()
+    completion_q = CompletionQueue(capacity=config.max_in_flight)
     shutdown = threading.Event()
     tracker = _Tracker()
     pool = WorkerPool(size=config.workers, shutdown=shutdown, completion_q=completion_q)

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -188,9 +188,9 @@ class _SyntheticRecoveryStage:
         job = BuildTestJob(
             repo=item.repo,
             cwd=Path.cwd(),
-            argv=("synthetic", f"recovery-{item.issue}"),
+            argv=("synthetic", item.payload.get("descr", f"recovery-{item.issue}")),
             timeout_s=2,
-            descr=f"recovery-{item.issue}",
+            descr=item.payload.get("descr", f"recovery-{item.issue}"),
         )
         return JobRequest(job, on_done_state=StageName.PLANNING)
 
@@ -214,6 +214,8 @@ class _ObservedCompletionQueue(CompletionQueue):
         self.rejection_high_water = 0
         self.overflow_observed = False
         self.publication_outcomes: list[tuple[str, bool]] = []
+        self.publication_ownership: list[tuple[str, bool]] = []
+        self.owner: Coordinator | None = None
 
     def offer(self, value: tuple[Any, Any]) -> bool:
         """Publish normally and capture exact paused-consumer high-water state."""
@@ -233,6 +235,9 @@ class _ObservedCompletionQueue(CompletionQueue):
             handle = value[0]
             description = str(getattr(getattr(handle, "job", None), "descr", ""))
             self.publication_outcomes.append((description, accepted))
+            self.publication_ownership.append(
+                (description, self.owner is not None and handle in self.owner.in_flight)
+            )
             self._offer_condition.notify_all()
         return accepted
 
@@ -295,6 +300,7 @@ def _make_recovery_coordinator(
     workers: int,
     *,
     observed: bool = False,
+    issue_count: int | None = None,
 ) -> Coordinator:
     """Build the same C-sized coordinator/pool topology used in production."""
     config = PipelineConfig(
@@ -323,15 +329,21 @@ def _make_recovery_coordinator(
     # Injected pools expose their queue but not their private shutdown event.
     # Use the same event on both sides, as production Coordinator does.
     coordinator.shutdown = shared_shutdown
+    if isinstance(completion_q, _ObservedCompletionQueue):
+        completion_q.owner = coordinator
     coordinator.stages[StageName.PLANNING] = _SyntheticRecoveryStage()
     monkeypatch.setattr(coordinator, "_seed_pass", lambda: 0)
-    for issue in range(workers):
+    for issue in range(issue_count if issue_count is not None else workers):
         item = WorkItem(
             repo="performance/worker-pool",
             kind=ItemKind.ISSUE,
             issue=issue,
             stage=StageName.PLANNING,
         )
+        if issue_count is not None and issue_count > workers:
+            # Rehydrate the complete durable parked set before admission; the
+            # live-work ledger then releases each item as recovery finishes.
+            coordinator._live_work_permit_ids.add(id(item))
         assert coordinator._push_item(item, StageName.PLANNING, enter=True)
     return coordinator
 
@@ -590,19 +602,33 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
         # may publish, so subsequent high-water marks cannot race a drain.
         assert stalled.completion_q.paused_publication_state() == (0, 0, 0, 0, 0, False)
 
-        # The coordinator owns C legitimate handles. Queue a separate C+1
-        # publication burst through the same real pool while all workers are
-        # occupied, then release each wave under the stalled consumer.
+        # Submit a separate C+1 publication burst through the coordinator
+        # while all workers are occupied. Register the items with the same
+        # live-work ledger used by finalization, then use the coordinator's
+        # submit chokepoint; bypassing Coordinator.in_flight would make
+        # rejected results impossible to park and recover.
         for index in range(workers + 1):
-            stalled.pool.submit(
-                BuildTestJob(
-                    repo="performance/worker-pool",
-                    cwd=Path.cwd(),
-                    argv=("synthetic", f"overflow-{index}"),
-                    timeout_s=2,
-                    descr=f"overflow-{index}",
+            item = WorkItem(
+                repo="performance/worker-pool",
+                kind=ItemKind.ISSUE,
+                issue=workers + index,
+                stage=StageName.PLANNING,
+                payload={"descr": f"overflow-{index}"},
+            )
+            stalled.items.append(item)
+            stalled._live_work_permit_ids.add(id(item))
+            stalled._submit(
+                item,
+                JobRequest(
+                    BuildTestJob(
+                        repo=item.repo,
+                        cwd=Path.cwd(),
+                        argv=("synthetic", f"overflow-{index}"),
+                        timeout_s=2,
+                        descr=f"overflow-{index}",
+                    ),
+                    on_done_state=StageName.PLANNING,
                 ),
-                StageName.PLANNING,
             )
 
         harness.release_legitimate.set()
@@ -634,26 +660,32 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
             *((f"recovery-{issue}", True) for issue in range(workers)),
             *((f"overflow-{issue}", False) for issue in range(workers + 1)),
         }
+        assert all(owned for _description, owned in stalled.completion_q.publication_ownership)
         assert stalled.completion_q.result_high_water == workers
         assert stalled.completion_q.rejection_high_water == workers
         assert stalled.completion_q.overflow_observed is True
         assert stalled.completion_q.qsize() == stalled.completion_q.capacity == workers
-        assert stalled.shutdown.is_set()
+        assert not stalled.shutdown.is_set()
 
         resume_consumer.set()
         run_thread.join(timeout=5.0)
 
     assert not run_thread.is_alive()
     assert run_codes == [1]
-    assert len(stalled.items) == workers
-    expected_issues = set(range(workers))
+    assert stalled.shutdown.is_set()
+    assert len(stalled.items) == (2 * workers) + 1
+    expected_issues = set(range((2 * workers) + 1))
     assert {item.issue for item in stalled.items} == expected_issues
     assert all(
         item.result is not None and item.result.reason.startswith("resumable at")
         for item in stalled.items
     )
 
-    recovered = _make_recovery_coordinator(monkeypatch, workers)
+    recovered = _make_recovery_coordinator(
+        monkeypatch,
+        workers,
+        issue_count=(2 * workers) + 1,
+    )
     assert recovered._work_window == workers
     assert recovered.completion_q.capacity == recovered._work_window
     with patch.object(
@@ -663,7 +695,7 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     ):
         assert recovered.run() == 0
 
-    assert len(recovered.items) == workers
+    assert len(recovered.items) == (2 * workers) + 1
     assert {item.issue for item in recovered.items} == expected_issues
     assert all(item.result is not None and item.result.passed for item in recovered.items)
 

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -215,6 +215,7 @@ class _ObservedCompletionQueue(CompletionQueue):
         self.overflow_observed = False
         self.publication_outcomes: list[tuple[str, bool]] = []
         self.publication_ownership: list[tuple[str, bool]] = []
+        self.publication_handles: list[JobHandle] = []
         self.owner: Coordinator | None = None
 
     def offer(self, value: tuple[Any, Any]) -> bool:
@@ -233,6 +234,7 @@ class _ObservedCompletionQueue(CompletionQueue):
             )
             self.overflow_observed = self.overflow_observed or self._rejection_overflowed
             handle = value[0]
+            self.publication_handles.append(handle)
             description = str(getattr(getattr(handle, "job", None), "descr", ""))
             self.publication_outcomes.append((description, accepted))
             self.publication_ownership.append(
@@ -266,32 +268,22 @@ class _ObservedCompletionQueue(CompletionQueue):
 
 
 class _StalledConsumerHarness:
-    """Synchronize two complete worker waves without relying on sleeps."""
+    """Synchronize one complete worker wave without relying on sleeps."""
 
     def __init__(self, workers: int) -> None:
         self.workers = workers
         self.legitimate_started = 0
-        self.overflow_started = 0
         self.state_lock = threading.Lock()
         self.legitimate_ready = threading.Event()
-        self.overflow_ready = threading.Event()
         self.release_legitimate = threading.Event()
-        self.release_overflow = threading.Event()
 
     def run_job(self, _pool: WorkerPool, job: BuildTestJob) -> JobResult:
-        """Hold two worker waves while the coordinator cannot consume."""
-        is_overflow = job.descr.startswith("overflow-")
+        """Hold the admitted worker wave while the coordinator cannot consume."""
         with self.state_lock:
-            if is_overflow:
-                self.overflow_started += 1
-                if self.overflow_started == self.workers:
-                    self.overflow_ready.set()
-            else:
-                self.legitimate_started += 1
-                if self.legitimate_started == self.workers:
-                    self.legitimate_ready.set()
-        release = self.release_overflow if is_overflow else self.release_legitimate
-        assert release.wait(timeout=5.0)
+            self.legitimate_started += 1
+            if self.legitimate_started == self.workers:
+                self.legitimate_ready.set()
+        assert self.release_legitimate.wait(timeout=5.0)
         return JobResult(ok=True, value=job.descr)
 
 
@@ -318,17 +310,18 @@ def _make_recovery_coordinator(
         completion_q = _ObservedCompletionQueue(capacity=work_window)
     else:
         completion_q = CompletionQueue(capacity=work_window)
-    shared_shutdown = threading.Event()
-    pool = WorkerPool(size=work_window, shutdown=shared_shutdown, completion_q=completion_q)
+    pool = WorkerPool(
+        size=work_window,
+        shutdown=threading.Event(),
+        completion_q=completion_q,
+    )
     coordinator = Coordinator(
         config,
         github=cast(Any, object()),
         pool=pool,
         install_signals=False,
     )
-    # Injected pools expose their queue but not their private shutdown event.
-    # Use the same event on both sides, as production Coordinator does.
-    coordinator.shutdown = shared_shutdown
+    assert pool.shutdown_event is coordinator.shutdown
     if isinstance(completion_q, _ObservedCompletionQueue):
         completion_q.owner = coordinator
     coordinator.stages[StageName.PLANNING] = _SyntheticRecoveryStage()
@@ -576,6 +569,16 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     harness = _StalledConsumerHarness(workers)
     consumer_paused = threading.Event()
     resume_consumer = threading.Event()
+    graceful_shutdown_reasons: list[str] = []
+
+    original_begin_graceful_shutdown = stalled._begin_graceful_shutdown
+
+    def record_graceful_shutdown(reason: str) -> None:
+        """Capture the coordinator graceful-shutdown path."""
+        graceful_shutdown_reasons.append(reason)
+        original_begin_graceful_shutdown(reason)
+
+    monkeypatch.setattr(stalled, "_begin_graceful_shutdown", record_graceful_shutdown)
 
     original_wait = stalled._wait_for_completion
 
@@ -602,41 +605,24 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
         # may publish, so subsequent high-water marks cannot race a drain.
         assert stalled.completion_q.paused_publication_state() == (0, 0, 0, 0, 0, False)
 
-        # Submit a separate C+1 publication burst through the coordinator
-        # while all workers are occupied. Register the items with the same
-        # live-work ledger used by finalization, then use the coordinator's
-        # submit chokepoint; bypassing Coordinator.in_flight would make
-        # rejected results impossible to park and recover.
-        for index in range(workers + 1):
-            item = WorkItem(
-                repo="performance/worker-pool",
-                kind=ItemKind.ISSUE,
-                issue=workers + index,
-                stage=StageName.PLANNING,
-                payload={"descr": f"overflow-{index}"},
-            )
-            stalled.items.append(item)
-            stalled._live_work_permit_ids.add(id(item))
-            stalled._submit(
-                item,
-                JobRequest(
-                    BuildTestJob(
-                        repo=item.repo,
-                        cwd=Path.cwd(),
-                        argv=("synthetic", f"overflow-{index}"),
-                        timeout_s=2,
-                        descr=f"overflow-{index}",
-                    ),
-                    on_done_state=StageName.PLANNING,
-                ),
-            )
-
         harness.release_legitimate.set()
         stalled.completion_q.wait_for_offers(workers, timeout=5.0)
-        assert harness.overflow_ready.wait(timeout=5.0)
         assert stalled.completion_q.qsize() == workers
 
-        harness.release_overflow.set()
+        # Explicitly model faulty worker publication by duplicating one
+        # already-admitted completion. This preserves the stalled-consumer
+        # overflow contract without submitting work outside Coordinator's
+        # admission and live-work permit bounds.
+        duplicate_handle = stalled.completion_q.publication_handles[0]
+        duplicate_description = str(duplicate_handle.job.descr)
+        for index in range(workers + 1):
+            accepted = stalled.completion_q.offer(
+                (duplicate_handle, JobResult(ok=True, value=f"duplicate-{index}"))
+            )
+            if not accepted:
+                # Match WorkerPool._on_future_done: a rejected worker
+                # publication requests coordinator shutdown without blocking.
+                stalled.shutdown.set()
         stalled.completion_q.wait_for_offers((2 * workers) + 1, timeout=5.0)
 
         # C results occupy the channel, C rejected results occupy its bounded
@@ -656,16 +642,18 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
         assert stalled.completion_q.offer_count == (2 * workers) + 1
         assert stalled.completion_q.accepted_count == workers
         assert stalled.completion_q.rejected_count == workers + 1
-        assert set(stalled.completion_q.publication_outcomes) == {
-            *((f"recovery-{issue}", True) for issue in range(workers)),
-            *((f"overflow-{issue}", False) for issue in range(workers + 1)),
+        assert set(stalled.completion_q.publication_outcomes[:workers]) == {
+            (f"recovery-{issue}", True) for issue in range(workers)
         }
+        assert stalled.completion_q.publication_outcomes[workers:] == [
+            (duplicate_description, False)
+        ] * (workers + 1)
         assert all(owned for _description, owned in stalled.completion_q.publication_ownership)
         assert stalled.completion_q.result_high_water == workers
         assert stalled.completion_q.rejection_high_water == workers
         assert stalled.completion_q.overflow_observed is True
         assert stalled.completion_q.qsize() == stalled.completion_q.capacity == workers
-        assert not stalled.shutdown.is_set()
+        assert stalled.shutdown.is_set()
 
         resume_consumer.set()
         run_thread.join(timeout=5.0)
@@ -673,8 +661,9 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     assert not run_thread.is_alive()
     assert run_codes == [1]
     assert stalled.shutdown.is_set()
-    assert len(stalled.items) == (2 * workers) + 1
-    expected_issues = set(range((2 * workers) + 1))
+    assert graceful_shutdown_reasons == ["external shutdown request"]
+    assert len(stalled.items) == workers
+    expected_issues = set(range(workers))
     assert {item.issue for item in stalled.items} == expected_issues
     assert all(
         item.result is not None and item.result.reason.startswith("resumable at")
@@ -684,7 +673,7 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     recovered = _make_recovery_coordinator(
         monkeypatch,
         workers,
-        issue_count=(2 * workers) + 1,
+        issue_count=workers,
     )
     assert recovered._work_window == workers
     assert recovered.completion_q.capacity == recovered._work_window
@@ -695,7 +684,7 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     ):
         assert recovered.run() == 0
 
-    assert len(recovered.items) == (2 * workers) + 1
+    assert len(recovered.items) == workers
     assert {item.issue for item in recovered.items} == expected_issues
     assert all(item.result is not None and item.result.passed for item in recovered.items)
 

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -247,6 +247,18 @@ class _ObservedCompletionQueue(CompletionQueue):
                 )
                 self._offer_condition.wait(timeout=remaining)
 
+    def paused_publication_state(self) -> tuple[int, int, int, int, int, bool]:
+        """Return an atomic channel snapshot while the consumer is parked."""
+        with self._offer_condition, self._rejection_lock:
+            return (
+                self.offer_count,
+                self.accepted_count,
+                self.rejected_count,
+                self.qsize(),
+                self._rejections.qsize(),
+                self._rejection_overflowed,
+            )
+
 
 class _StalledConsumerHarness:
     """Synchronize two complete worker waves without relying on sleeps."""
@@ -545,6 +557,8 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     workers = 3
     stalled = _make_recovery_coordinator(monkeypatch, workers, observed=True)
     assert isinstance(stalled.completion_q, _ObservedCompletionQueue)
+    assert stalled.config.parallel_repos == 1
+    assert stalled.config.max_workers == workers
     assert stalled._work_window == stalled.config.parallel_repos * stalled.config.max_workers
     assert stalled.completion_q.capacity == stalled._work_window == workers
     harness = _StalledConsumerHarness(workers)
@@ -602,6 +616,14 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
         assert run_thread.is_alive()
         assert not resume_consumer.is_set()
         assert harness.legitimate_started == workers
+        assert stalled.completion_q.paused_publication_state() == (
+            (2 * workers) + 1,
+            workers,
+            workers + 1,
+            workers,
+            workers,
+            True,
+        )
         assert stalled.completion_q.offer_count == (2 * workers) + 1
         assert stalled.completion_q.accepted_count == workers
         assert stalled.completion_q.rejected_count == workers + 1
@@ -619,7 +641,7 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
         run_thread.join(timeout=5.0)
 
     assert not run_thread.is_alive()
-    assert run_codes and run_codes[0] != 0
+    assert run_codes == [1]
     assert len(stalled.items) == workers
     expected_issues = set(range(workers))
     assert {item.issue for item in stalled.items} == expected_issues
@@ -629,6 +651,7 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     )
 
     recovered = _make_recovery_coordinator(monkeypatch, workers)
+    assert recovered._work_window == workers
     assert recovered.completion_q.capacity == recovered._work_window
     with patch.object(
         WorkerPool,

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -586,6 +586,9 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
         run_thread.start()
         assert harness.legitimate_ready.wait(timeout=5.0)
         assert consumer_paused.wait(timeout=5.0)
+        # Establish that the coordinator is parked before either worker wave
+        # may publish, so subsequent high-water marks cannot race a drain.
+        assert stalled.completion_q.paused_publication_state() == (0, 0, 0, 0, 0, False)
 
         # The coordinator owns C legitimate handles. Queue a separate C+1
         # publication burst through the same real pool while all workers are

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -684,9 +684,10 @@ def test_worker_pool_stalled_consumer_preserves_and_recovers(
     ):
         assert recovered.run() == 0
 
-    assert len(recovered.items) == workers
-    assert {item.issue for item in recovered.items} == expected_issues
-    assert all(item.result is not None and item.result.passed for item in recovered.items)
+    assert recovered.items == []
+    assert len(recovered.item_summaries) == workers
+    assert {item.issue for item in recovered.item_summaries} == expected_issues
+    assert all(item.result.passed for item in recovered.item_summaries)
 
 
 @pytest.mark.performance

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -9,7 +9,6 @@ so later coordinator tests can swap it in without renaming call sites.
 
 from __future__ import annotations
 
-import queue
 import threading
 from collections import deque
 from pathlib import Path
@@ -63,7 +62,7 @@ class FakeWorkerPool:
         self.size = size
         self.shutdown_event = shutdown if shutdown is not None else threading.Event()
         self.completion_q: CompletionQueue = (
-            completion_q if completion_q is not None else (queue.Queue())
+            completion_q if completion_q is not None else CompletionQueue(capacity=max(1, size))
         )
         self.submitted: list[JobHandle] = []
         self.submitted_claims: list[tuple[str, str]] = []
@@ -113,7 +112,8 @@ class FakeWorkerPool:
                 ok=False,
                 error=f"{type(outcome).__name__}: {outcome!s}",
             )
-        self.completion_q.put((handle, outcome))
+        if not self.completion_q.offer((handle, outcome)):
+            raise AssertionError("FakeWorkerPool completion queue unexpectedly saturated")
         return handle
 
     @staticmethod
@@ -291,7 +291,7 @@ def fake_github() -> FakeGitHub:
 @pytest.fixture
 def completion_q() -> CompletionQueue:
     """Fresh completion queue for tests."""
-    return queue.Queue()
+    return CompletionQueue(capacity=16)
 
 
 @pytest.fixture

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -223,7 +223,9 @@ class TestDiscover:
     ) -> list[int]:
         """Patch the repo-stage read seams; returns the classify-call order."""
         classified: list[int] = []
-        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_issue_meta", lambda org, repo: meta)
+        monkeypatch.setattr(
+            loop_repo_manager_mod, "_iter_open_issue_meta", lambda org, repo: iter(meta)
+        )
         monkeypatch.setattr(
             loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: open_prs or []
         )
@@ -237,7 +239,7 @@ class TestDiscover:
         monkeypatch.setattr(seeding_mod, "classify_issue", fake_classify)
         return classified
 
-    def test_discover_classifies_through_repo_scoped_github(
+    def test_discover_initializes_source_without_eager_issue_reads(
         self,
         repo_item: WorkItem,
         tmp_path: Path,
@@ -268,8 +270,10 @@ class TestDiscover:
         ctx = make_ctx(github=github, paths=_RepoPaths(tmp_path))
         monkeypatch.setattr(
             loop_repo_manager_mod,
-            "_list_open_issue_meta",
-            lambda org, repo: [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}],
+            "_iter_open_issue_meta",
+            lambda org, repo: iter(
+                [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}]
+            ),
         )
         monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: [])
         monkeypatch.setattr(
@@ -282,11 +286,10 @@ class TestDiscover:
         result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
-        assert github.issue_reads == [8]
-        # Issue-level implementation-go on an open PR is a legacy compatibility
-        # label (#2140): post-#2280 it routes back to review, not merge_wait.
-        assert repo_item.payload["products"][0]["stage"] is StageName.PR_REVIEW
-        assert repo_item.payload["products"][0]["pr"] == 44
+        assert result.next_state == "SOURCE"
+        assert github.issue_reads == []
+        assert "products" not in repo_item.payload
+        assert "_repo_issue_source" in repo_item.payload
 
     def test_discover_failure_finishes_fail(
         self,
@@ -295,11 +298,12 @@ class TestDiscover:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Discovery failures are not converted into a successful empty run."""
-        monkeypatch.setattr(
-            loop_repo_manager_mod,
-            "_list_open_issue_meta",
-            lambda org, repo: (_ for _ in ()).throw(RuntimeError("gh failed")),
-        )
+
+        def fail_discovery(org: str, repo: str) -> Any:
+            del org, repo
+            raise RuntimeError("gh failed")
+
+        monkeypatch.setattr(loop_repo_manager_mod, "_iter_open_issue_meta", fail_discovery)
         repo_item.state = "DISCOVER"
 
         result = RepoStage().step(repo_item, repo_ctx)
@@ -308,13 +312,13 @@ class TestDiscover:
         assert result.disposition is Disposition.FINISH_FAIL
         assert "discovery failed" in result.note
 
-    def test_discover_classifies_dedups_and_stages_products(
+    def test_discover_retains_only_a_metadata_cursor(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """N issues (with a duplicate) classify into entry-queue products."""
+        """Discovery does not classify/dedup into an unbounded product list."""
         meta = [
             {"number": 1, "labels": [], "title": "one"},
             {"number": 2, "labels": ["state:plan-go"], "title": "two"},
@@ -333,20 +337,18 @@ class TestDiscover:
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, Continue) and result.next_state == "SEEDED"
-        assert classified == [1, 2]  # dedup: issue 1 classified once
-        products = repo_item.payload["products"]
-        stages = {p["number"]: p["stage"] for p in products}
-        assert stages == {1: StageName.PLANNING, 2: StageName.IMPLEMENTATION}
-        assert repo_item.payload["seeded_count"] == 2
+        assert isinstance(result, Continue) and result.next_state == "SOURCE"
+        assert classified == []
+        assert "products" not in repo_item.payload
+        assert "seeded_count" not in repo_item.payload
 
-    def test_epics_tagged_durably_before_exclusion(
+    def test_discover_does_not_mutate_before_source_consumption(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The skip_epics write lands BEFORE the epic is excluded (order test)."""
+        """The source owns the later durable epic-tagging side effect."""
         meta = [
             {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
             {"number": 6, "labels": [], "title": "real work"},
@@ -362,22 +364,17 @@ class TestDiscover:
 
         RepoStage().step(repo_item, repo_ctx)
 
-        # Durable tag written through the sanctioned chokepoint...
-        assert ("skip_epics", ((5,),)) in gh.mutation_log
-        assert "state:skip" in gh.labels[5]
-        # ...BEFORE the exclusion was materialized: the epic never reached
-        # the classifier, and its product records the exclusion.
-        assert classified == [6]
-        epic_products = [p for p in repo_item.payload["products"] if p["number"] == 5]
-        assert epic_products[0]["stage"] is None
+        assert gh.mutation_log == []
+        assert classified == []
+        assert "products" not in repo_item.payload
 
-    def test_skip_epics_failure_blocks_exclusion_until_reseed(
+    def test_discover_defers_epic_tag_failure_to_source_consumption(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A failed skip write leaves no excluded product; a reseed retries it."""
+        """Source setup is read-only, even when the eventual write would fail."""
         meta = [
             {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
             {"number": 6, "labels": [], "title": "real work"},
@@ -399,22 +396,12 @@ class TestDiscover:
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition is Disposition.FINISH_FAIL
+        assert isinstance(result, Continue)
         assert "products" not in repo_item.payload
         assert classified == []
         assert 5 not in gh.labels
 
         monkeypatch.setattr(gh, "skip_epics", original_skip_epics)
-        reseed_item = WorkItem(
-            repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO, state="DISCOVER"
-        )
-
-        reseed = RepoStage().step(reseed_item, repo_ctx)
-
-        assert isinstance(reseed, Continue) and reseed.next_state == "SEEDED"
-        assert "state:skip" in gh.labels[5]
-        assert [p["number"] for p in reseed_item.payload["products"]] == [5, 6]
 
     @pytest.mark.parametrize(
         ("include_bot_prs", "include_all_authors", "expected"),
@@ -465,10 +452,12 @@ class TestDiscover:
         )
         repo_item.state = "DISCOVER"
 
-        RepoStage().step(repo_item, ctx)
+        result = RepoStage().step(repo_item, ctx)
 
-        orphan = [p for p in repo_item.payload["products"] if p.get("kind") == "pr"]
-        assert [p["number"] for p in orphan] == expected
+        assert expected == []
+        assert isinstance(result, Continue)
+        assert result.next_state == "SOURCE"
+        assert "products" not in repo_item.payload
 
     def test_drive_green_all_skips_viewer_resolution_for_all_authors(
         self,
@@ -498,14 +487,14 @@ class TestDiscover:
 
         resolver.assert_not_called()
 
-    def test_drive_green_all_pr_discovery_failure_finishes_fail(
+    def test_drive_green_all_does_not_query_orphan_pr_pages(
         self,
         repo_item: WorkItem,
         tmp_path: Path,
         make_ctx: Callable[..., Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Orphan-PR discovery failures are visible, not successful empty runs."""
+        """Orphan PR pages are not materialized by repository source setup."""
         config = type(
             "Cfg",
             (),
@@ -518,36 +507,25 @@ class TestDiscover:
             facts={1: _facts(1, pr=55, pr_open=True)},
             classifications={1: (StageName.PR_REVIEW, "open PR")},
         )
-        monkeypatch.setattr(
-            loop_repo_manager_mod,
-            "_list_open_pr_meta",
-            lambda org, repo: (_ for _ in ()).throw(RuntimeError("pr list failed")),
-        )
+        pr_pages = MagicMock(side_effect=AssertionError("orphan PR pages must stay unread"))
+        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_meta", pr_pages)
         repo_item.state = "DISCOVER"
 
         result = RepoStage().step(repo_item, ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition is Disposition.FINISH_FAIL
-        assert "discovery failed" in result.note
+        assert isinstance(result, Continue)
+        assert result.next_state == "SOURCE"
+        assert "products" not in repo_item.payload
+        pr_pages.assert_not_called()
 
-    def test_seeded_finishes_pass_with_cached_count(
-        self, repo_item: WorkItem, repo_ctx: Any
-    ) -> None:
-        """Terminal: FINISH_PASS(seeded:N) uses the cached discovery count."""
-        repo_item.state = "SEEDED"
-        repo_item.payload["products"] = [
-            {"number": 1, "stage": StageName.PLANNING, "reason": "r"},
-            {"number": 2, "stage": None, "reason": "excluded"},
-            {"number": 3, "stage": StageName.PR_REVIEW, "reason": "r"},
-        ]
-        repo_item.payload["seeded_count"] = 1
+    def test_source_state_yields_to_coordinator(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        """SOURCE is a non-spinning yield point for coordinator source pull."""
+        repo_item.state = "SOURCE"
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition is Disposition.FINISH_PASS
-        assert result.note == "seeded:1"
+        assert isinstance(result, Continue)
+        assert result.next_state == "SOURCE"
 
     def test_unknown_state_finishes_failed(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         repo_item.state = "BOGUS"

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -1,0 +1,262 @@
+"""Acceptance tests for bounded pipeline queues and completion recovery."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _job(issue: int) -> AgentJob:
+    """Create a lightweight job handle payload for queue tests."""
+    return AgentJob(
+        repo="repo-a",
+        issue=issue,
+        agent="claude",
+        model="test-model",
+        prompt_builder=lambda: "prompt",
+        cwd=Path("/tmp"),
+        timeout_s=1,
+    )
+
+
+class _JobRequestingStage:
+    """Stage that submits exactly one job for an end-to-end overflow test."""
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        """Perform no enter-time transition."""
+
+    def step(self, item: WorkItem, ctx: Any) -> JobRequest | StageOutcome:
+        """Request one agent job."""
+        return JobRequest(_job(item.issue or 0), on_done_state="VERIFY")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        """Keep the callback empty because the overflow path parks the item."""
+
+
+class _RecoveringStage(_JobRequestingStage):
+    """Complete normally when the same seed is submitted to a fresh run."""
+
+    def step(self, item: WorkItem, ctx: Any) -> JobRequest | StageOutcome:
+        """Submit once, then finish after the recovered completion."""
+        if item.state == "ENTER":
+            return JobRequest(_job(item.issue or 0), on_done_state="VERIFY")
+        return StageOutcome(Disposition.FINISH_PASS, "recovered")
+
+
+def _coordinator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pool: Any | None = None,
+    event_log_path: Path | None = None,
+    max_workers: int = 1,
+    parallel_repos: int = 1,
+) -> Coordinator:
+    """Build a coordinator with an explicitly matched bounded worker channel."""
+    capacity = max(1, max_workers * parallel_repos)
+    config = PipelineConfig(
+        org="org",
+        repos=["repo-a"],
+        max_workers=max_workers,
+        parallel_repos=parallel_repos,
+        projects_dir=tmp_path,
+        event_log_path=event_log_path,
+    )
+    if pool is None:
+        pool = FakeWorkerPool(size=capacity, completion_q=CompletionQueue(capacity=capacity))
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_from_cli",
+        lambda repos, issues, prs: [
+            seeding_mod.SeedEntry(
+                kind="issue", identifier=1, stage=StageName.PLANNING, reason="test seed"
+            )
+        ],
+    )
+    coordinator = Coordinator(config, github=FakeStageGitHub(), pool=pool, install_signals=False)
+    coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+    return coordinator
+
+
+def test_work_window_bounds_all_pipeline_queues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every stage and completion queue shares the worker-window capacity proof."""
+    coordinator = _coordinator(tmp_path, monkeypatch, max_workers=2, parallel_repos=3)
+
+    assert coordinator._work_window == 6
+    assert coordinator.completion_q.capacity == 6
+    assert {queue.capacity for queue in coordinator.queues.values()} == {6}
+
+    coordinator.in_flight.update(
+        {
+            JobHandle(job=_job(issue), on_done_state="VERIFY"): WorkItem(
+                repo="repo-a", kind=ItemKind.REPO
+            )
+            for issue in range(6)
+        }
+    )
+    assert coordinator._admit(WorkItem(repo="repo-a", kind=ItemKind.REPO)) is False
+
+
+def test_stage_burst_rejection_is_explicit_without_overflow_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A new item rejected by a full stage is not hidden in an overflow deque."""
+    coordinator = _coordinator(tmp_path, monkeypatch)
+    first = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+    second = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+
+    assert coordinator._push_item(first, StageName.REPO, enter=True)
+    assert coordinator._push_item(second, StageName.REPO, enter=True) is False
+
+    assert coordinator.queues[StageName.REPO].snapshot() == [first]
+    assert second not in coordinator.items
+    assert any(event[0] == "queue_saturated" for event in coordinator.event_log)
+
+
+def test_repeated_wakes_do_not_consume_completion_capacity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C completion results and any number of wake requests coexist safely."""
+    coordinator = _coordinator(tmp_path, monkeypatch, max_workers=2, parallel_repos=2)
+    for issue in range(4):
+        assert coordinator.completion_q.offer((object(), JobResult(ok=True, value=issue)))
+
+    for _ in range(100):
+        coordinator._wake_completion_wait()
+
+    assert coordinator.completion_q.qsize() == coordinator._work_window
+    assert coordinator._completion_wake.is_set()
+
+
+def test_snapshot_exports_capacity_depth_and_rejection_totals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runtime observability exposes bounded depth and durable rejection counters."""
+    base = _coordinator(tmp_path, monkeypatch)
+    config = replace(base.config, metrics_port=9123)
+    coordinator = Coordinator(
+        config,
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+        install_signals=False,
+    )
+    item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+    rejected = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+    assert coordinator._push_item(item, StageName.REPO, enter=True)
+    assert coordinator._push_item(rejected, StageName.REPO, enter=True) is False
+
+    snapshot = coordinator._observability_snapshot()
+    assert snapshot["queue_capacities"][StageName.REPO.value] == 1
+    assert snapshot["queue_depths"][StageName.REPO.value] == 1
+    assert snapshot["queue_rejection_totals"][StageName.REPO.value] == 1
+    assert snapshot["saturated_queues"] == [StageName.REPO.value]
+
+    coordinator._emit_observability_tick()
+    assert coordinator._metrics_registry is not None
+    rendered = coordinator._metrics_registry.render_prometheus()
+    assert 'hephaestus_pipeline_queue_capacity{stage="repo"} 1' in rendered
+    assert "hephaestus_pipeline_queue_rejections_total" in rendered
+
+
+class _OverflowingPool(FakeWorkerPool):
+    """Fill the result channel before rejecting the submitted completion."""
+
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> JobHandle:
+        """Return a handle whose result goes to the bounded rejection mailbox."""
+        handle = JobHandle(job=job, on_done_state=on_done_state)
+        self.submitted.append(handle)
+        self.submitted_claims.append((kwargs.get("claim_key", ""), kwargs.get("claim_stage", "")))
+        blocker = JobHandle(job=_job(999), on_done_state="VERIFY")
+        assert self.completion_q.offer((blocker, JobResult(ok=True)))
+        assert self.completion_q.offer((handle, JobResult(ok=True))) is False
+        self.shutdown_event.set()
+        return handle
+
+
+def test_completion_rejection_is_durable_and_terminates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rejected worker result parks its exact item and ends without grace expiry."""
+    event_log = tmp_path / "events.jsonl"
+    pool = _OverflowingPool(
+        size=1,
+        completion_q=CompletionQueue(capacity=1),
+    )
+    coordinator = _coordinator(tmp_path, monkeypatch, pool=pool, event_log_path=event_log)
+    coordinator.stages[StageName.PLANNING] = _JobRequestingStage()
+
+    started = time.monotonic()
+    assert coordinator.run() == 130
+
+    assert time.monotonic() - started < 1.0
+    assert coordinator.in_flight == {}
+    assert coordinator.items[0].result is not None
+    assert coordinator.items[0].result.reason.startswith("resumable at planning")
+    records = [json.loads(line) for line in event_log.read_text().splitlines()]
+    assert any(record["event"] == "queue_saturated" for record in records)
+
+
+def test_completion_rejection_recovers_from_the_same_seed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh coordinator can process the unchanged seed after saturation."""
+    first_pool = _OverflowingPool(size=1, completion_q=CompletionQueue(capacity=1))
+    first = _coordinator(tmp_path, monkeypatch, pool=first_pool)
+    first.stages[StageName.PLANNING] = _JobRequestingStage()
+
+    assert first.run() == 130
+    assert first.items[0].result is not None
+    assert first.items[0].result.reason.startswith("resumable at planning")
+
+    second = _coordinator(
+        tmp_path,
+        monkeypatch,
+        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+    )
+    second.stages[StageName.PLANNING] = _RecoveringStage()
+
+    assert second.run() == 0
+    assert second.items[0].result is not None
+    assert second.items[0].result.passed is True
+
+
+def test_rejection_mailbox_overflow_parks_all_live_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Catastrophic fallback parks remaining in-flight items instead of hanging."""
+    coordinator = _coordinator(tmp_path, monkeypatch)
+    first = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLANNING)
+    second = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLANNING)
+    handle1 = JobHandle(job=_job(1), on_done_state="VERIFY")
+    handle2 = JobHandle(job=_job(2), on_done_state="VERIFY")
+    coordinator.in_flight[handle1] = first
+    coordinator.in_flight[handle2] = second
+    coordinator.inflight_per_repo["repo-a"] = 2
+
+    assert coordinator.completion_q.offer((object(), JobResult(ok=True)))
+    assert coordinator.completion_q.offer((handle1, JobResult(ok=True))) is False
+    assert coordinator.completion_q.offer((handle2, JobResult(ok=True))) is False
+
+    assert coordinator._drain_completion_rejections()
+
+    assert coordinator.in_flight == {}
+    assert first.result is not None
+    assert second.result is not None
+    assert coordinator._pool_shut_down is True

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -66,6 +66,7 @@ def _coordinator(
     event_log_path: Path | None = None,
     max_workers: int = 1,
     parallel_repos: int = 1,
+    stage_queue_capacity: int | None = None,
 ) -> Coordinator:
     """Build a coordinator with an explicitly matched bounded worker channel."""
     capacity = max(1, max_workers * parallel_repos)
@@ -77,6 +78,8 @@ def _coordinator(
         projects_dir=tmp_path,
         event_log_path=event_log_path,
     )
+    if stage_queue_capacity is not None:
+        config = replace(config, stage_queue_capacity=stage_queue_capacity)
     if pool is None:
         pool = FakeWorkerPool(size=capacity, completion_q=CompletionQueue(capacity=capacity))
     monkeypatch.setattr(
@@ -96,12 +99,15 @@ def _coordinator(
 def test_work_window_bounds_all_pipeline_queues(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Every stage and completion queue shares the worker-window capacity proof."""
+    """Completion capacity follows workers while stage capacity stays independent."""
     coordinator = _coordinator(tmp_path, monkeypatch, max_workers=2, parallel_repos=3)
 
     assert coordinator._work_window == 6
     assert coordinator.completion_q.capacity == 6
-    assert {queue.capacity for queue in coordinator.queues.values()} == {6}
+    assert {queue.capacity for queue in coordinator.queues.values()} == {
+        coordinator.config.stage_queue_capacity
+    }
+    assert coordinator.config.stage_queue_capacity != coordinator._work_window
 
     coordinator.in_flight.update(
         {
@@ -114,39 +120,46 @@ def test_work_window_bounds_all_pipeline_queues(
     assert coordinator._admit(WorkItem(repo="repo-a", kind=ItemKind.REPO)) is False
 
 
-def test_stage_burst_rejection_tracks_new_work_and_requests_recovery(
+def test_stage_burst_is_deferred_until_queue_drains(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A rejected seed is resumable and cannot produce a false clean exit."""
+    """A full stage queue defers new work without stopping the coordinator."""
     event_log = tmp_path / "events.jsonl"
-    coordinator = _coordinator(tmp_path, monkeypatch, event_log_path=event_log)
+    coordinator = _coordinator(
+        tmp_path,
+        monkeypatch,
+        event_log_path=event_log,
+        stage_queue_capacity=1,
+    )
     first = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
     second = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
 
     assert coordinator._push_item(first, StageName.REPO, enter=True)
-    assert coordinator._push_item(second, StageName.REPO, enter=True) is False
+    assert coordinator._push_item(second, StageName.REPO, enter=True)
 
     assert coordinator.queues[StageName.REPO].snapshot() == [first]
     assert second in coordinator.items
-    assert second.result is not None
-    assert second.result.reason == "resumable at repo: stage enqueue rejected"
-    assert coordinator.shutdown.is_set()
-    assert coordinator._exit_code() == 130
-    assert any(event[0] == "queue_saturated" for event in coordinator.event_log)
+    assert second.result is None
+    assert coordinator._pending_admissions
+    assert not coordinator.shutdown.is_set()
+    assert coordinator._exit_code() == 0
+    assert any(event[0] == "queue_deferred" for event in coordinator.event_log)
+    assert not any(event[0] == "queue_saturated" for event in coordinator.event_log)
     records = [json.loads(line) for line in event_log.read_text().splitlines()]
-    assert any(record["event"] == "queue_saturated" for record in records)
+    assert any(record["event"] == "queue_deferred" for record in records)
 
 
-def test_c_plus_one_seed_has_resumable_non_successful_shutdown(
+def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A capacity-one run accounts for both seeds instead of returning zero."""
+    """A capacity-one run admits C+1 work and a fresh run accepts that seed again."""
     event_log = tmp_path / "c-plus-one-events.jsonl"
     config = PipelineConfig(
         org="org",
         repos=["repo-a"],
         max_workers=1,
         parallel_repos=1,
+        stage_queue_capacity=1,
         projects_dir=tmp_path,
         event_log_path=event_log,
     )
@@ -166,12 +179,50 @@ def test_c_plus_one_seed_has_resumable_non_successful_shutdown(
         pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
         install_signals=False,
     )
+    coordinator.stages[StageName.PLANNING] = _RecoveringStage()
 
-    assert coordinator.run() == 130
+    assert coordinator.run() == 0
     assert {item.issue for item in coordinator.items} == {1, 2}
-    assert all(item.result is not None for item in coordinator.items)
+    assert all(item.result is not None and item.result.passed for item in coordinator.items)
     records = [json.loads(line) for line in event_log.read_text().splitlines()]
-    assert any(record["event"] == "queue_saturated" for record in records)
+    assert any(record["event"] == "queue_deferred" for record in records)
+    assert not any(record["event"] == "queue_saturated" for record in records)
+
+    retry = Coordinator(
+        config,
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+        install_signals=False,
+    )
+    retry.stages[StageName.PLANNING] = _RecoveringStage()
+
+    assert retry.run() == 0
+    assert {item.issue for item in retry.items} == {1, 2}
+    assert all(item.result is not None and item.result.passed for item in retry.items)
+
+
+def test_c_plus_one_products_wait_for_stage_slots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repo discovery products use the same resumable admission spool as seeds."""
+    coordinator = _coordinator(tmp_path, monkeypatch, stage_queue_capacity=1)
+    repo_item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+    repo_item.payload["products"] = [
+        {"kind": "issue", "number": 1, "stage": StageName.PLANNING},
+        {"kind": "issue", "number": 2, "stage": StageName.PLANNING},
+    ]
+
+    coordinator._seed_products(repo_item)
+
+    queued = coordinator.queues[StageName.PLANNING].snapshot()
+    assert [item.issue for item in queued] == [1]
+    assert [item.issue for item, _stage, _enter in coordinator._pending_admissions] == [2]
+    assert not coordinator.shutdown.is_set()
+
+    coordinator.queues[StageName.PLANNING].pop()
+    coordinator._drain_pending_admissions()
+    assert [item.issue for item in coordinator.queues[StageName.PLANNING].snapshot()] == [2]
+    assert not coordinator._pending_admissions
 
 
 def test_repeated_wakes_do_not_consume_completion_capacity(
@@ -193,8 +244,8 @@ def test_snapshot_exports_capacity_depth_and_rejection_totals(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Runtime observability exposes bounded depth and durable rejection counters."""
-    base = _coordinator(tmp_path, monkeypatch)
-    config = replace(base.config, metrics_port=9123)
+    base = _coordinator(tmp_path, monkeypatch, stage_queue_capacity=1)
+    config = replace(base.config, metrics_port=9123, stage_queue_capacity=1)
     coordinator = Coordinator(
         config,
         github=FakeStageGitHub(),
@@ -204,7 +255,13 @@ def test_snapshot_exports_capacity_depth_and_rejection_totals(
     item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
     rejected = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
     assert coordinator._push_item(item, StageName.REPO, enter=True)
-    assert coordinator._push_item(rejected, StageName.REPO, enter=True) is False
+    assert coordinator._push_item(rejected, StageName.REPO, enter=True)
+    coordinator._record_queue_saturation(
+        queue=StageName.REPO.value,
+        capacity=1,
+        item=rejected,
+        source="test_rejection",
+    )
 
     snapshot = coordinator._observability_snapshot()
     assert snapshot["queue_capacities"][StageName.REPO.value] == 1
@@ -217,6 +274,27 @@ def test_snapshot_exports_capacity_depth_and_rejection_totals(
     rendered = coordinator._metrics_registry.render_prometheus()
     assert 'hephaestus_pipeline_queue_capacity{stage="repo"} 1' in rendered
     assert "hephaestus_pipeline_queue_rejections_total" in rendered
+
+
+def test_saturation_journal_append_failure_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A saturation event cannot continue when its configured journal is unwritable."""
+    event_log = tmp_path / "events.jsonl"
+    event_log.mkdir()
+    coordinator = _coordinator(tmp_path, monkeypatch, event_log_path=event_log)
+
+    coordinator._record_queue_saturation(
+        queue="completion",
+        capacity=1,
+        source="completion_publish_rejected",
+    )
+
+    assert coordinator._event_log_disabled is True
+    assert coordinator._journal_failure is True
+    assert coordinator._fatal is True
+    assert coordinator.shutdown.is_set()
+    assert coordinator._exit_code() == 1
 
 
 class _OverflowingPool(FakeWorkerPool):

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -149,6 +149,196 @@ def test_stage_burst_is_deferred_until_queue_drains(
     assert any(record["event"] == "queue_deferred" for record in records)
 
 
+def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stalled stage cannot move an arbitrary source burst into coordinator memory."""
+    event_log = tmp_path / "bounded-admission-events.jsonl"
+    burst_size = 10_000
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_from_cli",
+        lambda repos, issues, prs: [
+            seeding_mod.SeedEntry(
+                kind="issue",
+                identifier=issue,
+                stage=StageName.PLANNING,
+                reason="burst seed",
+            )
+            for issue in range(1, burst_size + 1)
+        ],
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            max_workers=1,
+            parallel_repos=1,
+            stage_queue_capacity=1,
+            metrics_port=9124,
+            projects_dir=tmp_path,
+            event_log_path=event_log,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+        install_signals=False,
+    )
+
+    pushed = coordinator._seed_pass()
+
+    assert coordinator._admission_spool_capacity == len(StageName)
+    assert pushed == 1 + coordinator._admission_spool_capacity
+    assert len(coordinator.queues[StageName.PLANNING]) == 1
+    assert len(coordinator._pending_admissions) == coordinator._admission_spool_capacity
+    resident_depth = sum(len(queue) for queue in coordinator.queues.values()) + len(
+        coordinator._pending_admissions
+    )
+    resident_capacity = sum(queue.capacity for queue in coordinator.queues.values()) + (
+        coordinator._admission_spool_capacity
+    )
+    assert resident_depth == 1 + coordinator._admission_spool_capacity
+    assert resident_depth <= resident_capacity
+    # The one item that crossed the hard boundary is retained as the exact
+    # RESUMABLE recovery receipt; the remaining source burst is not retained.
+    assert len(coordinator.items) == pushed + 1
+    assert len(coordinator.items) < burst_size
+    assert coordinator.items[-1].result is not None
+    assert "admission spool saturated" in coordinator.items[-1].result.reason
+    assert coordinator.shutdown.is_set()
+    assert coordinator._fatal is True
+
+    snapshot = coordinator._observability_snapshot()
+    assert snapshot["admission_depth"] == coordinator._admission_spool_capacity
+    assert snapshot["admission_capacity"] == coordinator._admission_spool_capacity
+    coordinator._emit_observability_tick()
+    assert coordinator._metrics_registry is not None
+    rendered = coordinator._metrics_registry.render_prometheus()
+    assert (
+        f"hephaestus_pipeline_admission_depth {coordinator._admission_spool_capacity}" in rendered
+    )
+    assert (
+        f"hephaestus_pipeline_admission_capacity {coordinator._admission_spool_capacity}"
+        in rendered
+    )
+    records = [json.loads(line) for line in event_log.read_text().splitlines()]
+    saturation = next(record for record in records if record["event"] == "queue_saturated")
+    assert saturation["fields"][0]["queue"] == "admission"
+    assert saturation["fields"][0]["item"] == f"repo-a#{pushed + 1}"
+
+
+def test_push_fallback_overflow_preserves_spool_and_journals_exact_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bounded fallback refuses overflow without deque maxlen eviction."""
+    event_log = tmp_path / "push-fallback-overflow.jsonl"
+    coordinator = _coordinator(
+        tmp_path,
+        monkeypatch,
+        event_log_path=event_log,
+        stage_queue_capacity=1,
+    )
+    queued = WorkItem(
+        repo="repo-a",
+        kind=ItemKind.ISSUE,
+        issue=1,
+        stage=StageName.PLANNING,
+    )
+    assert coordinator._push_item(queued, StageName.PLANNING, enter=True)
+    for issue in range(2, 2 + coordinator._admission_spool_capacity):
+        assert coordinator._push_item(
+            WorkItem(
+                repo="repo-a",
+                kind=ItemKind.ISSUE,
+                issue=issue,
+                stage=StageName.PLANNING,
+            ),
+            StageName.PLANNING,
+            enter=True,
+        )
+    pending_before = list(coordinator._pending_admissions)
+    boundary_issue = 2 + coordinator._admission_spool_capacity
+    boundary = WorkItem(
+        repo="repo-a",
+        kind=ItemKind.ISSUE,
+        issue=boundary_issue,
+        stage=StageName.PLANNING,
+    )
+
+    assert coordinator._push_item(boundary, StageName.PLANNING, enter=True) is False
+
+    assert list(coordinator._pending_admissions) == pending_before
+    assert boundary.result is not None
+    assert "admission spool saturated" in boundary.result.reason
+    receipt = next(
+        record
+        for record in (json.loads(line) for line in event_log.read_text().splitlines())
+        if record["event"] == "queue_saturated"
+    )
+    assert receipt["fields"][0]["item"] == f"repo-a#{boundary_issue}"
+    assert receipt["fields"][0]["details"] == {
+        "admission_depth": coordinator._admission_spool_capacity,
+        "blocked_stage": "planning",
+        "stage_capacity": 1,
+        "stage_depth": 1,
+    }
+
+
+def test_product_burst_beyond_spool_bound_records_exact_recovery_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery cannot retain products beyond the stage plus admission bounds."""
+    event_log = tmp_path / "bounded-product-events.jsonl"
+    burst_size = 10_000
+    coordinator = _coordinator(
+        tmp_path,
+        monkeypatch,
+        event_log_path=event_log,
+        stage_queue_capacity=1,
+    )
+    repo_item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+    repo_item.payload["products"] = [
+        {"kind": "issue", "number": issue, "stage": StageName.PLANNING}
+        for issue in range(1, burst_size + 1)
+    ]
+
+    coordinator._seed_products(repo_item)
+
+    resident_capacity = 1 + coordinator._admission_spool_capacity
+    assert len(coordinator.queues[StageName.PLANNING]) == 1
+    assert len(coordinator._pending_admissions) == coordinator._admission_spool_capacity
+    # One additional item is retained as the exact rejected recovery receipt;
+    # the remaining source products are reconstructible by repo discovery and
+    # are not copied into another coordinator-owned backlog.
+    assert len(coordinator.items) == resident_capacity + 1
+    assert len(coordinator.items) < burst_size
+    rejected = coordinator.items[-1]
+    assert rejected.issue == resident_capacity + 1
+    assert rejected.result is not None
+    assert "admission spool saturated" in rejected.result.reason
+    assert "products" not in repo_item.payload
+    assert coordinator.shutdown.is_set()
+    assert coordinator._fatal is True
+
+    snapshot = coordinator._observability_snapshot()
+    assert snapshot["admission_depth"] == coordinator._admission_spool_capacity
+    records = [json.loads(line) for line in event_log.read_text().splitlines()]
+    saturation = next(record for record in records if record["event"] == "queue_saturated")
+    assert saturation["fields"][0] == {
+        "capacity": coordinator._admission_spool_capacity,
+        "details": {
+            "admission_depth": coordinator._admission_spool_capacity,
+            "blocked_stage": "planning",
+            "stage_capacity": 1,
+            "stage_depth": 1,
+        },
+        "fatal": True,
+        "item": f"repo-a#{resident_capacity + 1}",
+        "queue": "admission",
+        "rejections": 1,
+        "source": "planning_stage_queue_overflow",
+    }
+
+
 def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -182,10 +372,18 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     coordinator.stages[StageName.PLANNING] = _RecoveringStage()
 
     assert coordinator.run() == 0
-    assert {item.issue for item in coordinator.items} == {1, 2}
+    assert [item.issue for item in coordinator.items] == [1, 2]
+    assert len(coordinator.items) == 2
+    assert len(coordinator.ledger) == 2
+    assert not coordinator._pending_admissions
     assert all(item.result is not None and item.result.passed for item in coordinator.items)
+    assert all(
+        item.payload["entry_stage"] == StageName.PLANNING.value for item in coordinator.items
+    )
     records = [json.loads(line) for line in event_log.read_text().splitlines()]
-    assert any(record["event"] == "queue_deferred" for record in records)
+    deferred = [record for record in records if record["event"] == "queue_deferred"]
+    assert len(deferred) == 1
+    assert deferred[0]["fields"][1] == "repo-a#2"
     assert not any(record["event"] == "queue_saturated" for record in records)
 
     retry = Coordinator(
@@ -197,7 +395,10 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     retry.stages[StageName.PLANNING] = _RecoveringStage()
 
     assert retry.run() == 0
-    assert {item.issue for item in retry.items} == {1, 2}
+    assert [item.issue for item in retry.items] == [1, 2]
+    assert len(retry.items) == 2
+    assert len(retry.ledger) == 2
+    assert not retry._pending_admissions
     assert all(item.result is not None and item.result.passed for item in retry.items)
 
 
@@ -266,6 +467,8 @@ def test_snapshot_exports_capacity_depth_and_rejection_totals(
     snapshot = coordinator._observability_snapshot()
     assert snapshot["queue_capacities"][StageName.REPO.value] == 1
     assert snapshot["queue_depths"][StageName.REPO.value] == 1
+    assert snapshot["admission_depth"] == 1
+    assert snapshot["admission_capacity"] == len(StageName)
     assert snapshot["queue_rejection_totals"][StageName.REPO.value] == 1
     assert snapshot["saturated_queues"] == [StageName.REPO.value]
 
@@ -273,6 +476,8 @@ def test_snapshot_exports_capacity_depth_and_rejection_totals(
     assert coordinator._metrics_registry is not None
     rendered = coordinator._metrics_registry.render_prometheus()
     assert 'hephaestus_pipeline_queue_capacity{stage="repo"} 1' in rendered
+    assert f"hephaestus_pipeline_admission_capacity {len(StageName)}" in rendered
+    assert "hephaestus_pipeline_admission_depth 1" in rendered
     assert "hephaestus_pipeline_queue_rejections_total" in rendered
 
 
@@ -325,9 +530,10 @@ def test_completion_rejection_is_durable_and_terminates(
     coordinator.stages[StageName.PLANNING] = _JobRequestingStage()
 
     started = time.monotonic()
-    assert coordinator.run() == 130
+    assert coordinator.run() == 1
 
     assert time.monotonic() - started < 1.0
+    assert coordinator._signal_received is False
     assert coordinator.in_flight == {}
     assert coordinator.items[0].result is not None
     assert coordinator.items[0].result.reason.startswith("resumable at planning")
@@ -343,7 +549,8 @@ def test_completion_rejection_recovers_from_the_same_seed(
     first = _coordinator(tmp_path, monkeypatch, pool=first_pool)
     first.stages[StageName.PLANNING] = _JobRequestingStage()
 
-    assert first.run() == 130
+    assert first.run() == 1
+    assert first._signal_received is False
     assert first.items[0].result is not None
     assert first.items[0].result.reason.startswith("resumable at planning")
 
@@ -362,7 +569,7 @@ def test_completion_rejection_recovers_from_the_same_seed(
 def test_rejection_mailbox_overflow_parks_all_live_work(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Catastrophic fallback parks remaining in-flight items instead of hanging."""
+    """Mailbox overflow parks live work and reports failure, not a signal."""
     coordinator = _coordinator(tmp_path, monkeypatch)
     first = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLANNING)
     second = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLANNING)
@@ -381,4 +588,9 @@ def test_rejection_mailbox_overflow_parks_all_live_work(
     assert coordinator.in_flight == {}
     assert first.result is not None
     assert second.result is not None
+    assert first.result.reason.startswith("resumable at planning")
+    assert second.result.reason.startswith("resumable at planning")
     assert coordinator._pool_shut_down is True
+    assert coordinator.shutdown.is_set()
+    assert coordinator._signal_received is False
+    assert coordinator._exit_code() == 1

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -114,11 +114,12 @@ def test_work_window_bounds_all_pipeline_queues(
     assert coordinator._admit(WorkItem(repo="repo-a", kind=ItemKind.REPO)) is False
 
 
-def test_stage_burst_rejection_is_explicit_without_overflow_storage(
+def test_stage_burst_rejection_tracks_new_work_and_requests_recovery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A new item rejected by a full stage is not hidden in an overflow deque."""
-    coordinator = _coordinator(tmp_path, monkeypatch)
+    """A rejected seed is resumable and cannot produce a false clean exit."""
+    event_log = tmp_path / "events.jsonl"
+    coordinator = _coordinator(tmp_path, monkeypatch, event_log_path=event_log)
     first = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
     second = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
 
@@ -126,8 +127,51 @@ def test_stage_burst_rejection_is_explicit_without_overflow_storage(
     assert coordinator._push_item(second, StageName.REPO, enter=True) is False
 
     assert coordinator.queues[StageName.REPO].snapshot() == [first]
-    assert second not in coordinator.items
+    assert second in coordinator.items
+    assert second.result is not None
+    assert second.result.reason == "resumable at repo: stage enqueue rejected"
+    assert coordinator.shutdown.is_set()
+    assert coordinator._exit_code() == 130
     assert any(event[0] == "queue_saturated" for event in coordinator.event_log)
+    records = [json.loads(line) for line in event_log.read_text().splitlines()]
+    assert any(record["event"] == "queue_saturated" for record in records)
+
+
+def test_c_plus_one_seed_has_resumable_non_successful_shutdown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A capacity-one run accounts for both seeds instead of returning zero."""
+    event_log = tmp_path / "c-plus-one-events.jsonl"
+    config = PipelineConfig(
+        org="org",
+        repos=["repo-a"],
+        max_workers=1,
+        parallel_repos=1,
+        projects_dir=tmp_path,
+        event_log_path=event_log,
+    )
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_from_cli",
+        lambda repos, issues, prs: [
+            seeding_mod.SeedEntry(
+                kind="issue", identifier=issue, stage=StageName.PLANNING, reason="seed"
+            )
+            for issue in (1, 2)
+        ],
+    )
+    coordinator = Coordinator(
+        config,
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+        install_signals=False,
+    )
+
+    assert coordinator.run() == 130
+    assert {item.issue for item in coordinator.items} == {1, 2}
+    assert all(item.result is not None for item in coordinator.items)
+    records = [json.loads(line) for line in event_log.read_text().splitlines()]
+    assert any(record["event"] == "queue_saturated" for record in records)
 
 
 def test_repeated_wakes_do_not_consume_completion_capacity(

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -580,6 +580,49 @@ def test_completion_rejection_recovers_from_the_same_seed(
     assert second.items[0].result.passed is True
 
 
+def test_completion_saturation_blocks_follow_on_submission_from_accepted_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After saturation, accepted completions are parked but cannot admit new work."""
+    completion_q = CompletionQueue(capacity=1)
+    pool = FakeWorkerPool(size=1, completion_q=completion_q)
+    coordinator = _coordinator(tmp_path, monkeypatch, pool=pool)
+
+    class SubmittingOnDoneStage(_JobRequestingStage):
+        def __init__(self) -> None:
+            self.job_done_calls = 0
+
+        def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+            self.job_done_calls += 1
+            item.payload["accepted_completion_processed"] = True
+            coordinator._submit(item, JobRequest(_job(300), on_done_state="VERIFY"))
+
+    stage = SubmittingOnDoneStage()
+    coordinator.stages[StageName.PLANNING] = stage
+    rejected_item = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=10, stage=StageName.PLANNING)
+    accepted_item = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=20, stage=StageName.PLANNING)
+    rejected_handle = JobHandle(job=_job(10), on_done_state="VERIFY")
+    accepted_handle = JobHandle(job=_job(20), on_done_state="VERIFY")
+    coordinator.in_flight[rejected_handle] = rejected_item
+    coordinator.in_flight[accepted_handle] = accepted_item
+    coordinator.inflight_per_repo["repo-a"] = 2
+
+    assert completion_q.offer((accepted_handle, JobResult(ok=True)))
+    assert completion_q.offer((rejected_handle, JobResult(ok=True))) is False
+
+    coordinator._drain_completions()
+
+    assert coordinator.shutdown.is_set()
+    assert stage.job_done_calls == 1
+    assert pool.submitted == []
+    assert coordinator.in_flight == {}
+    assert rejected_item.result is not None
+    assert rejected_item.result.reason.startswith("resumable at planning")
+    assert accepted_item.payload["accepted_completion_processed"] is True
+    assert accepted_item.result is not None
+    assert accepted_item.result.reason.startswith("resumable at planning")
+
+
 def test_rejection_mailbox_overflow_parks_all_live_work(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import Iterator
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -130,6 +129,7 @@ def test_stage_burst_is_deferred_until_queue_drains(
         tmp_path,
         monkeypatch,
         event_log_path=event_log,
+        max_workers=2,
         stage_queue_capacity=1,
     )
     first = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
@@ -153,35 +153,24 @@ def test_stage_burst_is_deferred_until_queue_drains(
 def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bounded(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A stalled stage cannot move an arbitrary source burst into coordinator memory."""
+    """Production seeding stays lazy when a stalled stage reaches its admission bound."""
     event_log = tmp_path / "bounded-admission-events.jsonl"
     burst_size = 10_000
-    produced = 0
+    repos = [f"repo-{index}" for index in range(1, burst_size + 1)]
+    created_entries = 0
+    seed_entry_type = seeding_mod.SeedEntry
 
-    def stream_seed_entries(
-        repos: list[str], issues: list[int], prs: list[int]
-    ) -> Iterator[seeding_mod.SeedEntry]:
-        """Yield a large source lazily and expose how far admission reads it."""
-        del repos, issues, prs
-        nonlocal produced
-        for issue in range(1, burst_size + 1):
-            produced += 1
-            yield seeding_mod.SeedEntry(
-                kind="issue",
-                identifier=issue,
-                stage=StageName.PLANNING,
-                reason="burst seed",
-            )
+    def counted_seed_entry(*args: Any, **kwargs: Any) -> seeding_mod.SeedEntry:
+        """Count production ``SeedEntry`` allocation without replacing its behavior."""
+        nonlocal created_entries
+        created_entries += 1
+        return seed_entry_type(*args, **kwargs)
 
-    monkeypatch.setattr(
-        seeding_mod,
-        "seed_from_cli",
-        stream_seed_entries,
-    )
+    monkeypatch.setattr(seeding_mod, "SeedEntry", counted_seed_entry)
     coordinator = Coordinator(
         PipelineConfig(
             org="org",
-            repos=["repo-a"],
+            repos=repos,
             max_workers=1,
             parallel_repos=1,
             stage_queue_capacity=1,
@@ -197,47 +186,41 @@ def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bound
     pushed = coordinator._seed_pass()
 
     assert coordinator._admission_spool_capacity == len(StageName)
-    assert pushed == 1 + coordinator._admission_spool_capacity
-    # The source is lazy: only the admitted batch and exact saturation receipt
-    # are materialized, rather than all 10,000 SeedEntry objects.
-    assert produced == pushed + 1
-    assert produced < burst_size
-    assert len(coordinator.queues[StageName.PLANNING]) == 1
-    assert len(coordinator._pending_admissions) == coordinator._admission_spool_capacity
+    assert pushed == 1
+    # The global permit check happens before advancing the real generator.
+    assert created_entries == 1
+    assert created_entries < burst_size
+    assert len(coordinator.queues[StageName.REPO]) == 1
+    assert len(coordinator._pending_admissions) == 0
     resident_depth = sum(len(queue) for queue in coordinator.queues.values()) + len(
         coordinator._pending_admissions
     )
     resident_capacity = sum(queue.capacity for queue in coordinator.queues.values()) + (
         coordinator._admission_spool_capacity
     )
-    assert resident_depth == 1 + coordinator._admission_spool_capacity
+    assert resident_depth == 1
     assert resident_depth <= resident_capacity
-    # The one item that crossed the hard boundary is retained as the exact
-    # RESUMABLE recovery receipt; the remaining source burst is not retained.
-    assert len(coordinator.items) == pushed + 1
+    assert len(coordinator.items) == pushed
     assert len(coordinator.items) < burst_size
-    assert coordinator.items[-1].result is not None
-    assert "admission spool saturated" in coordinator.items[-1].result.reason
-    assert coordinator.shutdown.is_set()
-    assert coordinator._fatal is True
+    assert coordinator.items[-1].result is None
+    assert coordinator.live_work_count == coordinator._work_window == 1
+    assert coordinator._seed_entries is not None
+    assert not coordinator.shutdown.is_set()
+    assert coordinator._fatal is False
 
     snapshot = coordinator._observability_snapshot()
-    assert snapshot["admission_depth"] == coordinator._admission_spool_capacity
+    assert snapshot["admission_depth"] == 0
     assert snapshot["admission_capacity"] == coordinator._admission_spool_capacity
     coordinator._emit_observability_tick()
     assert coordinator._metrics_registry is not None
     rendered = coordinator._metrics_registry.render_prometheus()
-    assert (
-        f"hephaestus_pipeline_admission_depth {coordinator._admission_spool_capacity}" in rendered
-    )
+    assert "hephaestus_pipeline_admission_depth 0" in rendered
     assert (
         f"hephaestus_pipeline_admission_capacity {coordinator._admission_spool_capacity}"
         in rendered
     )
     records = [json.loads(line) for line in event_log.read_text().splitlines()]
-    saturation = next(record for record in records if record["event"] == "queue_saturated")
-    assert saturation["fields"][0]["queue"] == "admission"
-    assert saturation["fields"][0]["item"] == f"repo-a#{pushed + 1}"
+    assert not any(record["event"] == "queue_saturated" for record in records)
 
 
 def test_push_fallback_overflow_preserves_spool_and_journals_exact_boundary(
@@ -249,6 +232,7 @@ def test_push_fallback_overflow_preserves_spool_and_journals_exact_boundary(
         tmp_path,
         monkeypatch,
         event_log_path=event_log,
+        max_workers=2 + len(StageName),
         stage_queue_capacity=1,
     )
     queued = WorkItem(
@@ -297,7 +281,7 @@ def test_push_fallback_overflow_preserves_spool_and_journals_exact_boundary(
     }
 
 
-def test_product_burst_beyond_spool_bound_records_exact_recovery_boundary(
+def test_product_burst_respects_global_live_work_bound(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Discovery cannot retain products beyond the stage plus admission bounds."""
@@ -315,42 +299,20 @@ def test_product_burst_beyond_spool_bound_records_exact_recovery_boundary(
         for issue in range(1, burst_size + 1)
     ]
 
-    coordinator._seed_products(repo_item)
+    with pytest.raises(RuntimeError, match="RepoIssueSource"):
+        coordinator._seed_products(repo_item)
 
-    resident_capacity = 1 + coordinator._admission_spool_capacity
-    assert len(coordinator.queues[StageName.PLANNING]) == 1
-    assert len(coordinator._pending_admissions) == coordinator._admission_spool_capacity
-    # One additional item is retained as the exact rejected recovery receipt;
-    # the remaining source products are reconstructible by repo discovery and
-    # are not copied into another coordinator-owned backlog.
-    assert len(coordinator.items) == resident_capacity + 1
+    assert len(coordinator.queues[StageName.PLANNING]) == 0
+    assert len(coordinator._pending_admissions) == 0
+    assert len(coordinator.items) == 0
     assert len(coordinator.items) < burst_size
-    rejected = coordinator.items[-1]
-    assert rejected.issue == resident_capacity + 1
-    assert rejected.result is not None
-    assert "admission spool saturated" in rejected.result.reason
     assert "products" not in repo_item.payload
-    assert coordinator.shutdown.is_set()
-    assert coordinator._fatal is True
+    assert not coordinator.shutdown.is_set()
+    assert coordinator._fatal is False
 
     snapshot = coordinator._observability_snapshot()
-    assert snapshot["admission_depth"] == coordinator._admission_spool_capacity
-    records = [json.loads(line) for line in event_log.read_text().splitlines()]
-    saturation = next(record for record in records if record["event"] == "queue_saturated")
-    assert saturation["fields"][0] == {
-        "capacity": coordinator._admission_spool_capacity,
-        "details": {
-            "admission_depth": coordinator._admission_spool_capacity,
-            "blocked_stage": "planning",
-            "stage_capacity": 1,
-            "stage_depth": 1,
-        },
-        "fatal": True,
-        "item": f"repo-a#{resident_capacity + 1}",
-        "queue": "admission",
-        "rejections": 1,
-        "source": "planning_stage_queue_overflow",
-    }
+    assert snapshot["admission_depth"] == 0
+    assert not event_log.exists()
 
 
 def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
@@ -396,8 +358,7 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     )
     records = [json.loads(line) for line in event_log.read_text().splitlines()]
     deferred = [record for record in records if record["event"] == "queue_deferred"]
-    assert len(deferred) == 1
-    assert deferred[0]["fields"][1] == "repo-a#2"
+    assert deferred == []
     assert not any(record["event"] == "queue_saturated" for record in records)
 
     retry = Coordinator(
@@ -416,7 +377,7 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     assert all(item.result is not None and item.result.passed for item in retry.items)
 
 
-def test_c_plus_one_products_wait_for_stage_slots(
+def test_c_plus_one_products_stop_at_global_permit_bound(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Repo discovery products use the same resumable admission spool as seeds."""
@@ -427,17 +388,13 @@ def test_c_plus_one_products_wait_for_stage_slots(
         {"kind": "issue", "number": 2, "stage": StageName.PLANNING},
     ]
 
-    coordinator._seed_products(repo_item)
+    with pytest.raises(RuntimeError, match="RepoIssueSource"):
+        coordinator._seed_products(repo_item)
 
-    queued = coordinator.queues[StageName.PLANNING].snapshot()
-    assert [item.issue for item in queued] == [1]
-    assert [item.issue for item, _stage, _enter in coordinator._pending_admissions] == [2]
-    assert not coordinator.shutdown.is_set()
-
-    coordinator.queues[StageName.PLANNING].pop()
-    coordinator._drain_pending_admissions()
-    assert [item.issue for item in coordinator.queues[StageName.PLANNING].snapshot()] == [2]
+    assert not coordinator.queues[StageName.PLANNING].snapshot()
     assert not coordinator._pending_admissions
+    assert coordinator.live_work_count == 0
+    assert not coordinator.shutdown.is_set()
 
 
 def test_repeated_wakes_do_not_consume_completion_capacity(
@@ -460,11 +417,11 @@ def test_snapshot_exports_capacity_depth_and_rejection_totals(
 ) -> None:
     """Runtime observability exposes bounded depth and durable rejection counters."""
     base = _coordinator(tmp_path, monkeypatch, stage_queue_capacity=1)
-    config = replace(base.config, metrics_port=9123, stage_queue_capacity=1)
+    config = replace(base.config, metrics_port=9123, max_workers=2, stage_queue_capacity=1)
     coordinator = Coordinator(
         config,
         github=FakeStageGitHub(),
-        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+        pool=FakeWorkerPool(size=2, completion_q=CompletionQueue(capacity=2)),
         install_signals=False,
     )
     item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
@@ -531,10 +488,10 @@ class _OverflowingPool(FakeWorkerPool):
         return handle
 
 
-def test_completion_rejection_is_durable_and_terminates(
+def test_completion_rejection_is_durable_and_returns_non_signal_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A rejected worker result parks its exact item and ends without grace expiry."""
+    """A rejected worker result parks its exact item and returns 1, never 130."""
     event_log = tmp_path / "events.jsonl"
     pool = _OverflowingPool(
         size=1,
@@ -544,10 +501,12 @@ def test_completion_rejection_is_durable_and_terminates(
     coordinator.stages[StageName.PLANNING] = _JobRequestingStage()
 
     started = time.monotonic()
-    assert coordinator.run() == 1
+    exit_code = coordinator.run()
 
     assert time.monotonic() - started < 1.0
     assert coordinator._signal_received is False
+    assert exit_code == 1
+    assert exit_code != 130
     assert coordinator.in_flight == {}
     assert coordinator.items[0].result is not None
     assert coordinator.items[0].result.reason.startswith("resumable at planning")

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -150,10 +150,10 @@ def test_stage_burst_is_deferred_until_queue_drains(
     assert any(record["event"] == "queue_deferred" for record in records)
 
 
-def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bounded(
+def test_large_production_seed_source_allocates_only_with_available_permits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Production seeding stays lazy when a stalled stage reaches its admission bound."""
+    """A 10,000-entry production source retains an iterator, not a seed list."""
     event_log = tmp_path / "bounded-admission-events.jsonl"
     burst_size = 10_000
     repos = [f"repo-{index}" for index in range(1, burst_size + 1)]
@@ -187,7 +187,9 @@ def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bound
 
     assert coordinator._admission_spool_capacity == len(StageName)
     assert pushed == 1
-    # The global permit check happens before advancing the real generator.
+    # The global permit check happens before advancing the real generator, so
+    # neither the coordinator nor seed_from_cli materializes the remaining
+    # 9,999 SeedEntry instances.
     assert created_entries == 1
     assert created_entries < burst_size
     assert len(coordinator.queues[StageName.REPO]) == 1
@@ -204,7 +206,12 @@ def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bound
     assert len(coordinator.items) < burst_size
     assert coordinator.items[-1].result is None
     assert coordinator.live_work_count == coordinator._work_window == 1
-    assert coordinator._seed_entries is not None
+    remaining_entries = coordinator._seed_entries
+    assert remaining_entries is not None
+    assert iter(remaining_entries) is remaining_entries
+    second_entry = next(remaining_entries)
+    assert second_entry.identifier == "repo-2"
+    assert created_entries == 2
     assert not coordinator.shutdown.is_set()
     assert coordinator._fatal is False
 
@@ -226,8 +233,9 @@ def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bound
 def test_push_fallback_overflow_preserves_spool_and_journals_exact_boundary(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The bounded fallback refuses overflow without deque maxlen eviction."""
+    """A far-over-bound burst retains only the spool and exact recovery boundary."""
     event_log = tmp_path / "push-fallback-overflow.jsonl"
+    burst_size = 10_000
     coordinator = _coordinator(
         tmp_path,
         monkeypatch,
@@ -264,14 +272,47 @@ def test_push_fallback_overflow_preserves_spool_and_journals_exact_boundary(
 
     assert coordinator._push_item(boundary, StageName.PLANNING, enter=True) is False
 
+    # Once the exact saturation boundary is parked, a burst far beyond C+1 is
+    # refused before acquiring a permit or entering coordinator accounting.
+    # This proves the bounded spool cannot become an alternate unbounded queue.
+    for issue in range(boundary_issue + 1, burst_size + 1):
+        assert (
+            coordinator._push_item(
+                WorkItem(
+                    repo="repo-a",
+                    kind=ItemKind.ISSUE,
+                    issue=issue,
+                    stage=StageName.PLANNING,
+                ),
+                StageName.PLANNING,
+                enter=True,
+            )
+            is False
+        )
+
     assert list(coordinator._pending_admissions) == pending_before
     assert boundary.result is not None
     assert "admission spool saturated" in boundary.result.reason
-    receipt = next(
+    assert len(coordinator.items) == coordinator._admission_spool_capacity + 2
+    assert coordinator.live_work_count == coordinator._admission_spool_capacity + 1
+    resident_depth = sum(queue.occupancy for queue in coordinator.queues.values()) + len(
+        coordinator._pending_admissions
+    )
+    resident_capacity = sum(queue.capacity for queue in coordinator.queues.values()) + (
+        coordinator._admission_spool_capacity
+    )
+    assert resident_depth == coordinator._admission_spool_capacity + 1
+    assert resident_depth <= resident_capacity
+    snapshot = coordinator._observability_snapshot()
+    assert snapshot["admission_depth"] == coordinator._admission_spool_capacity
+    assert snapshot["admission_capacity"] == coordinator._admission_spool_capacity
+    receipts = [
         record
         for record in (json.loads(line) for line in event_log.read_text().splitlines())
         if record["event"] == "queue_saturated"
-    )
+    ]
+    assert len(receipts) == 1
+    receipt = receipts[0]
     assert receipt["fields"][0]["item"] == f"repo-a#{boundary_issue}"
     assert receipt["fields"][0]["details"] == {
         "admission_depth": coordinator._admission_spool_capacity,

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -18,7 +18,7 @@ from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.stages.base import JobRequest
-from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -504,6 +504,28 @@ def test_completed_issue_payload_retention_stays_bounded_by_work_window(
     assert not hasattr(coordinator, "_terminal_pr_keys")
     gc.collect()
     assert all(payload_ref() is None for payload_ref in payload_refs)
+
+
+def test_fail_then_pass_reseed_uses_latest_terminal_disposition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A passing reseed replaces an earlier failed logical attempt."""
+    coordinator = _coordinator(tmp_path, monkeypatch)
+    failed = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=42, stage=StageName.PLANNING)
+    failed.result = ItemResult(
+        passed=False, reason="first attempt failed", final_stage=StageName.PLANNING
+    )
+    passed = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=42, stage=StageName.FINISHED)
+    passed.result = ItemResult(passed=True, reason="reseed passed", final_stage=StageName.FINISHED)
+
+    coordinator._seen_item_ids.update((id(failed), id(passed)))
+    coordinator.items.extend((failed, passed))
+    coordinator._record_terminal_summary(failed)
+    coordinator._record_terminal_summary(passed)
+
+    assert coordinator._terminal_item_count == 1
+    assert coordinator._terminal_dispositions == {"pass": 1}
+    assert coordinator._exit_code() == 0
 
 
 def test_c_plus_one_products_stop_at_global_permit_bound(

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -428,14 +428,16 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
 def test_completed_issue_payload_retention_stays_bounded_by_work_window(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Completing more than C issues retains summaries, not full WorkItems."""
+    """Completing more than C issues retains bounded terminal rows, not payloads."""
     issue_count = 5
+    terminal_capacity = 2
     config = PipelineConfig(
         org="org",
         repos=["repo-a"],
         max_workers=1,
         parallel_repos=1,
         stage_queue_capacity=1,
+        terminal_retention_capacity=terminal_capacity,
         projects_dir=tmp_path,
     )
     monkeypatch.setattr(
@@ -488,12 +490,18 @@ def test_completed_issue_payload_retention_stays_bounded_by_work_window(
     assert issue_count > coordinator._work_window
     assert max(observed_live_counts) <= coordinator._work_window
     assert coordinator.items == []
-    assert len(coordinator.item_summaries) == issue_count
-    assert len(coordinator.ledger) == issue_count
-    assert [item.issue for item in coordinator._effective_items()] == list(
-        range(1, issue_count + 1)
+    assert coordinator._terminal_item_count == issue_count
+    assert coordinator._terminal_dispositions == {"pass": issue_count}
+    assert len(coordinator.item_summaries) <= terminal_capacity
+    assert len(coordinator.ledger) <= terminal_capacity
+    assert len(coordinator.preserved) <= terminal_capacity
+    assert (
+        len(coordinator.item_summaries) + len(coordinator.ledger) + len(coordinator.preserved)
+        <= terminal_capacity * 3
     )
+    assert [item.issue for item in coordinator._effective_items()] == [4, 5]
     assert all(not hasattr(item, "payload") for item in coordinator.item_summaries)
+    assert not hasattr(coordinator, "_terminal_pr_keys")
     gc.collect()
     assert all(payload_ref() is None for payload_ref in payload_refs)
 

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -69,6 +69,7 @@ def _coordinator(
     max_workers: int = 1,
     parallel_repos: int = 1,
     stage_queue_capacity: int | None = None,
+    terminal_retention_capacity: int | None = None,
 ) -> Coordinator:
     """Build a coordinator with an explicitly matched bounded worker channel."""
     capacity = max(1, max_workers * parallel_repos)
@@ -82,6 +83,8 @@ def _coordinator(
     )
     if stage_queue_capacity is not None:
         config = replace(config, stage_queue_capacity=stage_queue_capacity)
+    if terminal_retention_capacity is not None:
+        config = replace(config, terminal_retention_capacity=terminal_retention_capacity)
     if pool is None:
         pool = FakeWorkerPool(size=capacity, completion_q=CompletionQueue(capacity=capacity))
     monkeypatch.setattr(
@@ -526,6 +529,25 @@ def test_fail_then_pass_reseed_uses_latest_terminal_disposition(
     assert coordinator._terminal_item_count == 1
     assert coordinator._terminal_dispositions == {"pass": 1}
     assert coordinator._exit_code() == 0
+
+
+def test_terminal_latest_cache_is_bounded_by_retention_capacity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Completed logical items cannot grow the attempt-reconciliation cache."""
+    capacity = 3
+    coordinator = _coordinator(
+        tmp_path,
+        monkeypatch,
+        terminal_retention_capacity=capacity,
+    )
+
+    for issue in range(capacity * 4):
+        item = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=StageName.FINISHED)
+        item.result = ItemResult(passed=True, reason="done", final_stage=StageName.FINISHED)
+        coordinator._record_terminal_summary(item)
+
+    assert len(coordinator._terminal_latest) == capacity
 
 
 def test_c_plus_one_products_stop_at_global_permit_bound(

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import gc
 import json
 import time
+import weakref
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -389,14 +391,16 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     coordinator.stages[StageName.PLANNING] = _RecoveringStage()
 
     assert coordinator.run() == 0
-    assert [item.issue for item in coordinator.items] == [1, 2]
-    assert len(coordinator.items) == 2
+    summaries = coordinator._effective_items()
+    assert [item.issue for item in summaries] == [1, 2]
+    assert coordinator.items == []
+    assert len(coordinator.items) <= coordinator._work_window
+    assert len(coordinator.item_summaries) == 2
     assert len(coordinator.ledger) == 2
     assert not coordinator._pending_admissions
-    assert all(item.result is not None and item.result.passed for item in coordinator.items)
-    assert all(
-        item.payload["entry_stage"] == StageName.PLANNING.value for item in coordinator.items
-    )
+    assert all(item.result is not None and item.result.passed for item in summaries)
+    assert all(item.entry_stage == StageName.PLANNING.value for item in coordinator.item_summaries)
+    assert all(not hasattr(item, "payload") for item in coordinator.item_summaries)
     records = [json.loads(line) for line in event_log.read_text().splitlines()]
     deferred = [record for record in records if record["event"] == "queue_deferred"]
     assert deferred == []
@@ -411,11 +415,87 @@ def test_c_plus_one_seed_drains_and_recovery_reuses_the_same_seed(
     retry.stages[StageName.PLANNING] = _RecoveringStage()
 
     assert retry.run() == 0
-    assert [item.issue for item in retry.items] == [1, 2]
-    assert len(retry.items) == 2
+    retry_summaries = retry._effective_items()
+    assert [item.issue for item in retry_summaries] == [1, 2]
+    assert retry.items == []
+    assert len(retry.items) <= retry._work_window
+    assert len(retry.item_summaries) == 2
     assert len(retry.ledger) == 2
     assert not retry._pending_admissions
-    assert all(item.result is not None and item.result.passed for item in retry.items)
+    assert all(item.result is not None and item.result.passed for item in retry_summaries)
+
+
+def test_completed_issue_payload_retention_stays_bounded_by_work_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Completing more than C issues retains summaries, not full WorkItems."""
+    issue_count = 5
+    config = PipelineConfig(
+        org="org",
+        repos=["repo-a"],
+        max_workers=1,
+        parallel_repos=1,
+        stage_queue_capacity=1,
+        projects_dir=tmp_path,
+    )
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_from_cli",
+        lambda repos, issues, prs: (
+            seeding_mod.SeedEntry(
+                kind="issue",
+                identifier=issue,
+                stage=StageName.PLANNING,
+                reason="seed",
+            )
+            for issue in range(1, issue_count + 1)
+        ),
+    )
+    coordinator = Coordinator(
+        config,
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(size=1, completion_q=CompletionQueue(capacity=1)),
+        install_signals=False,
+    )
+    observed_live_counts: list[int] = []
+
+    class _IssuePayload:
+        """Weak-referenceable stand-in for a large GitHub issue payload."""
+
+        def __init__(self) -> None:
+            self.body = "payload" * 10_000
+
+    payload_refs: list[weakref.ReferenceType[_IssuePayload]] = []
+
+    class PayloadStage:
+        """Attach a representative large payload, then complete immediately."""
+
+        def on_enter(self, item: WorkItem, ctx: Any) -> None:
+            payload = _IssuePayload()
+            payload_refs.append(weakref.ref(payload))
+            item.payload["issue_body"] = payload
+
+        def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+            observed_live_counts.append(len(coordinator.items))
+            return StageOutcome(Disposition.FINISH_PASS, "done")
+
+        def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+            """No jobs are submitted by this stage."""
+
+    coordinator.stages[StageName.PLANNING] = PayloadStage()
+
+    assert coordinator.run() == 0
+    assert issue_count > coordinator._work_window
+    assert max(observed_live_counts) <= coordinator._work_window
+    assert coordinator.items == []
+    assert len(coordinator.item_summaries) == issue_count
+    assert len(coordinator.ledger) == issue_count
+    assert [item.issue for item in coordinator._effective_items()] == list(
+        range(1, issue_count + 1)
+    )
+    assert all(not hasattr(item, "payload") for item in coordinator.item_summaries)
+    gc.collect()
+    assert all(payload_ref() is None for payload_ref in payload_refs)
 
 
 def test_c_plus_one_products_stop_at_global_permit_bound(
@@ -576,8 +656,8 @@ def test_completion_rejection_recovers_from_the_same_seed(
     second.stages[StageName.PLANNING] = _RecoveringStage()
 
     assert second.run() == 0
-    assert second.items[0].result is not None
-    assert second.items[0].result.passed is True
+    assert second.items == []
+    assert second.item_summaries[0].result.passed is True
 
 
 def test_completion_saturation_blocks_follow_on_submission_from_accepted_result(

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Iterator
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -155,18 +156,27 @@ def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bound
     """A stalled stage cannot move an arbitrary source burst into coordinator memory."""
     event_log = tmp_path / "bounded-admission-events.jsonl"
     burst_size = 10_000
-    monkeypatch.setattr(
-        seeding_mod,
-        "seed_from_cli",
-        lambda repos, issues, prs: [
-            seeding_mod.SeedEntry(
+    produced = 0
+
+    def stream_seed_entries(
+        repos: list[str], issues: list[int], prs: list[int]
+    ) -> Iterator[seeding_mod.SeedEntry]:
+        """Yield a large source lazily and expose how far admission reads it."""
+        del repos, issues, prs
+        nonlocal produced
+        for issue in range(1, burst_size + 1):
+            produced += 1
+            yield seeding_mod.SeedEntry(
                 kind="issue",
                 identifier=issue,
                 stage=StageName.PLANNING,
                 reason="burst seed",
             )
-            for issue in range(1, burst_size + 1)
-        ],
+
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_from_cli",
+        stream_seed_entries,
     )
     coordinator = Coordinator(
         PipelineConfig(
@@ -188,6 +198,10 @@ def test_stage_burst_beyond_spool_bound_is_durable_and_resident_work_stays_bound
 
     assert coordinator._admission_spool_capacity == len(StageName)
     assert pushed == 1 + coordinator._admission_spool_capacity
+    # The source is lazy: only the admitted batch and exact saturation receipt
+    # are materialized, rather than all 10,000 SeedEntry objects.
+    assert produced == pushed + 1
+    assert produced < burst_size
     assert len(coordinator.queues[StageName.PLANNING]) == 1
     assert len(coordinator._pending_admissions) == coordinator._admission_spool_capacity
     resident_depth = sum(len(queue) for queue in coordinator.queues.values()) + len(

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -188,8 +188,9 @@ def test_repo_source_is_lossless_and_ordered_at_capacity_one(
     """C+1 discovered issues classify only as capacity becomes available."""
     events: list[tuple[str, int]] = []
     metadata = [
-        {"number": 101, "labels": ["state:needs-plan"], "title": "first"},
-        {"number": 102, "labels": ["state:needs-plan"], "title": "second"},
+        {"number": 1, "labels": ["state:needs-plan"], "title": "first"},
+        {"number": 2, "labels": ["state:needs-plan"], "title": "second"},
+        {"number": 1, "labels": ["state:needs-plan"], "title": "duplicate"},
     ]
 
     monkeypatch.setattr(
@@ -221,14 +222,92 @@ def test_repo_source_is_lossless_and_ordered_at_capacity_one(
 
     assert coordinator.run() == 0
     assert events == [
-        ("classify", 101),
-        ("complete", 101),
-        ("classify", 102),
-        ("complete", 102),
+        ("classify", 1),
+        ("complete", 1),
+        ("classify", 2),
+        ("complete", 2),
     ]
+    assert Counter(issue for event, issue in events if event == "classify") == Counter({1: 1, 2: 1})
+    assert Counter(issue for event, issue in events if event == "complete") == Counter({1: 1, 2: 1})
     issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
-    assert [item.issue for item in issues] == [101, 102]
+    assert [item.issue for item in issues] == [1, 2]
     assert all(item.result is not None and item.result.passed for item in issues)
+
+
+def test_active_cursor_reserves_progress_before_next_repo_setup_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A C=1 cursor cannot be deadlocked by the next repo setup permit."""
+    events: list[tuple[str, int]] = []
+    metadata = {
+        "repo-a": iter(
+            [
+                {"number": 1, "labels": ["epic"], "title": "Epic"},
+                {"number": 2, "labels": ["state:needs-plan"], "title": "actionable"},
+            ]
+        ),
+        "repo-b": iter(()),
+    }
+    monkeypatch.setattr(
+        loop_repo_manager,
+        "_iter_open_issue_meta",
+        lambda _org, repo: metadata[repo],
+    )
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_issue_from_github",
+        lambda issue, github: _facts(issue),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a", "repo-b"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            stage_queue_capacity=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator._seed_pass() == 1
+    coordinator._drain_queues()
+    assert [active.repo for active in coordinator._repo_issue_sources] == ["repo-a"]
+    assert coordinator.repo_source_owner_count == 1
+    assert coordinator.live_work_count == 0
+
+    # The first row is an excluded epic, so A has not consumed a work permit.
+    # B must nevertheless remain in the lazy seed iterator: admitting it here
+    # would recreate B-permit -> A-cursor -> B-cursor at C=1.
+    coordinator._drain_repo_issue_sources()
+    assert coordinator.live_work_count == 0
+    assert coordinator._drain_seed_entries() == 0
+    assert coordinator.repo_source_owner_count == 1
+    assert not coordinator.queues[StageName.REPO].snapshot()
+
+    # A can now classify its next row and acquire the still-free permit.
+    coordinator._drain_repo_issue_sources()
+    planning = coordinator.queues[StageName.PLANNING].snapshot()
+    assert [item.issue for item in planning] == [2]
+    assert coordinator.live_work_count == 1
+
+    # Once A's work completes and its source exhausts, the same source slot
+    # transfers to B; reserving progress does not starve later repositories.
+    coordinator._drain_queues()
+    coordinator._drain_queues()
+    assert events == [("complete", 2)]
+    assert coordinator.live_work_count == 0
+    coordinator._drain_repo_issue_sources()
+    assert not coordinator._repo_issue_sources
+    assert coordinator._drain_seed_entries() == 1
+    repo_items = coordinator.queues[StageName.REPO].snapshot()
+    assert [item.repo for item in repo_items] == ["repo-b"]
+    assert coordinator.repo_source_owner_count == 1
 
 
 def test_repo_source_deduplicates_metadata_after_completed_work_at_capacity_one(

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from hephaestus.automation import loop_repo_manager
+from hephaestus.automation import loop_repo_manager, pr_discovery
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
-from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.routing import (
+    PIPELINE_ORDER,
+    Disposition,
+    StageName,
+    StageOutcome,
+)
 from hephaestus.automation.pipeline.seeding import IssueFacts
 from hephaestus.automation.pipeline.stages.repo import RepoStage
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
@@ -32,6 +38,26 @@ class _ImmediatePassStage:
         assert item.issue is not None
         self._events.append(("complete", item.issue))
         return StageOutcome(Disposition.FINISH_PASS, f"completed #{item.issue}")
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        del item, result, ctx
+        raise AssertionError("source-pull test must not submit a worker job")
+
+
+class _ImmediatePrPassStage:
+    """Finish PR review synchronously so bounded PR admission is observable."""
+
+    def __init__(self, events: list[int]) -> None:
+        self._events = events
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del ctx
+        assert item.pr is not None
+        self._events.append(item.pr)
+        return StageOutcome(Disposition.FINISH_PASS, f"reviewed PR #{item.pr}")
 
     def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
         del item, result, ctx
@@ -89,7 +115,7 @@ def test_large_repo_discovery_retains_only_page_cursor_and_one_pending_row(
 
     # Fill every possible downstream stage and the bounded spool so the
     # cursor can retain only one not-yet-classified metadata row.
-    for stage in StageName:
+    for stage in PIPELINE_ORDER:
         if stage is StageName.REPO:
             continue
         blocker = WorkItem(repo="block", kind=ItemKind.REPO, stage=stage)
@@ -207,6 +233,97 @@ def test_repo_source_deduplicates_metadata_after_completed_work_at_capacity_one(
         ("classify", 2),
         ("complete", 2),
     ]
+    assert Counter(events) == Counter(
+        {
+            ("classify", 1): 1,
+            ("complete", 1): 1,
+            ("classify", 2): 1,
+            ("complete", 2): 1,
+        }
+    )
     issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
     assert [item.issue for item in issues] == [1, 2]
     assert all(item.result is not None and item.result.passed for item in issues)
+
+
+def test_drive_green_pr_source_is_filtered_lossless_and_capacity_controlled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Eligible linked PRs stream after issues and drain through a C=1 window."""
+    produced: list[int] = []
+    reviewed: list[int] = []
+    pulls: list[dict[str, Any]] = [
+        {
+            "number": 31,
+            "state": "OPEN",
+            "isDraft": False,
+            "user": {"login": "alice", "type": "User"},
+        },
+        {
+            "number": 32,
+            "state": "OPEN",
+            "isDraft": False,
+            "user": {"login": "alice", "type": "User"},
+        },
+        {
+            "number": 33,
+            "state": "OPEN",
+            "isDraft": False,
+            "user": {"login": "bob", "type": "User"},
+        },
+        {
+            "number": 34,
+            "state": "OPEN",
+            "isDraft": False,
+            "user": {"login": "alice", "type": "Bot"},
+        },
+        {
+            "number": 35,
+            "state": "OPEN",
+            "isDraft": True,
+            "user": {"login": "alice", "type": "User"},
+        },
+    ]
+
+    def pull_source(_org: str, _repo: str):
+        for pull in pulls:
+            produced.append(int(pull["number"]))
+            yield pull
+
+    monkeypatch.setattr(loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(()))
+    monkeypatch.setattr(loop_repo_manager, "_iter_open_pr_meta", pull_source)
+    monkeypatch.setattr(pr_discovery, "_resolve_viewer_login", lambda: "alice")
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_issue_from_github",
+        lambda issue, github: _facts(issue),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            stage_queue_capacity=1,
+            drive_green_all=True,
+            include_all_authors=False,
+            include_bot_prs=False,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(pr_issue=901),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PR_REVIEW] = _ImmediatePrPassStage(reviewed)
+
+    assert coordinator.run() == 0
+
+    assert produced == [31, 32, 33, 34, 35]
+    assert reviewed == [31, 32]
+    prs = [item for item in coordinator.items if item.kind is ItemKind.PR]
+    assert [item.pr for item in prs] == [31, 32]
+    assert all(item.issue == 901 for item in prs)
+    assert all(item.result is not None and item.result.passed for item in prs)
+    assert not coordinator._repo_issue_sources

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -161,3 +161,52 @@ def test_repo_source_is_lossless_and_ordered_at_capacity_one(
     issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
     assert [item.issue for item in issues] == [101, 102]
     assert all(item.result is not None and item.result.passed for item in issues)
+
+
+def test_repo_source_deduplicates_metadata_after_completed_work_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A repeated source row cannot re-run after its first item finishes."""
+    events: list[tuple[str, int]] = []
+    metadata = [
+        {"number": 1, "labels": ["state:needs-plan"], "title": "first"},
+        {"number": 2, "labels": ["state:needs-plan"], "title": "second"},
+        {"number": 1, "labels": ["state:needs-plan"], "title": "duplicate"},
+    ]
+    monkeypatch.setattr(
+        loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(metadata)
+    )
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            stage_queue_capacity=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+    assert events == [
+        ("classify", 1),
+        ("complete", 1),
+        ("classify", 2),
+        ("complete", 2),
+    ]
+    issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
+    assert [item.issue for item in issues] == [1, 2]
+    assert all(item.result is not None and item.result.passed for item in issues)

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -229,7 +229,7 @@ def test_repo_source_is_lossless_and_ordered_at_capacity_one(
     ]
     assert Counter(issue for event, issue in events if event == "classify") == Counter({1: 1, 2: 1})
     assert Counter(issue for event, issue in events if event == "complete") == Counter({1: 1, 2: 1})
-    issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
+    issues = [item for item in coordinator._effective_items() if item.kind is ItemKind.ISSUE]
     assert [item.issue for item in issues] == [1, 2]
     assert all(item.result is not None and item.result.passed for item in issues)
 
@@ -356,7 +356,7 @@ def test_repo_source_deduplicates_metadata_after_completed_work_at_capacity_one(
     ]
     assert Counter(issue for event, issue in events if event == "classify") == Counter({1: 1, 2: 1})
     assert Counter(issue for event, issue in events if event == "complete") == Counter({1: 1, 2: 1})
-    issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
+    issues = [item for item in coordinator._effective_items() if item.kind is ItemKind.ISSUE]
     assert [item.issue for item in issues] == [1, 2]
     assert all(item.result is not None and item.result.passed for item in issues)
 
@@ -437,7 +437,7 @@ def test_drive_green_pr_source_is_filtered_lossless_and_capacity_controlled(
 
     assert produced == [31, 32, 33, 34, 35]
     assert reviewed == [31, 32]
-    prs = [item for item in coordinator.items if item.kind is ItemKind.PR]
+    prs = [item for item in coordinator.item_summaries if item.kind is ItemKind.PR]
     assert [item.pr for item in prs] == [31, 32]
     assert all(item.issue == 901 for item in prs)
     assert all(item.result is not None and item.result.passed for item in prs)

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -1,0 +1,163 @@
+"""Repository-discovery source-pull regression coverage for bounded queues."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation import loop_repo_manager
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.stages.repo import RepoStage
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _ImmediatePassStage:
+    """Finish planning synchronously so admission order is observable."""
+
+    def __init__(self, events: list[tuple[str, int]]) -> None:
+        self._events = events
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del ctx
+        assert item.issue is not None
+        self._events.append(("complete", item.issue))
+        return StageOutcome(Disposition.FINISH_PASS, f"completed #{item.issue}")
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        del item, result, ctx
+        raise AssertionError("source-pull test must not submit a worker job")
+
+
+def _facts(issue: int) -> IssueFacts:
+    """Return one eligible planning-entry issue classification."""
+    return IssueFacts(
+        number=issue,
+        title=f"Issue {issue}",
+        body="",
+        is_epic=False,
+        labels={"state:needs-plan"},
+        pr_number=None,
+        pr_is_open=False,
+        pr_is_merged=False,
+    )
+
+
+def test_large_repo_discovery_retains_only_page_cursor_and_one_pending_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ten thousand issues never become a products list or resident WorkItems."""
+    produced = 0
+
+    def metadata_source(_org: str, _repo: str):
+        nonlocal produced
+        for issue in range(1, 10_001):
+            produced += 1
+            yield {"number": issue, "labels": ["state:needs-plan"], "title": f"Issue {issue}"}
+
+    monkeypatch.setattr(loop_repo_manager, "_iter_open_issue_meta", metadata_source)
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            stage_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    repo_item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO, state="DISCOVER")
+    ctx = coordinator._ctx_for_repo("repo-a")
+
+    result = RepoStage().step(repo_item, ctx)
+    repo_item.state = result.next_state  # type: ignore[union-attr]
+    source = repo_item.payload["_repo_issue_source"]
+    assert coordinator._externalize_repo_issue_source(repo_item, source)
+
+    # Fill every possible downstream stage and the bounded spool so the
+    # cursor can retain only one not-yet-classified metadata row.
+    for stage in StageName:
+        if stage is StageName.REPO:
+            continue
+        blocker = WorkItem(repo="block", kind=ItemKind.REPO, stage=stage)
+        assert coordinator.queues[stage].offer(blocker)
+    for _index in range(coordinator._admission_spool_capacity):
+        coordinator._pending_admissions.append(
+            (
+                WorkItem(repo="pending", kind=ItemKind.REPO),
+                StageName.PLANNING,
+                True,
+            )
+        )
+
+    coordinator._drain_repo_issue_sources()
+
+    assert produced == 1
+    assert len(coordinator._repo_issue_sources) == 1
+    active = coordinator._repo_issue_sources[0]
+    assert active.source.pending is not None
+    assert active.source.pending["number"] == 1
+    assert "products" not in repo_item.payload
+    assert not [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
+
+
+def test_repo_source_is_lossless_and_ordered_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C+1 discovered issues classify only as capacity becomes available."""
+    events: list[tuple[str, int]] = []
+    metadata = [
+        {"number": 101, "labels": ["state:needs-plan"], "title": "first"},
+        {"number": 102, "labels": ["state:needs-plan"], "title": "second"},
+    ]
+
+    monkeypatch.setattr(
+        loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(metadata)
+    )
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            stage_queue_capacity=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+    assert events == [
+        ("classify", 101),
+        ("complete", 101),
+        ("classify", 102),
+        ("complete", 102),
+    ]
+    issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
+    assert [item.issue for item in issues] == [101, 102]
+    assert all(item.result is not None and item.result.passed for item in issues)

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -10,7 +10,11 @@ import pytest
 
 from hephaestus.automation import loop_repo_manager, pr_discovery
 from hephaestus.automation.pipeline import seeding as seeding_mod
-from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.coordinator import (
+    Coordinator,
+    PipelineConfig,
+    _ActiveRepoIssueSource,
+)
 from hephaestus.automation.pipeline.routing import (
     PIPELINE_ORDER,
     Disposition,
@@ -18,7 +22,7 @@ from hephaestus.automation.pipeline.routing import (
     StageOutcome,
 )
 from hephaestus.automation.pipeline.seeding import IssueFacts
-from hephaestus.automation.pipeline.stages.repo import RepoStage
+from hephaestus.automation.pipeline.stages.repo import RepoIssueSource, RepoStage
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
@@ -140,6 +144,44 @@ def test_large_repo_discovery_retains_only_page_cursor_and_one_pending_row(
     assert not [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
 
 
+def test_repo_source_drain_stops_after_admission_saturation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Later cursors retain metadata when an earlier cursor saturates admission."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a", "repo-b"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    first = _ActiveRepoIssueSource("repo-a", RepoIssueSource(iter(()), pending={"number": 1}))
+    second_metadata = {"number": 2, "labels": ["state:needs-plan"], "title": "pending"}
+    second = _ActiveRepoIssueSource("repo-b", RepoIssueSource(iter(()), pending=second_metadata))
+    coordinator._repo_issue_sources.extend((first, second))
+    drained: list[str] = []
+
+    def drain(active: _ActiveRepoIssueSource) -> bool:
+        drained.append(active.repo)
+        coordinator._admission_saturated = True
+        coordinator._begin_graceful_shutdown("test admission saturation")
+        return True
+
+    monkeypatch.setattr(coordinator, "_drain_repo_issue_source", drain)
+
+    coordinator._drain_repo_issue_sources()
+
+    assert drained == ["repo-a"]
+    assert list(coordinator._repo_issue_sources) == [second, first]
+    assert second.source.pending is second_metadata
+
+
 def test_repo_source_is_lossless_and_ordered_at_capacity_one(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -233,14 +275,8 @@ def test_repo_source_deduplicates_metadata_after_completed_work_at_capacity_one(
         ("classify", 2),
         ("complete", 2),
     ]
-    assert Counter(events) == Counter(
-        {
-            ("classify", 1): 1,
-            ("complete", 1): 1,
-            ("classify", 2): 1,
-            ("complete", 2): 1,
-        }
-    )
+    assert Counter(issue for event, issue in events if event == "classify") == Counter({1: 1, 2: 1})
+    assert Counter(issue for event, issue in events if event == "complete") == Counter({1: 1, 2: 1})
     issues = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
     assert [item.issue for item in issues] == [1, 2]
     assert all(item.result is not None and item.result.passed for item in issues)

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -491,6 +491,8 @@ class TestFatalTeardown:
 
         def seed_then_immediate() -> int:
             pushed = original_seed()
+            coordinator._signal_received = True
+            coordinator.shutdown.set()
             coordinator._immediate = True
             return pushed
 
@@ -1355,6 +1357,47 @@ class TestDurableEventLog:
         assert records[-1]["event"] == "push"
         assert records[-1]["fields"] == ["planning", "repo-a#44"]
         assert coordinator.event_log[-1] == ("push", "planning", "repo-a#44")
+
+    def test_event_log_retains_only_configured_recent_events(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The in-memory diagnostic event view cannot grow for a long-lived run."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        config = replace(coordinator.config, event_log_capacity=2)
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(
+                size=2,
+                completion_q=CompletionQueue(capacity=2),
+            ),
+            install_signals=False,
+        )
+
+        for index in range(3):
+            coordinator._record_event("test", index)
+
+        assert coordinator.event_log.maxlen == 2
+        assert list(coordinator.event_log) == [("test", 1), ("test", 2)]
+
+    @pytest.mark.parametrize("capacity", [0, -1])
+    def test_event_log_rejects_non_positive_capacity(self, tmp_path: Path, capacity: int) -> None:
+        """A coordinator needs a positive in-memory diagnostic retention bound."""
+        with pytest.raises(ValueError, match="event log capacity must be positive"):
+            Coordinator(
+                PipelineConfig(
+                    org="org",
+                    repos=["repo-a"],
+                    projects_dir=tmp_path,
+                    event_log_capacity=capacity,
+                ),
+                github=FakeStageGitHub(),
+                pool=FakeWorkerPool(
+                    size=1,
+                    completion_q=CompletionQueue(capacity=1),
+                ),
+                install_signals=False,
+            )
 
     def test_zero_thread_nogo_event_is_durable_and_bounded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -13,7 +13,7 @@ import json
 import logging
 from collections import deque
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -31,6 +31,7 @@ from hephaestus.automation.pipeline.events import (
     ZeroThreadNogoAction,
 )
 from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import (
     Disposition,
     PipelineScope,
@@ -108,12 +109,17 @@ def make_coordinator(
         repos=repos if repos is not None else ["repo-a"],
         loops=loops,
         max_workers=max_workers,
+        parallel_repos=2,
         dry_run=dry_run,
         serialize_file_overlap=serialize_file_overlap,
         projects_dir=tmp_path,
     )
     gh = github or FakeStageGitHub()
-    pool = FakeWorkerPool()
+    work_window = max(1, config.parallel_repos * config.max_workers)
+    pool = FakeWorkerPool(
+        size=work_window,
+        completion_q=CompletionQueue(capacity=work_window),
+    )
     passes = deque(seed_entries or [[]])
 
     def fake_seed(repos_arg: Any, issues_arg: Any, prs_arg: Any) -> list[SeedEntry]:
@@ -1790,8 +1796,13 @@ class TestPipelineScopeWiring:
             "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
             fake_filter,
         )
-        config = self._scoped_config(tmp_path, issues=[1, 2, 3])
-        coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
+        config = replace(self._scoped_config(tmp_path, issues=[1, 2, 3]), parallel_repos=2)
+        coordinator = Coordinator(
+            config,
+            github=gh,
+            pool=FakeWorkerPool(size=2, completion_q=CompletionQueue(capacity=2)),
+            install_signals=False,
+        )
 
         assert coordinator._seed_pass() == 2
         assert [item.issue for item in coordinator.items] == [1, 3]

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -211,8 +211,10 @@ class TestQuiescence:
         )
 
         assert coordinator.run() == 0
-        assert [item.issue for item in coordinator.items] == [1850]
-        assert all(item.kind is not ItemKind.REPO for item in coordinator.items)
+        effective_items = coordinator._effective_items()
+        assert [item.issue for item in effective_items] == [1850]
+        assert coordinator.items == []
+        assert all(item.kind is not ItemKind.REPO for item in effective_items)
 
     def test_repo_products_flow_to_finished(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1944,7 +1946,7 @@ class TestPipelineScopeWiring:
         assert result.passed
         assert result.final_stage is StageName.FINISHED
         # The item never entered an out-of-scope IMPLEMENTATION stage.
-        assert all(item.stage is StageName.FINISHED for item in coordinator.items)
+        assert all(item.stage is StageName.FINISHED for item in coordinator._effective_items())
 
     def test_force_reroutes_plan_go_issue_to_planning(self, tmp_path: Path) -> None:
         """--force re-routes an at-or-past-plan-go issue back to the scope's first stage."""

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -31,7 +31,7 @@ from hephaestus.automation.pipeline.events import (
     ZeroThreadNogoAction,
 )
 from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobHandle, JobResult
-from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue
 from hephaestus.automation.pipeline.routing import (
     Disposition,
     PipelineScope,
@@ -553,7 +553,7 @@ class TestDrainOrder:
 
     def test_downstream_first(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """merge_wait drains before review, planning, and repo."""
-        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
         for stage in (
             StageName.PLANNING,
             StageName.MERGE_WAIT,
@@ -576,6 +576,36 @@ class TestDrainOrder:
         assert drained.index("merge_wait") < drained.index("pr_review")
         assert drained.index("pr_review") < drained.index("planning")
         assert drained.index("planning") < drained.index("repo")
+
+    def test_full_destination_retains_source_lease_until_handoff(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed action stays source-owned until its target has capacity."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            StageOutcome(Disposition.ADVANCE, "planned")
+        )
+        coordinator.queues[StageName.PLAN_REVIEW] = StageQueue(capacity=1)
+        source = _issue_item(1, StageName.PLANNING)
+        blocker = _issue_item(2, StageName.PLAN_REVIEW)
+        assert coordinator._push_item(source, StageName.PLANNING, enter=True)
+        coordinator.queues[StageName.PLAN_REVIEW].push(blocker)
+
+        claimed = coordinator._claim_item(StageName.PLANNING)
+        assert claimed is source
+        coordinator._run_item(source)
+
+        assert coordinator.queues[StageName.PLANNING].occupancy == 1
+        assert coordinator.queues[StageName.PLAN_REVIEW].snapshot() == [blocker]
+        assert coordinator._pending_handoffs[id(source)].target is StageName.PLAN_REVIEW
+
+        assert coordinator.queues[StageName.PLAN_REVIEW].pop() is blocker
+        coordinator._drain_pending_handoffs()
+
+        assert coordinator.queues[StageName.PLANNING].occupancy == 0
+        assert coordinator.queues[StageName.PLAN_REVIEW].snapshot() == [source]
+        assert id(source) not in coordinator._leases
+        assert id(source) not in coordinator._pending_handoffs
 
 
 class TestAdmission:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -599,7 +599,8 @@ class TestDrainOrder:
         assert coordinator.queues[StageName.PLAN_REVIEW].snapshot() == [blocker]
         assert coordinator._pending_handoffs[id(source)].target is StageName.PLAN_REVIEW
 
-        assert coordinator.queues[StageName.PLAN_REVIEW].pop() is blocker
+        released = coordinator.queues[StageName.PLAN_REVIEW].pop()
+        assert released is blocker
         coordinator._drain_pending_handoffs()
 
         assert coordinator.queues[StageName.PLANNING].occupancy == 0
@@ -1391,9 +1392,14 @@ class TestDurableEventLog:
     def test_event_log_retains_only_configured_recent_events(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The in-memory diagnostic event view cannot grow for a long-lived run."""
+        """Memory stays bounded while the durable JSONL history stays complete."""
         coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
-        config = replace(coordinator.config, event_log_capacity=2)
+        event_log_path = tmp_path / "bounded-events.jsonl"
+        config = replace(
+            coordinator.config,
+            event_log_capacity=2,
+            event_log_path=event_log_path,
+        )
         coordinator = Coordinator(
             config,
             github=FakeStageGitHub(),
@@ -1409,6 +1415,8 @@ class TestDurableEventLog:
 
         assert coordinator.event_log.maxlen == 2
         assert list(coordinator.event_log) == [("test", 1), ("test", 2)]
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        assert [record["fields"] for record in records] == [[0], [1], [2]]
 
     @pytest.mark.parametrize("capacity", [0, -1])
     def test_event_log_rejects_non_positive_capacity(self, tmp_path: Path, capacity: int) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -385,7 +385,7 @@ class TestQuiescence:
             install_signals=False,
         )
 
-        entries = coordinator._seed_direct_scope("repo-a")
+        entries = list(coordinator._seed_direct_scope("repo-a"))
 
         assert len(entries) == 1
         assert entries[0].stage is StageName.FINISHED
@@ -410,7 +410,7 @@ class TestQuiescence:
             config, github=github, pool=FakeWorkerPool(), install_signals=False
         )
 
-        entries = coordinator._seed_direct_scope("repo-a")
+        entries = list(coordinator._seed_direct_scope("repo-a"))
         item = coordinator._entry_to_item(entries[0], "repo-a")
 
         assert item.pr == 701
@@ -1807,7 +1807,7 @@ class TestPipelineScopeWiring:
         config = self._scoped_config(tmp_path, issues=[1881])
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
-        entries = coordinator._seed_direct_scope("repo-a")
+        entries = list(coordinator._seed_direct_scope("repo-a"))
         item = coordinator._entry_to_item(entries[0], "repo-a")
 
         assert entries[0].issue_title == "Hydrate planner context"
@@ -1871,7 +1871,7 @@ class TestPipelineScopeWiring:
         config = self._scoped_config(tmp_path, issues=[1], force=True)
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
-        entries = coordinator._seed_direct_scope("repo-a")
+        entries = list(coordinator._seed_direct_scope("repo-a"))
 
         assert len(entries) == 1
         assert entries[0].stage is StageName.PLANNING
@@ -1906,7 +1906,7 @@ class TestPipelineScopeWiring:
         config = self._scoped_config(tmp_path, issues=[1])
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
-        entries = coordinator._seed_direct_scope("repo-a")
+        entries = list(coordinator._seed_direct_scope("repo-a"))
 
         assert len(entries) == 1
         assert entries[0].stage is StageName.PLANNING

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1437,6 +1437,49 @@ class TestDurableEventLog:
                 install_signals=False,
             )
 
+    @pytest.mark.parametrize("threshold", [-1, 101])
+    def test_alert_queue_depth_threshold_is_validated_without_metrics(
+        self, tmp_path: Path, threshold: int
+    ) -> None:
+        """Invalid alert thresholds fail even when the metrics server is disabled."""
+        with pytest.raises(
+            ValueError, match="alert queue depth threshold must be between 0 and 100"
+        ):
+            Coordinator(
+                PipelineConfig(
+                    org="org",
+                    repos=["repo-a"],
+                    projects_dir=tmp_path,
+                    alert_queue_depth_threshold=threshold,
+                ),
+                github=FakeStageGitHub(),
+                pool=FakeWorkerPool(
+                    size=1,
+                    completion_q=CompletionQueue(capacity=1),
+                ),
+                install_signals=False,
+            )
+
+    @pytest.mark.parametrize("threshold", [0, 100])
+    def test_alert_queue_depth_threshold_accepts_bounds_without_metrics(
+        self, tmp_path: Path, threshold: int
+    ) -> None:
+        """The inclusive alert threshold bounds remain valid without metrics."""
+        Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                alert_queue_depth_threshold=threshold,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(
+                size=1,
+                completion_q=CompletionQueue(capacity=1),
+            ),
+            install_signals=False,
+        )
+
     def test_zero_thread_nogo_event_is_durable_and_bounded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -143,10 +143,14 @@ class TestWiring:
             "hephaestus.automation.pipeline_github.PipelineGitHub",
             MagicMock(return_value=accessor),
         )
-        monkeypatch.setattr(coordinator_mod.Coordinator, "run", lambda self: 7)
+        coordinator_factory = MagicMock()
+        coordinator_factory.return_value.run.return_value = 7
+        monkeypatch.setattr(coordinator_mod, "Coordinator", coordinator_factory)
         config = PipelineConfig(org="org", repos=["r"], dry_run=True, projects_dir=tmp_path)
 
         assert run_pipeline(config) == 7
+        wired_config = coordinator_factory.call_args.args[0]
+        assert wired_config.event_log_path is not None
 
     @staticmethod
     def _stub_pipeline_runtime(

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -299,6 +299,7 @@ class TestExitCode:
                 final_stage=StageName.FINISHED,
             )
         )
+        coordinator._signal_received = True
         coordinator.shutdown.set()
 
         assert coordinator._exit_code() == 130
@@ -1084,6 +1085,7 @@ class TestLivenessAndFatal:
         coordinator = _coordinator(tmp_path, monkeypatch, grace_s=0.0)
         item = _item()
         coordinator.in_flight[object()] = item  # type: ignore[index]
+        coordinator._signal_received = True
         coordinator.shutdown.set()
         coordinator._grace_deadline = 0.0  # already expired
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -142,16 +142,20 @@ class TestWiring:
     ) -> None:
         """Injected workers observe signal and saturation shutdown requests."""
         config = PipelineConfig(org="org", repos=["r"], projects_dir=tmp_path)
-        pool = FakeWorkerPool(
+        pool: Any = FakeWorkerPool(
             shutdown=threading.Event(),
             completion_q=queues_mod.CompletionQueue(capacity=config.max_workers),
         )
+        stale_shutdown = threading.Event()
+        pool._shutdown = stale_shutdown
 
         coordinator = Coordinator(
             config, github=FakeStageGitHub(), pool=pool, install_signals=False
         )
 
         assert pool.shutdown_event is coordinator.shutdown
+        assert pool._shutdown is coordinator.shutdown
+        assert pool._shutdown is not stale_shutdown
 
     def test_run_pipeline_wires_accessor_and_runs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
+import threading
 from pathlib import Path
 from typing import Any, get_type_hints
 from unittest.mock import MagicMock
@@ -22,6 +23,7 @@ from jinja2 import TemplateNotFound, TemplateSyntaxError
 import hephaestus.automation.pipeline as pipeline_pkg
 import hephaestus.automation.pipeline.coordinator as coordinator_mod
 import hephaestus.automation.pipeline.jobs as jobs_mod
+import hephaestus.automation.pipeline.queues as queues_mod
 import hephaestus.automation.pipeline.routing as routing_mod
 import hephaestus.automation.pipeline.seeding as seeding_mod
 import hephaestus.automation.pipeline.stages.base as stage_base_mod
@@ -134,6 +136,22 @@ class TestWiring:
         assert created["size"] == 12
         assert created["shutdown"] is coordinator.shutdown
         assert created["completion_q"] is coordinator.completion_q
+
+    def test_injected_pool_shares_coordinator_shutdown_event(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Injected workers observe signal and saturation shutdown requests."""
+        config = PipelineConfig(org="org", repos=["r"], projects_dir=tmp_path)
+        pool = FakeWorkerPool(
+            shutdown=threading.Event(),
+            completion_q=queues_mod.CompletionQueue(capacity=config.max_workers),
+        )
+
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=pool, install_signals=False
+        )
+
+        assert pool.shutdown_event is coordinator.shutdown
 
     def test_run_pipeline_wires_accessor_and_runs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -88,12 +88,13 @@ class InterruptingPool(FakeWorkerPool):
     event is set mid-job and the result comes back ``interrupted=True``.
     """
 
-    def __init__(self, coordinator_shutdown: Any) -> None:
+    def __init__(self, coordinator: Coordinator) -> None:
         super().__init__()
-        self._coordinator_shutdown = coordinator_shutdown
+        self._coordinator = coordinator
 
     def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
-        self._coordinator_shutdown.set()
+        self._coordinator._signal_received = True
+        self._coordinator.shutdown.set()
         self.queue_result(JobResult(ok=False, interrupted=True, error="interrupted"))
         return super().submit(job, on_done_state, **kwargs)
 
@@ -168,7 +169,7 @@ class TestInterruptSemantics:
         """An interrupted job parks its item RESUMABLE; on_job_done never runs."""
         seed = [SeedEntry(kind="issue", identifier=1, stage=StageName.PLANNING, reason="r")]
         coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)
-        pool = InterruptingPool(coordinator.shutdown)
+        pool = InterruptingPool(coordinator)
         coordinator.pool = pool
         coordinator.completion_q = pool.completion_q
         stage = JobRequestingStage()
@@ -194,6 +195,7 @@ class TestInterruptSemantics:
             repo="repo-a", kind=ItemKind.ISSUE, issue=2, stage=StageName.PR_REVIEW, state="ENTER"
         )
         coordinator._push_item(item, StageName.PR_REVIEW, enter=True)
+        coordinator._signal_received = True
         coordinator.shutdown.set()
 
         exit_code = coordinator.run()

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -269,13 +269,15 @@ class TestInterruptSemantics:
         assert coordinator.shutdown.is_set()
         assert coordinator._grace_deadline is not None
         assert coordinator._immediate is False
-        assert not coordinator.completion_q.empty()
-        coordinator._drain_completions()
+        assert coordinator._completion_wake.is_set()
         assert coordinator.completion_q.empty()
+        coordinator._drain_completions()
+        assert not coordinator._completion_wake.is_set()
 
         handler(signal_mod.SIGTERM, None)
         assert coordinator._immediate is True
-        assert not coordinator.completion_q.empty()
+        assert coordinator._completion_wake.is_set()
+        assert coordinator.completion_q.empty()
 
 
 class TestNormalTeardownExitSemantics:

--- a/tests/unit/automation/pipeline/test_fakes.py
+++ b/tests/unit/automation/pipeline/test_fakes.py
@@ -51,10 +51,9 @@ class TestFakeWorkerPool:
 
     def test_matches_real_constructor_signature(self) -> None:
         """Positional (size, shutdown, completion_q) construction works."""
-        import queue
         import threading
 
-        q: CompletionQueue = queue.Queue()
+        q = CompletionQueue(capacity=2)
         event = threading.Event()
         fake = FakeWorkerPool(2, event, q)
         assert fake.size == 2
@@ -118,7 +117,7 @@ class TestFakeWorkerPool:
 
     def test_handles_are_unique_per_submit(self) -> None:
         """Identical job specs still yield distinct, dict-keyable handles."""
-        fake = FakeWorkerPool()
+        fake = FakeWorkerPool(size=2, completion_q=CompletionQueue(capacity=2))
         _, _, git, _ = _jobs()
         h1 = fake.submit(git, StageName.PR_REVIEW)
         h2 = fake.submit(git, StageName.PR_REVIEW)

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -92,6 +92,8 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
             "--no-advise",
             "--no-serialize-file-overlap",
             "--nitpick",
+            "--alert-queue-depth-threshold",
+            "75",
         ]
     )
 
@@ -107,6 +109,7 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.no_advise is True
     assert config.serialize_file_overlap is False
     assert config.nitpick is True
+    assert config.alert_queue_depth_threshold == 75
     assert config.scope is None
     assert config.event_log_path is not None
     assert config.event_log_path.name.startswith("pipeline-events-")

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -121,7 +121,8 @@ class TestStageQueueLeases:
         assert source.offer(_item("replacement")) is True
         assert destination.occupancy == 1
         assert destination.snapshot() == [item]
-        assert destination.pop() is item
+        popped = destination.pop()
+        assert popped is item
         assert destination.occupancy == 0
 
     def test_full_destination_retains_source_lease_for_retry(self) -> None:
@@ -140,11 +141,13 @@ class TestStageQueueLeases:
         assert source.offer(_item("must-not-enter-while-leased")) is False
         assert destination.snapshot() == [destination_item]
 
-        assert destination.pop() is destination_item
+        popped_destination_item = destination.pop()
+        assert popped_destination_item is destination_item
         assert lease.handoff(destination) is True
         assert source.occupancy == 0
         assert destination.snapshot() == [item]
-        assert destination.pop() is item
+        handed_off_item = destination.pop()
+        assert handed_off_item is item
         assert destination.occupancy == 0
 
     def test_empty_claim_is_explicit(self) -> None:

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -1,0 +1,154 @@
+"""Contract tests for lossless, bounded ``StageQueue`` handoffs."""
+
+from hephaestus.automation.pipeline import ItemKind, StageQueue, WorkItem
+
+
+def _item(name: str) -> WorkItem:
+    """Create a distinct valid pipeline item for queue identity assertions."""
+    return WorkItem(repo=name, kind=ItemKind.REPO)
+
+
+class TestStageQueueLeases:
+    """Lossless handoff behavior for bounded source and destination queues."""
+
+    def test_claim_reserves_capacity_and_blocks_new_source_offer(self) -> None:
+        """Claiming ready work keeps a full source occupied until release."""
+        source = StageQueue(capacity=2)
+        claimed_item = _item("claimed")
+        still_ready = _item("still-ready")
+        source.push(claimed_item)
+        source.push(still_ready)
+
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.item is claimed_item
+        assert source.snapshot() == [still_ready]
+        assert source.occupancy == source.capacity == 2
+        assert source.offer(_item("replacement")) is False
+
+    def test_restore_preserves_claimed_item_and_uses_remaining_capacity(self) -> None:
+        """A lease reserves its item but does not serialize unused capacity."""
+        source = StageQueue(capacity=2)
+        claimed_item = _item("claimed")
+        source.push(claimed_item)
+
+        lease = source.claim()
+
+        assert lease is not None
+        later = _item("may-enter-before-restore")
+        assert source.offer(later) is True
+        lease.restore()
+
+        assert source.occupancy == 2
+        assert source.snapshot() == [claimed_item, later]
+
+    def test_concurrent_claims_restore_in_original_fifo_order(self) -> None:
+        """Multiple active claims retain capacity and original FIFO tickets."""
+        source = StageQueue(capacity=3)
+        first = _item("first")
+        second = _item("second")
+        third = _item("third")
+        source.push(first)
+        source.push(second)
+        source.push(third)
+
+        first_lease = source.claim()
+        second_lease = source.claim()
+
+        assert first_lease is not None
+        assert second_lease is not None
+        assert first_lease.item is first
+        assert second_lease.item is second
+        assert source.snapshot() == [third]
+
+        second_lease.restore()
+        first_lease.restore()
+
+        assert source.snapshot() == [first, second, third]
+
+    def test_selected_claim_restores_original_queue_position(self) -> None:
+        """Topo scheduling may lease a non-head item without reordering retry."""
+        source = StageQueue(capacity=3)
+        first = _item("first")
+        selected = _item("selected")
+        third = _item("third")
+        for item in (first, selected, third):
+            source.push(item)
+
+        selected_lease = source.claim_at(1)
+
+        assert selected_lease is not None
+        assert selected_lease.item is selected
+        assert source.snapshot() == [first, third]
+        first_lease = source.claim()
+        assert first_lease is not None
+        assert first_lease.item is first
+
+        first_lease.restore()
+        selected_lease.restore()
+
+        assert source.snapshot() == [first, selected, third]
+
+    def test_selected_claim_release_does_not_remove_queue_head(self) -> None:
+        """A timer can take selected work without accidentally popping a peer."""
+        source = StageQueue(capacity=2)
+        first = _item("first")
+        selected = _item("selected")
+        source.push(first)
+        source.push(selected)
+
+        lease = source.claim_at(1)
+
+        assert lease is not None
+        lease.release()
+
+        assert source.snapshot() == [first]
+        assert source.occupancy == 1
+
+    def test_successful_handoff_releases_source_and_enqueues_once(self) -> None:
+        """A successful handoff transfers the source reservation exactly once."""
+        source = StageQueue(capacity=1)
+        destination = StageQueue(capacity=1)
+        item = _item("handoff")
+        source.push(item)
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.handoff(destination) is True
+
+        assert source.occupancy == 0
+        assert source.offer(_item("replacement")) is True
+        assert destination.occupancy == 1
+        assert destination.snapshot() == [item]
+        assert destination.pop() is item
+        assert destination.occupancy == 0
+
+    def test_full_destination_retains_source_lease_for_retry(self) -> None:
+        """A failed handoff neither drops nor spills work and remains retryable."""
+        source = StageQueue(capacity=1)
+        destination = StageQueue(capacity=1)
+        item = _item("source-item")
+        destination_item = _item("destination-item")
+        source.push(item)
+        destination.push(destination_item)
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.handoff(destination) is False
+        assert source.occupancy == source.capacity == 1
+        assert source.offer(_item("must-not-enter-while-leased")) is False
+        assert destination.snapshot() == [destination_item]
+
+        assert destination.pop() is destination_item
+        assert lease.handoff(destination) is True
+        assert source.occupancy == 0
+        assert destination.snapshot() == [item]
+        assert destination.pop() is item
+        assert destination.occupancy == 0
+
+    def test_empty_claim_is_explicit(self) -> None:
+        """An empty source reports no lease instead of inventing work."""
+        source = StageQueue(capacity=1)
+
+        assert source.claim() is None

--- a/tests/unit/automation/pipeline/test_queues.py
+++ b/tests/unit/automation/pipeline/test_queues.py
@@ -10,6 +10,7 @@ from hephaestus.automation.pipeline import (
     StageQueue,
     WorkItem,
 )
+from hephaestus.automation.pipeline.queues import CompletionRejection
 
 
 class TestStageQueue:
@@ -17,17 +18,18 @@ class TestStageQueue:
 
     def test_stage_queue_creation(self) -> None:
         """Create an empty StageQueue."""
-        q = StageQueue()
+        q = StageQueue(capacity=2)
         assert len(q) == 0
+        assert q.capacity == 2
 
     def test_stage_queue_push_pop(self) -> None:
         """Push and pop items in FIFO order."""
-        q = StageQueue()
+        q = StageQueue(capacity=2)
         item1 = WorkItem(repo="repo1", kind=ItemKind.REPO)
         item2 = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=1)
 
-        q.push(item1)
-        q.push(item2)
+        assert q.push(item1)
+        assert q.push(item2)
 
         assert len(q) == 2
         first = q.pop()
@@ -38,20 +40,20 @@ class TestStageQueue:
 
     def test_stage_queue_pop_empty_raises(self) -> None:
         """Popping from empty queue raises IndexError."""
-        q = StageQueue()
+        q = StageQueue(capacity=1)
         with pytest.raises(IndexError):
             q.pop()
 
     def test_stage_queue_snapshot(self) -> None:
         """snapshot() returns a list copy of all items."""
-        q = StageQueue()
+        q = StageQueue(capacity=3)
         item1 = WorkItem(repo="repo1", kind=ItemKind.REPO)
         item2 = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=1)
         item3 = WorkItem(repo="repo3", kind=ItemKind.PR, pr=2)
 
-        q.push(item1)
-        q.push(item2)
-        q.push(item3)
+        assert q.push(item1)
+        assert q.push(item2)
+        assert q.push(item3)
 
         snap = q.snapshot()
         assert len(snap) == 3
@@ -59,7 +61,7 @@ class TestStageQueue:
 
     def test_stage_queue_snapshot_returns_copy(self) -> None:
         """Mutating snapshot() does not affect the queue."""
-        q = StageQueue()
+        q = StageQueue(capacity=1)
         item = WorkItem(repo="repo", kind=ItemKind.REPO)
         q.push(item)
 
@@ -71,39 +73,89 @@ class TestStageQueue:
 
     def test_stage_queue_len_tracking(self) -> None:
         """len() tracks the queue size accurately."""
-        q = StageQueue()
+        q = StageQueue(capacity=5)
         assert len(q) == 0
 
         for i in range(5):
-            q.push(WorkItem(repo=f"repo{i}", kind=ItemKind.REPO))
+            assert q.push(WorkItem(repo=f"repo{i}", kind=ItemKind.REPO))
             assert len(q) == i + 1
 
         for i in range(5, 0, -1):
             q.pop()
             assert len(q) == i - 1
 
+    @pytest.mark.parametrize("capacity", [0, -1])
+    def test_stage_queue_rejects_invalid_capacity(self, capacity: int) -> None:
+        """A stage queue cannot be configured without storage."""
+        with pytest.raises(ValueError):
+            StageQueue(capacity=capacity)
+
+    def test_stage_queue_rejects_burst_without_overflow_storage(self) -> None:
+        """A full stage queue rejects work explicitly and retains its bound."""
+        q = StageQueue(capacity=1)
+        first = WorkItem(repo="repo1", kind=ItemKind.REPO)
+        second = WorkItem(repo="repo2", kind=ItemKind.REPO)
+
+        assert q.push(first)
+        assert q.push(second) is False
+        assert q.snapshot() == [first]
+
 
 class TestCompletionQueue:
-    """Tests for CompletionQueue type alias."""
+    """Tests for the bounded cross-thread completion channel."""
 
     def test_completion_queue_type(self) -> None:
         """CompletionQueue is a queue.Queue type alias."""
-        cq = CompletionQueue()
+        cq = CompletionQueue(capacity=2)
         assert isinstance(cq, queue.Queue)
+        assert cq.maxsize == 2
+        assert cq.capacity == 2
 
     def test_completion_queue_put_get(self) -> None:
         """Put and get items from CompletionQueue."""
-        cq = CompletionQueue()
+        cq = CompletionQueue(capacity=1)
         item = WorkItem(repo="repo", kind=ItemKind.REPO)
         data = (item, "completed")
 
-        cq.put(data)
+        assert cq.offer(data)
         result = cq.get(timeout=1)
 
         assert result == data
 
     def test_completion_queue_empty_get_blocks(self) -> None:
         """Getting from empty queue times out."""
-        cq = CompletionQueue()
+        cq = CompletionQueue(capacity=1)
         with pytest.raises(queue.Empty):
             cq.get(timeout=0.1)
+
+    def test_completion_queue_rejection_is_retained_for_coordinator(self) -> None:
+        """A full result channel preserves the rejected completion in its mailbox."""
+        cq = CompletionQueue(capacity=1)
+
+        assert cq.offer(("first", "ok"))
+        assert cq.offer(("second", "result")) is False
+
+        rejected, overflowed = cq.take_rejections()
+
+        assert rejected == [CompletionRejection("second", "result")]
+        assert overflowed is False
+        assert cq.get_nowait() == ("first", "ok")
+
+    def test_completion_queue_marks_rejection_mailbox_overflow(self) -> None:
+        """The bounded fallback reports when it cannot retain every rejection."""
+        cq = CompletionQueue(capacity=1)
+
+        assert cq.offer(("first", "ok"))
+        assert cq.offer(("second", "result")) is False
+        assert cq.offer(("third", "result")) is False
+
+        rejected, overflowed = cq.take_rejections()
+
+        assert rejected == [CompletionRejection("second", "result")]
+        assert overflowed is True
+
+    @pytest.mark.parametrize("capacity", [0, -1])
+    def test_completion_queue_rejects_invalid_capacity(self, capacity: int) -> None:
+        """A completion queue cannot be configured without storage."""
+        with pytest.raises(ValueError):
+            CompletionQueue(capacity=capacity)

--- a/tests/unit/automation/pipeline/test_queues.py
+++ b/tests/unit/automation/pipeline/test_queues.py
@@ -21,6 +21,7 @@ class TestStageQueue:
         q = StageQueue(capacity=2)
         assert len(q) == 0
         assert q.capacity == 2
+        assert q.occupancy == 0
 
     def test_stage_queue_push_pop(self) -> None:
         """Push and pop items in FIFO order."""
@@ -28,8 +29,8 @@ class TestStageQueue:
         item1 = WorkItem(repo="repo1", kind=ItemKind.REPO)
         item2 = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=1)
 
-        assert q.push(item1)
-        assert q.push(item2)
+        q.push(item1)
+        q.push(item2)
 
         assert len(q) == 2
         first = q.pop()
@@ -51,9 +52,9 @@ class TestStageQueue:
         item2 = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=1)
         item3 = WorkItem(repo="repo3", kind=ItemKind.PR, pr=2)
 
-        assert q.push(item1)
-        assert q.push(item2)
-        assert q.push(item3)
+        q.push(item1)
+        q.push(item2)
+        q.push(item3)
 
         snap = q.snapshot()
         assert len(snap) == 3
@@ -77,7 +78,7 @@ class TestStageQueue:
         assert len(q) == 0
 
         for i in range(5):
-            assert q.push(WorkItem(repo=f"repo{i}", kind=ItemKind.REPO))
+            q.push(WorkItem(repo=f"repo{i}", kind=ItemKind.REPO))
             assert len(q) == i + 1
 
         for i in range(5, 0, -1):
@@ -96,9 +97,18 @@ class TestStageQueue:
         first = WorkItem(repo="repo1", kind=ItemKind.REPO)
         second = WorkItem(repo="repo2", kind=ItemKind.REPO)
 
-        assert q.push(first)
-        assert q.push(second) is False
+        assert q.offer(first) is True
+        assert q.offer(second) is False
+        assert q.occupancy == q.capacity == 1
         assert q.snapshot() == [first]
+
+    def test_stage_queue_push_raises_when_full(self) -> None:
+        """Strict push callers cannot silently lose ownership on saturation."""
+        q = StageQueue(capacity=1)
+        q.push(WorkItem(repo="repo1", kind=ItemKind.REPO))
+
+        with pytest.raises(OverflowError, match="full"):
+            q.push(WorkItem(repo="repo2", kind=ItemKind.REPO))
 
 
 class TestCompletionQueue:

--- a/tests/unit/automation/pipeline/test_queues.py
+++ b/tests/unit/automation/pipeline/test_queues.py
@@ -10,7 +10,7 @@ from hephaestus.automation.pipeline import (
     StageQueue,
     WorkItem,
 )
-from hephaestus.automation.pipeline.queues import CompletionRejection
+from hephaestus.automation.pipeline.queues import CompletionRejection, StageQueueLease
 
 
 class TestStageQueue:
@@ -101,6 +101,21 @@ class TestStageQueue:
         assert q.offer(second) is False
         assert q.occupancy == q.capacity == 1
         assert q.snapshot() == [first]
+
+    def test_stage_queue_claim_keeps_public_capacity_reserving_lease(self) -> None:
+        """The queue API retains the lease contract used by the coordinator."""
+        q = StageQueue(capacity=1)
+        item = WorkItem(repo="repo1", kind=ItemKind.REPO)
+        q.push(item)
+
+        lease = q.claim()
+
+        assert isinstance(lease, StageQueueLease)
+        assert lease.item is item
+        assert q.occupancy == q.capacity == 1
+        assert q.offer(WorkItem(repo="repo2", kind=ItemKind.REPO)) is False
+        lease.restore()
+        assert q.snapshot() == [item]
 
     def test_stage_queue_push_raises_when_full(self) -> None:
         """Strict push callers cannot silently lose ownership on saturation."""

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -552,9 +552,21 @@ class TestSeedIssueFailClosed:
 class TestSeedFromCli:
     """CLI mapping: repos → repo queue; issues → classified; prs → review/merge."""
 
+    def test_issue_source_is_classified_lazily(self) -> None:
+        """A large issue scope does not materialize every SeedEntry up front."""
+        with patch(
+            "hephaestus.automation.pipeline.seeding.seed_issue",
+            side_effect=lambda issue: _facts(number=issue),
+        ) as mock_seed:
+            entries = seed_from_cli([], range(10_000), [])
+
+            assert mock_seed.call_count == 0
+            assert next(entries).identifier == 0
+            assert mock_seed.call_count == 1
+
     def test_repos_arm(self) -> None:
         """Each repo becomes a StageName.REPO discovery seed."""
-        entries = seed_from_cli(["RepoA", "RepoB"], [], [])
+        entries = list(seed_from_cli(["RepoA", "RepoB"], [], []))
         assert [e.kind for e in entries] == ["repo", "repo"]
         assert [e.identifier for e in entries] == ["RepoA", "RepoB"]
         assert all(e.stage is StageName.REPO for e in entries)
@@ -570,7 +582,7 @@ class TestSeedFromCli:
         with patch(
             "hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts
         ) as mock_seed:
-            entries = seed_from_cli([], [9], [])
+            entries = list(seed_from_cli([], [9], []))
         mock_seed.assert_called_once_with(9)
         assert entries == [
             SeedEntry(
@@ -593,7 +605,7 @@ class TestSeedFromCli:
             pr_has_implementation_go=True,
         )
         with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
-            entries = seed_from_cli([], [9], [])
+            entries = list(seed_from_cli([], [9], []))
 
         assert entries == [
             SeedEntry(
@@ -610,14 +622,14 @@ class TestSeedFromCli:
         """An excluded (skip/epic) issue surfaces stage=None to the caller."""
         facts = _facts(number=10, labels={STATE_SKIP})
         with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
-            entries = seed_from_cli([], [10], [])
+            entries = list(seed_from_cli([], [10], []))
         assert entries[0].stage is None
 
     def test_untagged_epic_surfaces_a_typed_skip_tag_obligation(self) -> None:
         """The coordinator receives an explicit durable-write obligation, not a reason prefix."""
         facts = _facts(number=10, is_epic=True)
         with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
-            entry = seed_from_cli([], [10], [])[0]
+            entry = next(seed_from_cli([], [10], []))
 
         assert entry.skip_tag_obligation == EpicSkipTagObligation(issue=10)
 
@@ -630,7 +642,7 @@ class TestSeedFromCli:
                 return_value=[STATE_IMPLEMENTATION_GO],
             ),
         ):
-            entries = seed_from_cli([], [], [77])
+            entries = list(seed_from_cli([], [], [77]))
         assert entries == [
             SeedEntry(
                 kind="pr",
@@ -650,7 +662,7 @@ class TestSeedFromCli:
                 return_value=[STATE_IMPLEMENTATION_NO_GO],
             ),
         ):
-            entries = seed_from_cli([], [], [78])
+            entries = list(seed_from_cli([], [], [78]))
         assert entries[0].stage is StageName.PR_REVIEW
 
     def test_prs_arm_label_fetch_failure_reads_as_not_reviewed(self) -> None:
@@ -662,7 +674,7 @@ class TestSeedFromCli:
             patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
             patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]),
         ):
-            entries = seed_from_cli([], [], [79])
+            entries = list(seed_from_cli([], [], [79]))
         assert entries[0].stage is StageName.PR_REVIEW
 
     def test_prs_arm_uses_repo_scoped_accessor_when_given(self) -> None:
@@ -684,7 +696,7 @@ class TestSeedFromCli:
                 side_effect=AssertionError("must not call ambient label read when github is given"),
             ),
         ):
-            entries = seed_from_cli([], [], [77], github=github)
+            entries = list(seed_from_cli([], [], [77], github=github))
         github.gh_pr_state.assert_called_once_with(77)
         github.pr_has_implementation_state_label.assert_called_once_with(77)
         assert entries == [
@@ -702,14 +714,14 @@ class TestSeedFromCli:
         github = MagicMock()
         github.gh_pr_state.return_value = None
         github.pr_has_implementation_state_label.return_value = (False, True)
-        entries = seed_from_cli([], [], [78], github=github)
+        entries = list(seed_from_cli([], [], [78], github=github))
         assert entries[0].stage is StageName.PR_REVIEW
 
     def test_prs_arm_repo_scoped_merged_pr_routes_to_finished(self) -> None:
         """Repo-scoped accessor: a merged PR classifies FINISHED via github.gh_pr_state (#1865)."""
         github = MagicMock()
         github.gh_pr_state.return_value = {"state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z"}
-        entries = seed_from_cli([], [], [80], github=github)
+        entries = list(seed_from_cli([], [], [80], github=github))
         assert entries == [
             SeedEntry(
                 kind="pr",
@@ -725,7 +737,7 @@ class TestSeedFromCli:
         """Repo-scoped accessor: a closed PR is excluded via github.gh_pr_state (#1865)."""
         github = MagicMock()
         github.gh_pr_state.return_value = {"state": "CLOSED", "mergedAt": None}
-        entries = seed_from_cli([], [], [81], github=github)
+        entries = list(seed_from_cli([], [], [81], github=github))
         assert entries[0].stage is None
         github.pr_has_implementation_state_label.assert_not_called()
 
@@ -735,7 +747,7 @@ class TestSeedFromCli:
             "hephaestus.automation.pipeline.seeding.gh_pr_state",
             return_value={"state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z"},
         ):
-            entries = seed_from_cli([], [], [80])
+            entries = list(seed_from_cli([], [], [80]))
         assert entries == [
             SeedEntry(
                 kind="pr",
@@ -752,7 +764,7 @@ class TestSeedFromCli:
             "hephaestus.automation.pipeline.seeding.gh_pr_state",
             return_value={"state": "CLOSED", "mergedAt": None},
         ):
-            entries = seed_from_cli([], [], [81])
+            entries = list(seed_from_cli([], [], [81]))
         assert entries[0].stage is None
 
     def test_prs_arm_state_fetch_failure_falls_through_to_labels(self) -> None:
@@ -764,7 +776,7 @@ class TestSeedFromCli:
                 return_value=[STATE_IMPLEMENTATION_GO],
             ),
         ):
-            entries = seed_from_cli([], [], [82])
+            entries = list(seed_from_cli([], [], [82]))
         assert entries[0].stage is StageName.MERGE_WAIT
 
     def test_order_repos_then_issues_then_prs(self) -> None:
@@ -775,7 +787,7 @@ class TestSeedFromCli:
             patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
             patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]),
         ):
-            entries = seed_from_cli(["R"], [5], [6])
+            entries = list(seed_from_cli(["R"], [5], [6]))
         assert [e.kind for e in entries] == ["repo", "issue", "pr"]
 
 

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -20,6 +20,7 @@ from hephaestus.automation.pipeline.coordinator import (
     Coordinator,
     PipelineConfig,
 )
+from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
@@ -46,9 +47,14 @@ def clocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Coordinato
         SimpleNamespace(monotonic=clock.monotonic, time=lambda: clock.now),
     )
     monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
-    config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+    config = PipelineConfig(
+        org="org", repos=["repo-a"], projects_dir=tmp_path, parallel_repos=3
+    )
     coordinator = Coordinator(
-        config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        config,
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(size=3, completion_q=CompletionQueue(capacity=3)),
+        install_signals=False,
     )
     return coordinator, clock
 

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -47,9 +47,7 @@ def clocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Coordinato
         SimpleNamespace(monotonic=clock.monotonic, time=lambda: clock.now),
     )
     monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
-    config = PipelineConfig(
-        org="org", repos=["repo-a"], projects_dir=tmp_path, parallel_repos=3
-    )
+    config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path, parallel_repos=3)
     coordinator = Coordinator(
         config,
         github=FakeStageGitHub(),

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -103,6 +103,27 @@ class TestTimerHeap:
         pushes = [entry[2] for entry in coordinator.event_log if entry[0] == "push"]
         assert pushes == ["repo-a#1", "repo-a#2"]
 
+    def test_saturated_admission_preserves_expired_tracked_timer(
+        self, clocked: tuple[Coordinator, FakeClock]
+    ) -> None:
+        """A rejected timer wake is parked for finalization, not dropped."""
+        coordinator, clock = clocked
+        item = _item(13)
+        coordinator._seen_item_ids.add(id(item))
+        coordinator.items.append(item)
+        coordinator._timer_park(item, 1.0)
+        coordinator._admission_saturated = True
+
+        clock.now += 2.0
+        coordinator._wake_timers()
+
+        assert coordinator.timers == []
+        assert coordinator.items == [item]
+        assert item.result is not None
+        assert item.result.reason == (
+            "resumable at pr_review: timer wake rejected by admission saturation"
+        )
+
 
 class TestRetryDelayConsumption:
     """RETRY timer contract: payload["retry_delay_s"] -> heap park."""

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -109,20 +109,32 @@ def test_shutdown_can_reap_without_marking_interrupted(
     assert not shutdown_event.is_set()
 
 
-def test_full_completion_queue_never_blocks_worker_callback() -> None:
+def test_full_completion_queue_never_blocks_worker_callback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """A full result channel requests shutdown and retains the rejected result."""
     shutdown = threading.Event()
     completion_q = CompletionQueue(capacity=1)
     pool = WorkerPool(size=1, shutdown=shutdown, completion_q=completion_q)
     existing_handle = JobHandle(job=_agent_job(issue=1), on_done_state="VERIFY")
-    handle = JobHandle(job=_agent_job(issue=2), on_done_state="VERIFY")
+    untrusted_content = "untrusted issue body and session data must not reach logs"
+    handle = JobHandle(
+        job=_agent_job(
+            issue=2,
+            descr="r" * 200,
+            resume_session_id=untrusted_content,
+            prompt_kwargs={"issue_body": untrusted_content},
+        ),
+        on_done_state="VERIFY",
+    )
     future: Future[JobResult] = Future()
     future.set_result(JobResult(ok=True, value="done"))
 
     try:
         assert completion_q.offer((existing_handle, JobResult(ok=True)))
         started = time.monotonic()
-        pool._on_future_done(handle, future)
+        with caplog.at_level(logging.CRITICAL, logger=_WP):
+            pool._on_future_done(handle, future)
         assert time.monotonic() - started < 1.0
     finally:
         pool.shutdown(mark_interrupted=False)
@@ -131,6 +143,9 @@ def test_full_completion_queue_never_blocks_worker_callback() -> None:
     assert shutdown.is_set()
     assert [entry.handle for entry in rejected] == [handle]
     assert overflowed is False
+    assert untrusted_content not in caplog.text
+    assert "job_type=AgentJob repo=test/repo issue=2" in caplog.text
+    assert "description=" + ("r" * 159) + "…" in caplog.text
 
 
 class TestWorkerPoolSubmitComplete:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -109,6 +109,30 @@ def test_shutdown_can_reap_without_marking_interrupted(
     assert not shutdown_event.is_set()
 
 
+def test_full_completion_queue_never_blocks_worker_callback() -> None:
+    """A full result channel requests shutdown and retains the rejected result."""
+    shutdown = threading.Event()
+    completion_q = CompletionQueue(capacity=1)
+    pool = WorkerPool(size=1, shutdown=shutdown, completion_q=completion_q)
+    existing_handle = JobHandle(job=_agent_job(issue=1), on_done_state="VERIFY")
+    handle = JobHandle(job=_agent_job(issue=2), on_done_state="VERIFY")
+    future: Future[JobResult] = Future()
+    future.set_result(JobResult(ok=True, value="done"))
+
+    try:
+        assert completion_q.offer((existing_handle, JobResult(ok=True)))
+        started = time.monotonic()
+        pool._on_future_done(handle, future)
+        assert time.monotonic() - started < 1.0
+    finally:
+        pool.shutdown(mark_interrupted=False)
+
+    rejected, overflowed = completion_q.take_rejections()
+    assert shutdown.is_set()
+    assert [entry.handle for entry in rejected] == [handle]
+    assert overflowed is False
+
+
 class TestWorkerPoolSubmitComplete:
     """Tests for basic submit/complete workflow."""
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -19,7 +19,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
-from hephaestus.automation import git_utils
+from hephaestus.automation import git_utils, subprocess_registry
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
@@ -3087,7 +3087,10 @@ class TestShutdownReapsSubprocess:
         ):
             pool.submit(job, StageName.IMPLEMENTATION)
             assert started.wait(timeout=10), "agent subprocess never started"
-            time.sleep(0.2)  # let the child settle inside communicate()
+            deadline = time.monotonic() + 10.0
+            while subprocess_registry.live_count() == 0:
+                assert time.monotonic() < deadline, "agent subprocess was not registered"
+                time.sleep(0.01)
 
             t0 = time.monotonic()
             pool.shutdown()

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -132,10 +132,15 @@ def test_full_completion_queue_never_blocks_worker_callback(
 
     try:
         assert completion_q.offer((existing_handle, JobResult(ok=True)))
-        started = time.monotonic()
+        callback_thread = threading.Thread(
+            target=pool._on_future_done,
+            args=(handle, future),
+            daemon=True,
+        )
         with caplog.at_level(logging.CRITICAL, logger=_WP):
-            pool._on_future_done(handle, future)
-        assert time.monotonic() - started < 1.0
+            callback_thread.start()
+            callback_thread.join(timeout=1.0)
+        assert not callback_thread.is_alive(), "completion callback blocked on publication"
     finally:
         pool.shutdown(mark_interrupted=False)
 

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -775,6 +775,16 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             ),
         ),
         _action_spec(
+            ("--alert-queue-depth-threshold",),
+            "alert_queue_depth_threshold",
+            "_StoreAction",
+            100,
+            help_text=(
+                "Queue-capacity percentage that triggers a backlog alert when local metrics "
+                "are enabled (0-100, default: 100)."
+            ),
+        ),
+        _action_spec(
             ("--repos",),
             "repos",
             "_StoreAction",

--- a/tests/unit/automation/test_ci_driver_main.py
+++ b/tests/unit/automation/test_ci_driver_main.py
@@ -78,6 +78,7 @@ def test_main_builds_review_merge_wait_scope_and_dispatches() -> None:
     assert config.repos == ["widget"]
     assert config.issues == [123]
     assert config.dry_run is True
+    assert config.event_log_path is not None
     # Direct PRs without an approval label must receive PR review first.
     assert config.scope is not None
     assert config.scope.stages == frozenset({StageName.PR_REVIEW, StageName.MERGE_WAIT})

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -79,6 +79,7 @@ def test_main_builds_implementation_scope_and_dispatches(tmp_path: Path) -> None
     assert config.repos == ["widget"]
     assert config.issues == [123]
     assert config.dry_run is True
+    assert config.event_log_path is not None
     # Scope includes implementation, review, and merge wait.
     assert config.scope is not None
     assert config.scope.stages == frozenset(

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -599,6 +599,42 @@ def test_main_wires_metrics_port_to_pipeline_config(monkeypatch: pytest.MonkeyPa
     assert config.metrics_port == 9123  # type: ignore[attr-defined]
 
 
+@pytest.mark.parametrize("threshold", [0, 100])
+def test_alert_queue_depth_threshold_parser_accepts_percentage_bounds(threshold: int) -> None:
+    """The alert threshold accepts the full inclusive percentage range."""
+    args = loop_runner._parse_args(["--alert-queue-depth-threshold", str(threshold)])
+
+    assert args.alert_queue_depth_threshold == threshold
+
+
+@pytest.mark.parametrize("threshold", [-1, 101])
+def test_alert_queue_depth_threshold_parser_rejects_out_of_range_values(threshold: int) -> None:
+    """Bad alert thresholds fail during CLI parsing, before coordinator setup."""
+    with pytest.raises(SystemExit):
+        loop_runner._parse_args(["--alert-queue-depth-threshold", str(threshold)])
+
+
+def test_main_wires_alert_queue_depth_threshold_to_pipeline_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The validated alert threshold reaches the coordinator configuration."""
+    config = _capture_config(
+        [
+            "--repos",
+            "Repo",
+            "--alert-queue-depth-threshold",
+            "75",
+            "--loops",
+            "1",
+            "--agent",
+            "claude",
+        ],
+        monkeypatch,
+    )
+
+    assert config.alert_queue_depth_threshold == 75  # type: ignore[attr-defined]
+
+
 def test_main_installs_sigtstp_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper.
 

--- a/tests/unit/automation/test_planner_main.py
+++ b/tests/unit/automation/test_planner_main.py
@@ -71,6 +71,7 @@ def test_main_builds_planning_scope_and_dispatches() -> None:
     assert config.repos == ["widget"]
     assert config.issues == [123]
     assert config.dry_run is True
+    assert config.event_log_path is not None
     # Scope is trimmed to exactly planning + plan_review.
     assert config.scope is not None
     assert config.scope.stages == frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})

--- a/tests/unit/automation/test_pr_reviewer_main.py
+++ b/tests/unit/automation/test_pr_reviewer_main.py
@@ -60,6 +60,7 @@ def test_main_builds_pr_review_scope_and_dispatches() -> None:
     assert config.repos == ["widget"]
     assert config.issues == [123]
     assert config.dry_run is True
+    assert config.event_log_path is not None
     # Scope is trimmed to exactly the single pr_review stage.
     assert config.scope is not None
     assert config.scope.stages == frozenset({StageName.PR_REVIEW})

--- a/tests/unit/observability/test_alerts.py
+++ b/tests/unit/observability/test_alerts.py
@@ -10,15 +10,22 @@ import pytest
 def test_alert_tracker_emits_one_fire_and_one_resolution() -> None:
     """Persistent degradation produces no repeated alert-event spam."""
     alerts = importlib.import_module("hephaestus.observability.alerts")
-    tracker = alerts.AlertTracker(queue_depth_threshold=2)
+    tracker = alerts.AlertTracker(queue_depth_threshold=100)
     unhealthy = {
         "queue_depths": {"planning": 3},
+        "queue_capacities": {"planning": 3},
         "circuit_breakers": {"github": {"state": "open"}},
     }
 
     fired = tracker.observe(unhealthy)
     repeated = tracker.observe(unhealthy)
-    resolved = tracker.observe({"queue_depths": {"planning": 0}, "circuit_breakers": {}})
+    resolved = tracker.observe(
+        {
+            "queue_depths": {"planning": 0},
+            "queue_capacities": {"planning": 3},
+            "circuit_breakers": {},
+        }
+    )
 
     assert {(event.name, event.status) for event in fired} == {
         ("circuit_breaker_open", "fired"),
@@ -71,3 +78,28 @@ def test_negative_stalled_threshold_rejected() -> None:
         alerts.evaluate_alerts({}, stalled_ticks_threshold=-1)
     with pytest.raises(ValueError):
         alerts.AlertTracker(stalled_ticks_threshold=-1)
+
+
+def test_backlog_and_saturation_are_independent_alerts() -> None:
+    """A full queue warns about backlog; only a rejection fires saturation."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+    full = {
+        "queue_depths": {"planning": 2},
+        "queue_capacities": {"planning": 2},
+        "saturated_queues": [],
+    }
+
+    assert [event.name for event in alerts.evaluate_alerts(full)] == [
+        "queue_depth_exceeds"
+    ]
+    saturated = alerts.evaluate_alerts({**full, "saturated_queues": ["planning"]})
+    assert {event.name for event in saturated} == {"queue_depth_exceeds", "queue_saturated"}
+
+
+@pytest.mark.parametrize("threshold", [-1, 101])
+def test_queue_depth_threshold_must_be_percentage(threshold: int) -> None:
+    """Backlog thresholds outside the percentage range are rejected."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+
+    with pytest.raises(ValueError):
+        alerts.evaluate_alerts({}, queue_depth_threshold=threshold)

--- a/tests/unit/observability/test_alerts.py
+++ b/tests/unit/observability/test_alerts.py
@@ -89,9 +89,7 @@ def test_backlog_and_saturation_are_independent_alerts() -> None:
         "saturated_queues": [],
     }
 
-    assert [event.name for event in alerts.evaluate_alerts(full)] == [
-        "queue_depth_exceeds"
-    ]
+    assert [event.name for event in alerts.evaluate_alerts(full)] == ["queue_depth_exceeds"]
     saturated = alerts.evaluate_alerts({**full, "saturated_queues": ["planning"]})
     assert {event.name for event in saturated} == {"queue_depth_exceeds", "queue_saturated"}
 


### PR DESCRIPTION
## Summary
Implemented #2399 in the working tree.

- Added bounded stage/completion queues with rejection recovery and coalesced wake handling.
- Added saturation durability, metrics, alerts, shutdown safety, and recovery tests.
- Updated architecture and observability documentation.
- Tests: 6,694 passed, 24 skipped, 13 deselected.
- Ruff and mypy passed.

No commit or GitHub mutations were made.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2399

Generated by Hephaestus automation
