### PR TITLE
fix(automation): make queue pipeline globally bounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ The package currently installs 49 console scripts from `[project.scripts]`.
 | `hephaestus-agent-stage` | Run one Claude or Codex automation stage with prompt and skill context |
 | `hephaestus-ensure-state-labels` | Idempotently provision the planning labels (`state:needs-plan`, `state:plan-no-go`, `state:plan-go`, and `state:plan-blocked`) on one or more repos |
 | `hephaestus-audit-prs` | Audit ALL open PRs in one coordinator agent invocation |
-| `hephaestus-drive-prs-green` | Review open PRs and wait for their required branch-protection checks through the pr_review/merge_wait pipeline slice |
+| `hephaestus-drive-prs-green` | Review directly scoped PRs or PRs linked from discovered issues through the pr_review/merge_wait pipeline slice; it does not sweep unrelated open PRs |
 
 #### Private Pi provider setup
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Remediation of the strict 2026-05-28 audit findings (`audit-finding` issues) con
 
 2. **Automation Pipeline Hardening** — Stabilizing the queue-based
    plan → implement → review pipeline (Epic #1809): drive-green loop
-   behavior, orphan-PR recovery, epic/skip-tag scoping, and restoring
+   behavior, linked-issue PR recovery, epic/skip-tag scoping, and restoring
    the reviewed-head interlock while `merge_wait` safely stands by on a
    confirmed-unarmed PR pending the separately reviewed #2419 merge path.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,14 @@ in §5.1, which tags `state:skip` on epics before any other durable mutation.
  attempts; cross-stage regression cycles terminate in finite steps
  ([`_FAIL_BACK_CAP`](hephaestus/automation/pipeline/coordinator.py),
  [`ROUTES`](hephaestus/automation/pipeline/routing.py)).
+- **Globally bounded live work.** The coordinator admits at most
+ `C = max(1, parallel_repos × max_workers)` nonterminal work items at once.
+ A work permit remains with an item while it is queued, leased, running,
+ timer-parked, or waiting for a full destination queue; it is released only
+ after the finished sink records the terminal result
+ ([`_work_window`](hephaestus/automation/pipeline/coordinator.py),
+ [`Coordinator._push_item`](hephaestus/automation/pipeline/coordinator.py),
+ [`Coordinator._release_work_permit`](hephaestus/automation/pipeline/coordinator.py)).
 
 ### Non-goals
 
@@ -171,14 +179,23 @@ thread lock, outer) **and**
 [`_interruptible_file_lock`](hephaestus/automation/pipeline/worker_pool.py)
 (cross-process flock, inner). Worktrees share `.git`, so two concurrent
 operations on the same checkout would race.
-The only cross-thread channel is
+The only cross-thread **payload** channel is the bounded
 [`CompletionQueue`](hephaestus/automation/pipeline/queues.py)
-(`queue.Queue[(JobHandle, JobResult)]`); its blocking
-`get(timeout=…)` is the loop's idle sleep
-([`_wait_for_completion`](hephaestus/automation/pipeline/coordinator.py)).
-Poll interval = [`_IDLE_POLL_S = 1.0`](hephaestus/automation/pipeline/coordinator.py).
-Pool size = `parallel_repos × max_workers`
-([`WorkerPool(size=…)`](hephaestus/automation/pipeline/worker_pool.py)).
+(`queue.Queue[(JobHandle, JobResult)]`, capacity `C`). A separate
+`threading.Event` latch is control-plane-only: workers set it after a
+non-blocking completion publish, and signal handlers set it to wake an idle
+coordinator. Neither writes a sentinel into the completion queue or blocks on
+queue capacity
+([`WorkerPool._on_future_done`](hephaestus/automation/pipeline/worker_pool.py),
+[`Coordinator._wait_for_completion`](hephaestus/automation/pipeline/coordinator.py),
+[`Coordinator._wake_completion_wait`](hephaestus/automation/pipeline/coordinator.py)).
+The idle coordinator may wait on that event for its bounded poll interval
+([`_IDLE_POLL_S = 1.0`](hephaestus/automation/pipeline/coordinator.py)); it
+does not make a producer or signal handler wait. Pool size = `parallel_repos × max_workers`.
+Each stage-queue capacity and the
+completion-queue capacity are `C = max(1, parallel_repos × max_workers)`
+([`_work_window`](hephaestus/automation/pipeline/coordinator.py),
+[`WorkerPool(size=…)`](hephaestus/automation/pipeline/worker_pool.py)).
 
 ### Ticks
 
@@ -205,14 +222,19 @@ tick does, in order:
  ([`_DRAIN_ORDER`](hephaestus/automation/pipeline/coordinator.py)).
  Implementation drains separately to enforce dependency topo-order
  and file-overlap serialization; other queues drain with the per-repo
- in-flight cap ([`_drain_implementation`](hephaestus/automation/pipeline/coordinator.py),
+ in-flight cap. Pending destination-first handoffs are retried before and
+ between drains, and bounded direct/repository sources are admitted only at
+ safe capacity points ([`_drain_implementation`](hephaestus/automation/pipeline/coordinator.py),
  [`_drain_queues`](hephaestus/automation/pipeline/coordinator.py),
+ [`_drain_pending_handoffs`](hephaestus/automation/pipeline/coordinator.py),
+ [`_drain_repo_issue_sources`](hephaestus/automation/pipeline/coordinator.py),
  [`_admit`](hephaestus/automation/pipeline/coordinator.py)).
 6. **Idle-or-loop check** — if all queues + timers + in-flight are empty,
  re-seed up to `--loops` and either exit on zero work or continue
  ([`_all_idle`](hephaestus/automation/pipeline/coordinator.py),
  [`_reseed_if_converged`](hephaestus/automation/pipeline/coordinator.py)).
- Otherwise block on [`completion_q`](hephaestus/automation/pipeline/coordinator.py).
+ Otherwise wait on the completion/signal latch and drain the bounded
+ completion queue.
 A defensive step watchdog ([`_STEP_WATCHDOG_S = 15.0`](hephaestus/automation/pipeline/coordinator.py))
 warns when any `stage.step()` call exceeds ~15 s. 5 s proved too tight in
 practice: routine repo-stage steps (clone + label reads over the network)
@@ -250,6 +272,54 @@ protocol, then returns `StageOutcome(…)`. The coordinator's
 [`_route`](hephaestus/automation/pipeline/coordinator.py) applies the
 disposition to the queue.
 
+### Global capacity, leases, and source cursors
+
+Let `C = max(1, parallel_repos × max_workers)`. `C` is a global live-work
+window, not a per-stage concurrency target. Every stage queue and the
+completion queue have capacity `C`, while the coordinator holds one global
+permit for every nonterminal `WorkItem`. Consequently, seven stage queues do
+not permit `7C` simultaneous work items: an item holds the same permit as it
+moves through the pipeline and releases it only after `finished` records its
+outcome.
+
+Queue draining claims an item through a
+[`StageQueueLease`](hephaestus/automation/pipeline/queues.py). The lease keeps
+the source queue slot occupied while a stage runs. A transition is
+destination-first: the destination must accept the item before the source
+lease is released and the item stage/history/result are changed. When the
+destination is full, the coordinator retains exactly one pending handoff on
+that source lease and retries it after downstream drains. The completed stage
+action is therefore not replayed, and a full destination is ordinary
+backpressure rather than a spill list, shutdown, or failure
+([`StageQueueLease.handoff`](hephaestus/automation/pipeline/queues.py),
+[`Coordinator._handoff_item`](hephaestus/automation/pipeline/coordinator.py),
+[`Coordinator._drain_pending_handoffs`](hephaestus/automation/pipeline/coordinator.py)).
+
+Intake is also source-driven rather than an eager list of classified products:
+
+- Explicit `--issues` and `--prs` use one cursor each. The coordinator
+  classifies the next value only after every possible entry queue and the
+  global live-work window can accept it; unadmitted caller input remains in
+  the iterator, not in a `SeedEntry` or `WorkItem` spill buffer.
+- Repository intake uses a FIFO repository source. Once a repo has prepared
+  its checkout, its `RepoIssueSource` retains at most one pending metadata row
+  and one fetched GitHub page. The coordinator keeps at most `C` active repo
+  sources and gives each one admission attempt per FIFO round-robin, so a large
+  repository cannot monopolize discovery.
+- Organization repositories, issues, and open PRs use REST pages of at most 100 rows.
+  Pagination continues until the short terminal
+  page; there is no `gh ... --limit 500` discovery cap. Organization scope
+  resolution returns the filtered repository names before the FIFO source
+  admits repo work, while issue and PR runtime cursors consume their pages
+  lazily.
+
+The implementation is in
+[`Coordinator._drain_direct_issue_source`](hephaestus/automation/pipeline/coordinator.py),
+[`Coordinator._drain_repo_entry_source`](hephaestus/automation/pipeline/coordinator.py),
+[`Coordinator._drain_repo_issue_sources`](hephaestus/automation/pipeline/coordinator.py),
+[`RepoIssueSource`](hephaestus/automation/pipeline/stages/repo.py), and
+[`loop_repo_manager`](hephaestus/automation/loop_repo_manager.py).
+
 ### Non-blocking retry / timer-park contract
 
 Stages never sleep — the coordinator's timer heap owns every delay.
@@ -262,6 +332,13 @@ key and parks the item on the heap
 A missing key means "retry on the next drain tick" (no delay).
 [`BACKOFF_CAP_S = 60`](hephaestus/automation/pipeline/stages/base.py) is
 shared by every stage that uses the legacy exponential poll delay.
+Timer parking releases the source-stage lease but retains the item's global
+work permit. On expiry, the timer heap remains the item's owner until its
+stage queue accepts it; an occupied stage queue leaves the expired entry at
+the heap head for a later tick. That is bounded backpressure, not an overflow
+or a reason to repeat the delayed stage action
+([`_timer_park`](hephaestus/automation/pipeline/coordinator.py),
+[`_wake_timers`](hephaestus/automation/pipeline/coordinator.py)).
 
 ### Interrupt semantics
 
@@ -278,10 +355,17 @@ end-of-run summary lists them under `RESUMABLE at <stage>`. Resume is
 label/PR/worktree reconstruction: rerunning the same scoped command
 re-seeds each item into the correct entry queue. There is no persisted
 queue snapshot.
+The signal handler only sets the shutdown and wake latches; it never writes
+to, or waits on, the bounded completion queue. Completion-queue saturation is
+an internal invariant violation: the worker callback records a latch without
+blocking or spilling, the coordinator fails the run, and still-live work is
+finalized resumably. It does not set `shutdown` and does not turn into exit
+code 130 ([`WorkerPool._on_future_done`](hephaestus/automation/pipeline/worker_pool.py),
+[`Coordinator._drain_completions`](hephaestus/automation/pipeline/coordinator.py)).
 
 ### Exit codes
 
-- `130` — interrupted run.
+- `130` — interrupted by SIGINT, SIGTERM, or SIGHUP.
 - `1` — any effective item failed, skipped, blocked; or the coordinator hit a fatal error.
 - `0` — clean run.
 [`_exit_code`](hephaestus/automation/pipeline/coordinator.py) deliberately
@@ -380,8 +464,9 @@ cross-stage cycles terminate even if a stage has a budget bookkeeping bug
 
 The single per-item record moving through the queue. Thread-safety is by
 construction: a `WorkItem` and its `StageQueue` are only ever touched by
-the coordinator thread; the single cross-thread channel is
-[`CompletionQueue`](hephaestus/automation/pipeline/queues.py).
+the coordinator thread; the only cross-thread payload channel is the bounded
+[`CompletionQueue`](hephaestus/automation/pipeline/queues.py). Event latches
+carry wake/fault signals only, never `WorkItem` or `JobResult` payloads.
 Key fields:
 
 - `repo`, `kind` ([`ItemKind`](hephaestus/automation/pipeline/work_item.py)) —
@@ -506,6 +591,12 @@ audit a decision but never authorize a transition, block a stage, or backfill a
 missing label. Comment markers locate actor-owned journal artifacts only;
 foreign marker text is ignored.
 
+Likewise, prose such as `Verdict: GO` or `Verdict: NOGO` is reviewer output,
+not durable routing authority. A reviewer may propose a label from that
+analysis, but the coordinator advances only after the relevant GitHub
+`state:*` mutation succeeds and is confirmed. On restart, seeding reads the
+labels and PR state, not verdict text.
+
 ---
 
 ## 5. The seven queue stages
@@ -540,15 +631,17 @@ resume.
 
 ### 5.1 Repo intake
 
-Repo intake discovers candidate work, records exclusions, and routes each
-eligible issue or pull request to the stage implied by its durable state.
+Repo intake discovers candidate work through a bounded source, records
+exclusions, and routes each eligible issue or pull request to the stage implied
+by its durable state.
 
 #### Boundary diagram
 
 ```mermaid
 flowchart LR
-    Repository --> Discover --> Classify
-    Classify -->|"eligible"| WorkItems["Routed work items"]
+    Repository --> Discover --> Source["Bounded issue source"]
+    Source --> Classify
+    Classify -->|"eligible"| WorkItems["One routed work item"]
     Classify -->|"excluded"| DurableSkip["Durable skip state"]
     WorkItems --> Queues["Downstream queues"]
     DurableSkip --> Complete
@@ -562,12 +655,14 @@ stateDiagram-v2
     Prepare --> Discover: repository available
     Prepare --> Prepare: transient failure
     Prepare --> Failed: retry limit reached
-    Discover --> Classify: candidates loaded
+    Discover --> Source: source initialized
+    Source --> Classify: one candidate admitted
     Discover --> Failed: discovery failed
     Classify --> RecordExclusions: exclusions found
     Classify --> Dispatch: no exclusions
     RecordExclusions --> Dispatch: exclusions durable
-    Dispatch --> Complete: eligible items routed
+    Dispatch --> Source: next candidate
+    Source --> Complete: cursor exhausted
     Complete --> [*]
     Failed --> [*]
 ```
@@ -577,6 +672,10 @@ Architectural contract:
 - Exclusions become durable before excluded work leaves the queue.
 - Discovery never writes planning, review, implementation, or merge verdicts.
 - Failure of the repository item does not fabricate outcomes for its issues.
+- Runtime repository discovery does not eagerly build `products` or downstream
+  `WorkItem` lists. It fetches one issue page at a time, holds at most one
+  pending metadata row per active repository cursor, and drains active cursors
+  in FIFO round-robin order.
 
 ### 5.2 Planning
 
@@ -834,7 +933,7 @@ Architectural contract:
 - Every implementation review is posted to the pull request.
 - Actionable findings use durable inline threads and severity.
 - Prior rounds remain visible in the PR timeline.
-- Blocking findings produce `state:implementation-nogo`; only a clean review
+- Blocking findings produce `state:implementation-no-go`; only a clean review
   produces `state:implementation-go`.
 - Human-owned findings stop automation with an explanatory PR comment.
 - The review proof is a fresh GitHub snapshot plus a clean checkout at that
@@ -1031,18 +1130,21 @@ BEFORE the exclusion is honored
 
 ### Seeding and re-seed scope
 
-- `--repos` seeds one repo item per named repository
- ([`seed_from_cli`](hephaestus/automation/pipeline/seeding.py)).
-- `--issues` seeds issue-scoped items through the classifier and routes
- them past the durable-label-based decision.
-- `--prs` routes direct PRs by merge/close state then impl label.
-- `--org` expands to non-fork, non-archived repository seeds
- ([`loop_runner.py`](hephaestus/automation/loop_runner.py)).
+- `--repos` is consumed by a FIFO repository cursor; it creates repo work only
+ when both the REPO queue and the global live-work window have capacity.
+- `--issues` and `--prs` are direct bounded cursors. Each value is classified
+ only when its eventual entry queue is guaranteed to accept it, so a large
+ CLI scope is not converted into an eager seed list.
+- `--org` follows the GitHub REST repository pagination until exhaustion,
+ filters forked/archived repos, then passes the resolved names to that FIFO
+ source. Issue and PR discovery likewise use 100-row REST pages rather than a
+ 500-item CLI limit ([`loop_repo_manager.py`](hephaestus/automation/loop_repo_manager.py)).
 When `--issues` or `--prs` is set, the resolved `--repos` list is used
 ONLY for context — repo discovery is NOT enqueued, so a scoped run
 cannot reconstruct every open issue in the repo (deliberate scope
 isolation).
-After `coordinator._seed_pass`, if all queues + timers + in-flight are empty,
+After `coordinator._seed_pass`, if all queues, active leases, source cursors,
+timers, and in-flight jobs are empty,
 [`_reseed_if_converged`](hephaestus/automation/pipeline/coordinator.py)
 re-seeds up to `--loops` and either exits on a zero-work pass or
 continues.
@@ -1100,8 +1202,8 @@ mutations.
 
 [`JobResult.ok = False, value = None, error`](hephaestus/automation/pipeline/jobs.py)
 on any failure (return code != 0, `subprocess.TimeoutExpired`,
-exception). Stdout/stderr tails trimmed to 4 KiB for the JSONL event
-log; error message truncated to 500 chars.
+exception). Stdout/stderr tails are trimmed to 4 KiB in the `JobResult`;
+the error message is truncated to 500 chars.
 
 ### Completion contract
 
@@ -1114,6 +1216,15 @@ that escapes `future.result()` (exception + process-control escapes
 `worker_crash` result so a non-cancelled submit never silently loses
 its completion. Only futures cancelled before starting emit no
 completion (the coordinator synthesizes those).
+
+The completion queue is bounded to `C`, and the worker callback uses
+`put_nowait`. Under the global permit invariant, every in-flight job has a
+reserved completion slot. If that invariant is ever violated, the callback
+sets a saturation latch and wakes the coordinator; it neither blocks nor keeps
+an overflow buffer. The coordinator treats that latch as a fatal internal
+fault and preserves remaining in-flight items as resumable work. Signal
+handlers use the same wake mechanism but only a real OS signal sets shutdown
+and selects exit code 130.
 
 ### Per-repo lock layering
 
@@ -1223,6 +1334,23 @@ the constructor so the default construction path keeps its zero-I/O
 import contract
 ([`Coordinator.__init__`](hephaestus/automation/pipeline/coordinator.py)).
 
+### Bounded diagnostics and non-authoritative JSONL
+
+The coordinator retains only finite local diagnostic state: the in-memory
+event deque defaults to 1,024 records, detailed terminal items/ledger/
+preserved-worktree entries default to 128, and the per-repository stage-context
+cache is an LRU capped at `C`. A constant-space terminal summary still
+aggregates the entire run's pass/fail totals after older details are trimmed
+([`PipelineConfig.event_log_capacity`](hephaestus/automation/pipeline/coordinator.py),
+[`PipelineConfig.terminal_detail_capacity`](hephaestus/automation/pipeline/coordinator.py),
+[`Coordinator._record_terminal_result`](hephaestus/automation/pipeline/coordinator.py)).
+
+When `event_log_path` is configured, the coordinator also appends diagnostic
+records to JSONL. That file is best-effort: an I/O failure logs a
+warning and disables further JSONL writes without changing pipeline routing.
+It is not a queue snapshot or recovery journal. GitHub labels, comments, and
+PR state remain the only restart authority.
+
 ### Gauges
 
 [`_emit_observability_tick`](hephaestus/automation/pipeline/coordinator.py)
@@ -1250,8 +1378,8 @@ terminate a production automation loop.
 [`AlertTracker.observe(snapshot)`](hephaestus/observability/alerts.py) is
 called once per tick with the coordinator's
 [`_observability_snapshot`](hephaestus/automation/pipeline/coordinator.py).
-Emitted events drive `hephaestus_pipeline_alert_active` and a durable
-`alert_<fired|resolved>` event log entry.
+Emitted events drive `hephaestus_pipeline_alert_active` and a best-effort
+`alert_<fired|resolved>` diagnostic event-log entry.
 
 - **Default trigger**: queue-depth threshold is read from
  [`PipelineConfig.alert_queue_depth_threshold`](hephaestus/automation/pipeline/coordinator.py)
@@ -1267,6 +1395,11 @@ Emitted events drive `hephaestus_pipeline_alert_active` and a durable
 - **Failure-mode safety**: alerts are emitted only from measured queue
  depths and circuit-breaker snapshots, never from worker pool internal
  liveness (so a slow worker never causes an alert).
+
+Queue depth measures ready backlog, not a queue fault: a full stage queue is
+normal backpressure while a lease, timer, or source cursor retains ownership.
+Completion saturation is instead an invariant-breaking fatal error and is not
+represented as ordinary queue-depth pressure.
 
 ### Health endpoint
 
@@ -1335,7 +1468,7 @@ Exit-code priority is:
 
 | Priority | Code | Meaning |
 |---|---:|---|
-| 1 | `130` | The run was interrupted; this takes priority over other outcomes. |
+| 1 | `130` | SIGINT, SIGTERM, or SIGHUP interrupted the run; this takes priority over other outcomes. |
 | 2 | `1` | At least one effective item failed, skipped, or blocked. |
 | 3 | `0` | Every effective item completed successfully. |
 
@@ -1353,8 +1486,9 @@ Exit-code priority is:
 - **StageQueue** — FIFO queue for one
  [`StageName`](hephaestus/automation/pipeline/routing.py), owned only
  by the coordinator. [`queues.py`](hephaestus/automation/pipeline/queues.py).
-- **CompletionQueue** — the only cross-thread channel
- (`queue.Queue[(JobHandle, JobResult)]`).
+- **CompletionQueue** — the bounded cross-thread payload channel
+ (`queue.Queue[(JobHandle, JobResult)]`, capacity `C`). Event latches carry
+ wake and saturation signals without queue payloads.
  [`queues.py`](hephaestus/automation/pipeline/queues.py).
 - **Durable journal** — GitHub labels, comments, PR state, and
  `ArmingStateStore` records. Restart reconstruction reads this;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,6 +294,9 @@ backpressure rather than a spill list, shutdown, or failure
 ([`StageQueueLease.handoff`](hephaestus/automation/pipeline/queues.py),
 [`Coordinator._handoff_item`](hephaestus/automation/pipeline/coordinator.py),
 [`Coordinator._drain_pending_handoffs`](hephaestus/automation/pipeline/coordinator.py)).
+Leases carry stable FIFO tickets, so multiple ready items can be claimed and
+run concurrently up to `C`; a retry restores ahead of later-admitted work
+without serializing the whole stage.
 
 Intake is also source-driven rather than an eager list of classified products:
 
@@ -308,9 +311,11 @@ Intake is also source-driven rather than an eager list of classified products:
   repository cannot monopolize discovery.
 - Organization repositories and linked-issue metadata use REST pages of at
   most 100 rows. Pagination continues until the short terminal page; there is
-  no `gh ... --limit 500` discovery cap. Organization scope resolution returns
-  the filtered repository names before the FIFO source admits repo work, while
-  each active repository cursor consumes issue metadata lazily. Repository
+  no `gh ... --limit 500` discovery cap. An organization invocation passes a
+  resettable paged repository iterator directly to the FIFO source; it never
+  materializes the organization's names in CLI scope resolution or pipeline
+  configuration. Each active repository cursor consumes issue metadata lazily.
+  Repository
   discovery does not pre-scan open-PR pages: PR review context enters through
   the linked issue's classification. An orphan PR has no issue requirements
   and remains outside this source; an explicit `--prs` scope can select one
@@ -1139,9 +1144,10 @@ BEFORE the exclusion is honored
  only when its eventual entry queue is guaranteed to accept it, so a large
  CLI scope is not converted into an eager seed list. `--prs` is the explicit
  route for a PR that is not reached from linked-issue discovery.
-- `--org` follows the GitHub REST repository pagination until exhaustion,
- filters forked/archived repos, then passes the resolved names to that FIFO
- source. Linked-issue discovery uses 100-row REST pages rather than a 500-item
+- `--org` is a resettable, paged GitHub REST repository source. It filters the
+ `archived` and `fork` response fields before each name enters the FIFO source;
+ repository names are not materialized up front. Linked-issue discovery uses
+ 100-row REST pages rather than a 500-item
  CLI limit; it does not bulk-scan every open PR
  ([`loop_repo_manager.py`](hephaestus/automation/loop_repo_manager.py)).
 When `--issues` or `--prs` is set, the resolved `--repos` list is used

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,12 +306,15 @@ Intake is also source-driven rather than an eager list of classified products:
   and one fetched GitHub page. The coordinator keeps at most `C` active repo
   sources and gives each one admission attempt per FIFO round-robin, so a large
   repository cannot monopolize discovery.
-- Organization repositories, issues, and open PRs use REST pages of at most 100 rows.
-  Pagination continues until the short terminal
-  page; there is no `gh ... --limit 500` discovery cap. Organization scope
-  resolution returns the filtered repository names before the FIFO source
-  admits repo work, while issue and PR runtime cursors consume their pages
-  lazily.
+- Organization repositories and linked-issue metadata use REST pages of at
+  most 100 rows. Pagination continues until the short terminal page; there is
+  no `gh ... --limit 500` discovery cap. Organization scope resolution returns
+  the filtered repository names before the FIFO source admits repo work, while
+  each active repository cursor consumes issue metadata lazily. Repository
+  discovery does not pre-scan open-PR pages: PR review context enters through
+  the linked issue's classification. An orphan PR has no issue requirements
+  and remains outside this source; an explicit `--prs` scope can select one
+  for fail-closed direct evaluation, but cannot supply missing requirements.
 
 The implementation is in
 [`Coordinator._drain_direct_issue_source`](hephaestus/automation/pipeline/coordinator.py),
@@ -1134,11 +1137,13 @@ BEFORE the exclusion is honored
  when both the REPO queue and the global live-work window have capacity.
 - `--issues` and `--prs` are direct bounded cursors. Each value is classified
  only when its eventual entry queue is guaranteed to accept it, so a large
- CLI scope is not converted into an eager seed list.
+ CLI scope is not converted into an eager seed list. `--prs` is the explicit
+ route for a PR that is not reached from linked-issue discovery.
 - `--org` follows the GitHub REST repository pagination until exhaustion,
  filters forked/archived repos, then passes the resolved names to that FIFO
- source. Issue and PR discovery likewise use 100-row REST pages rather than a
- 500-item CLI limit ([`loop_repo_manager.py`](hephaestus/automation/loop_repo_manager.py)).
+ source. Linked-issue discovery uses 100-row REST pages rather than a 500-item
+ CLI limit; it does not bulk-scan every open PR
+ ([`loop_repo_manager.py`](hephaestus/automation/loop_repo_manager.py)).
 When `--issues` or `--prs` is set, the resolved `--repos` list is used
 ONLY for context — repo discovery is NOT enqueued, so a scoped run
 cannot reconstruct every open issue in the repo (deliberate scope

--- a/docs/auto-label-needs-plan.md
+++ b/docs/auto-label-needs-plan.md
@@ -6,7 +6,7 @@ source of truth for an issue's plan-review status:
 | Label | Meaning |
 |-------|---------|
 | `state:needs-plan` | Issue is new; planner should run on the next loop. |
-| `state:plan-no-go` | Reviewer's latest verdict was NOGO; re-plan next loop. |
+| `state:plan-no-go` | Confirmed plan-review label; re-plan next loop. Review prose is audit context, not routing authority. |
 | `state:plan-go` | Plan approved; implementer may proceed. |
 | `state:plan-blocked` | Planning requires named external feedback or a dependency. |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -5,8 +5,8 @@ pipeline (`hephaestus.automation.pipeline`): the metrics it exports, the alert
 rules it evaluates, the Service Level Objectives (SLOs) those metrics measure,
 and who owns responding to a fired alert.
 
-It closes the Section 9 audit finding (issue #2153): the pipeline already wrote
-structured JSONL events and served a local `/metrics` + `/health` endpoint, but
+It closes the Section 9 audit finding (issue #2153): the pipeline already emits
+structured JSONL diagnostic events and serves a local `/metrics` + `/health` endpoint, but
 job outcomes and stall state were not exported, and no document defined the
 metric catalog, alert ownership, or SLOs.
 
@@ -32,13 +32,17 @@ are constructed only when a metrics port is configured.
 - **`/health`** serves the JSON snapshot returned by the coordinator's
   `_health_snapshot`: the same lifecycle fields as the metrics, plus a
   top-level `status` of `ok` (running) or `stopping` (shutdown requested).
-- **Structured event log (JSONL).** When a loop runs, the coordinator writes a
-  durable JSONL event log (default:
+- **Structured event log (JSONL).** When a loop runs, the coordinator can append
+  a best-effort JSONL diagnostic log (default:
   `build/.issue_implementer/pipeline-events-<timestamp>-<pid>.jsonl`, set via
   `PipelineConfig.event_log_path`). Each metrics tick appends a
   `metrics_snapshot` record, and every alert transition appends an
   `alert_fired` or `alert_resolved` record carrying the alert `name`,
-  `severity`, and `message`. These are the lines to cite when escalating.
+  `severity`, and `message`. Local JSONL and the in-memory event window are
+  diagnostic only: a write failure disables further JSONL writes without
+  changing routing, and restart always reconstructs from GitHub labels,
+  comments, and PR state rather than this file. These are useful lines to cite
+  when escalating, not a durable authority.
 
 The alert queue-depth threshold is configurable via
 `PipelineConfig.alert_queue_depth_threshold` (default `100`); the stall
@@ -67,7 +71,7 @@ points at the emission chokepoint in `coordinator.py`.
 
 Alert rules read **only** live coordinator snapshot data — there are no
 speculative rules. `hephaestus/observability/alerts.py` evaluates the current
-snapshot each tick, and `AlertTracker` emits a durable transition (an
+snapshot each tick, and `AlertTracker` emits a diagnostic transition (an
 `alert_fired` / `alert_resolved` JSONL event and an update to
 `hephaestus_pipeline_alert_active`) only when a condition changes state, so a
 persistent degradation never produces repeated event spam.
@@ -75,7 +79,7 @@ persistent degradation never produces repeated event spam.
 | Alert | Severity | Condition | Owner | Runbook |
 | --- | --- | --- | --- | --- |
 | `circuit_breaker_open` | critical | Any circuit breaker in the snapshot reports `state == "open"`. | repository maintainer | [`docs/runbooks/automation-loop-crash.md`](runbooks/automation-loop-crash.md) |
-| `queue_depth_exceeds` | warning | Any stage queue depth exceeds `alert_queue_depth_threshold` (default `100`). | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
+| `queue_depth_exceeds` | warning | Any stage queue's ready backlog exceeds `alert_queue_depth_threshold` (default `100`). Full queues are ordinary backpressure, not a completion fault. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
 | `pipeline_stalled` | warning | `stalled_ticks` reaches the stall threshold (default `3`) — drain ticks with no progress. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
 
 ## SLOs

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -8,9 +8,13 @@ arguments, builds a
 :class:`~hephaestus.automation.pipeline.coordinator.PipelineConfig` trimmed to
 the ``(pr_review, merge_wait)`` stage scope via
 :class:`~hephaestus.automation.pipeline.routing.PipelineScope`, seeds the
-requested issues / PRs (and, in no-scope discovery mode, the repo-wide open-PR
-sweep via ``drive_green_all``), and dispatches to
+requested issues / PRs (or, in no-scope discovery mode, the repository's
+bounded linked-issue source), and dispatches to
 :func:`~hephaestus.automation.pipeline.coordinator.run_pipeline`.
+
+It does not enumerate unrelated open PRs. An orphan PR has no issue
+requirements and remains out of repository discovery; ``--prs`` can select it
+for fail-closed direct evaluation but cannot supply the missing requirements.
 
 The former CI repair/rebase/poll stage was deliberately removed: CI/CD remains
 independent branch protection and never supplies automation-loop input. The
@@ -107,8 +111,8 @@ Examples:
   # Verbose
   %(prog)s -v
 
-  # Drive every open PR, including teammates' and bots' (default is @me only)
-  %(prog)s --all
+  # Drive one explicitly selected PR
+  %(prog)s --prs 123
         """,
         add_github_throttle=True,
         dry_run_prefix=(
@@ -124,8 +128,8 @@ Examples:
         default=[],
         help=(
             "Scope to these issue numbers' PRs. Requires at least one issue "
-            "number when given. Omit the flag entirely to drive every open "
-            "PR discovered via gh (issue-linked PRs plus bot-authored PRs)."
+            "number when given. Omit the flag to use bounded linked-issue "
+            "discovery; unrelated open PRs are not enumerated."
         ),
     )
     parser.add_argument(
@@ -152,9 +156,9 @@ Examples:
         action="store_false",
         default=True,
         help=(
-            "Exclude open bot-authored PRs (Dependabot, github-actions, etc.) "
-            "from the no-scope discovery sweep. Bot-authored PRs are included "
-            "by default so they are not architecturally invisible (#848)."
+            "Compatibility option retained for the retired open-PR sweep. "
+            "No-scope discovery is linked-issue based, so unrelated bot PRs "
+            "remain out of scope; use --prs to select a PR explicitly."
         ),
     )
     parser.add_argument(
@@ -163,10 +167,9 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Include PRs opened by other actors (teammates and bots). Without "
-            "this flag, no-scope discovery drives only PRs authored by the "
-            "authenticated viewer (`gh api user`) (#821). Explicit --issues "
-            "and --prs scopes are processed regardless of author."
+            "Compatibility option retained for the retired author-filtered "
+            "open-PR sweep. It does not widen linked-issue discovery; explicit "
+            "--issues and --prs scopes are processed regardless of author."
         ),
     )
     add_agent_timeout_arg(parser)
@@ -236,10 +239,9 @@ def main() -> int:
         issues = list(dict.fromkeys(args.issues))
         prs = list(dict.fromkeys(args.prs))
 
-        # No-scope discovery mode: with neither --issues nor --prs, the
-        # coordinator's repo-discovery seed unions every open non-draft PR on the
-        # repo (the legacy bot-PR sweep, #819 / #848) — enabled via
-        # drive_green_all. A scoped run (issues or PRs given) stays narrow (POLA).
+        # No-scope discovery mode keeps the compatibility flag true, but the
+        # coordinator now consumes only the bounded linked-issue source. It
+        # never enumerates unrelated open PRs; a scoped run stays narrow (POLA).
         drive_green_all = not issues and not prs
 
         config = PipelineConfig(

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -223,57 +223,68 @@ def _list_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
     return _iter_open_issue_meta(org, repo)
 
 
-def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
-    """Return open PR numbers and author metadata, sorted ascending.
+def _iter_open_pr_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
+    """Yield open-PR metadata one REST page at a time.
 
-    Read-only helper for the pipeline repo stage's ``--drive-green-all``
-    orphan-PR discovery (#1817): PRs with no tracked issue are terminalized
-    without requirements context. Raises RuntimeError on failures so discovery
-    does not masquerade as a clean empty run.
+    The runtime ``--drive-green-all`` path consumes this cursor directly.  Do
+    not use ``gh api --paginate --slurp`` here: it accumulates every PR page
+    before the caller can apply bounded source admission.
     """
-    try:
-        out = gh_call(
-            [
-                "api",
-                f"/repos/{org}/{repo}/pulls?state=open&per_page=100",
-                "--paginate",
-                "--slurp",
-            ],
-            timeout=NETWORK_TIMEOUT,
-        )
-        pages = json.loads(out.stdout or "[]")
-        if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
-            raise ValueError("expected paginated pull response")
-    except (
-        subprocess.SubprocessError,
-        RuntimeError,
-        OSError,
-        ValueError,
-        json.JSONDecodeError,
-    ) as exc:
-        raise RuntimeError(f"failed to list open PRs for {org}/{repo}: {exc}") from exc
-    pulls: list[dict[str, Any]] = []
-    for page in pages:
-        for entry in page:
-            number = entry.get("number") if isinstance(entry, dict) else None
+    page = 1
+    while True:
+        try:
+            out = gh_call(
+                [
+                    "api",
+                    (
+                        f"/repos/{org}/{repo}/pulls?state=open&per_page=100"
+                        f"&sort=created&direction=asc&page={page}"
+                    ),
+                ],
+                timeout=NETWORK_TIMEOUT,
+            )
+            entries = json.loads(out.stdout or "[]")
+            if not isinstance(entries, list):
+                raise ValueError("expected pull-response array")
+        except (
+            subprocess.SubprocessError,
+            RuntimeError,
+            OSError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as exc:
+            raise RuntimeError(f"failed to list open PRs for {org}/{repo}: {exc}") from exc
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"failed to list open PRs for {org}/{repo}: malformed PR entry")
+            number = entry.get("number")
             if not isinstance(number, int):
-                continue
+                raise RuntimeError(f"failed to list open PRs for {org}/{repo}: malformed PR number")
             raw_user = entry.get("user")
             user = raw_user if isinstance(raw_user, dict) else {}
             raw_state = entry.get("state")
             state = raw_state if isinstance(raw_state, str) else "open"
-            pulls.append(
-                {
-                    "number": number,
-                    "state": state.upper(),
-                    "isDraft": bool(entry.get("draft", False)),
-                    "user": {
-                        "login": user.get("login"),
-                        "type": user.get("type"),
-                    },
-                }
-            )
-    return sorted(pulls, key=lambda pr: pr["number"])
+            yield {
+                "number": number,
+                "state": state.upper(),
+                "isDraft": bool(entry.get("draft", False)),
+                "user": {"login": user.get("login"), "type": user.get("type")},
+            }
+
+        if len(entries) < 100:
+            return
+        page += 1
+
+
+def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
+    """Materialize the bounded cursor for compatibility-only callers.
+
+    Pipeline runtime code must use :func:`_iter_open_pr_meta`; this legacy
+    wrapper remains for callers that specifically require a complete sorted
+    list.
+    """
+    return sorted(_iter_open_pr_meta(org, repo), key=lambda pr: pr["number"])
 
 
 def _list_open_issue_numbers(org: str, repo: str, *, dry_run: bool = False) -> list[int]:

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 from hephaestus.automation.git_utils import COMMIT_POLICY_REWRITE_EXEC
 from hephaestus.automation.github_api import skip_epics
-from hephaestus.automation.state_labels import partition_epics
+from hephaestus.automation.state_labels import is_epic
 from hephaestus.github.client import gh_call
 from hephaestus.resilience.subprocess_resilience import resilient_call
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
@@ -116,46 +117,91 @@ def _gh_list_repos(org: str) -> list[str]:
     ]
 
 
-def _list_open_issue_meta(org: str, repo: str) -> list[dict[str, Any]]:
-    """Return open-issue metadata for ``org/repo`` — reads only, no tagging.
+def _iter_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
+    """Yield normalized open-issue metadata one GitHub page at a time.
 
-    One ``gh issue list`` returning ``{number, labels, title}`` dicts (labels
-    flattened to names). Extracted from :func:`_list_open_issue_numbers` so
-    the pipeline repo stage (#1817) can reuse the read while routing the epic
-    ``state:skip`` tagging through its coordinator-owned accessor instead of
-    the in-band :func:`skip_epics` side effect below.
+    The REST issues endpoint is deliberately requested one bounded page at a
+    time.  In particular, do not replace this with ``gh api --paginate
+    --slurp``: that command retains every page before Python can apply
+    backpressure, and the old ``gh issue list --limit 500`` silently omitted
+    the tail of a busy repository.  The cursor is the next page number; one
+    page's JSON body is the maximum discovery metadata retained here.
 
-    Raises RuntimeError on GitHub/JSON failures so pipeline discovery never
-    converts an unreadable repo into a successful empty run.
+    GitHub's issues endpoint also returns pull requests.  Those rows are
+    ignored because this helper preserves the historical ``gh issue list``
+    contract.  Every other malformed row or malformed page is fatal rather
+    than being mistaken for an empty/converged repository.
+
+    Raises:
+        RuntimeError: On a network/CLI/JSON failure or malformed API page.
+
     """
-    try:
-        out = gh_call(
-            [
-                "issue",
-                "list",
-                "--repo",
-                f"{org}/{repo}",
-                "--state",
-                "open",
-                "--limit",
-                "500",
-                "--json",
-                "number,labels,title",
-            ],
-            timeout=NETWORK_TIMEOUT,
-        )
-        entries = json.loads(out.stdout or "[]")
-    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"failed to list open issues for {org}/{repo}: {exc}") from exc
-    return [
-        {
-            "number": e["number"],
-            "labels": [lbl["name"] for lbl in e.get("labels", [])],
-            "title": e.get("title", ""),
-        }
-        for e in entries
-        if isinstance(e, dict) and "number" in e
-    ]
+    page = 1
+    while True:
+        try:
+            out = gh_call(
+                [
+                    "api",
+                    f"/repos/{org}/{repo}/issues?state=open&per_page=100"
+                    f"&sort=created&direction=asc&page={page}",
+                ],
+                timeout=NETWORK_TIMEOUT,
+            )
+            entries = json.loads(out.stdout or "[]")
+            if not isinstance(entries, list):
+                raise ValueError("expected an issue-list page")
+        except (
+            subprocess.SubprocessError,
+            RuntimeError,
+            OSError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as exc:
+            raise RuntimeError(f"failed to list open issues for {org}/{repo}: {exc}") from exc
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(
+                    f"failed to list open issues for {org}/{repo}: malformed issue row"
+                )
+            # REST's /issues includes PRs.  They are not issue-source rows.
+            if "pull_request" in entry:
+                continue
+            number = entry.get("number")
+            title = entry.get("title", "")
+            labels = entry.get("labels", [])
+            if not isinstance(number, int) or number <= 0:
+                raise RuntimeError(
+                    f"failed to list open issues for {org}/{repo}: malformed issue number"
+                )
+            if not isinstance(title, str) or not isinstance(labels, list):
+                raise RuntimeError(
+                    f"failed to list open issues for {org}/{repo}: malformed issue metadata"
+                )
+            label_names: list[str] = []
+            for label in labels:
+                if not isinstance(label, dict) or not isinstance(label.get("name"), str):
+                    raise RuntimeError(
+                        f"failed to list open issues for {org}/{repo}: malformed issue label"
+                    )
+                label_names.append(label["name"])
+            yield {"number": number, "labels": label_names, "title": title}
+
+        # A short response is the terminal cursor.  An exact 100-row page is
+        # followed by one inexpensive empty-page probe, avoiding a hard cap.
+        if len(entries) < 100:
+            return
+        page += 1
+
+
+def _list_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
+    """Return the bounded open-issue metadata iterator for ``org/repo``.
+
+    The historical name is retained for import compatibility, but callers
+    must consume it as a source rather than materializing it.  See
+    :func:`_iter_open_issue_meta` for the page and validation contract.
+    """
+    return _iter_open_issue_meta(org, repo)
 
 
 def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
@@ -234,29 +280,35 @@ def _list_open_issue_numbers(org: str, repo: str, *, dry_run: bool = False) -> l
     read failures propagate as RuntimeError so automation does not treat an
     unreadable repo as converged.
     """
-    meta = _list_open_issue_meta(org, repo)
-    kept, epics = partition_epics(meta)
-    if epics:
-        epic_set = set(epics)
-        for num in epics:
-            LOG.info(
-                "[%s] issue #%s is an epic/roadmap tracking issue; excluding from planning loop",
-                repo,
-                num,
-            )
-        epic_labels = {m["number"]: m["labels"] for m in meta if m["number"] in epic_set}
+    kept: list[int] = []
+    for metadata in _list_open_issue_meta(org, repo):
+        number = int(metadata["number"])
+        labels = list(metadata["labels"])
+        if not is_epic(labels, str(metadata["title"])):
+            kept.append(number)
+            continue
+
+        LOG.info(
+            "[%s] issue #%s is an epic/roadmap tracking issue; excluding from planning loop",
+            repo,
+            number,
+        )
         # Best-effort skip-tagging: never let a label write break discovery.
         # The owning repo is passed explicitly — this runs in the multi-repo
         # parent process, where ambient cwd resolution wrote other repos'
-        # epic numbers onto the launch-directory repo (#2245).
+        # epic numbers onto the launch-directory repo (#2245).  The write is
+        # performed before the exclusion is honored, one bounded metadata row
+        # at a time; do not first collect all epic labels in a spill list.
         if dry_run:
-            LOG.info("[dry-run] [%s] would tag excluded epics state:skip", repo)
+            LOG.info("[dry-run] [%s] would tag excluded epic #%s state:skip", repo, number)
         else:
             try:
-                skip_epics(epic_labels, repo=(org, repo))
+                skip_epics({number: labels}, repo=(org, repo))
             except Exception as exc:  # pragma: no cover - defensive
-                LOG.warning("[%s] could not tag excluded epics state:skip: %s", repo, exc)
-    return kept
+                LOG.warning(
+                    "[%s] could not tag excluded epic #%s state:skip: %s", repo, number, exc
+                )
+    return sorted(kept)
 
 
 def _count_open_issues(org: str, repo: str, *, dry_run: bool = False) -> int:

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -86,16 +86,15 @@ def _detect_cwd_repo() -> tuple[str | None, str | None]:
     return (org, repo)
 
 
-def _gh_list_repos(org: str) -> list[str]:
-    """Return non-archived, non-fork repos for ``org`` one page at a time.
+def _iter_gh_repos(org: str) -> Iterator[str]:
+    """Yield non-archived, non-fork organization repos one REST page at a time.
 
-    ``gh repo list --limit`` silently caps organization discovery.  Requesting
-    an explicit REST page bounds the response held in memory and lets an
-    organization larger than that historical cap reach the coordinator.  The
-    coordinator then admits the returned names through its bounded repository
-    source; this helper deliberately does *not* inspect issue backlogs.
+    The generator does not prefetch the next page: the coordinator owns when
+    it asks for the next repository, so an organization-wide run retains one
+    REST page and its bounded pipeline cursors rather than every repository.
+    The API uses ``archived`` and ``fork`` (not GraphQL's ``isArchived`` /
+    ``isFork``); malformed flags fail closed before automation touches a repo.
     """
-    repos: list[str] = []
     page = 1
     while True:
         try:
@@ -110,30 +109,46 @@ def _gh_list_repos(org: str) -> list[str]:
                 timeout=NETWORK_TIMEOUT,
             )
         except subprocess.TimeoutExpired as exc:
-            raise SystemExit(f"gh repo list {org} timed out after {exc.timeout}s") from exc
+            raise RuntimeError(f"gh repo list {org} timed out after {exc.timeout}s") from exc
         except subprocess.CalledProcessError as exc:
-            raise SystemExit(
+            raise RuntimeError(
                 f"gh repo list {org} failed (rc={exc.returncode}): {(exc.stderr or '').strip()}"
             ) from exc
         try:
             entries = json.loads(out.stdout or "[]")
         except json.JSONDecodeError as exc:
-            raise SystemExit(f"gh repo list returned invalid JSON: {exc}") from exc
+            raise RuntimeError(f"gh repo list returned invalid JSON: {exc}") from exc
         if not isinstance(entries, list):
-            raise SystemExit("gh repo list returned a JSON value other than an array")
+            raise RuntimeError("gh repo list returned a JSON value other than an array")
 
         for entry in entries:
             if not isinstance(entry, dict):
-                raise SystemExit("gh repo list returned a malformed repository entry")
+                raise RuntimeError("gh repo list returned a malformed repository entry")
             name = entry.get("name")
             if not isinstance(name, str) or not name:
-                raise SystemExit("gh repo list returned a repository entry without a name")
-            if not entry.get("isArchived", False) and not entry.get("isFork", False):
-                repos.append(name)
+                raise RuntimeError("gh repo list returned a repository entry without a name")
+            archived = entry.get("archived")
+            fork = entry.get("fork")
+            if not isinstance(archived, bool) or not isinstance(fork, bool):
+                raise RuntimeError("gh repo list returned a repository entry with malformed flags")
+            if not archived and not fork:
+                yield name
 
         if len(entries) < 100:
-            return repos
+            return
         page += 1
+
+
+def _gh_list_repos(org: str) -> list[str]:
+    """Materialize :func:`_iter_gh_repos` for legacy callers and tests only.
+
+    Production ``--org`` execution passes the iterator factory to the
+    coordinator instead, retaining only a bounded source window.
+    """
+    try:
+        return list(_iter_gh_repos(org))
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def _iter_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -224,11 +224,12 @@ def _list_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
 
 
 def _iter_open_pr_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
-    """Yield open-PR metadata one REST page at a time.
+    """Yield open-PR metadata one REST page at a time for compatibility callers.
 
-    The runtime ``--drive-green-all`` path consumes this cursor directly.  Do
-    not use ``gh api --paginate --slurp`` here: it accumulates every PR page
-    before the caller can apply bounded source admission.
+    Pipeline repository discovery does not consume this cursor: it advances
+    through linked issue metadata, and unrelated orphan PRs remain out of that
+    source. Do not use ``gh api --paginate --slurp`` in an out-of-band caller:
+    it accumulates every PR page before the caller can apply its own bounds.
     """
     page = 1
     while True:
@@ -280,7 +281,7 @@ def _iter_open_pr_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:
 def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
     """Materialize the bounded cursor for compatibility-only callers.
 
-    Pipeline runtime code must use :func:`_iter_open_pr_meta`; this legacy
+    Pipeline runtime code consumes no repository-wide open-PR cursor; this
     wrapper remains for callers that specifically require a complete sorted
     list.
     """

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -87,34 +87,53 @@ def _detect_cwd_repo() -> tuple[str | None, str | None]:
 
 
 def _gh_list_repos(org: str) -> list[str]:
-    """Return non-archived, non-fork repos for ``org``."""
-    try:
-        out = gh_call(
-            [
-                "repo",
-                "list",
-                org,
-                "--no-archived",
-                "--json",
-                "name,isArchived,isFork",
-                "--limit",
-                "200",
-            ],
-            timeout=NETWORK_TIMEOUT,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise SystemExit(f"gh repo list {org} timed out after {exc.timeout}s") from exc
-    except subprocess.CalledProcessError as exc:
-        raise SystemExit(
-            f"gh repo list {org} failed (rc={exc.returncode}): {(exc.stderr or '').strip()}"
-        ) from exc
-    try:
-        entries = json.loads(out.stdout or "[]")
-    except json.JSONDecodeError as exc:
-        raise SystemExit(f"gh repo list returned invalid JSON: {exc}") from exc
-    return [
-        e["name"] for e in entries if not e.get("isArchived", False) and not e.get("isFork", False)
-    ]
+    """Return non-archived, non-fork repos for ``org`` one page at a time.
+
+    ``gh repo list --limit`` silently caps organization discovery.  Requesting
+    an explicit REST page bounds the response held in memory and lets an
+    organization larger than that historical cap reach the coordinator.  The
+    coordinator then admits the returned names through its bounded repository
+    source; this helper deliberately does *not* inspect issue backlogs.
+    """
+    repos: list[str] = []
+    page = 1
+    while True:
+        try:
+            out = gh_call(
+                [
+                    "api",
+                    (
+                        f"/orgs/{org}/repos?per_page=100&type=all&sort=full_name"
+                        f"&direction=asc&page={page}"
+                    ),
+                ],
+                timeout=NETWORK_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SystemExit(f"gh repo list {org} timed out after {exc.timeout}s") from exc
+        except subprocess.CalledProcessError as exc:
+            raise SystemExit(
+                f"gh repo list {org} failed (rc={exc.returncode}): {(exc.stderr or '').strip()}"
+            ) from exc
+        try:
+            entries = json.loads(out.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"gh repo list returned invalid JSON: {exc}") from exc
+        if not isinstance(entries, list):
+            raise SystemExit("gh repo list returned a JSON value other than an array")
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise SystemExit("gh repo list returned a malformed repository entry")
+            name = entry.get("name")
+            if not isinstance(name, str) or not name:
+                raise SystemExit("gh repo list returned a repository entry without a name")
+            if not entry.get("isArchived", False) and not entry.get("isFork", False):
+                repos.append(name)
+
+        if len(entries) < 100:
+            return repos
+        page += 1
 
 
 def _iter_open_issue_meta(org: str, repo: str) -> Iterator[dict[str, Any]]:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -210,6 +210,8 @@ class LoopConfig:
     dry_run: bool = False
     no_advise: bool = False
     nitpick: bool = False
+    # Retained CLI/config compatibility option. It does not expand the queue's
+    # linked-issue repository discovery into an unrelated open-PR sweep.
     drive_green_all: bool = False
     run_pre_pr_tests: bool = False
     # ``model`` is the catch-all applied to every phase when set; per-phase
@@ -330,10 +332,9 @@ def _build_parser() -> argparse.ArgumentParser:
         "--drive-green-all",
         action="store_true",
         help=(
-            "Pass --all to the drive-green phase: drive every open PR, "
-            "including those opened by teammates and bots. By default "
-            "drive-green operates only on PRs authored by the authenticated "
-            "viewer (#821)."
+            "Compatibility option for the retired broad drive-green sweep. "
+            "Repository discovery remains linked-issue based and never scans "
+            "unrelated open PRs; use --prs for an explicit PR scope."
         ),
     )
     p.add_argument(

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -33,6 +33,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -48,6 +49,7 @@ from hephaestus.automation.loop_repo_manager import (
     _clone_missing_repos as _clone_missing_repos,
     _detect_cwd_repo as _detect_cwd_repo,
     _gh_list_repos as _gh_list_repos,
+    _iter_gh_repos as _iter_gh_repos,
     _resolve_repo_dir as _resolve_repo_dir,
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
@@ -507,7 +509,9 @@ def _pipeline_scope_for_phases(phases: tuple[str, ...]) -> PipelineScope | None:
         raise SystemExit(str(exc)) from exc
 
 
-def _pipeline_event_log_path(projects_dir: Path, repos: list[str]) -> Path | None:
+def _pipeline_event_log_path(
+    projects_dir: Path, repos: list[str], *, has_repo_source: bool = False
+) -> Path | None:
     """Return the default durable event-log path for a loop invocation.
 
     The coordinator writes ``run_start`` before repo discovery. Keeping the
@@ -515,7 +519,7 @@ def _pipeline_event_log_path(projects_dir: Path, repos: list[str]) -> Path | Non
     ``projects_dir / repo`` early, which would look like a cloned checkout to
     the repo stage.
     """
-    if not repos:
+    if not repos and not has_repo_source:
         return None
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     return Path(DEFAULT_STATE_DIR) / f"pipeline-events-{stamp}-{os.getpid()}.jsonl"
@@ -613,15 +617,21 @@ def _resolve_org_and_repos(
             org = detected_org
         else:
             org = args.org
-        LOG.info("Discovering repos in %s ...", org)
+        # The coordinator owns a resettable, paged source for an org-wide
+        # run. Do not enumerate every repository here merely to construct the
+        # pipeline configuration; that would recreate the eager O(org) spill
+        # this wrapper is meant to avoid.
+        if not args.issues and not args.prs:
+            LOG.info("Streaming repositories in %s through the bounded pipeline source ...", org)
+            return (org, [], None)
+
+        # An explicit numeric issue/PR is only meaningful within a concrete
+        # repository. Preserve the legacy compatibility behavior for that
+        # ambiguous form rather than assigning a streamed org's first page
+        # implicitly.
         candidates = _gh_list_repos(org)
         if not candidates:
             return (org, [], "No repos returned from gh repo list — possible rate limit.")
-        LOG.info(
-            "Discovered %d repos in deterministic full-name order; "
-            "issue discovery begins in the bounded pipeline source.",
-            len(candidates),
-        )
         return (org, candidates, None)
 
     # Branch 4: no flags — default to cwd repo
@@ -638,7 +648,12 @@ def _resolve_org_and_repos(
 
 
 def _build_pipeline_config(
-    args: argparse.Namespace, cfg: LoopConfig, org: str, repos: list[str]
+    args: argparse.Namespace,
+    cfg: LoopConfig,
+    org: str,
+    repos: list[str],
+    *,
+    repo_source_factory: Callable[[], Iterator[str]] | None = None,
 ) -> PipelineConfig:
     """Build a PipelineConfig from the parsed args and LoopConfig.
 
@@ -665,6 +680,7 @@ def _build_pipeline_config(
     return PipelineConfig(
         org=org,
         repos=repos,
+        repo_source_factory=repo_source_factory,
         issues=cfg.issues,
         prs=cfg.prs,
         loops=cfg.loops,
@@ -691,7 +707,9 @@ def _build_pipeline_config(
         serialize_file_overlap=cfg.serialize_file_overlap,
         metrics_port=cfg.metrics_port,
         circuit_breaker_snapshot_provider=circuit_breaker_snapshot_provider,
-        event_log_path=_pipeline_event_log_path(cfg.projects_dir, repos),
+        event_log_path=_pipeline_event_log_path(
+            cfg.projects_dir, repos, has_repo_source=repo_source_factory is not None
+        ),
         projects_dir=cfg.projects_dir,
         repo_roots=cfg.repo_roots,
         json_out=args.json,
@@ -764,7 +782,12 @@ def _error_exit(args: argparse.Namespace, message: str, json_message: str | None
 
 
 def _dispatch_pipeline(
-    args: argparse.Namespace, cfg: LoopConfig, org: str, repos: list[str]
+    args: argparse.Namespace,
+    cfg: LoopConfig,
+    org: str,
+    repos: list[str],
+    *,
+    repo_source_factory: Callable[[], Iterator[str]] | None = None,
 ) -> int:
     """Run the queue-based pipeline and return its exit code.
 
@@ -782,11 +805,19 @@ def _dispatch_pipeline(
         The pipeline's exit code.
 
     """
-    if not cfg.dry_run:
+    if not cfg.dry_run and repos:
         _preflight_token_scopes(cfg.org, repos[0])
     from hephaestus.automation.pipeline.coordinator import run_pipeline
 
-    return run_pipeline(_build_pipeline_config(args, cfg, org, repos))
+    return run_pipeline(
+        _build_pipeline_config(
+            args,
+            cfg,
+            org,
+            repos,
+            repo_source_factory=repo_source_factory,
+        )
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -806,6 +837,14 @@ def main(argv: list[str] | None = None) -> int:
         return _error_exit(args, err)
 
     projects_dir = resolve_projects_dir(args.projects_dir, prefer_cwd_parent=True)
+    streaming_org_scope = args.org is not None and not args.repos and not (args.issues or args.prs)
+    root_scope_repos = repos
+    if streaming_org_scope:
+        cwd_org, cwd_repo = _detect_cwd_repo()
+        if cwd_repo and cwd_org and cwd_org.casefold() == org.casefold():
+            # Preserve the current checkout for its matching repository even
+            # though the streamed source has not yet yielded that name.
+            root_scope_repos = [cwd_repo]
     cfg = LoopConfig(
         loops=args.loops,
         max_workers=args.max_workers,
@@ -832,7 +871,7 @@ def main(argv: list[str] | None = None) -> int:
         gh_global_burst=args.gh_global_burst,
         org=org,
         projects_dir=projects_dir,
-        repo_roots=_current_checkout_repo_roots(args, org, repos, projects_dir),
+        repo_roots=_current_checkout_repo_roots(args, org, root_scope_repos, projects_dir),
         # A non-positive --phase-timeout explicitly disables the bound; any
         # positive value (including the env-overridable default) applies it.
         phase_timeout_s=(
@@ -841,10 +880,15 @@ def main(argv: list[str] | None = None) -> int:
         metrics_port=args.metrics_port,
     )
 
-    if not repos:
+    org_repo_source = (lambda: _iter_gh_repos(org)) if streaming_org_scope else None
+
+    if not repos and org_repo_source is None:
         return _error_exit(args, "Repo list is empty; nothing to do.", "empty repo list")
 
-    LOG.info("Repos to process: %s", " ".join(repos))
+    if org_repo_source is not None:
+        LOG.info("Repos to process: streamed from organization %s", org)
+    else:
+        LOG.info("Repos to process: %s", " ".join(repos))
     LOG.info(
         "Loops: %d | Max workers: %d | Parallel repos: %d | Agent: %s | Dry run: %s",
         cfg.loops,
@@ -862,7 +906,13 @@ def main(argv: list[str] | None = None) -> int:
     from hephaestus.utils.terminal import install_sigtstp_only
 
     install_sigtstp_only()
-    return _dispatch_pipeline(args, cfg, org, repos)
+    return _dispatch_pipeline(
+        args,
+        cfg,
+        org,
+        repos,
+        repo_source_factory=org_repo_source,
+    )
 
 
 if __name__ == "__main__":

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -401,6 +401,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Enumerate non-fork, non-archived repos in a GitHub org. "
             "Pass `--org NAME` for a specific org, or `--org` alone to auto-detect "
             "the org from the current repo's git remote. "
+            "With --issues or --prs, also pass exactly one --repos REPO. "
             "Default (no flag): run only for the current repo."
         ),
     )
@@ -585,14 +586,20 @@ def _resolve_org_and_repos(
 
     Precedence:
       1. ``--repos`` given → use it; org from cwd (preferred) or ``--org NAME``.
-      2. ``--org NAME`` (explicit) → enumerate non-fork repos in NAME.
-      3. ``--org`` (no arg) → detect org from cwd; enumerate non-fork repos.
+      2. ``--org NAME`` (explicit) → stream non-fork repos in NAME.
+      3. ``--org`` (no arg) → detect org from cwd; stream non-fork repos.
       4. (no flags) → use only the cwd repo + its org.
 
     Returns ``("", [], "<reason>")`` on error so ``main()`` can log and exit.
     """
     # Branch 1: explicit --repos
     if args.repos:
+        if (args.issues or args.prs) and len(args.repos) != 1:
+            return (
+                "",
+                [],
+                "--issues/--prs require exactly one repository via --repos REPO.",
+            )
         detected_org, _ = _detect_cwd_repo()
         explicit_org = args.org if isinstance(args.org, str) else None
         org = explicit_org or detected_org
@@ -625,14 +632,14 @@ def _resolve_org_and_repos(
             LOG.info("Streaming repositories in %s through the bounded pipeline source ...", org)
             return (org, [], None)
 
-        # An explicit numeric issue/PR is only meaningful within a concrete
-        # repository. Preserve the legacy compatibility behavior for that
-        # ambiguous form rather than assigning a streamed org's first page
-        # implicitly.
-        candidates = _gh_list_repos(org)
-        if not candidates:
-            return (org, [], "No repos returned from gh repo list — possible rate limit.")
-        return (org, candidates, None)
+        # Issue and PR numbers are repository-local.  Refuse the ambiguous
+        # combination instead of materializing an entire organization and
+        # silently choosing its first repository as the direct-scope target.
+        return (
+            org,
+            [],
+            "--org with --issues/--prs requires exactly one --repos REPO scope.",
+        )
 
     # Branch 4: no flags — default to cwd repo
     detected_org, detected_repo = _detect_cwd_repo()

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -616,12 +616,12 @@ def _resolve_org_and_repos(
         candidates = _gh_list_repos(org)
         if not candidates:
             return (org, [], "No repos returned from gh repo list — possible rate limit.")
-        LOG.info("Sorting %d repos by open-issue count ...", len(candidates))
-        if args.dry_run:
-            repos = _sort_repos_by_open_count(org, candidates, dry_run=True)
-        else:
-            repos = _sort_repos_by_open_count(org, candidates)
-        return (org, repos, None)
+        LOG.info(
+            "Discovered %d repos in deterministic full-name order; "
+            "issue discovery begins in the bounded pipeline source.",
+            len(candidates),
+        )
+        return (org, candidates, None)
 
     # Branch 4: no flags — default to cwd repo
     detected_org, detected_repo = _detect_cwd_repo()

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -293,16 +293,14 @@ class CIDriverOptions(VerboseParallelWorkerOptionsBase):
     enable_ui: bool = True
     max_fix_iterations: int = 1  # number of fix attempts before giving up
     force_merge_on_stall: bool = False  # attempt squash-merge fallback if auto-merge fails
-    # When True, _discover_prs unions the issue-driven set with every open
-    # bot-authored PR on the repo (#848). Bot PRs (Dependabot, github-actions,
-    # etc.) carry no ``Closes #N`` link so they are architecturally invisible
-    # to issue-driven discovery; without this they leak forever.
+    # Retained compatibility option for the retired open-PR sweep. Linked-issue
+    # discovery can reach a bot-authored PR only when a discovered issue links
+    # to it; unrelated bot PRs remain out of scope.
     include_bot_prs: bool = True
-    # When False (default, #821), discovery is restricted to PRs whose
-    # author.login matches the authenticated `gh api user` viewer login.
-    # Set True via the CLI's --all flag to drive every open PR (teammates'
-    # and bots' included). Issue-scoped lookups (`--issues N`) bypass this
-    # filter — they always resolve to the matching PR regardless of author.
+    # Retained compatibility option for the retired author-filtered open-PR
+    # sweep. Queue repository discovery is linked-issue based and does not
+    # enumerate unrelated open PRs; explicit `--issues` / `--prs` scopes are
+    # resolved regardless of author.
     include_all_authors: bool = False
     # When True (default), _drive_issue first attempts a mechanical ``git
     # rebase`` onto the base branch for PRs that are behind/conflicting, pushing

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -374,6 +374,20 @@ class _DirectIssueSource:
     issues: Iterator[int]
 
 
+@dataclass
+class _RepoEntrySource:
+    """One bounded FIFO cursor over repository discovery entries.
+
+    A REPO-stage lease remains with the active repository through its issue
+    cursor, so this source advances only when both the global permit and the
+    REPO queue admit the next repository. ``pending`` is a defensive single
+    retry slot; it never becomes a repository spill list.
+    """
+
+    repos: Iterator[str]
+    pending: str | None = None
+
+
 def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
     """Resolve *repo* to its explicit checkout or conventional projects path."""
     return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
@@ -470,6 +484,7 @@ class Coordinator:
         self._leases: dict[int, StageQueueLease] = {}
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self._direct_issue_source: _DirectIssueSource | None = None
+        self._repo_entry_source: _RepoEntrySource | None = None
         # A StageQueue's capacity only bounds that one stage.  This permit
         # set is the coordinator-wide admission budget: an item acquires one
         # permit on first entry and keeps it while it moves between queues,
@@ -787,6 +802,7 @@ class Coordinator:
                     self._wait_for_completion(timeout=0.2)
                     continue
                 self._drain_queues()
+                self._drain_repo_entry_source()
                 self._drain_repo_issue_sources()
                 self._drain_direct_issue_source()
                 if self._all_idle():
@@ -888,6 +904,7 @@ class Coordinator:
             and not self._leases
             and not self._pending_handoffs
             and self._direct_issue_source is None
+            and self._repo_entry_source is None
         )
 
     @property
@@ -2020,7 +2037,12 @@ class Coordinator:
         self._terminal_summary.reset()
         self._pass_work_count = 0
         discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
-        entries = _seeding.seed_from_cli(discovery_repos, [], [])
+        # Repository discovery is a source, not a list of pre-built
+        # ``SeedEntry``/``WorkItem`` values.  Keep the legacy empty call so
+        # direct test seams and any non-repository synthetic entries retain
+        # their established contract; production returns no entries here.
+        entries = _seeding.seed_from_cli([], [], [])
+        self._begin_repo_entry_source(discovery_repos if not entries else [])
         default_repo = self.config.repos[0] if self.config.repos else ""
         self._begin_direct_issue_source(default_repo)
         if self.config.prs:
@@ -2044,7 +2066,47 @@ class Coordinator:
                 )
             if self._push_item(item, item.stage, enter=True):
                 pushed += 1
-        return pushed + self._drain_direct_issue_source()
+        return pushed + self._drain_repo_entry_source() + self._drain_direct_issue_source()
+
+    def _begin_repo_entry_source(self, repos: list[str]) -> None:
+        """Initialize one FIFO source for this pass's repository discovery.
+
+        Strict source-order fairness is intentional: an active repository
+        holds its REPO-stage lease until its bounded issue cursor finishes, so
+        the next repository is admitted only after that stage slot is free.
+        This prevents both an unbounded source spill and starvation from
+        repeatedly retrying a later repository ahead of an earlier one.
+        """
+        self._repo_entry_source = _RepoEntrySource(repos=iter(repos)) if repos else None
+
+    def _drain_repo_entry_source(self) -> int:
+        """Admit repository discovery items from the FIFO source when safe."""
+        source = self._repo_entry_source
+        if source is None:
+            return 0
+
+        pushed = 0
+        while (
+            self.live_work_count < _work_window(self.config)
+            and self.queues[StageName.REPO].can_offer()
+        ):
+            repo = source.pending
+            if repo is None:
+                try:
+                    repo = next(source.repos)
+                except StopIteration:
+                    self._repo_entry_source = None
+                    break
+            item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.REPO)
+            if not self._push_item(item, StageName.REPO, enter=True):
+                # The coordinator is single-threaded and the predicate above
+                # reserves both capacities. Retain exactly one retry value if
+                # an injected/custom queue declines unexpectedly.
+                source.pending = repo
+                break
+            source.pending = None
+            pushed += 1
+        return pushed
 
     def _begin_direct_issue_source(self, repo: str) -> None:
         """Initialize one bounded cursor for this pass's ``--issues`` input."""

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -2545,6 +2545,23 @@ class Coordinator:
         item.payload["entry_reason"] = entry.reason
         return item
 
+    def _has_pending_seed_source(self) -> bool:
+        """Return whether this pass still owns an unclassified input cursor.
+
+        A source may have admitted no issue yet, so ``_pass_work_count`` alone
+        cannot distinguish a converged pass from one awaiting its first safe
+        queue slot.  Sources themselves remain bounded: one direct cursor,
+        one repository-entry cursor, and at most C active repo cursors.
+        """
+        return any(
+            (
+                self._repo_entry_source is not None,
+                bool(self._repo_issue_sources),
+                self._direct_issue_source is not None,
+                self._direct_pr_source is not None,
+            )
+        )
+
     def _reseed_if_converged(self) -> bool:
         """Re-seed after full drain; False = stop (loops or zero-work exit).
 
@@ -2556,7 +2573,7 @@ class Coordinator:
         if self._loops_run >= self.config.loops:
             logger.info("loop budget exhausted (%d/%d)", self._loops_run, self.config.loops)
             return False
-        if self._pass_work_count == 0:
+        if self._pass_work_count == 0 and not self._has_pending_seed_source():
             logger.info(
                 "zero-work convergence: pass %d produced no actionable items; exiting early",
                 self._loops_run,
@@ -2565,7 +2582,7 @@ class Coordinator:
         self._loops_run += 1
         logger.info("re-seeding: loop %d/%d", self._loops_run, self.config.loops)
         self._seed_pass()
-        return self._pass_work_count > 0
+        return self._pass_work_count > 0 or self._has_pending_seed_source()
 
     # -- shutdown ---------------------------------------------------------------
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -752,11 +752,6 @@ class Coordinator:
                     continue
                 self._drain_queues()
                 self._drain_direct_issue_source()
-                if self._direct_issue_source is not None:
-                    # The explicit scope is a live source, not a fully
-                    # materialized seed batch.  Pull it again immediately
-                    # after normal draining instead of treating it as idle.
-                    continue
                 if self._all_idle():
                     if not self._reseed_if_converged():
                         break

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -81,7 +81,7 @@ import queue as queue_mod
 import signal
 import threading
 import time
-from collections import Counter
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -119,7 +119,12 @@ from hephaestus.automation.pipeline.stages import (
 )
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.stages.repo import RepoIssueSource, product_to_work_item
-from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
+from hephaestus.automation.pipeline.summary import (
+    RunStats,
+    TerminalSummary,
+    latest_logical_items,
+    print_summary,
+)
 from hephaestus.automation.pipeline.work_item import (
     ItemKind,
     ItemResult,
@@ -159,6 +164,12 @@ _FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
 
 _PROMPT_PREFLIGHT_TEMPLATE = "shared/untrusted_notice.j2"
 _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — reinstall: `uv sync`."
+
+# In-memory diagnostics are intentionally finite.  The durable JSONL stream,
+# when configured, remains a best-effort diagnostic artifact only; GitHub
+# state is still the restart authority.
+_DEFAULT_EVENT_LOG_CAPACITY = 1_024
+_DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
@@ -271,6 +282,10 @@ class PipelineConfig:
     # resilience capability directly.
     circuit_breaker_snapshot_provider: Callable[[], dict[str, dict[str, Any]]] | None = None
     event_log_path: Path | None = None
+    # Recent local diagnostic retention.  These limits intentionally do not
+    # alter the GitHub journal or restart behavior.
+    event_log_capacity: int = _DEFAULT_EVENT_LOG_CAPACITY
+    terminal_detail_capacity: int = _DEFAULT_TERMINAL_DETAIL_CAPACITY
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
     # Optional exceptions to the normal ``projects_dir / repo`` checkout
     # layout.  The loop runner only sets an entry for a matching noncanonical
@@ -399,6 +414,10 @@ class Coordinator:
         self.config = config
         self.github = github
         self._github_factory = github_factory
+        if config.event_log_capacity < 1:
+            raise ValueError("event_log_capacity must be positive")
+        if config.terminal_detail_capacity < 1:
+            raise ValueError("terminal_detail_capacity must be positive")
         self.shutdown = threading.Event()
         # These latches are the control plane for the bounded completion
         # queue.  They carry no WorkItem/JobResult payload and therefore
@@ -461,7 +480,8 @@ class Coordinator:
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
-        self.event_log: list[tuple[Any, ...]] = []
+        self._terminal_summary = TerminalSummary()
+        self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
         self._event_log_disabled = False
         # Observability is opt-in.  Keep imports and all socket setup out of
         # the default construction path so the product layer retains its
@@ -536,7 +556,12 @@ class Coordinator:
             pre_pr_test_argv=config.pre_pr_test_argv,
             run_pre_pr_tests=config.run_pre_pr_tests,
         )
-        self._ctx_cache: dict[str, StageContext] = {}
+        # A context contains a GitHub accessor and path configuration but no
+        # mutable item state.  At most C items can be live, so an LRU of C is
+        # enough for concurrent work and prevents all-org discovery from
+        # retaining one accessor per repository.
+        self._ctx_cache: OrderedDict[str, StageContext] = OrderedDict()
+        self._ctx_cache_capacity = work_window
 
     # -- wiring ---------------------------------------------------------------
 
@@ -555,7 +580,9 @@ class Coordinator:
     def _ctx_for_repo(self, repo: str) -> StageContext:
         """Return the (cached, per-repo) StageContext for *repo*."""
         ctx = self._ctx_cache.get(repo)
-        if ctx is None:
+        if ctx is not None:
+            self._ctx_cache.move_to_end(repo)
+        else:
             root = _effective_repo_root(self.config, repo)
             ctx = StageContext(
                 config=self._stage_config,
@@ -574,6 +601,8 @@ class Coordinator:
                 budget_fn=self._budget_for,
                 event_fn=self._record_stage_event,
             )
+            if len(self._ctx_cache) >= self._ctx_cache_capacity:
+                self._ctx_cache.popitem(last=False)
             self._ctx_cache[repo] = ctx
         return ctx
 
@@ -796,7 +825,15 @@ class Coordinator:
                         "wall_s": stats.wall_s,
                     },
                 )
-                print_summary(summary_items, stats, preserved, json_out=self.config.json_out)
+                print_summary(
+                    summary_items,
+                    stats,
+                    preserved,
+                    json_out=self.config.json_out,
+                    terminal_summary=(
+                        self._terminal_summary if self._terminal_summary.total else None
+                    ),
+                )
             finally:
                 if self._metrics_server is not None:
                     self._metrics_server.stop()
@@ -831,9 +868,14 @@ class Coordinator:
             # not complete, so wrappers must classify it as cancellation even
             # if earlier work had already failed.
             return 130
+        if self._fatal:
+            return 1
+        if self._terminal_summary.total:
+            passing = self._terminal_summary.dispositions.get("pass", 0)
+            return 1 if passing < self._terminal_summary.total else 0
         effective_results = [item.result for item in self._effective_items() if item.result]
         results = effective_results or self.ledger
-        if self._fatal or any(not result.passed for result in results):
+        if any(not result.passed for result in results):
             return 1
         return 0
 
@@ -866,6 +908,47 @@ class Coordinator:
     def _release_work_permit(self, item: WorkItem) -> None:
         """Release *item*'s permit after the terminal sink has completed."""
         self._live_work_permit_ids.discard(id(item))
+
+    def _record_terminal_result(self, item: WorkItem) -> None:
+        """Aggregate one completed/resumable item and trim detailed retention.
+
+        The local result collections are an operator convenience, not recovery
+        state.  Keep only the configured newest completed details while a
+        constant-space aggregate preserves the full run's pass/fail/total
+        reporting and exit status.
+        """
+        if item.result is None or item.payload.get("_summary_recorded", False):
+            return
+        item.payload["_summary_recorded"] = True
+        self._terminal_summary.record(item)
+        self._seen_item_ids.discard(id(item))
+
+        # Move a completed item to the tail so the bounded window is ordered
+        # by terminal completion rather than by its initial seed time.  An
+        # item can be absent in narrow direct unit tests; runtime items are
+        # always tracked by _push_item first.
+        for index, candidate in enumerate(self.items):
+            if candidate is item:
+                self.items.pop(index)
+                self.items.append(item)
+                break
+
+        retained = self.config.terminal_detail_capacity
+        completed = [
+            index
+            for index, candidate in enumerate(self.items)
+            if candidate.payload.get("_summary_recorded", False)
+        ]
+        for index in reversed(completed[:-retained]):
+            self.items.pop(index)
+
+        # The sink may record a result before a cleanup job completes.  At
+        # most C such items can coexist, so these lists are bounded by N + C
+        # between records and by N after every terminal completion.
+        if len(self.ledger) > retained:
+            del self.ledger[:-retained]
+        if len(self.preserved) > retained:
+            del self.preserved[:-retained]
 
     # -- stage-queue leases -------------------------------------------------
 
@@ -1203,6 +1286,7 @@ class Coordinator:
             reason=f"resumable at {item.stage.value}",
             final_stage=item.stage,
         )
+        self._record_terminal_result(item)
         item.add_history_event(item.stage, item.state, note="interrupted; resumable")
         self._record_event("resumable", self._item_key(item), item.stage.value, item.state)
         logger.info(
@@ -1707,6 +1791,7 @@ class Coordinator:
         if item.stage is StageName.FINISHED:
             # Sink outcomes are terminal: the result is already recorded.
             self._record_event("done", self._item_key(item), outcome.note)
+            self._record_terminal_result(item)
             self._release_source_lease(item)
             self._release_work_permit(item)
             return
@@ -1796,6 +1881,7 @@ class Coordinator:
             if not item.payload.get("_recorded", False):
                 self.ledger.append(item.result)
                 item.payload["_recorded"] = True
+            self._record_terminal_result(item)
             self._release_source_lease(item)
             self._release_work_permit(item)
             return

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -274,6 +274,11 @@ class PipelineConfig:
     force: bool = False
 
 
+def _work_window(config: PipelineConfig) -> int:
+    """Return the global bound for queued and executing pipeline work."""
+    return max(1, config.parallel_repos * config.max_workers)
+
+
 @dataclass
 class _StageRunConfig:
     """PlannerOptions-like config injected as ``StageContext.config``."""
@@ -349,24 +354,36 @@ class Coordinator:
         self.github = github
         self._github_factory = github_factory
         self.shutdown = threading.Event()
-        self.completion_q: CompletionQueue = queue_mod.Queue()
+        work_window = _work_window(config)
+        self.completion_q: CompletionQueue = queue_mod.Queue(maxsize=work_window)
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
             # I/O-capable module and tests never need it.
             from hephaestus.automation.pipeline.worker_pool import WorkerPool
 
             pool = WorkerPool(
-                size=max(1, config.parallel_repos * config.max_workers),
+                size=work_window,
                 shutdown=self.shutdown,
                 completion_q=self.completion_q,
             )
         else:
-            # Share channels with an injected pool when it exposes them.
-            if getattr(pool, "completion_q", None) is not None:
-                self.completion_q = pool.completion_q
+            # The coordinator owns the cross-thread transport.  An injected
+            # unbounded fake queue is replaced; a differently bounded queue
+            # is rejected so it cannot silently weaken the global capacity.
+            injected_completion_q = getattr(pool, "completion_q", None)
+            injected_maxsize = getattr(injected_completion_q, "maxsize", 0)
+            if isinstance(injected_maxsize, int) and (
+                injected_maxsize > 0 and injected_maxsize != work_window
+            ):
+                raise ValueError(
+                    "injected completion queue capacity must match the coordinator work window"
+                )
+            pool.completion_q = self.completion_q
         self.pool: Any = pool
 
-        self.queues: dict[StageName, StageQueue] = {name: StageQueue() for name in StageName}
+        self.queues: dict[StageName, StageQueue] = {
+            name: StageQueue(work_window) for name in StageName
+        }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
         self.inflight_per_repo: Counter[str] = Counter()
@@ -1115,7 +1132,9 @@ class Coordinator:
 
     def _admit(self, item: WorkItem) -> bool:
         """Admission control: per-repo in-flight cap (O(1) Counter lookup)."""
-        return self.inflight_per_repo[item.repo] < max(1, self.config.max_workers)
+        return len(self.in_flight) < _work_window(self.config) and self.inflight_per_repo[
+            item.repo
+        ] < max(1, self.config.max_workers)
 
     # -- item execution -----------------------------------------------------
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -82,7 +82,7 @@ import signal
 import threading
 import time
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, TypeAlias
@@ -171,6 +171,21 @@ _DRAIN_ORDER: tuple[StageName, ...] = (
     StageName.PLAN_REVIEW,
     StageName.PLANNING,
     StageName.REPO,
+)
+
+# An explicit issue can classify into any of these queues.  The source cursor
+# classifies only when every possible destination can accept one item, so the
+# classification result never needs an unbounded spill buffer while it waits
+# for a full stage queue.
+_DIRECT_ISSUE_ENTRY_STAGES: frozenset[StageName] = frozenset(
+    {
+        StageName.PLANNING,
+        StageName.PLAN_REVIEW,
+        StageName.IMPLEMENTATION,
+        StageName.PR_REVIEW,
+        StageName.MERGE_WAIT,
+        StageName.FINISHED,
+    }
 )
 
 StageStepResult: TypeAlias = Continue | JobRequest | StageOutcome
@@ -331,6 +346,19 @@ class _PendingHandoff:
     result: ItemResult | None = None
 
 
+@dataclass
+class _DirectIssueSource:
+    """One bounded cursor over the caller-provided explicit issue scope.
+
+    The cursor stores no classified :class:`SeedEntry` or :class:`WorkItem`.
+    Classification happens only after all possible direct-entry queues can
+    accept an item, allowing the resulting item to enter immediately.
+    """
+
+    repo: str
+    issues: Iterator[int]
+
+
 def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
     """Resolve *repo* to its explicit checkout or conventional projects path."""
     return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
@@ -422,6 +450,7 @@ class Coordinator:
         # single intent attached to that lease, never by an overflow queue.
         self._leases: dict[int, StageQueueLease] = {}
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
+        self._direct_issue_source: _DirectIssueSource | None = None
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
@@ -722,6 +751,12 @@ class Coordinator:
                     self._wait_for_completion(timeout=0.2)
                     continue
                 self._drain_queues()
+                self._drain_direct_issue_source()
+                if self._direct_issue_source is not None:
+                    # The explicit scope is a live source, not a fully
+                    # materialized seed batch.  Pull it again immediately
+                    # after normal draining instead of treating it as idle.
+                    continue
                 if self._all_idle():
                     if not self._reseed_if_converged():
                         break
@@ -807,6 +842,7 @@ class Coordinator:
             and not self.in_flight
             and not self._leases
             and not self._pending_handoffs
+            and self._direct_issue_source is None
         )
 
     # -- stage-queue leases -------------------------------------------------
@@ -1659,8 +1695,9 @@ class Coordinator:
         discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
         entries = _seeding.seed_from_cli(discovery_repos, [], [])
         default_repo = self.config.repos[0] if self.config.repos else ""
-        if self.config.issues or self.config.prs:
-            entries.extend(self._seed_direct_scope(default_repo))
+        self._begin_direct_issue_source(default_repo)
+        if self.config.prs:
+            entries.extend(self._seed_direct_pr_scope(default_repo))
         pushed = 0
         for entry in entries:
             if entry.stage is None:
@@ -1678,6 +1715,64 @@ class Coordinator:
                 item.result = ItemResult(
                     passed=entry.passed, reason=entry.reason, final_stage=StageName.FINISHED
                 )
+            self._push_item(item, item.stage, enter=True)
+            pushed += 1
+        return pushed + self._drain_direct_issue_source()
+
+    def _begin_direct_issue_source(self, repo: str) -> None:
+        """Initialize one bounded cursor for this pass's ``--issues`` input."""
+        self._direct_issue_source = None
+        if not self.config.issues:
+            return
+        open_issues = _admission._filter_open_issues(repo, self.config.issues)
+        self._direct_issue_source = _DirectIssueSource(repo=repo, issues=iter(open_issues))
+
+    def _direct_issue_queues_can_accept(self) -> bool:
+        """Return whether any direct issue can be classified and enqueued now."""
+        return all(self.queues[stage].can_offer() for stage in _DIRECT_ISSUE_ENTRY_STAGES)
+
+    def _drain_direct_issue_source(self) -> int:
+        """Pull explicit issues directly into queues without a seed spill buffer.
+
+        An issue is classified only after its eventual destination is
+        guaranteed to have capacity.  The loop fills immediately available
+        capacity, then leaves the remaining caller-owned iterator live until
+        normal queue draining creates another safe admission point.
+        """
+        source = self._direct_issue_source
+        if source is None:
+            return 0
+
+        pushed = 0
+        while self._direct_issue_queues_can_accept():
+            try:
+                issue = next(source.issues)
+            except StopIteration:
+                self._direct_issue_source = None
+                break
+
+            entry = self._seed_direct_issue_entry(source.repo, issue)
+            if entry.stage is None:
+                # Epic tagging is the one sanctioned seeding write.  Complete
+                # it before honoring the source exclusion, exactly as the
+                # ordinary seed path does.
+                if entry.skip_tag_obligation is not None:
+                    self.github.skip_epics({entry.skip_tag_obligation.issue: []})
+                logger.info("seed excluded: %s", entry.reason)
+                continue
+
+            item = self._entry_to_item(entry, source.repo)
+            if item.stage not in (StageName.REPO, StageName.FINISHED):
+                self._pass_work_count += 1
+            if item.stage is StageName.FINISHED and item.result is None:
+                item.result = ItemResult(
+                    passed=entry.passed,
+                    reason=entry.reason,
+                    final_stage=StageName.FINISHED,
+                )
+            # ``_direct_issue_queues_can_accept`` covers every possible
+            # classifier result and this method owns the coordinator thread,
+            # so the ordinary lifecycle push cannot overflow here.
             self._push_item(item, item.stage, enter=True)
             pushed += 1
         return pushed
@@ -1763,22 +1858,37 @@ class Coordinator:
         return stage, reason, True
 
     def _seed_direct_scope(self, repo: str) -> list[_seeding.SeedEntry]:
-        """Seed explicit ``--issues`` / ``--prs`` through the target repo accessor."""
+        """Classify direct entries for legacy direct-classifier callers.
+
+        Runtime seeding never materializes the explicit issue scope here;
+        :meth:`_drain_direct_issue_source` owns its bounded cursor.  This
+        compatibility helper remains for direct classifier tests.
+        """
+        entries: list[_seeding.SeedEntry] = []
+        issue_numbers = _admission._filter_open_issues(repo, self.config.issues)
+        for issue in issue_numbers:
+            entries.append(self._seed_direct_issue_entry(repo, issue))
+        entries.extend(self._seed_direct_pr_scope(repo))
+        return entries
+
+    def _seed_direct_issue_entry(self, repo: str, issue: int) -> _seeding.SeedEntry:
+        """Classify one direct issue through its target repository accessor."""
+        github = self._ctx_for_repo(repo).github if repo else self.github
+        scope_stages = self.config.scope.stages if self.config.scope is not None else None
+        facts = _seeding.seed_issue_from_github(issue, github)
+        if STATE_PLAN_BLOCKED in facts.labels:
+            github.ensure_blocked_audit(issue)
+        entry = _seeding.seed_entry_from_facts(facts)
+        stage, reason, passed = self._scope_seed_decision(
+            issue, entry.stage, entry.reason, scope_stages
+        )
+        return replace(entry, stage=stage, reason=reason, passed=passed)
+
+    def _seed_direct_pr_scope(self, repo: str) -> list[_seeding.SeedEntry]:
+        """Eagerly classify the (separate) explicit ``--prs`` scope."""
         github = self._ctx_for_repo(repo).github if repo else self.github
         entries: list[_seeding.SeedEntry] = []
         scope_stages = self.config.scope.stages if self.config.scope is not None else None
-        requested_issues = list(self.config.issues)
-        issue_numbers = requested_issues
-        if issue_numbers:
-            issue_numbers = _admission._filter_open_issues(repo, issue_numbers)
-        for issue in issue_numbers:
-            facts = _seeding.seed_issue_from_github(issue, github)
-            if STATE_PLAN_BLOCKED in facts.labels:
-                github.ensure_blocked_audit(issue)
-            entry = _seeding.seed_entry_from_facts(facts)
-            stage, reason = entry.stage, entry.reason
-            stage, reason, passed = self._scope_seed_decision(issue, stage, reason, scope_stages)
-            entries.append(replace(entry, stage=stage, reason=reason, passed=passed))
         for pr in self.config.prs:
             issue_number = github.find_issue_for_pr(pr)
             if issue_number is None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -82,7 +82,8 @@ import signal
 import threading
 import time
 from collections import Counter, OrderedDict, deque
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, TypeAlias
@@ -375,6 +376,33 @@ class _DirectIssueSource:
 
 
 @dataclass
+class _DirectPrSource:
+    """One bounded cursor over the caller-provided explicit PR scope.
+
+    As with direct issues, a PR is classified only at a safe admission point.
+    This avoids retaining an eager list of potentially large review-context
+    payloads while one of the downstream review queues is saturated.
+    """
+
+    repo: str
+    prs: Iterator[int]
+
+
+@dataclass
+class _ActiveRepoIssueSource:
+    """One detached, bounded repository issue cursor owned by the coordinator.
+
+    Repository setup is a normal REPO-stage work item.  Once it has produced
+    this cursor, retaining that item would monopolize a REPO queue lease and
+    let one repository starve its peers.  The cursor registry keeps only this
+    minimal state and is capped by the global work window.
+    """
+
+    repo: str
+    source: RepoIssueSource
+
+
+@dataclass
 class _RepoEntrySource:
     """One bounded FIFO cursor over repository discovery entries.
 
@@ -484,7 +512,9 @@ class Coordinator:
         self._leases: dict[int, StageQueueLease] = {}
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self._direct_issue_source: _DirectIssueSource | None = None
+        self._direct_pr_source: _DirectPrSource | None = None
         self._repo_entry_source: _RepoEntrySource | None = None
+        self._repo_issue_sources: deque[_ActiveRepoIssueSource] = deque()
         # A StageQueue's capacity only bounds that one stage.  This permit
         # set is the coordinator-wide admission budget: an item acquires one
         # permit on first entry and keeps it while it moves between queues,
@@ -804,6 +834,7 @@ class Coordinator:
                 self._drain_queues()
                 self._drain_repo_entry_source()
                 self._drain_repo_issue_sources()
+                self._drain_direct_pr_source()
                 self._drain_direct_issue_source()
                 if self._all_idle():
                     if not self._reseed_if_converged():
@@ -904,7 +935,9 @@ class Coordinator:
             and not self._leases
             and not self._pending_handoffs
             and self._direct_issue_source is None
+            and self._direct_pr_source is None
             and self._repo_entry_source is None
+            and not self._repo_issue_sources
         )
 
     @property
@@ -1365,70 +1398,82 @@ class Coordinator:
                 self._run_item(item)
             self._drain_pending_handoffs()
 
-    def _repo_source_can_admit(self, item: WorkItem) -> bool:
-        """Return whether a repo source can transfer its permit to one issue.
+    def _externalize_repo_issue_source(self, item: WorkItem, source: RepoIssueSource) -> bool:
+        """Retire setup work and enroll its cursor in the bounded fair registry.
 
-        The source itself is initially a normal live item.  Before admitting
-        its next classified child it relinquishes that permit, so C=1 can
-        make forward progress without a second slot.  Once a child owns the
-        sole permit, the source retains only its source-stage lease and waits
-        without holding an unbounded product buffer.
+        A repository cursor is not a pipeline work item: it carries no global
+        permit and no REPO-stage lease once checkout/setup finishes.  Keeping
+        those owners would both count as an extra live object and let the
+        first repository hold the REPO queue while its entire issue backlog
+        drains.  The registry holds at most C cursor objects and drains them
+        in FIFO rotation instead.
         """
-        source_owns_permit = id(item) in self._live_work_permit_ids
-        prospective_live = self.live_work_count - int(source_owns_permit)
-        return prospective_live < _work_window(self.config) and all(
+        if len(self._repo_issue_sources) >= _work_window(self.config):
+            return False
+
+        item.payload.pop("_repo_issue_source", None)
+        self._repo_issue_sources.append(_ActiveRepoIssueSource(repo=item.repo, source=source))
+        self._release_source_lease(item)
+        self._release_work_permit(item)
+        self._seen_item_ids.discard(id(item))
+        with suppress(ValueError):  # provisional item is normally tracked
+            self.items.remove(item)
+        self._record_event("repo_source_activate", item.repo, len(self._repo_issue_sources))
+        return True
+
+    def _repo_source_can_admit(self) -> bool:
+        """Return whether a detached repo cursor may classify and admit one issue."""
+        return self.live_work_count < _work_window(self.config) and all(
             self.queues[stage].can_offer() for stage in _DIRECT_ISSUE_ENTRY_STAGES
         )
 
     def _drain_repo_issue_sources(self) -> None:
-        """Pull at most one admitted issue from each active repository cursor.
-
-        ``RepoStage`` establishes a :class:`RepoIssueSource` after checkout
-        preparation.  The coordinator is the only queue owner, so it keeps
-        the source-stage lease while a single raw metadata row waits for
-        global capacity, transfers the source's permit to the child at
-        admission, and retries the same row on the next available slot.
-        """
-        for lease in list(self._leases.values()):
-            item = lease.item
-            if item.kind is not ItemKind.REPO or item.state != "SOURCE":
-                continue
-            source = item.payload.get("_repo_issue_source")
-            if not isinstance(source, RepoIssueSource):
-                continue
-            if id(item) in self._pending_handoffs:
-                continue
-            self._drain_repo_issue_source(item, source)
+        """Run one round-robin admission attempt for every active repo cursor."""
+        for _ in range(len(self._repo_issue_sources)):
+            active = self._repo_issue_sources.popleft()
+            if self._drain_repo_issue_source(active):
+                self._repo_issue_sources.append(active)
 
     def _drain_repo_issue_source(  # noqa: C901 - source lifecycle is intentionally linear
-        self, item: WorkItem, source: RepoIssueSource
-    ) -> None:
-        """Consume one repository source cursor until one child is admitted.
+        self, active: _ActiveRepoIssueSource
+    ) -> bool:
+        """Consume one detached repository cursor until one child is admitted.
 
         Exclusions (notably epics) need no child capacity and are consumed in
         order after their durable skip write.  An eligible pending row stays
         in ``source.pending`` until every possible entry queue and the global
         permit budget can accept it; no classified product is retained.
+
+        Returns:
+            ``True`` while this cursor remains active, otherwise ``False``
+            after normal exhaustion or a recorded discovery failure.
+
         """
-        ctx = self._ctx_for(item)
+        repo = active.repo
+        source = active.source
+        ctx = self._ctx_for_repo(repo)
         while True:
             metadata = source.pending
             if metadata is None:
                 try:
                     metadata = next(source.metadata)
                 except StopIteration:
-                    item.payload.pop("_repo_issue_source", None)
-                    self._finish(item, passed=True, reason=f"seeded:{source.seeded_count}")
-                    return
+                    self._record_event("repo_source_complete", repo, source.seeded_count)
+                    return False
                 except Exception as exc:
-                    logger.warning("repo:%s: discovery source failed: %s", item.repo, exc)
-                    item.payload.pop("_repo_issue_source", None)
-                    self._finish(item, passed=False, reason=f"discovery failed: {exc}")
-                    return
+                    logger.warning("repo:%s: discovery source failed: %s", repo, exc)
+                    self._record_repo_source_failure(repo, f"discovery failed: {exc}")
+                    return False
 
-            number = int(metadata["number"])
-            labels = list(metadata.get("labels") or [])
-            title = str(metadata.get("title") or "")
+            try:
+                number = int(metadata["number"])
+                labels = list(metadata.get("labels") or [])
+                title = str(metadata.get("title") or "")
+            except (KeyError, TypeError, ValueError) as exc:
+                self._record_repo_source_failure(
+                    repo, f"discovery failed: malformed metadata: {exc}"
+                )
+                return False
             # Metadata epics need no expensive issue fetch.  The durable
             # label write is completed before source consumption advances.
             if is_epic(labels, title):
@@ -1437,23 +1482,20 @@ class Coordinator:
                 except Exception as exc:
                     logger.warning(
                         "repo:%s: could not tag excluded epic #%d state:skip: %s",
-                        item.repo,
+                        repo,
                         number,
                         exc,
                     )
-                    item.payload.pop("_repo_issue_source", None)
-                    self._finish(item, passed=False, reason=f"epic skip tag failed: {exc}")
-                    return
-                logger.info(
-                    "repo:%s: #%d is an epic; tagged state:skip, excluded", item.repo, number
-                )
+                    self._record_repo_source_failure(repo, f"epic skip tag failed: {exc}")
+                    return False
+                logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", repo, number)
                 source.pending = None
                 self._progress = True
-                return
+                return True
 
-            if not self._repo_source_can_admit(item):
+            if not self._repo_source_can_admit():
                 source.pending = metadata
-                return
+                return True
 
             try:
                 facts = _seeding.seed_issue_from_github(number, ctx.github)
@@ -1466,12 +1508,9 @@ class Coordinator:
                 )
                 entry = replace(entry, stage=stage, reason=reason, passed=passed)
             except Exception as exc:
-                logger.warning(
-                    "repo:%s: issue #%d classification failed: %s", item.repo, number, exc
-                )
-                item.payload.pop("_repo_issue_source", None)
-                self._finish(item, passed=False, reason=f"discovery failed: {exc}")
-                return
+                logger.warning("repo:%s: issue #%d classification failed: %s", repo, number, exc)
+                self._record_repo_source_failure(repo, f"discovery failed: {exc}")
+                return False
 
             if entry.stage is None:
                 try:
@@ -1480,19 +1519,18 @@ class Coordinator:
                 except Exception as exc:
                     logger.warning(
                         "repo:%s: could not tag excluded epic #%d state:skip: %s",
-                        item.repo,
+                        repo,
                         number,
                         exc,
                     )
-                    item.payload.pop("_repo_issue_source", None)
-                    self._finish(item, passed=False, reason=f"epic skip tag failed: {exc}")
-                    return
-                logger.info("[%s] excluded: %s", item.repo, entry.reason)
+                    self._record_repo_source_failure(repo, f"epic skip tag failed: {exc}")
+                    return False
+                logger.info("[%s] excluded: %s", repo, entry.reason)
                 source.pending = None
                 self._progress = True
-                return
+                return True
 
-            new_item = self._entry_to_item(entry, item.repo)
+            new_item = self._entry_to_item(entry, repo)
             if new_item.stage is StageName.FINISHED and new_item.result is None:
                 new_item.result = ItemResult(
                     passed=entry.passed,
@@ -1502,21 +1540,25 @@ class Coordinator:
             elif new_item.stage is not StageName.REPO:
                 self._pass_work_count += 1
 
-            # This is the source-to-child permit transfer.  The source keeps
-            # its queue lease, but no longer consumes global live-work budget
-            # while the admitted child progresses through the pipeline.
-            self._release_work_permit(item)
             source.pending = None
             if self._push_item(new_item, new_item.stage, enter=True):
                 source.seeded_count += 1
                 self._progress = True
-                return
+                return True
             # The preflight covers capacity; a false push is therefore only
             # the existing idempotent duplicate guard.  Do not retain it in
             # a second source buffer.  The duplicate's live peer now governs
             # the next admission opportunity.
             self._progress = True
-            return
+            return True
+
+    def _record_repo_source_failure(self, repo: str, reason: str) -> None:
+        """Retain a bounded terminal failure after a detached cursor aborts."""
+        item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.FINISHED)
+        item.result = ItemResult(passed=False, reason=reason, final_stage=StageName.REPO)
+        item.payload["entry_stage"] = StageName.REPO.value
+        self.items.append(item)
+        self._record_terminal_result(item)
 
     def _drain_implementation(self) -> None:
         """Drain the implementation queue under topo order + file-overlap gating.
@@ -1687,10 +1729,13 @@ class Coordinator:
                         and item.state == "SOURCE"
                         and isinstance(item.payload.get("_repo_issue_source"), RepoIssueSource)
                     ):
-                        # The source owns this repo's active queue lease.  It
-                        # is consumed only by _drain_repo_issue_sources(),
-                        # which admits no more than one classified issue at a
-                        # time and therefore cannot spin or spill products.
+                        source = item.payload["_repo_issue_source"]
+                        # Setup work has completed. Move only its bounded
+                        # cursor into the fair registry, releasing the REPO
+                        # lease and provisional permit so one repository
+                        # cannot monopolize the stage while it streams.
+                        if not self._externalize_repo_issue_source(item, source):
+                            logger.debug("repo:%s: waiting for a source-registry slot", item.repo)
                         return
                     continue
                 if isinstance(result, JobRequest):
@@ -2044,9 +2089,8 @@ class Coordinator:
         entries = _seeding.seed_from_cli([], [], [])
         self._begin_repo_entry_source(discovery_repos if not entries else [])
         default_repo = self.config.repos[0] if self.config.repos else ""
+        self._begin_direct_pr_source(default_repo)
         self._begin_direct_issue_source(default_repo)
-        if self.config.prs:
-            entries.extend(self._seed_direct_pr_scope(default_repo))
         pushed = 0
         for entry in entries:
             if entry.stage is None:
@@ -2066,7 +2110,12 @@ class Coordinator:
                 )
             if self._push_item(item, item.stage, enter=True):
                 pushed += 1
-        return pushed + self._drain_repo_entry_source() + self._drain_direct_issue_source()
+        return (
+            pushed
+            + self._drain_repo_entry_source()
+            + self._drain_direct_pr_source()
+            + self._drain_direct_issue_source()
+        )
 
     def _begin_repo_entry_source(self, repos: list[str]) -> None:
         """Initialize one FIFO source for this pass's repository discovery.
@@ -2089,6 +2138,7 @@ class Coordinator:
         while (
             self.live_work_count < _work_window(self.config)
             and self.queues[StageName.REPO].can_offer()
+            and len(self._repo_issue_sources) < _work_window(self.config)
         ):
             repo = source.pending
             if repo is None:
@@ -2115,6 +2165,12 @@ class Coordinator:
             return
         open_issues = _admission._filter_open_issues(repo, self.config.issues)
         self._direct_issue_source = _DirectIssueSource(repo=repo, issues=iter(open_issues))
+
+    def _begin_direct_pr_source(self, repo: str) -> None:
+        """Initialize one bounded cursor for this pass's ``--prs`` input."""
+        self._direct_pr_source = None
+        if self.config.prs:
+            self._direct_pr_source = _DirectPrSource(repo=repo, prs=iter(self.config.prs))
 
     def _direct_issue_queues_can_accept(self) -> bool:
         """Return whether one direct issue can be classified and enqueued now."""
@@ -2166,6 +2222,50 @@ class Coordinator:
             # source owns the coordinator thread, so a failed lifecycle push
             # can only be an idempotent duplicate; it never represents
             # saturation or a completion/shutdown fault.
+            if self._push_item(item, item.stage, enter=True):
+                pushed += 1
+        return pushed
+
+    def _drain_direct_pr_source(self) -> int:
+        """Pull explicit PRs into queues without an eager seed-entry spill.
+
+        Explicit PRs retain their historical precedence over explicit issues
+        when both flags are supplied.  As a source advances only after the
+        prior PR leaves the global live-work window, that precedence cannot
+        discard later PRs on a saturated queue.
+        """
+        source = self._direct_pr_source
+        if source is None:
+            return 0
+
+        pushed = 0
+        while self._direct_issue_queues_can_accept():
+            try:
+                pr = next(source.prs)
+            except StopIteration:
+                self._direct_pr_source = None
+                break
+
+            # The compatibility helper returns exactly one entry here; unlike
+            # the legacy call over ``config.prs`` it cannot retain a source
+            # sized list while waiting for capacity.
+            entry = self._seed_direct_pr_scope(source.repo, (pr,))[0]
+            if entry.stage is None:
+                logger.info("seed excluded: %s", entry.reason)
+                continue
+
+            item = self._entry_to_item(entry, source.repo)
+            if item.stage not in (StageName.REPO, StageName.FINISHED):
+                self._pass_work_count += 1
+            if item.stage is StageName.FINISHED and item.result is None:
+                item.result = ItemResult(
+                    passed=entry.passed,
+                    reason=entry.reason,
+                    final_stage=StageName.FINISHED,
+                )
+            # The common direct-entry admission predicate reserves every
+            # possible classifier target and the global permit. A failed push
+            # is therefore only an idempotent duplicate, not saturation.
             if self._push_item(item, item.stage, enter=True):
                 pushed += 1
         return pushed
@@ -2277,12 +2377,14 @@ class Coordinator:
         )
         return replace(entry, stage=stage, reason=reason, passed=passed)
 
-    def _seed_direct_pr_scope(self, repo: str) -> list[_seeding.SeedEntry]:
-        """Eagerly classify the (separate) explicit ``--prs`` scope."""
+    def _seed_direct_pr_scope(
+        self, repo: str, prs: Iterable[int] | None = None
+    ) -> list[_seeding.SeedEntry]:
+        """Classify explicit PRs for compatibility callers or a one-PR source pull."""
         github = self._ctx_for_repo(repo).github if repo else self.github
         entries: list[_seeding.SeedEntry] = []
         scope_stages = self.config.scope.stages if self.config.scope is not None else None
-        for pr in self.config.prs:
+        for pr in self.config.prs if prs is None else prs:
             issue_number = github.find_issue_for_pr(pr)
             if issue_number is None:
                 entries.append(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -2013,6 +2013,11 @@ class Coordinator:
             The number of items pushed (repo seeds included).
 
         """
+        # A reseed pass creates fresh WorkItems for the same logical issues.
+        # Keep final status semantics aligned with _effective_items(): the
+        # latest pass supersedes earlier attempts without retaining an
+        # unbounded logical-identity map in the terminal aggregate.
+        self._terminal_summary.reset()
         self._pass_work_count = 0
         discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
         entries = _seeding.seed_from_cli(discovery_repos, [], [])

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -458,11 +458,6 @@ class Coordinator:
         # only after the finished sink completes.  The set is therefore
         # bounded by ``_work_window(config)``, not by the number of stages.
         self._live_work_permit_ids: set[int] = set()
-        # Implementation claims an entire bounded round to derive topo order.
-        # Source retries in that round stay leased until all deferred peers can
-        # be restored in their original FIFO order.
-        self._implementation_round_item_ids: set[int] | None = None
-        self._implementation_round_source_retries: set[int] = set()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
@@ -873,9 +868,9 @@ class Coordinator:
 
     # -- stage-queue leases -------------------------------------------------
 
-    def _claim_item(self, stage_name: StageName) -> WorkItem | None:
+    def _claim_item(self, stage_name: StageName, *, index: int = 0) -> WorkItem | None:
         """Claim one ready item while retaining its source-stage capacity."""
-        lease = self.queues[stage_name].claim()
+        lease = self.queues[stage_name].claim_at(index)
         if lease is None:
             return None
         item = lease.item
@@ -898,21 +893,16 @@ class Coordinator:
     def _release_source_lease(self, item: WorkItem) -> bool:
         """Release an active lease when work leaves every stage queue.
 
-        ``StageQueueLease`` intentionally exposes only restore or
-        destination-first handoff.  Timers and terminal sink completion are
-        neither, so restore to the source front and immediately remove that
-        same item.  This is not queue draining: it is the one coordinator
-        escape hatch into a timer/terminal ledger and preserves FIFO for all
-        remaining ready items.
+        Timers and terminal sink completion are neither source restores nor
+        destination-first handoffs.  The external owner takes responsibility
+        for the item, so release its source slot directly without disturbing a
+        different queue head selected ahead of it by topo scheduling.
         """
         self._pending_handoffs.pop(id(item), None)
         lease = self._leases.pop(id(item), None)
         if lease is None:
             return False
-        lease.restore()
-        released = self.queues[item.stage].pop()
-        if released is not item:  # pragma: no cover - queue ownership invariant
-            raise RuntimeError("lease restored a different work item")
+        lease.release()
         return True
 
     def _activate_handoff(
@@ -1295,101 +1285,90 @@ class Coordinator:
         q = self.queues[StageName.IMPLEMENTATION]
         if not len(q):
             return
-        # Take bounded source leases for the whole ready round before deriving
-        # the topological order. A raw ``pop`` would make a completed item
-        # ownerless while it is routed; when PR review is full that used to
-        # poison an already-completed implementation action instead of
-        # retaining its source slot for a pending handoff.
-        claimed_items: list[WorkItem] = []
-        for _ in range(len(q)):
-            item = self._claim_item(StageName.IMPLEMENTATION)
-            if item is None:  # pragma: no cover - coordinator-thread atomicity
-                break
-            claimed_items.append(item)
-        items = self._dedup_implementation_items(claimed_items)
-        self._implementation_round_item_ids = {id(item) for item in items}
-        self._implementation_round_source_retries.clear()
-        ran: set[int] = set()
-        try:
-            issue_items, ambiguous = self._index_issue_items(items)
-            infos = [
-                IssueInfo(
-                    number=number,
-                    title=str(item.payload.get("issue_title", "")),
-                    dependencies=list(item.payload.get("dependencies", [])),
-                )
+        # Derive topology from a bounded snapshot, then lease only the chosen
+        # item. A raw pop makes that item ownerless; claiming every item would
+        # violate the one-active-lease FIFO invariant. ``claim_at`` keeps a
+        # selected dependency's original restore position when it retries.
+        for duplicate in self._implementation_duplicates(q.snapshot()):
+            if not self._claim_selected_implementation_item(duplicate):
+                return
+            logger.warning(
+                "implementation %s#%s already queued; dropping duplicate work item",
+                duplicate.repo,
+                duplicate.issue,
+            )
+            self._finish(
+                duplicate,
+                passed=True,
+                reason=f"{duplicate.repo}#{duplicate.issue} superseded by queued duplicate",
+            )
+            if id(duplicate) in self._leases:
+                return
+
+        items = q.snapshot()
+        issue_items, ambiguous = self._index_issue_items(items)
+        infos = [
+            IssueInfo(
+                number=number,
+                title=str(item.payload.get("issue_title", "")),
+                dependencies=list(item.payload.get("dependencies", [])),
+            )
+            for number, item in issue_items.items()
+        ]
+        ordered = _admission.order_for_implementation(infos)
+        dispatch = ordered
+        if self.config.serialize_file_overlap and self.config.max_workers > 1 and len(ordered) > 1:
+            # Resolve each issue's owning repo from its own WorkItem: the queue is
+            # keyed by stage, so one round can hold issues from several repos (#1795).
+            repo_of = {
+                number: (self.config.org, item.repo)
                 for number, item in issue_items.items()
-            ]
-            ordered = _admission.order_for_implementation(infos)
-            dispatch = ordered
-            if (
-                self.config.serialize_file_overlap
-                and self.config.max_workers > 1
-                and len(ordered) > 1
-            ):
-                # Resolve each issue's owning repo from its own WorkItem: the queue is
-                # keyed by stage, so one round can hold issues from several repos (#1795).
-                repo_of = {
-                    number: (self.config.org, item.repo)
-                    for number, item in issue_items.items()
-                    if item.repo
-                }
-                dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
-                for number in deferred:
-                    logger.info("implementation #%s deferred (file overlap)", number)
-            # Cross-repo same-number items bypass the number-keyed gates and dispatch
-            # directly — they are distinct work that the ordering model cannot rank.
-            dispatch_items = [issue_items[number] for number in dispatch]
-            dispatch_items.extend(it for group in ambiguous.values() for it in group)
-            for item in dispatch_items:
-                if self.shutdown.is_set() or not self._admit(item):
-                    continue  # source lease is restored below
-                ran.add(id(item))
-                self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
-                self._run_item(item)
-        finally:
-            # Preserve original queue order for deferred / non-admitted /
-            # non-issue items, plus no-delay retries from this round. Each
-            # lease restores to the queue front, so release all source returns
-            # in reverse original order.
-            source_returns = {id(it) for it in items if id(it) not in ran}
-            source_returns.update(self._implementation_round_source_retries)
-            for it in reversed(claimed_items):
-                if id(it) in source_returns:
-                    self._restore_source_lease(it)
-            self._implementation_round_item_ids = None
-            self._implementation_round_source_retries.clear()
+                if item.repo
+            }
+            dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
+            for number in deferred:
+                logger.info("implementation #%s deferred (file overlap)", number)
+        # Cross-repo same-number items bypass the number-keyed gates and dispatch
+        # directly — they are distinct work that the ordering model cannot rank.
+        dispatch_items = [issue_items[number] for number in dispatch]
+        dispatch_items.extend(it for group in ambiguous.values() for it in group)
+        for item in dispatch_items:
+            if self.shutdown.is_set() or not self._admit(item):
+                continue
+            if not self._claim_selected_implementation_item(item):
+                continue
+            self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
+            self._run_item(item)
+            # A job, timer, or full-destination handoff retains the only
+            # implementation lease. Wait until it routes before selecting the
+            # next topo item.
+            if id(item) in self._leases:
+                return
 
-    def _dedup_implementation_items(self, items: list[WorkItem]) -> list[WorkItem]:
-        """Drop transient duplicate work items, keyed by ``(repo, issue)`` (#2057).
-
-        A retry/fail-back can re-enqueue an issue while a prior copy is still
-        queued, so the round may briefly hold two items for the same
-        ``(repo, issue)``. Keep the first-queued and terminalize the rest as
-        superseded (was a hard assert that crashed the whole run, #1952). Keyed
-        by ``(repo, issue)`` so a cross-repo same-number pair (``A#71``/``B#71``)
-        is preserved as distinct work. ``issue is None`` items never dedup.
-        """
+    @staticmethod
+    def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
+        """Return non-first queued duplicates keyed by ``(repo, issue)`` (#2057)."""
         seen: set[tuple[str, int]] = set()
-        deduped: list[WorkItem] = []
-        for it in items:
-            if it.issue is None:
-                deduped.append(it)
+        duplicates: list[WorkItem] = []
+        for item in items:
+            if item.issue is None:
                 continue
-            key = (it.repo, it.issue)
+            key = (item.repo, item.issue)
             if key in seen:
-                logger.warning(
-                    "implementation %s#%s already queued; dropping duplicate work item",
-                    it.repo,
-                    it.issue,
-                )
-                self._finish(
-                    it, passed=True, reason=f"{it.repo}#{it.issue} superseded by queued duplicate"
-                )
-                continue
-            seen.add(key)
-            deduped.append(it)
-        return deduped
+                duplicates.append(item)
+            else:
+                seen.add(key)
+        return duplicates
+
+    def _claim_selected_implementation_item(self, item: WorkItem) -> bool:
+        """Claim *item* at its current position, preserving FIFO retry order."""
+        for index, queued in enumerate(self.queues[StageName.IMPLEMENTATION].snapshot()):
+            if queued is item:
+                claimed = self._claim_item(StageName.IMPLEMENTATION, index=index)
+                if claimed is not item:  # pragma: no cover - coordinator-thread invariant
+                    raise RuntimeError("implementation queue selected a different item")
+                return True
+        return False
 
     @staticmethod
     def _index_issue_items(
@@ -1609,15 +1588,6 @@ class Coordinator:
         """
         delay = item.payload.pop("retry_delay_s", None)
         if delay is None:
-            if (
-                self._implementation_round_item_ids is not None
-                and id(item) in self._implementation_round_item_ids
-            ):
-                # The implementation drain has leased a complete bounded
-                # round for topo ordering. Keep this retry's source lease
-                # until every deferred peer can be restored FIFO below.
-                self._implementation_round_source_retries.add(id(item))
-                return
             if not self._restore_source_lease(item):
                 self._push_item(item, item.stage, enter=False)
         elif self.config.dry_run:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -171,6 +171,7 @@ _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — rei
 # state is still the restart authority.
 _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
+_SOURCE_REGISTRY_RETRY_DELAY_S = 0.05
 
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
@@ -242,6 +243,11 @@ class PipelineConfig:
 
     org: str
     repos: list[str]
+    # An org-wide invocation supplies a fresh paged source per pass instead
+    # of materializing every repository in ``repos``.  The callable keeps
+    # source state out of the durable configuration and makes reseeds restart
+    # discovery from GitHub, which remains the sole routing authority.
+    repo_source_factory: Callable[[], Iterator[str]] | None = None
     issues: list[int] = field(default_factory=list)
     prs: list[int] = field(default_factory=list)
     loops: int = 1
@@ -490,7 +496,13 @@ class Coordinator:
                 raise ValueError(
                     "injected completion queue capacity must match the coordinator work window"
                 )
+            # Test doubles conventionally expose ``completion_q`` while the
+            # production WorkerPool keeps the channel private. Rebind both
+            # shapes so an injected real pool cannot publish into the stale
+            # queue supplied to its constructor.
             pool.completion_q = self.completion_q
+            if hasattr(pool, "_completion_q"):
+                pool._completion_q = self.completion_q
         self.pool: Any = pool
         set_completion_notifiers = getattr(pool, "set_completion_notifiers", None)
         if callable(set_completion_notifiers):
@@ -810,6 +822,7 @@ class Coordinator:
                 {
                     "org": self.config.org,
                     "repos": self.config.repos,
+                    "repo_source": "streamed" if self.config.repo_source_factory else "explicit",
                     "issues": self.config.issues,
                     "prs": self.config.prs,
                     "loops": self.config.loops,
@@ -1421,6 +1434,30 @@ class Coordinator:
         self._record_event("repo_source_activate", item.repo, len(self._repo_issue_sources))
         return True
 
+    def _repo_source_slots_used(self) -> int:
+        """Return active cursors plus every live REPO setup reservation.
+
+        A repository setup item becomes a detached cursor after ``SOURCE``.
+        Reserve that future cursor slot from its first queue admission through
+        terminalization so a later setup item cannot strand at ``SOURCE``
+        merely because earlier setups filled the registry first.
+        """
+        candidates: dict[int, WorkItem] = {}
+        for queue in self.queues.values():
+            for item in queue.snapshot():
+                candidates[id(item)] = item
+        for _wake, _sequence, item in self.timers:
+            candidates[id(item)] = item
+        for item in self.in_flight.values():
+            candidates[id(item)] = item
+        for lease in self._leases.values():
+            candidates[id(lease.item)] = lease.item
+        reservations = sum(
+            item.kind is ItemKind.REPO and id(item) in self._live_work_permit_ids
+            for item in candidates.values()
+        )
+        return len(self._repo_issue_sources) + reservations
+
     def _repo_source_can_admit(self) -> bool:
         """Return whether a detached repo cursor may classify and admit one issue."""
         return self.live_work_count < _work_window(self.config) and all(
@@ -1582,10 +1619,9 @@ class Coordinator:
         q = self.queues[StageName.IMPLEMENTATION]
         if not len(q):
             return
-        # Derive topology from a bounded snapshot, then lease only the chosen
-        # item. A raw pop makes that item ownerless; claiming every item would
-        # violate the one-active-lease FIFO invariant. ``claim_at`` keeps a
-        # selected dependency's original restore position when it retries.
+        # Derive topology from a bounded snapshot, then lease only selected
+        # items. A raw pop makes an item ownerless; each lease preserves its
+        # original FIFO ticket while other ready work may still dispatch.
         for duplicate in self._implementation_duplicates(q.snapshot()):
             if not self._claim_selected_implementation_item(duplicate):
                 return
@@ -1636,11 +1672,6 @@ class Coordinator:
                 continue
             self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
             self._run_item(item)
-            # A job, timer, or full-destination handoff retains the only
-            # implementation lease. Wait until it routes before selecting the
-            # next topo item.
-            if id(item) in self._leases:
-                return
 
     @staticmethod
     def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
@@ -1735,7 +1766,13 @@ class Coordinator:
                         # lease and provisional permit so one repository
                         # cannot monopolize the stage while it streams.
                         if not self._externalize_repo_issue_source(item, source):
+                            # Admission reserves a registry slot before a
+                            # setup item enters REPO. This fallback preserves
+                            # liveness for an injected/custom queue that
+                            # violates that invariant: a bounded timer owns
+                            # the item until a cursor slot becomes free.
                             logger.debug("repo:%s: waiting for a source-registry slot", item.repo)
+                            self._timer_park(item, _SOURCE_REGISTRY_RETRY_DELAY_S)
                         return
                     continue
                 if isinstance(result, JobRequest):
@@ -2126,7 +2163,12 @@ class Coordinator:
         This prevents both an unbounded source spill and starvation from
         repeatedly retrying a later repository ahead of an earlier one.
         """
-        self._repo_entry_source = _RepoEntrySource(repos=iter(repos)) if repos else None
+        if self.config.repo_source_factory is not None:
+            self._repo_entry_source = _RepoEntrySource(repos=self.config.repo_source_factory())
+        elif repos:
+            self._repo_entry_source = _RepoEntrySource(repos=iter(repos))
+        else:
+            self._repo_entry_source = None
 
     def _drain_repo_entry_source(self) -> int:
         """Admit repository discovery items from the FIFO source when safe."""
@@ -2138,7 +2180,7 @@ class Coordinator:
         while (
             self.live_work_count < _work_window(self.config)
             and self.queues[StageName.REPO].can_offer()
-            and len(self._repo_issue_sources) < _work_window(self.config)
+            and self._repo_source_slots_used() < _work_window(self.config)
         ):
             repo = source.pending
             if repo is None:
@@ -2147,6 +2189,8 @@ class Coordinator:
                 except StopIteration:
                     self._repo_entry_source = None
                     break
+                except Exception as exc:
+                    raise RuntimeError(f"repository discovery source failed: {exc}") from exc
             item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.REPO)
             if not self._push_item(item, StageName.REPO, enter=True):
                 # The coordinator is single-threaded and the predicate above

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -290,7 +290,7 @@ class PipelineConfig:
 
 
 def _work_window(config: PipelineConfig) -> int:
-    """Return the global bound for queued and executing pipeline work."""
+    """Return the global bound for all nonterminal pipeline work."""
     return max(1, config.parallel_repos * config.max_workers)
 
 
@@ -451,6 +451,13 @@ class Coordinator:
         self._leases: dict[int, StageQueueLease] = {}
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self._direct_issue_source: _DirectIssueSource | None = None
+        # A StageQueue's capacity only bounds that one stage.  This permit
+        # set is the coordinator-wide admission budget: an item acquires one
+        # permit on first entry and keeps it while it moves between queues,
+        # leases, in-flight jobs, timers, and a retained handoff.  It releases
+        # only after the finished sink completes.  The set is therefore
+        # bounded by ``_work_window(config)``, not by the number of stages.
+        self._live_work_permit_ids: set[int] = set()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
@@ -839,6 +846,25 @@ class Coordinator:
             and not self._pending_handoffs
             and self._direct_issue_source is None
         )
+
+    @property
+    def live_work_count(self) -> int:
+        """Return the number of nonterminal work permits currently held."""
+        return len(self._live_work_permit_ids)
+
+    def _try_acquire_work_permit(self, item: WorkItem) -> bool:
+        """Reserve one global live-work slot for a newly admitted item."""
+        item_id = id(item)
+        if item_id in self._live_work_permit_ids:
+            return True
+        if self.live_work_count >= _work_window(self.config):
+            return False
+        self._live_work_permit_ids.add(item_id)
+        return True
+
+    def _release_work_permit(self, item: WorkItem) -> None:
+        """Release *item*'s permit after the terminal sink has completed."""
+        self._live_work_permit_ids.discard(id(item))
 
     # -- stage-queue leases -------------------------------------------------
 
@@ -1501,6 +1527,7 @@ class Coordinator:
             # Sink outcomes are terminal: the result is already recorded.
             self._record_event("done", self._item_key(item), outcome.note)
             self._release_source_lease(item)
+            self._release_work_permit(item)
             return
 
         if disposition is Disposition.ADVANCE:
@@ -1589,6 +1616,7 @@ class Coordinator:
                 self.ledger.append(item.result)
                 item.payload["_recorded"] = True
             self._release_source_lease(item)
+            self._release_work_permit(item)
             return
         result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
         self._handoff_item(item, StageName.FINISHED, enter=True, result=result)
@@ -1635,7 +1663,7 @@ class Coordinator:
                 keys.add((it.repo, it.issue))
         return keys
 
-    def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> None:
+    def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> bool:
         """Push *item* into *stage*'s queue (the single push chokepoint).
 
         Every durable GitHub mutation for this transition already happened
@@ -1648,25 +1676,34 @@ class Coordinator:
         from an already-tracked item re-pushing itself on timer/retry/fail-back/
         advance, which must always be allowed through.
         """
+        is_new_item = id(item) not in self._seen_item_ids
         if (
-            id(item) not in self._seen_item_ids
+            is_new_item
             and item.kind is ItemKind.ISSUE
             and item.issue is not None
             and (item.repo, item.issue) in self._live_issue_keys()
         ):
             logger.info("seed skipped: #%s already queued/in-flight in %s", item.issue, item.repo)
-            return
+            return False
+        if is_new_item and not self._try_acquire_work_permit(item):
+            logger.debug(
+                "global live-work capacity reached (%d); deferring %s",
+                _work_window(self.config),
+                self._item_key(item),
+            )
+            return False
         item.stage = stage
         if enter:
             item.state = "ENTER"
             item.payload["_enter_pending"] = True
             item.add_history_event(stage, item.state, note="enqueued")
-        if id(item) not in self._seen_item_ids:
+        if is_new_item:
             self._seen_item_ids.add(id(item))
             self.items.append(item)
             item.payload.setdefault("entry_stage", stage.value)
         self.queues[stage].push(item)
         self._record_event("push", stage.value, self._item_key(item))
+        return True
 
     @staticmethod
     def _item_key(item: WorkItem) -> str:
@@ -1710,8 +1747,8 @@ class Coordinator:
                 item.result = ItemResult(
                     passed=entry.passed, reason=entry.reason, final_stage=StageName.FINISHED
                 )
-            self._push_item(item, item.stage, enter=True)
-            pushed += 1
+            if self._push_item(item, item.stage, enter=True):
+                pushed += 1
         return pushed + self._drain_direct_issue_source()
 
     def _begin_direct_issue_source(self, repo: str) -> None:
@@ -1723,8 +1760,10 @@ class Coordinator:
         self._direct_issue_source = _DirectIssueSource(repo=repo, issues=iter(open_issues))
 
     def _direct_issue_queues_can_accept(self) -> bool:
-        """Return whether any direct issue can be classified and enqueued now."""
-        return all(self.queues[stage].can_offer() for stage in _DIRECT_ISSUE_ENTRY_STAGES)
+        """Return whether one direct issue can be classified and enqueued now."""
+        return self.live_work_count < _work_window(self.config) and all(
+            self.queues[stage].can_offer() for stage in _DIRECT_ISSUE_ENTRY_STAGES
+        )
 
     def _drain_direct_issue_source(self) -> int:
         """Pull explicit issues directly into queues without a seed spill buffer.
@@ -1766,10 +1805,12 @@ class Coordinator:
                     final_stage=StageName.FINISHED,
                 )
             # ``_direct_issue_queues_can_accept`` covers every possible
-            # classifier result and this method owns the coordinator thread,
-            # so the ordinary lifecycle push cannot overflow here.
-            self._push_item(item, item.stage, enter=True)
-            pushed += 1
+            # classifier result and the coordinator-wide permit budget. This
+            # source owns the coordinator thread, so a failed lifecycle push
+            # can only be an idempotent duplicate; it never represents
+            # saturation or a completion/shutdown fault.
+            if self._push_item(item, item.stage, enter=True):
+                pushed += 1
         return pushed
 
     def _clamp_seed_stage_to_scope(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -6,8 +6,10 @@ The coordinator runs on the process main thread and owns all seven stage
 queues, the timer heap, the in-flight registry, all routing, and (through the
 :class:`~hephaestus.automation.pipeline_github.PipelineGitHub` accessor) every
 GitHub API mutation. A single worker pool executes agent, build/test, and
-git/network jobs; the ONLY cross-thread channel is the completion queue, whose
-blocking ``get(timeout=...)`` doubles as the loop's idle sleep.
+git/network jobs; the ONLY cross-thread data channel is the completion queue.
+A separate event latch wakes the idle loop for both accepted completions and
+signals, so neither a worker callback nor a signal handler can block on a
+full queue.
 
 Per tick (epic #1809 "Coordinator event loop"):
 
@@ -154,8 +156,6 @@ _MAX_STEPS_PER_TICK = 100
 #: house on_job_done pattern); this cap only guarantees cross-stage regression
 #: cycles terminate even if a stage's own bookkeeping has a bug.
 _FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
-
-_WAKE_HANDLE = object()
 
 _PROMPT_PREFLIGHT_TEMPLATE = "shared/untrusted_notice.j2"
 _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — reinstall: `uv sync`."
@@ -372,6 +372,11 @@ class Coordinator:
         self.github = github
         self._github_factory = github_factory
         self.shutdown = threading.Event()
+        # These latches are the control plane for the bounded completion
+        # queue.  They carry no WorkItem/JobResult payload and therefore
+        # cannot become a second, unbounded completion buffer.
+        self._completion_wakeup = threading.Event()
+        self._completion_saturation = threading.Event()
         work_window = _work_window(config)
         self.completion_q: CompletionQueue = queue_mod.Queue(maxsize=work_window)
         if pool is None:
@@ -398,6 +403,12 @@ class Coordinator:
                 )
             pool.completion_q = self.completion_q
         self.pool: Any = pool
+        set_completion_notifiers = getattr(pool, "set_completion_notifiers", None)
+        if callable(set_completion_notifiers):
+            set_completion_notifiers(
+                wakeup=self._completion_wakeup,
+                saturation=self._completion_saturation,
+            )
 
         self.queues: dict[StageName, StageQueue] = {
             name: StageQueue(work_window) for name in StageName
@@ -671,8 +682,8 @@ class Coordinator:
             )
 
     def _wake_completion_wait(self) -> None:
-        """Wake the coordinator if it is blocked in completion_q.get()."""
-        self.completion_q.put((_WAKE_HANDLE, JobResult(ok=False, interrupted=True, error="wake")))
+        """Wake the coordinator without writing a sentinel into its bounded queue."""
+        self._completion_wakeup.set()
 
     # -- run loop ---------------------------------------------------------------
 
@@ -1008,26 +1019,34 @@ class Coordinator:
 
     def _drain_completions(self) -> None:
         """Drain ALL ready completions without blocking."""
+        # Clear before inspection.  A callback that publishes between this
+        # clear and the final get_nowait() either has its result drained now
+        # (leaving a harmless set latch) or sets the latch for the next wait.
+        self._completion_wakeup.clear()
         while True:
             try:
                 handle, result = self.completion_q.get_nowait()
             except queue_mod.Empty:
-                return
-            if handle is _WAKE_HANDLE:
-                self._record_event("wake", "completion_q")
-                continue
+                break
             self._handle_completion(handle, result)
 
+        if self._completion_saturation.is_set():
+            # This cannot occur when the C-in-flight invariant holds: each
+            # active job has one reserved slot in the C-sized completion
+            # queue.  A WorkerPool callback never blocks or spills when that
+            # invariant is violated; fail the run and finalize its still-live
+            # item resumably instead.  Crucially, this is not a signal.
+            self._record_event("completion_saturation")
+            raise RuntimeError("completion queue saturated")
+
     def _wait_for_completion(self, timeout: float) -> None:
-        """Block up to *timeout* for one completion; handle it if one arrives."""
-        try:
-            handle, result = self.completion_q.get(timeout=timeout)
-        except queue_mod.Empty:
-            return
-        if handle is _WAKE_HANDLE:
-            self._record_event("wake", "completion_q")
-            return
-        self._handle_completion(handle, result)
+        """Wait for a completion, a saturation fault, or a signal wake latch."""
+        # A test double may synchronously enqueue without owning the notifier;
+        # avoid an unnecessary idle wait in that compatible case.  Production
+        # callbacks set the event after every accepted completion.
+        if self.completion_q.empty() and not self._completion_saturation.is_set():
+            self._completion_wakeup.wait(timeout=timeout)
+        self._drain_completions()
 
     def _handle_completion(self, handle: JobHandle, result: JobResult) -> None:
         """Route one completed job back to its item.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -91,7 +91,7 @@ from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
 from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
-from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue
+from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue, StageQueueLease
 from hephaestus.automation.pipeline.routing import (
     PIPELINE_ORDER,
     ROUTES,
@@ -313,6 +313,24 @@ class _Paths:
     projects_dir: Path
 
 
+@dataclass(frozen=True)
+class _PendingHandoff:
+    """A completed route retained by its source-stage lease.
+
+    ``StageQueueLease`` keeps the source slot occupied until the destination
+    accepts the item.  The coordinator records only the next intent here; it
+    deliberately does not mutate ``WorkItem.stage``, ``state``, history, or a
+    terminal result until that destination-first admission succeeds.  There
+    can be at most one pending handoff per active lease, so this is bounded by
+    the fixed capacity of the coordinator's stage queues rather than acting as
+    a spill buffer.
+    """
+
+    target: StageName
+    enter: bool
+    result: ItemResult | None = None
+
+
 def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
     """Resolve *repo* to its explicit checkout or conventional projects path."""
     return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
@@ -387,6 +405,12 @@ class Coordinator:
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
         self.inflight_per_repo: Counter[str] = Counter()
+        # A normal (non-implementation) drain claims instead of popping.  The
+        # active lease reserves its source capacity while an item executes or
+        # waits for a worker completion.  A pending route is represented by a
+        # single intent attached to that lease, never by an overflow queue.
+        self._leases: dict[int, StageQueueLease] = {}
+        self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
@@ -765,12 +789,149 @@ class Coordinator:
         return 0
 
     def _all_idle(self) -> bool:
-        """Return True when queues, timer heap, and in-flight map are all empty."""
+        """Return True when no ready, leased, timed, or in-flight work remains."""
         return (
             all(len(q) == 0 for q in self.queues.values())
             and not self.timers
             and not self.in_flight
+            and not self._leases
+            and not self._pending_handoffs
         )
+
+    # -- stage-queue leases -------------------------------------------------
+
+    def _claim_item(self, stage_name: StageName) -> WorkItem | None:
+        """Claim one ready item while retaining its source-stage capacity."""
+        lease = self.queues[stage_name].claim()
+        if lease is None:
+            return None
+        item = lease.item
+        item_id = id(item)
+        if item_id in self._leases:  # pragma: no cover - internal invariant
+            lease.restore()
+            raise RuntimeError(f"duplicate active lease for {self._item_key(item)}")
+        self._leases[item_id] = lease
+        return item
+
+    def _restore_source_lease(self, item: WorkItem) -> bool:
+        """Return an active item lease to its source queue without a transition."""
+        self._pending_handoffs.pop(id(item), None)
+        lease = self._leases.pop(id(item), None)
+        if lease is None:
+            return False
+        lease.restore()
+        return True
+
+    def _release_source_lease(self, item: WorkItem) -> bool:
+        """Release an active lease when work leaves every stage queue.
+
+        ``StageQueueLease`` intentionally exposes only restore or
+        destination-first handoff.  Timers and terminal sink completion are
+        neither, so restore to the source front and immediately remove that
+        same item.  This is not queue draining: it is the one coordinator
+        escape hatch into a timer/terminal ledger and preserves FIFO for all
+        remaining ready items.
+        """
+        self._pending_handoffs.pop(id(item), None)
+        lease = self._leases.pop(id(item), None)
+        if lease is None:
+            return False
+        lease.restore()
+        released = self.queues[item.stage].pop()
+        if released is not item:  # pragma: no cover - queue ownership invariant
+            raise RuntimeError("lease restored a different work item")
+        return True
+
+    def _activate_handoff(
+        self,
+        item: WorkItem,
+        target: StageName,
+        *,
+        enter: bool,
+        result: ItemResult | None,
+    ) -> None:
+        """Publish a route only after its destination accepted the item."""
+        item.stage = target
+        if enter:
+            item.state = "ENTER"
+            item.payload["_enter_pending"] = True
+            item.add_history_event(target, item.state, note="enqueued")
+        if result is not None:
+            item.result = result
+        self._record_event("push", target.value, self._item_key(item))
+
+    def _handoff_item(
+        self,
+        item: WorkItem,
+        target: StageName,
+        *,
+        enter: bool,
+        result: ItemResult | None = None,
+    ) -> bool:
+        """Route an item destination-first, retaining a full-target intent.
+
+        Direct unit-test calls do not own a source lease and retain the
+        historical push behavior.  Normal drains always carry a lease, so a
+        full destination only records a bounded intent and the completed
+        stage action is never replayed.
+        """
+        lease = self._leases.get(id(item))
+        if lease is None:
+            if result is not None:
+                item.result = result
+            self._push_item(item, target, enter=enter)
+            return True
+
+        if target is item.stage:
+            # RETRY to the source is a restore, not a self-handoff: a held
+            # lease deliberately blocks its source's ``offer`` method.
+            if result is not None:  # pragma: no cover - terminal target is FINISHED
+                raise RuntimeError("terminal result cannot route to the source stage")
+            return self._restore_source_lease(item)
+
+        if lease.handoff(self.queues[target]):
+            self._leases.pop(id(item), None)
+            self._pending_handoffs.pop(id(item), None)
+            self._activate_handoff(item, target, enter=enter, result=result)
+            self._progress = True
+            return True
+
+        pending = _PendingHandoff(target=target, enter=enter, result=result)
+        existing = self._pending_handoffs.setdefault(id(item), pending)
+        if existing != pending:  # pragma: no cover - no item can route twice while leased
+            raise RuntimeError(f"conflicting pending handoff for {self._item_key(item)}")
+        self._record_event(
+            "handoff_pending",
+            item.stage.value,
+            target.value,
+            self._item_key(item),
+        )
+        return False
+
+    def _drain_pending_handoffs(self) -> None:
+        """Retry every retained route whose destination may have opened."""
+        for item_id, pending in list(self._pending_handoffs.items()):
+            lease = self._leases.get(item_id)
+            if lease is None:  # pragma: no cover - defensive bookkeeping repair
+                self._pending_handoffs.pop(item_id, None)
+                continue
+            item = lease.item
+            if not lease.handoff(self.queues[pending.target]):
+                continue
+            self._leases.pop(item_id, None)
+            self._pending_handoffs.pop(item_id, None)
+            self._activate_handoff(
+                item,
+                pending.target,
+                enter=pending.enter,
+                result=pending.result,
+            )
+            self._record_event(
+                "handoff_retry",
+                item.stage.value,
+                self._item_key(item),
+            )
+            self._progress = True
 
     def _grace_exceeded(self) -> bool:
         """Return True when a graceful shutdown has outlived its grace window."""
@@ -808,7 +969,9 @@ class Coordinator:
         for stage_name in _DRAIN_ORDER:
             q = self.queues[stage_name]
             if len(q):
-                item = q.pop()
+                item = self._claim_item(stage_name)
+                if item is None:  # pragma: no cover - len/claim are coordinator-thread atomic
+                    continue
                 logger.error(
                     "pipeline stalled with no in-flight work; "
                     "force-running %s item %s; inflight_per_repo=%s",
@@ -823,6 +986,10 @@ class Coordinator:
 
     def _timer_park(self, item: WorkItem, delay_s: float) -> None:
         """Park *item* on the timer heap for ``delay_s`` seconds."""
+        # A timer is outside every stage queue.  Release a normal drain's
+        # source lease before parking so its capacity is not stranded while
+        # preserving the timer's single owner for the work item.
+        self._release_source_lease(item)
         wake = time.monotonic() + max(0.0, delay_s)
         heapq.heappush(self.timers, (wake, self._seq, item))
         self._seq += 1
@@ -951,6 +1118,7 @@ class Coordinator:
         seeding reconstruction resumes exactly here with no shutdown
         bookkeeping.
         """
+        self._release_source_lease(item)
         item.result = ItemResult(
             passed=False,
             reason=f"resumable at {item.stage.value}",
@@ -992,22 +1160,30 @@ class Coordinator:
 
     def _drain_queues(self) -> None:
         """Drain queues downstream-first with admission control."""
+        # A transition that previously found a full target owns its source
+        # lease.  Retry it before ordinary draining, then again after each
+        # stage: draining a target can open exactly the slot it needs.
+        self._drain_pending_handoffs()
         for stage_name in _DRAIN_ORDER:
             if self.shutdown.is_set():
                 return
             if stage_name is StageName.IMPLEMENTATION:
                 self._drain_implementation()
+                self._drain_pending_handoffs()
                 continue
             q = self.queues[stage_name]
             for _ in range(len(q)):
                 if self.shutdown.is_set():
                     return
-                item = q.pop()
+                item = self._claim_item(stage_name)
+                if item is None:  # pragma: no cover - len/claim are coordinator-thread atomic
+                    break
                 if not self._admit(item):
-                    q.push(item)
+                    self._restore_source_lease(item)
                     continue
                 self._record_event("drain", stage_name.value, self._item_key(item))
                 self._run_item(item)
+            self._drain_pending_handoffs()
 
     def _drain_implementation(self) -> None:
         """Drain the implementation queue under topo order + file-overlap gating.
@@ -1274,6 +1450,7 @@ class Coordinator:
         if item.stage is StageName.FINISHED:
             # Sink outcomes are terminal: the result is already recorded.
             self._record_event("done", self._item_key(item), outcome.note)
+            self._release_source_lease(item)
             return
 
         if disposition is Disposition.ADVANCE:
@@ -1282,7 +1459,7 @@ class Coordinator:
             if target is StageName.FINISHED:
                 self._finish(item, passed=True, reason=outcome.note or "advance")
             else:
-                self._push_item(item, target, enter=True)
+                self._handoff_item(item, target, enter=True)
             return
 
         if disposition is Disposition.RETRY:
@@ -1317,7 +1494,8 @@ class Coordinator:
         """
         delay = item.payload.pop("retry_delay_s", None)
         if delay is None:
-            self._push_item(item, item.stage, enter=False)
+            if not self._restore_source_lease(item):
+                self._push_item(item, item.stage, enter=False)
         elif self.config.dry_run:
             self._finish(
                 item, passed=False, reason=f"[dry-run] would wait {delay}s: {outcome.note}"
@@ -1350,18 +1528,20 @@ class Coordinator:
         if target is StageName.FINISHED:
             self._finish(item, passed=False, reason=outcome.note or "fail_back")
         else:
-            self._push_item(item, target, enter=True)
+            self._handoff_item(item, target, enter=True)
 
     def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
         """Set the item's result and hand it to the finished sink."""
-        item.result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
         if item.stage is StageName.FINISHED:
             # Poisoned inside the sink: record directly, never re-queue.
+            item.result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
             if not item.payload.get("_recorded", False):
                 self.ledger.append(item.result)
                 item.payload["_recorded"] = True
+            self._release_source_lease(item)
             return
-        self._push_item(item, StageName.FINISHED, enter=True)
+        result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
+        self._handoff_item(item, StageName.FINISHED, enter=True, result=result)
 
     def _seed_products(self, item: WorkItem) -> None:
         """Push a terminal repo item's discovered products into entry queues."""
@@ -1397,6 +1577,10 @@ class Coordinator:
                 if it.kind is ItemKind.ISSUE and it.issue is not None:
                     keys.add((it.repo, it.issue))
         for it in self.in_flight.values():
+            if it.kind is ItemKind.ISSUE and it.issue is not None:
+                keys.add((it.repo, it.issue))
+        for lease in self._leases.values():
+            it = lease.item
             if it.kind is ItemKind.ISSUE and it.issue is not None:
                 keys.add((it.repo, it.issue))
         return keys
@@ -1829,7 +2013,12 @@ class Coordinator:
                 continue
             leftovers.extend(q.snapshot())
         leftovers.extend(self.in_flight.values())
+        leftovers.extend(lease.item for lease in self._leases.values())
+        seen: set[int] = set()
         for item in leftovers:
+            if id(item) in seen:
+                continue
+            seen.add(id(item))
             if item.result is None:
                 self._park_resumable(item)
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -458,6 +458,11 @@ class Coordinator:
         # only after the finished sink completes.  The set is therefore
         # bounded by ``_work_window(config)``, not by the number of stages.
         self._live_work_permit_ids: set[int] = set()
+        # Implementation claims an entire bounded round to derive topo order.
+        # Source retries in that round stay leased until all deferred peers can
+        # be restored in their original FIFO order.
+        self._implementation_round_item_ids: set[int] | None = None
+        self._implementation_round_source_retries: set[int] = set()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
@@ -1065,12 +1070,19 @@ class Coordinator:
         self._record_event("timer_park", item.stage.value, self._item_key(item), delay_s)
 
     def _wake_timers(self) -> None:
-        """Move every expired timer entry back into its stage queue."""
+        """Move expired timer entries back only after their stage accepts them.
+
+        The timer heap owns an item until its stage queue accepts it.  An
+        expired entry whose stage is at capacity remains at the heap head for a
+        later tick; it is ordinary bounded backpressure, not a pipeline fault.
+        """
         now = time.monotonic()
         while self.timers and self.timers[0][0] <= now:
-            _, _, item = heapq.heappop(self.timers)
+            _, _, item = self.timers[0]
+            if not self._push_item(item, item.stage, enter=False, defer_if_full=True):
+                return
+            heapq.heappop(self.timers)
             self._progress = True
-            self._push_item(item, item.stage, enter=False)
 
     # -- completions ----------------------------------------------------------
 
@@ -1283,44 +1295,70 @@ class Coordinator:
         q = self.queues[StageName.IMPLEMENTATION]
         if not len(q):
             return
-        items = self._dedup_implementation_items([q.pop() for _ in range(len(q))])
-        issue_items, ambiguous = self._index_issue_items(items)
-        infos = [
-            IssueInfo(
-                number=number,
-                title=str(item.payload.get("issue_title", "")),
-                dependencies=list(item.payload.get("dependencies", [])),
-            )
-            for number, item in issue_items.items()
-        ]
-        ordered = _admission.order_for_implementation(infos)
-        dispatch = ordered
-        if self.config.serialize_file_overlap and self.config.max_workers > 1 and len(ordered) > 1:
-            # Resolve each issue's owning repo from its own WorkItem: the queue is
-            # keyed by stage, so one round can hold issues from several repos (#1795).
-            repo_of = {
-                number: (self.config.org, item.repo)
-                for number, item in issue_items.items()
-                if item.repo
-            }
-            dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
-            for number in deferred:
-                logger.info("implementation #%s deferred (file overlap)", number)
+        # Take bounded source leases for the whole ready round before deriving
+        # the topological order. A raw ``pop`` would make a completed item
+        # ownerless while it is routed; when PR review is full that used to
+        # poison an already-completed implementation action instead of
+        # retaining its source slot for a pending handoff.
+        claimed_items: list[WorkItem] = []
+        for _ in range(len(q)):
+            item = self._claim_item(StageName.IMPLEMENTATION)
+            if item is None:  # pragma: no cover - coordinator-thread atomicity
+                break
+            claimed_items.append(item)
+        items = self._dedup_implementation_items(claimed_items)
+        self._implementation_round_item_ids = {id(item) for item in items}
+        self._implementation_round_source_retries.clear()
         ran: set[int] = set()
-        # Cross-repo same-number items bypass the number-keyed gates and dispatch
-        # directly — they are distinct work that the ordering model cannot rank.
-        dispatch_items = [issue_items[number] for number in dispatch]
-        dispatch_items.extend(it for group in ambiguous.values() for it in group)
-        for item in dispatch_items:
-            if self.shutdown.is_set() or not self._admit(item):
-                continue  # stays queued (re-pushed below)
-            ran.add(id(item))
-            self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
-            self._run_item(item)
-        # Preserve original queue order for deferred / non-admitted / non-issue items.
-        for it in items:
-            if id(it) not in ran:
-                q.push(it)
+        try:
+            issue_items, ambiguous = self._index_issue_items(items)
+            infos = [
+                IssueInfo(
+                    number=number,
+                    title=str(item.payload.get("issue_title", "")),
+                    dependencies=list(item.payload.get("dependencies", [])),
+                )
+                for number, item in issue_items.items()
+            ]
+            ordered = _admission.order_for_implementation(infos)
+            dispatch = ordered
+            if (
+                self.config.serialize_file_overlap
+                and self.config.max_workers > 1
+                and len(ordered) > 1
+            ):
+                # Resolve each issue's owning repo from its own WorkItem: the queue is
+                # keyed by stage, so one round can hold issues from several repos (#1795).
+                repo_of = {
+                    number: (self.config.org, item.repo)
+                    for number, item in issue_items.items()
+                    if item.repo
+                }
+                dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
+                for number in deferred:
+                    logger.info("implementation #%s deferred (file overlap)", number)
+            # Cross-repo same-number items bypass the number-keyed gates and dispatch
+            # directly — they are distinct work that the ordering model cannot rank.
+            dispatch_items = [issue_items[number] for number in dispatch]
+            dispatch_items.extend(it for group in ambiguous.values() for it in group)
+            for item in dispatch_items:
+                if self.shutdown.is_set() or not self._admit(item):
+                    continue  # source lease is restored below
+                ran.add(id(item))
+                self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
+                self._run_item(item)
+        finally:
+            # Preserve original queue order for deferred / non-admitted /
+            # non-issue items, plus no-delay retries from this round. Each
+            # lease restores to the queue front, so release all source returns
+            # in reverse original order.
+            source_returns = {id(it) for it in items if id(it) not in ran}
+            source_returns.update(self._implementation_round_source_retries)
+            for it in reversed(claimed_items):
+                if id(it) in source_returns:
+                    self._restore_source_lease(it)
+            self._implementation_round_item_ids = None
+            self._implementation_round_source_retries.clear()
 
     def _dedup_implementation_items(self, items: list[WorkItem]) -> list[WorkItem]:
         """Drop transient duplicate work items, keyed by ``(repo, issue)`` (#2057).
@@ -1571,6 +1609,15 @@ class Coordinator:
         """
         delay = item.payload.pop("retry_delay_s", None)
         if delay is None:
+            if (
+                self._implementation_round_item_ids is not None
+                and id(item) in self._implementation_round_item_ids
+            ):
+                # The implementation drain has leased a complete bounded
+                # round for topo ordering. Keep this retry's source lease
+                # until every deferred peer can be restored FIFO below.
+                self._implementation_round_source_retries.add(id(item))
+                return
             if not self._restore_source_lease(item):
                 self._push_item(item, item.stage, enter=False)
         elif self.config.dry_run:
@@ -1663,7 +1710,14 @@ class Coordinator:
                 keys.add((it.repo, it.issue))
         return keys
 
-    def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> bool:
+    def _push_item(
+        self,
+        item: WorkItem,
+        stage: StageName,
+        enter: bool,
+        *,
+        defer_if_full: bool = False,
+    ) -> bool:
         """Push *item* into *stage*'s queue (the single push chokepoint).
 
         Every durable GitHub mutation for this transition already happened
@@ -1675,6 +1729,16 @@ class Coordinator:
         exercised. Object identity (``_seen_item_ids``) distinguishes a new item
         from an already-tracked item re-pushing itself on timer/retry/fail-back/
         advance, which must always be allowed through.
+
+        ``defer_if_full`` makes bounded capacity an ordinary backpressure
+        result rather than an exception. It is reserved for timer wake-ups,
+        whose heap entry must remain the item's owner until the stage accepts
+        it. All ordinary callers retain the strict overflow invariant.
+
+        Returns:
+            ``True`` when the queue accepted the item; ``False`` when a
+            duplicate seed was skipped or a deferred queue is full.
+
         """
         is_new_item = id(item) not in self._seen_item_ids
         if (
@@ -1692,6 +1756,13 @@ class Coordinator:
                 self._item_key(item),
             )
             return False
+        acquired_permit = is_new_item
+        if not self.queues[stage].offer(item):
+            if acquired_permit:
+                self._release_work_permit(item)
+            if defer_if_full:
+                return False
+            raise OverflowError("StageQueue is full")
         item.stage = stage
         if enter:
             item.state = "ENTER"
@@ -1701,7 +1772,6 @@ class Coordinator:
             self._seen_item_ids.add(id(item))
             self.items.append(item)
             item.payload.setdefault("entry_stage", stage.value)
-        self.queues[stage].push(item)
         self._record_event("push", stage.value, self._item_key(item))
         return True
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -118,7 +118,7 @@ from hephaestus.automation.pipeline.stages import (
     StageGitHub,
 )
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
-from hephaestus.automation.pipeline.stages.repo import product_to_work_item
+from hephaestus.automation.pipeline.stages.repo import RepoIssueSource, product_to_work_item
 from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
 from hephaestus.automation.pipeline.work_item import (
     ItemKind,
@@ -126,7 +126,7 @@ from hephaestus.automation.pipeline.work_item import (
     PreservedWorktree,
     WorkItem,
 )
-from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO, STATE_PLAN_BLOCKED
+from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO, STATE_PLAN_BLOCKED, is_epic
 from hephaestus.prompts import PromptCatalog
 
 logger = logging.getLogger(__name__)
@@ -758,6 +758,7 @@ class Coordinator:
                     self._wait_for_completion(timeout=0.2)
                     continue
                 self._drain_queues()
+                self._drain_repo_issue_sources()
                 self._drain_direct_issue_source()
                 if self._all_idle():
                     if not self._reseed_if_converged():
@@ -1263,6 +1264,159 @@ class Coordinator:
                 self._run_item(item)
             self._drain_pending_handoffs()
 
+    def _repo_source_can_admit(self, item: WorkItem) -> bool:
+        """Return whether a repo source can transfer its permit to one issue.
+
+        The source itself is initially a normal live item.  Before admitting
+        its next classified child it relinquishes that permit, so C=1 can
+        make forward progress without a second slot.  Once a child owns the
+        sole permit, the source retains only its source-stage lease and waits
+        without holding an unbounded product buffer.
+        """
+        source_owns_permit = id(item) in self._live_work_permit_ids
+        prospective_live = self.live_work_count - int(source_owns_permit)
+        return prospective_live < _work_window(self.config) and all(
+            self.queues[stage].can_offer() for stage in _DIRECT_ISSUE_ENTRY_STAGES
+        )
+
+    def _drain_repo_issue_sources(self) -> None:
+        """Pull at most one admitted issue from each active repository cursor.
+
+        ``RepoStage`` establishes a :class:`RepoIssueSource` after checkout
+        preparation.  The coordinator is the only queue owner, so it keeps
+        the source-stage lease while a single raw metadata row waits for
+        global capacity, transfers the source's permit to the child at
+        admission, and retries the same row on the next available slot.
+        """
+        for lease in list(self._leases.values()):
+            item = lease.item
+            if item.kind is not ItemKind.REPO or item.state != "SOURCE":
+                continue
+            source = item.payload.get("_repo_issue_source")
+            if not isinstance(source, RepoIssueSource):
+                continue
+            if id(item) in self._pending_handoffs:
+                continue
+            self._drain_repo_issue_source(item, source)
+
+    def _drain_repo_issue_source(  # noqa: C901 - source lifecycle is intentionally linear
+        self, item: WorkItem, source: RepoIssueSource
+    ) -> None:
+        """Consume one repository source cursor until one child is admitted.
+
+        Exclusions (notably epics) need no child capacity and are consumed in
+        order after their durable skip write.  An eligible pending row stays
+        in ``source.pending`` until every possible entry queue and the global
+        permit budget can accept it; no classified product is retained.
+        """
+        ctx = self._ctx_for(item)
+        while True:
+            metadata = source.pending
+            if metadata is None:
+                try:
+                    metadata = next(source.metadata)
+                except StopIteration:
+                    item.payload.pop("_repo_issue_source", None)
+                    self._finish(item, passed=True, reason=f"seeded:{source.seeded_count}")
+                    return
+                except Exception as exc:
+                    logger.warning("repo:%s: discovery source failed: %s", item.repo, exc)
+                    item.payload.pop("_repo_issue_source", None)
+                    self._finish(item, passed=False, reason=f"discovery failed: {exc}")
+                    return
+
+            number = int(metadata["number"])
+            labels = list(metadata.get("labels") or [])
+            title = str(metadata.get("title") or "")
+            # Metadata epics need no expensive issue fetch.  The durable
+            # label write is completed before source consumption advances.
+            if is_epic(labels, title):
+                try:
+                    ctx.github.skip_epics({number: labels})
+                except Exception as exc:
+                    logger.warning(
+                        "repo:%s: could not tag excluded epic #%d state:skip: %s",
+                        item.repo,
+                        number,
+                        exc,
+                    )
+                    item.payload.pop("_repo_issue_source", None)
+                    self._finish(item, passed=False, reason=f"epic skip tag failed: {exc}")
+                    return
+                logger.info(
+                    "repo:%s: #%d is an epic; tagged state:skip, excluded", item.repo, number
+                )
+                source.pending = None
+                self._progress = True
+                return
+
+            if not self._repo_source_can_admit(item):
+                source.pending = metadata
+                return
+
+            try:
+                facts = _seeding.seed_issue_from_github(number, ctx.github)
+                if STATE_PLAN_BLOCKED in facts.labels:
+                    ctx.github.ensure_blocked_audit(number)
+                entry = _seeding.seed_entry_from_facts(facts)
+                scope_stages = self.config.scope.stages if self.config.scope is not None else None
+                stage, reason, passed = self._scope_seed_decision(
+                    number, entry.stage, entry.reason, scope_stages
+                )
+                entry = replace(entry, stage=stage, reason=reason, passed=passed)
+            except Exception as exc:
+                logger.warning(
+                    "repo:%s: issue #%d classification failed: %s", item.repo, number, exc
+                )
+                item.payload.pop("_repo_issue_source", None)
+                self._finish(item, passed=False, reason=f"discovery failed: {exc}")
+                return
+
+            if entry.stage is None:
+                try:
+                    if entry.skip_tag_obligation is not None:
+                        ctx.github.skip_epics({entry.skip_tag_obligation.issue: []})
+                except Exception as exc:
+                    logger.warning(
+                        "repo:%s: could not tag excluded epic #%d state:skip: %s",
+                        item.repo,
+                        number,
+                        exc,
+                    )
+                    item.payload.pop("_repo_issue_source", None)
+                    self._finish(item, passed=False, reason=f"epic skip tag failed: {exc}")
+                    return
+                logger.info("[%s] excluded: %s", item.repo, entry.reason)
+                source.pending = None
+                self._progress = True
+                return
+
+            new_item = self._entry_to_item(entry, item.repo)
+            if new_item.stage is StageName.FINISHED and new_item.result is None:
+                new_item.result = ItemResult(
+                    passed=entry.passed,
+                    reason=entry.reason,
+                    final_stage=StageName.FINISHED,
+                )
+            elif new_item.stage is not StageName.REPO:
+                self._pass_work_count += 1
+
+            # This is the source-to-child permit transfer.  The source keeps
+            # its queue lease, but no longer consumes global live-work budget
+            # while the admitted child progresses through the pipeline.
+            self._release_work_permit(item)
+            source.pending = None
+            if self._push_item(new_item, new_item.stage, enter=True):
+                source.seeded_count += 1
+                self._progress = True
+                return
+            # The preflight covers capacity; a false push is therefore only
+            # the existing idempotent duplicate guard.  Do not retain it in
+            # a second source buffer.  The duplicate's live peer now governs
+            # the next admission opportunity.
+            self._progress = True
+            return
+
     def _drain_implementation(self) -> None:
         """Drain the implementation queue under topo order + file-overlap gating.
 
@@ -1427,6 +1581,16 @@ class Coordinator:
                 if isinstance(result, Continue):
                     item.state = result.next_state
                     item.add_history_event(item.stage, item.state)
+                    if (
+                        item.kind is ItemKind.REPO
+                        and item.state == "SOURCE"
+                        and isinstance(item.payload.get("_repo_issue_source"), RepoIssueSource)
+                    ):
+                        # The source owns this repo's active queue lease.  It
+                        # is consumed only by _drain_repo_issue_sources(),
+                        # which admits no more than one classified issue at a
+                        # time and therefore cannot spin or spill products.
+                        return
                     continue
                 if isinstance(result, JobRequest):
                     if self.config.dry_run:

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -23,16 +23,64 @@ class StageQueue:
     """FIFO queue of work items for a stage.
 
     Owned exclusively by the coordinator thread; not thread-safe.
-    Used to route items through the pipeline stage by stage.
+    Used to route items through the pipeline stage by stage.  Every queue has
+    an explicit, positive capacity.  Callers that can defer admission should
+    use :meth:`offer`, which reports a full queue without changing it.
     """
 
-    def __init__(self) -> None:
-        """Initialize an empty queue."""
+    def __init__(self, capacity: int) -> None:
+        """Initialize an empty queue with a positive item capacity.
+
+        Args:
+            capacity: Maximum number of work items the queue may hold.
+
+        Raises:
+            ValueError: If ``capacity`` is not positive.
+
+        """
+        if capacity <= 0:
+            raise ValueError("StageQueue capacity must be positive")
+
+        self._capacity = capacity
         self._items: deque[WorkItem] = deque()
 
+    @property
+    def capacity(self) -> int:
+        """Return the maximum number of items the queue can hold."""
+        return self._capacity
+
+    @property
+    def occupancy(self) -> int:
+        """Return the number of items currently held by the queue."""
+        return len(self._items)
+
     def push(self, item: WorkItem) -> None:
-        """Append an item to the queue."""
+        """Append an item or raise if the queue is full.
+
+        Callers that need to retain an item for a later retry should use
+        :meth:`offer` instead.
+
+        Raises:
+            OverflowError: If the queue has reached its capacity.
+
+        """
+        if not self.offer(item):
+            raise OverflowError("StageQueue is full")
+
+    def offer(self, item: WorkItem) -> bool:
+        """Append an item when capacity is available.
+
+        Returns:
+            ``True`` when ``item`` was appended, otherwise ``False``.  A
+            rejected offer leaves the queue unchanged so the caller retains
+            ownership of the work item and can retry it later.
+
+        """
+        if len(self._items) >= self._capacity:
+            return False
+
         self._items.append(item)
+        return True
 
     def pop(self) -> WorkItem:
         """Remove and return the front item. Raises IndexError if empty."""

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -28,10 +28,11 @@ class StageQueueLease:
     retry after the destination makes capacity available.
     """
 
-    def __init__(self, source: StageQueue, item: WorkItem) -> None:
+    def __init__(self, source: StageQueue, item: WorkItem, restore_index: int = 0) -> None:
         """Create an active lease owned by *source* for *item*."""
         self._source = source
         self.item = item
+        self._restore_index = restore_index
         self._active = True
 
     def restore(self) -> None:
@@ -43,7 +44,7 @@ class StageQueueLease:
         if not self._active:
             return
 
-        self._source._restore_lease(self.item)
+        self._source._restore_lease(self.item, self._restore_index)
         self._active = False
 
     def handoff(self, destination: StageQueue) -> bool:
@@ -59,6 +60,20 @@ class StageQueueLease:
         self._source._release_lease()
         self._active = False
         return True
+
+    def release(self) -> None:
+        """Release a lease when an external owner takes the item.
+
+        Timers and the terminal ledger are neither source restores nor stage
+        handoffs. Their coordinator-owned containers take responsibility for
+        the item after this method returns, while the source slot becomes
+        available without disturbing another ready item's FIFO position.
+        """
+        if not self._active:
+            return
+
+        self._source._release_lease()
+        self._active = False
 
 
 class StageQueue:
@@ -153,16 +168,28 @@ class StageQueue:
         # A lease can restore its item to the front.  Serializing claims keeps
         # that restoration ahead of every item that was already ready, rather
         # than reversing two independently restored leases.
-        if self._held or not self._items:
+        return self.claim_at(0)
+
+    def claim_at(self, index: int) -> StageQueueLease | None:
+        """Claim one ready item at *index* while preserving its retry position.
+
+        Implementation's topological scheduler may need to execute a
+        dependency that is ready behind the FIFO head. A selected lease still
+        serializes every other claim, and restoring it returns the item to the
+        exact position it occupied when claimed.
+        """
+        if self._held or not 0 <= index < len(self._items):
             return None
 
+        item = self._items[index]
+        del self._items[index]
         self._held += 1
-        return StageQueueLease(self, self._items.popleft())
+        return StageQueueLease(self, item, restore_index=index)
 
-    def _restore_lease(self, item: WorkItem) -> None:
-        """Restore one active lease at the front without changing occupancy."""
+    def _restore_lease(self, item: WorkItem, index: int = 0) -> None:
+        """Restore one active lease at its claimed position without opening capacity."""
         self._held -= 1
-        self._items.appendleft(item)
+        self._items.insert(index, item)
 
     def _release_lease(self) -> None:
         """Release one active lease after its item was admitted elsewhere."""

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -28,15 +28,15 @@ class StageQueueLease:
     retry after the destination makes capacity available.
     """
 
-    def __init__(self, source: StageQueue, item: WorkItem, restore_index: int = 0) -> None:
+    def __init__(self, source: StageQueue, item: WorkItem, ticket: int) -> None:
         """Create an active lease owned by *source* for *item*."""
         self._source = source
         self.item = item
-        self._restore_index = restore_index
+        self._ticket = ticket
         self._active = True
 
     def restore(self) -> None:
-        """Return this active lease's item to the front of its source queue.
+        """Return this active lease's item to its original FIFO position.
 
         A released lease is a harmless no-op.  This makes cleanup paths safe
         to repeat while preserving the item's exact-once queue ownership.
@@ -44,7 +44,7 @@ class StageQueueLease:
         if not self._active:
             return
 
-        self._source._restore_lease(self.item, self._restore_index)
+        self._source._restore_lease(self.item, self._ticket)
         self._active = False
 
     def handoff(self, destination: StageQueue) -> bool:
@@ -57,7 +57,7 @@ class StageQueueLease:
         if not self._active or not destination.offer(self.item):
             return False
 
-        self._source._release_lease()
+        self._source._release_lease(self.item, self._ticket)
         self._active = False
         return True
 
@@ -72,7 +72,7 @@ class StageQueueLease:
         if not self._active:
             return
 
-        self._source._release_lease()
+        self._source._release_lease(self.item, self._ticket)
         self._active = False
 
 
@@ -99,8 +99,9 @@ class StageQueue:
             raise ValueError("StageQueue capacity must be positive")
 
         self._capacity = capacity
-        self._items: deque[WorkItem] = deque()
-        self._held = 0
+        self._items: deque[tuple[int, WorkItem]] = deque()
+        self._leased: dict[int, int] = {}
+        self._next_ticket = 0
 
     @property
     def capacity(self) -> int:
@@ -110,7 +111,7 @@ class StageQueue:
     @property
     def occupancy(self) -> int:
         """Return all ready and leased items currently held by the queue."""
-        return len(self._items) + self._held
+        return len(self._items) + len(self._leased)
 
     def push(self, item: WorkItem) -> None:
         """Append an item or raise if the queue is full.
@@ -128,11 +129,11 @@ class StageQueue:
     def can_offer(self) -> bool:
         """Return whether :meth:`offer` can append one new item now.
 
-        A claimed item retains the source queue's FIFO ownership until it is
-        restored or handed off.  New producers must not insert behind that
-        held item, even if the numeric capacity has remaining room.
+        A claimed item retains its source capacity until it is restored or
+        handed off, while an immutable FIFO ticket lets other ready work use
+        remaining capacity without allowing a retry to overtake it.
         """
-        return not self._held and self.occupancy < self._capacity
+        return self.occupancy < self._capacity
 
     def offer(self, item: WorkItem) -> bool:
         """Append an item when capacity is available.
@@ -143,57 +144,66 @@ class StageQueue:
             ownership of the work item and can retry it later.
 
         """
-        # A held lease may need to return to the front of this queue.  Do not
-        # admit newer work ahead of it, even when the numeric bound has spare
-        # capacity; admission resumes only once every lease is released.
+        # Each ready item receives a monotonic ticket. A held lease keeps its
+        # original ticket, so a later restore can reinsert before newer work
+        # without wasting otherwise available capacity now.
         if not self.can_offer():
             return False
 
-        self._items.append(item)
+        self._items.append((self._next_ticket, item))
+        self._next_ticket += 1
         return True
 
     def pop(self) -> WorkItem:
         """Remove and return the front item. Raises IndexError if empty."""
-        return self._items.popleft()
+        _ticket, item = self._items.popleft()
+        return item
 
     def claim(self) -> StageQueueLease | None:
         """Claim the FIFO-ready item without releasing this queue's capacity.
 
         The returned lease owns the item until it is restored or handed off.
-        Only one lease may be active at a time, so an outstanding lease also
-        returns ``None`` even when later items are ready. Ready work inspection
-        remains available through :meth:`snapshot`, but the claim continues to
-        count toward :attr:`occupancy`.
+        Several claims may be active concurrently up to :attr:`capacity`.
+        Their immutable tickets retain the original FIFO order whenever any
+        retry restores, while ready work inspection remains available through
+        :meth:`snapshot`.
         """
-        # A lease can restore its item to the front.  Serializing claims keeps
-        # that restoration ahead of every item that was already ready, rather
-        # than reversing two independently restored leases.
         return self.claim_at(0)
 
     def claim_at(self, index: int) -> StageQueueLease | None:
         """Claim one ready item at *index* while preserving its retry position.
 
         Implementation's topological scheduler may need to execute a
-        dependency that is ready behind the FIFO head. A selected lease still
-        serializes every other claim, and restoring it returns the item to the
-        exact position it occupied when claimed.
+        dependency that is ready behind the FIFO head. A selected lease keeps
+        its immutable ticket, so restoring it returns the item to the exact
+        order it occupied when claimed even while other work is active.
         """
-        if self._held or not 0 <= index < len(self._items):
+        if not 0 <= index < len(self._items):
             return None
 
-        item = self._items[index]
+        ticket, item = self._items[index]
         del self._items[index]
-        self._held += 1
-        return StageQueueLease(self, item, restore_index=index)
+        self._leased[id(item)] = ticket
+        return StageQueueLease(self, item, ticket=ticket)
 
-    def _restore_lease(self, item: WorkItem, index: int = 0) -> None:
-        """Restore one active lease at its claimed position without opening capacity."""
-        self._held -= 1
-        self._items.insert(index, item)
+    def _restore_lease(self, item: WorkItem, ticket: int) -> None:
+        """Restore one active lease in original FIFO order without opening capacity."""
+        if self._leased.pop(id(item), None) != ticket:
+            raise RuntimeError("StageQueue lease ticket mismatch")
+        index = next(
+            (
+                position
+                for position, (ready_ticket, _ready) in enumerate(self._items)
+                if ticket < ready_ticket
+            ),
+            len(self._items),
+        )
+        self._items.insert(index, (ticket, item))
 
-    def _release_lease(self) -> None:
+    def _release_lease(self, item: WorkItem, ticket: int) -> None:
         """Release one active lease after its item was admitted elsewhere."""
-        self._held -= 1
+        if self._leased.pop(id(item), None) != ticket:
+            raise RuntimeError("StageQueue lease ticket mismatch")
 
     def __len__(self) -> int:
         """Return the number of items in the queue."""
@@ -201,4 +211,4 @@ class StageQueue:
 
     def snapshot(self) -> list[WorkItem]:
         """Return a copy of all items in queue order (for inspection/debugging)."""
-        return list(self._items)
+        return [item for _ticket, item in self._items]

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -110,6 +110,15 @@ class StageQueue:
         if not self.offer(item):
             raise OverflowError("StageQueue is full")
 
+    def can_offer(self) -> bool:
+        """Return whether :meth:`offer` can append one new item now.
+
+        A claimed item retains the source queue's FIFO ownership until it is
+        restored or handed off.  New producers must not insert behind that
+        held item, even if the numeric capacity has remaining room.
+        """
+        return not self._held and self.occupancy < self._capacity
+
     def offer(self, item: WorkItem) -> bool:
         """Append an item when capacity is available.
 
@@ -122,7 +131,7 @@ class StageQueue:
         # A held lease may need to return to the front of this queue.  Do not
         # admit newer work ahead of it, even when the numeric bound has spare
         # capacity; admission resumes only once every lease is released.
-        if self._held or self.occupancy >= self._capacity:
+        if not self.can_offer():
             return False
 
         self._items.append(item)

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -145,10 +145,15 @@ class StageQueue:
         """Claim the FIFO-ready item without releasing this queue's capacity.
 
         The returned lease owns the item until it is restored or handed off.
-        Ready work inspection remains available through :meth:`snapshot`, but
-        the claim continues to count toward :attr:`occupancy`.
+        Only one lease may be active at a time, so an outstanding lease also
+        returns ``None`` even when later items are ready. Ready work inspection
+        remains available through :meth:`snapshot`, but the claim continues to
+        count toward :attr:`occupancy`.
         """
-        if not self._items:
+        # A lease can restore its item to the front.  Serializing claims keeps
+        # that restoration ahead of every item that was already ready, rather
+        # than reversing two independently restored leases.
+        if self._held or not self._items:
             return None
 
         self._held += 1

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -19,6 +19,48 @@ if TYPE_CHECKING:
 CompletionQueue = Queue[tuple[Any, Any]]
 
 
+class StageQueueLease:
+    """A temporary, capacity-reserving claim on one stage-queue item.
+
+    Leases are coordinator-thread objects: they are not thread-safe and their
+    lifetime is bounded by one successful :meth:`handoff` or :meth:`restore`.
+    A failed handoff intentionally leaves the lease active so the caller can
+    retry after the destination makes capacity available.
+    """
+
+    def __init__(self, source: StageQueue, item: WorkItem) -> None:
+        """Create an active lease owned by *source* for *item*."""
+        self._source = source
+        self.item = item
+        self._active = True
+
+    def restore(self) -> None:
+        """Return this active lease's item to the front of its source queue.
+
+        A released lease is a harmless no-op.  This makes cleanup paths safe
+        to repeat while preserving the item's exact-once queue ownership.
+        """
+        if not self._active:
+            return
+
+        self._source._restore_lease(self.item)
+        self._active = False
+
+    def handoff(self, destination: StageQueue) -> bool:
+        """Move this active lease to *destination* when it has capacity.
+
+        Destination admission happens before the source reservation is
+        released.  Therefore a full destination leaves the item held by this
+        lease and does not create a spill buffer or lose work.
+        """
+        if not self._active or not destination.offer(self.item):
+            return False
+
+        self._source._release_lease()
+        self._active = False
+        return True
+
+
 class StageQueue:
     """FIFO queue of work items for a stage.
 
@@ -43,6 +85,7 @@ class StageQueue:
 
         self._capacity = capacity
         self._items: deque[WorkItem] = deque()
+        self._held = 0
 
     @property
     def capacity(self) -> int:
@@ -51,8 +94,8 @@ class StageQueue:
 
     @property
     def occupancy(self) -> int:
-        """Return the number of items currently held by the queue."""
-        return len(self._items)
+        """Return all ready and leased items currently held by the queue."""
+        return len(self._items) + self._held
 
     def push(self, item: WorkItem) -> None:
         """Append an item or raise if the queue is full.
@@ -76,7 +119,10 @@ class StageQueue:
             ownership of the work item and can retry it later.
 
         """
-        if len(self._items) >= self._capacity:
+        # A held lease may need to return to the front of this queue.  Do not
+        # admit newer work ahead of it, even when the numeric bound has spare
+        # capacity; admission resumes only once every lease is released.
+        if self._held or self.occupancy >= self._capacity:
             return False
 
         self._items.append(item)
@@ -85,6 +131,28 @@ class StageQueue:
     def pop(self) -> WorkItem:
         """Remove and return the front item. Raises IndexError if empty."""
         return self._items.popleft()
+
+    def claim(self) -> StageQueueLease | None:
+        """Claim the FIFO-ready item without releasing this queue's capacity.
+
+        The returned lease owns the item until it is restored or handed off.
+        Ready work inspection remains available through :meth:`snapshot`, but
+        the claim continues to count toward :attr:`occupancy`.
+        """
+        if not self._items:
+            return None
+
+        self._held += 1
+        return StageQueueLease(self, self._items.popleft())
+
+    def _restore_lease(self, item: WorkItem) -> None:
+        """Restore one active lease at the front without changing occupancy."""
+        self._held -= 1
+        self._items.appendleft(item)
+
+    def _release_lease(self) -> None:
+        """Release one active lease after its item was admitted elsewhere."""
+        self._held -= 1
 
     def __len__(self) -> int:
         """Return the number of items in the queue."""

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -209,25 +209,25 @@ class RepoStage(Stage):
             include_bot_prs = bool(getattr(ctx.config, "include_bot_prs", True))
             include_all_authors = bool(getattr(ctx.config, "include_all_authors", False))
             try:
-                open_prs = _repo_manager._list_open_pr_meta(ctx.org, item.repo)
+                open_prs = _repo_manager._iter_open_pr_meta(ctx.org, item.repo)
                 viewer_login = "" if include_all_authors else _pr_discovery._resolve_viewer_login()
+                # Issue metadata now arrives lazily, so this preflight cannot
+                # know which PRs are linked without retaining an unbounded
+                # set. The loop never queues orphan PRs from this path; retain
+                # that safety boundary without materializing a coverage spill.
+                for pr in open_prs:
+                    if _drive_green_pr_is_in_scope(
+                        pr, include_bot_prs=include_bot_prs, viewer_login=viewer_login
+                    ):
+                        logger.info(
+                            "repo:%s: leaving PR #%d outside repository discovery "
+                            "until linked issue source provides requirements",
+                            item.repo,
+                            int(pr["number"]),
+                        )
             except Exception as exc:
                 logger.warning("repo:%s: PR discovery failed: %s", item.repo, exc)
                 return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
-            # Issue metadata now arrives lazily, so this preflight cannot
-            # know which PRs are linked without retaining an unbounded set.
-            # The loop never queues orphan PRs from this path; retain that
-            # safety boundary without materializing a coverage spill.
-            for pr in open_prs:
-                if _drive_green_pr_is_in_scope(
-                    pr, include_bot_prs=include_bot_prs, viewer_login=viewer_login
-                ):
-                    logger.info(
-                        "repo:%s: leaving PR #%d outside repository discovery "
-                        "until linked issue source provides requirements",
-                        item.repo,
-                        int(pr["number"]),
-                    )
 
         item.payload["_repo_issue_source"] = source
         return Continue(next_state="SOURCE")

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -2,7 +2,7 @@
 
 Binding contract: docs/architecture.md §5.1 "repo".
 
-States: ENTER -> CLONE_WAIT -> DISCOVER -> SEEDED.
+States: ENTER -> CLONE_WAIT -> DISCOVER -> SOURCE.
 
 Steps:
 
@@ -14,16 +14,13 @@ Steps:
    checkout. Both operations are logged-skipped under dry-run — the
    coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
-3. [M] DISCOVER: list issues (read-only ``_list_open_issue_meta``), dedup,
-   ``partition_epics`` -> tag epics ``state:skip`` via
-   ``ctx.github.skip_epics`` [durable, BEFORE excluding], classify each kept
-   issue via the REUSED :func:`~..seeding.seed_issue` /
-   :func:`~..seeding.classify_issue`, and (``--drive-green-all``) route
-   open PRs with a linked tracked issue to PR review.
-4. [M] SEEDED: expose the classified products in
-   ``item.payload["products"]`` — the coordinator (queue owner) performs the
-   actual queue pushes when routing the repo item — and finish
-   ``FINISH_PASS(seeded:N)``. The repo item is terminal.
+3. [M] DISCOVER: initialize one page-at-a-time metadata cursor and perform
+   the independent ``--drive-green-all`` read.  It never materializes a
+   list of classified products.
+4. [M] SOURCE: the coordinator owns source admission.  It takes one metadata
+   row only when it can transfer the repo source's live-work permit to the
+   classified issue, tagging epics ``state:skip`` [durable, BEFORE excluding].
+   Once the cursor is exhausted the repo item finishes ``FINISH_PASS``.
 
 Discovery seams (``_repo_manager`` / ``_seeding`` module attributes) mirror
 the ``loop_runner._admission`` seam pattern so unit tests patch the reads
@@ -33,12 +30,12 @@ without network I/O.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from hephaestus.automation import loop_repo_manager as _repo_manager, pr_discovery as _pr_discovery
-from hephaestus.automation.pipeline import seeding as _seeding
-from hephaestus.automation.state_labels import STATE_PLAN_BLOCKED, partition_epics
 
 from .base import (
     GIT_JOB_TIMEOUT_S,
@@ -89,43 +86,23 @@ def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
     return projects_dir / item.repo if repo_root == projects_dir else repo_root
 
 
-def _tag_epics(repo: str, ctx: StageContext, epics_labels: dict[int, list[str]]) -> None:
-    """Write epic skip labels and log the resulting durable exclusions."""
-    ctx.github.skip_epics(epics_labels)
-    for number in epics_labels:
-        logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", repo, number)
+@dataclass
+class RepoIssueSource:
+    """Bounded discovery cursor retained by one in-flight repo item.
 
+    ``pending`` holds at most the one metadata row whose possible issue entry
+    is waiting for a coordinator-owned queue slot.  The iterator itself holds
+    at most one fetched GitHub page.  In particular, this object never stores
+    a classified ``SeedEntry``/``WorkItem`` product list.
+    """
 
-def _partition_and_tag_epics(
-    repo: str, ctx: StageContext, issues_meta: list[dict[str, Any]]
-) -> tuple[list[int], list[int]]:
-    """Return issue partitions after durably tagging every discovered epic."""
-    kept, epics = partition_epics(issues_meta)
-    if not epics:
-        return kept, epics
-    epic_set = set(epics)
-    epics_labels = {
-        int(metadata["number"]): list(metadata.get("labels") or [])
-        for metadata in issues_meta
-        if int(metadata["number"]) in epic_set
-    }
-    _tag_epics(repo, ctx, epics_labels)
-    return kept, epics
-
-
-def _repair_blocked_audit(facts: _seeding.IssueFacts, ctx: StageContext) -> None:
-    """Repair an interrupted BLOCKED explanation before excluding the issue."""
-    if STATE_PLAN_BLOCKED in facts.labels:
-        ctx.github.ensure_blocked_audit(facts.number)
+    metadata: Iterator[dict[str, Any]]
+    pending: dict[str, Any] | None = None
+    seeded_count: int = 0
 
 
 class RepoStage(Stage):
-    """Repo discovery and classification stage (the pipeline's sole producer).
-
-    Products are ``(kind, identifier, stage, reason, facts)`` tuples staged
-    in ``item.payload["products"]``; the coordinator turns them into
-    :class:`WorkItem` pushes because stage code never touches queues.
-    """
+    """Repo discovery stage that initializes the coordinator-owned source."""
 
     kind = StageName.REPO
 
@@ -163,14 +140,12 @@ class RepoStage(Stage):
         if item.state == "DISCOVER":
             return self._discover(item, ctx)
 
-        if item.state == "SEEDED":
-            seeded_count = item.payload.get("seeded_count")
-            if seeded_count is None:
-                seeded_count = sum(
-                    1 for p in item.payload.get("products", []) if p.get("stage") is not None
-                )
-            seeded = int(seeded_count)
-            return StageOutcome(Disposition.FINISH_PASS, note=f"seeded:{seeded}")
+        if item.state == "SOURCE":
+            # The coordinator parks the source lease after DISCOVER and is
+            # its only consumer.  Returning Continue retains stage-protocol
+            # compatibility for direct unit calls; Coordinator._run_item
+            # recognizes this state and yields rather than spinning.
+            return Continue(next_state="SOURCE")
 
         return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
 
@@ -221,60 +196,12 @@ class RepoStage(Stage):
         return JobRequest(job=job, on_done_state="DISCOVER")
 
     def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """[M] List, dedup, tag-then-exclude epics, classify, stage products."""
+        """[M] Initialize a bounded metadata source; do not classify eagerly."""
         try:
-            meta = _repo_manager._list_open_issue_meta(ctx.org, item.repo)
+            source = RepoIssueSource(_repo_manager._iter_open_issue_meta(ctx.org, item.repo))
         except Exception as exc:
             logger.warning("repo:%s: discovery failed: %s", item.repo, exc)
             return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
-
-        # Dedup while preserving listing order.
-        seen: set[int] = set()
-        deduped: list[dict[str, Any]] = []
-        for entry in meta:
-            number = int(entry["number"])
-            if number in seen:
-                continue
-            seen.add(number)
-            deduped.append(entry)
-
-        # Epic tagging: the ONE sanctioned seeding write, durable and BEFORE
-        # the exclusion is final (doc row "Epic tagging is the one seeding
-        # write; done BEFORE excluding").
-        try:
-            kept, epics = _partition_and_tag_epics(item.repo, ctx, deduped)
-        except Exception as exc:
-            logger.warning("repo:%s: could not tag excluded epics state:skip: %s", item.repo, exc)
-            return StageOutcome(Disposition.FINISH_FAIL, note=f"epic skip tag failed: {exc}")
-
-        products: list[dict[str, Any]] = [
-            {
-                "kind": "issue",
-                "number": num,
-                "stage": None,
-                "reason": f"epic #{num} excluded",
-            }
-            for num in epics
-        ]
-        covered_prs: set[int] = set()
-        for num in kept:
-            facts = _seeding.seed_issue_from_github(num, ctx.github)
-            _repair_blocked_audit(facts, ctx)
-            stage, reason = _seeding.classify_issue(facts)
-            if facts.pr_number is not None:
-                covered_prs.add(facts.pr_number)
-            products.append(
-                {
-                    "kind": "issue",
-                    "number": num,
-                    "stage": stage,
-                    "reason": reason,
-                    "pr": facts.pr_number if facts.pr_is_open else None,
-                    "labels": sorted(facts.labels),
-                    "title": facts.title,
-                    "body": facts.body,
-                }
-            )
 
         # --drive-green-all: only linked PRs can be reviewed. Orphans have no
         # requirements context and must remain outside the automation loop.
@@ -287,23 +214,23 @@ class RepoStage(Stage):
             except Exception as exc:
                 logger.warning("repo:%s: PR discovery failed: %s", item.repo, exc)
                 return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
+            # Issue metadata now arrives lazily, so this preflight cannot
+            # know which PRs are linked without retaining an unbounded set.
+            # The loop never queues orphan PRs from this path; retain that
+            # safety boundary without materializing a coverage spill.
             for pr in open_prs:
-                pr_number = int(pr["number"])
-                if pr_number in covered_prs:
-                    continue
-                if not _drive_green_pr_is_in_scope(
+                if _drive_green_pr_is_in_scope(
                     pr, include_bot_prs=include_bot_prs, viewer_login=viewer_login
                 ):
-                    continue
-                logger.info(
-                    "repo:%s: skipping orphan PR #%d; no linked issue supplies requirements",
-                    item.repo,
-                    pr_number,
-                )
+                    logger.info(
+                        "repo:%s: leaving PR #%d outside repository discovery "
+                        "until linked issue source provides requirements",
+                        item.repo,
+                        int(pr["number"]),
+                    )
 
-        item.payload["products"] = products
-        item.payload["seeded_count"] = sum(1 for p in products if p.get("stage") is not None)
-        return Continue(next_state="SEEDED")
+        item.payload["_repo_issue_source"] = source
+        return Continue(next_state="SOURCE")
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Record checkout preparation success/failure (state still CLONE_WAIT).

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -14,13 +14,12 @@ Steps:
    checkout. Both operations are logged-skipped under dry-run — the
    coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
-3. [M] DISCOVER: initialize one page-at-a-time metadata cursor and perform
-   the independent ``--drive-green-all`` read.  It never materializes a
-   list of classified products.
-4. [M] SOURCE: the coordinator owns source admission.  It takes one metadata
-   row only when it can transfer the repo source's live-work permit to the
-   classified issue, tagging epics ``state:skip`` [durable, BEFORE excluding].
-   Once the cursor is exhausted the repo item finishes ``FINISH_PASS``.
+3. [M] DISCOVER: initialize one page-at-a-time metadata cursor. It never
+   materializes a list of classified products.
+4. [M] SOURCE: the coordinator transfers the bounded cursor to its fair
+   C-capped registry, then admits one metadata row only when an issue can own
+   a live-work permit. Epics are tagged ``state:skip`` [durable, BEFORE
+   excluding].
 
 Discovery seams (``_repo_manager`` / ``_seeding`` module attributes) mirror
 the ``loop_runner._admission`` seam pattern so unit tests patch the reads
@@ -35,7 +34,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from hephaestus.automation import loop_repo_manager as _repo_manager, pr_discovery as _pr_discovery
+from hephaestus.automation import loop_repo_manager as _repo_manager
 
 from .base import (
     GIT_JOB_TIMEOUT_S,
@@ -56,24 +55,6 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
-def _drive_green_pr_is_in_scope(
-    pr: dict[str, Any], *, include_bot_prs: bool, viewer_login: str
-) -> bool:
-    """Return whether an orphan PR is eligible and belongs to author scope."""
-    if not _pr_discovery.pr_needs_loop_review(pr):
-        return False
-    if not include_bot_prs and _pr_discovery._is_bot_pr_author(pr):
-        return False
-    if not _pr_discovery._is_viewer_authored(pr, viewer_login):
-        if (pr.get("user") or {}).get("login") is None:
-            logger.warning(
-                "PR #%s has no user.login; skipping under author filter (#821)",
-                pr.get("number"),
-            )
-        return False
-    return True
-
-
 def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
     """Return the effective local checkout path for the repo item.
 
@@ -88,7 +69,7 @@ def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
 
 @dataclass
 class RepoIssueSource:
-    """Bounded discovery cursor retained by one in-flight repo item.
+    """Bounded discovery cursor retained by the coordinator after repo setup.
 
     ``pending`` holds at most the one metadata row whose possible issue entry
     is waiting for a coordinator-owned queue slot.  The iterator itself holds
@@ -141,10 +122,9 @@ class RepoStage(Stage):
             return self._discover(item, ctx)
 
         if item.state == "SOURCE":
-            # The coordinator parks the source lease after DISCOVER and is
-            # its only consumer.  Returning Continue retains stage-protocol
-            # compatibility for direct unit calls; Coordinator._run_item
-            # recognizes this state and yields rather than spinning.
+            # Coordinator._run_item externalizes this cursor into its fair
+            # registry. Returning Continue retains stage-protocol compatibility
+            # for direct unit calls while avoiding an eager product list.
             return Continue(next_state="SOURCE")
 
         return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
@@ -203,31 +183,11 @@ class RepoStage(Stage):
             logger.warning("repo:%s: discovery failed: %s", item.repo, exc)
             return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
 
-        # --drive-green-all: only linked PRs can be reviewed. Orphans have no
-        # requirements context and must remain outside the automation loop.
-        if getattr(ctx.config, "drive_green_all", False):
-            include_bot_prs = bool(getattr(ctx.config, "include_bot_prs", True))
-            include_all_authors = bool(getattr(ctx.config, "include_all_authors", False))
-            try:
-                open_prs = _repo_manager._iter_open_pr_meta(ctx.org, item.repo)
-                viewer_login = "" if include_all_authors else _pr_discovery._resolve_viewer_login()
-                # Issue metadata now arrives lazily, so this preflight cannot
-                # know which PRs are linked without retaining an unbounded
-                # set. The loop never queues orphan PRs from this path; retain
-                # that safety boundary without materializing a coverage spill.
-                for pr in open_prs:
-                    if _drive_green_pr_is_in_scope(
-                        pr, include_bot_prs=include_bot_prs, viewer_login=viewer_login
-                    ):
-                        logger.info(
-                            "repo:%s: leaving PR #%d outside repository discovery "
-                            "until linked issue source provides requirements",
-                            item.repo,
-                            int(pr["number"]),
-                        )
-            except Exception as exc:
-                logger.warning("repo:%s: PR discovery failed: %s", item.repo, exc)
-                return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
+        # ``--drive-green-all`` does not pre-scan unrelated PRs here. Orphan
+        # PRs have no linked issue requirements, and consuming their complete
+        # page stream would add unbounded latency without producing an
+        # admissible source item. Linked PR review context enters only through
+        # this repository's bounded issue cursor.
 
         item.payload["_repo_issue_source"] = source
         return Continue(next_state="SOURCE")

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 import logging
 import sys
+from collections import Counter
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from hephaestus.automation.pipeline.work_item import ItemKind, PreservedWorktree, WorkItem
 from hephaestus.cli.utils import emit_json_status
@@ -114,6 +115,37 @@ def _disposition_bucket(item: WorkItem) -> str:
     return cell.split(":")[0].split(" ")[0].lower()
 
 
+@dataclass
+class TerminalSummary:
+    """Constant-space aggregates for terminal pipeline outcomes.
+
+    The coordinator may retain only a recent bounded window of detailed
+    :class:`WorkItem` objects during an all-organization run.  This accumulator
+    preserves the run-wide counts needed for the final status and aggregate
+    summary without becoming a second per-item ledger.
+    """
+
+    total: int = 0
+    _dispositions: Counter[str] = field(default_factory=Counter)
+    _per_stage: Counter[str] = field(default_factory=Counter)
+
+    def record(self, item: WorkItem) -> None:
+        """Add one terminal or resumable item outcome to the aggregate."""
+        self.total += 1
+        self._dispositions[_disposition_bucket(item)] += 1
+        self._per_stage[item.stage.value] += 1
+
+    @property
+    def dispositions(self) -> dict[str, int]:
+        """Return a stable copy of counts grouped by disposition."""
+        return dict(sorted(self._dispositions.items()))
+
+    @property
+    def per_stage(self) -> dict[str, int]:
+        """Return a stable copy of counts grouped by final stage."""
+        return dict(sorted(self._per_stage.items()))
+
+
 def _json_message(exit_code: int) -> str:
     """Map a pipeline exit code to its JSON summary message."""
     if exit_code == 130:
@@ -142,14 +174,18 @@ def print_summary(
     preserved: list[PreservedWorktree],
     *,
     json_out: bool,
+    terminal_summary: TerminalSummary | None = None,
 ) -> None:
     """Log the end-of-run summary; emit the JSON envelope when requested.
 
     Args:
-        items: Every work item the run ever queued (results attached).
+        items: Recent detailed work items (results attached).
         stats: Aggregate run statistics (exit code, loops, agent time, wall).
         preserved: ``(repo, issue_number, worktree_path)`` tuples for failed items.
         json_out: Emit the machine-readable ``emit_json_status`` envelope.
+        terminal_summary: Optional constant-space aggregate for all terminal
+            outcomes.  When supplied, it controls aggregate counts while
+            ``items`` remains the bounded detailed reporting window.
 
     """
     items = latest_logical_items(items)
@@ -165,16 +201,26 @@ def print_summary(
     for item in items:
         logger.info("%s", _item_row(item))
 
-    dispositions: dict[str, int] = {}
-    per_stage: dict[str, int] = {}
-    for item in items:
-        dispositions[_disposition_bucket(item)] = dispositions.get(_disposition_bucket(item), 0) + 1
-        per_stage[item.stage.value] = per_stage.get(item.stage.value, 0) + 1
+    if terminal_summary is None:
+        dispositions: dict[str, int] = {}
+        per_stage: dict[str, int] = {}
+        for item in items:
+            dispositions[_disposition_bucket(item)] = (
+                dispositions.get(_disposition_bucket(item), 0) + 1
+            )
+            per_stage[item.stage.value] = per_stage.get(item.stage.value, 0) + 1
+        total_items = len(items)
+    else:
+        dispositions = terminal_summary.dispositions
+        per_stage = terminal_summary.per_stage
+        total_items = terminal_summary.total
 
     logger.info("")
     logger.info("=== Aggregates ===")
-    logger.info("  items: %d  dispositions: %s", len(items), dict(sorted(dispositions.items())))
+    logger.info("  items: %d  dispositions: %s", total_items, dict(sorted(dispositions.items())))
     logger.info("  per-stage: %s", dict(sorted(per_stage.items())))
+    if terminal_summary is not None and total_items > len(items):
+        logger.info("  detailed terminal rows retained: %d of %d", len(items), total_items)
     logger.info(
         "  agent jobs: %d (%.1fs total)  loops: %d  wall: %.1fs  interrupted: %s",
         stats.agent_job_count,

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -135,6 +135,12 @@ class TerminalSummary:
         self._dispositions[_disposition_bucket(item)] += 1
         self._per_stage[item.stage.value] += 1
 
+    def reset(self) -> None:
+        """Start a fresh reseed-pass aggregate without retaining item identities."""
+        self.total = 0
+        self._dispositions.clear()
+        self._per_stage.clear()
+
     @property
     def dispositions(self) -> dict[str, int]:
         """Return a stable copy of counts grouped by disposition."""

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import queue as queue_mod
 import shlex
 import shutil
 import subprocess
@@ -323,6 +324,8 @@ class WorkerPool:
         )
         self._shutdown = shutdown
         self._completion_q = completion_q
+        self._completion_wakeup: threading.Event | None = None
+        self._completion_saturation: threading.Event | None = None
         self._repo_locks: dict[str, _RepoLockEntry] = {}
         self._repo_locks_guard = threading.Lock()
         self._lock_dir = lock_dir
@@ -345,6 +348,24 @@ class WorkerPool:
                 entry.users -= 1
                 if entry.users == 0 and self._repo_locks.get(repo) is entry:
                     self._repo_locks.pop(repo, None)
+
+    def set_completion_notifiers(
+        self,
+        *,
+        wakeup: threading.Event,
+        saturation: threading.Event,
+    ) -> None:
+        """Bind coordinator-owned completion wake and saturation latches.
+
+        The coordinator creates these latches before it submits work.  A
+        successful non-blocking completion write wakes its event loop; an
+        impossible full completion queue instead latches a fatal coordinator
+        fault.  The callback deliberately has no overflow buffer: retaining
+        the owning item in the coordinator's in-flight registry makes it
+        resumable during that fatal teardown.
+        """
+        self._completion_wakeup = wakeup
+        self._completion_saturation = saturation
 
     def submit(
         self,
@@ -438,7 +459,24 @@ class WorkerPool:
                 error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
                 worker_id=worker_id,
             )
-        self._completion_q.put((handle, result))
+        try:
+            self._completion_q.put_nowait((handle, result))
+        except queue_mod.Full:
+            # With the coordinator's global C-in-flight invariant, a C-sized
+            # completion queue cannot fill before a worker has a slot to
+            # publish.  Treat a violation as an internal fault rather than
+            # blocking this callback forever.  There is intentionally no
+            # unbounded spill structure: finalization retains the in-flight
+            # WorkItem as RESUMABLE for the next run.
+            logger.error("completion queue saturated; refusing to block worker callback")
+            if self._completion_saturation is not None:
+                self._completion_saturation.set()
+            if self._completion_wakeup is not None:
+                self._completion_wakeup.set()
+            return
+
+        if self._completion_wakeup is not None:
+            self._completion_wakeup.set()
 
     def _run(
         self,

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock
 import pytest
 
 import hephaestus.automation.loop_repo_manager as loop_repo_manager_mod
-import hephaestus.automation.pr_discovery as pr_discovery_mod
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.jobs import GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName
@@ -219,15 +218,11 @@ class TestDiscover:
         meta: list[dict[str, Any]],
         facts: dict[int, IssueFacts],
         classifications: dict[int, tuple[StageName | None, str]],
-        open_prs: list[dict[str, Any]] | None = None,
     ) -> list[int]:
         """Patch the repo-stage read seams; returns the classify-call order."""
         classified: list[int] = []
         monkeypatch.setattr(
             loop_repo_manager_mod, "_iter_open_issue_meta", lambda org, repo: iter(meta)
-        )
-        monkeypatch.setattr(
-            loop_repo_manager_mod, "_iter_open_pr_meta", lambda org, repo: iter(open_prs or [])
         )
         monkeypatch.setattr(seeding_mod, "seed_issue", lambda num: facts[num])
         monkeypatch.setattr(seeding_mod, "seed_issue_from_github", lambda num, github: facts[num])
@@ -275,7 +270,6 @@ class TestDiscover:
                 [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}]
             ),
         )
-        monkeypatch.setattr(loop_repo_manager_mod, "_iter_open_pr_meta", lambda org, repo: iter([]))
         monkeypatch.setattr(
             seeding_mod,
             "seed_issue",
@@ -401,31 +395,19 @@ class TestDiscover:
         assert 5 not in gh.labels
         monkeypatch.setattr(gh, "skip_epics", original_skip_epics)
 
-    @pytest.mark.parametrize(
-        ("include_bot_prs", "include_all_authors"),
-        [
-            pytest.param(True, False, id="viewer-only-including-bots"),
-            pytest.param(False, False, id="viewer-only-without-bots"),
-            pytest.param(True, True, id="all-authors-including-bots"),
-            pytest.param(False, True, id="all-authors-without-bots"),
-        ],
-    )
-    def test_drive_green_all_honors_author_and_bot_filters(
+    def test_drive_green_all_does_not_query_or_exhaust_orphan_pr_pages(
         self,
-        include_bot_prs: bool,
-        include_all_authors: bool,
         repo_item: WorkItem,
         tmp_path: Path,
         make_ctx: Callable[..., Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Unlinked PR pages are no-op work and must not delay source setup."""
         config = type(
             "Cfg",
             (),
             {
                 "drive_green_all": True,
-                "include_bot_prs": include_bot_prs,
-                "include_all_authors": include_all_authors,
                 "dry_run": False,
             },
         )()
@@ -435,85 +417,19 @@ class TestDiscover:
             meta=[{"number": 1, "labels": [], "title": "covered"}],
             facts={1: _facts(1)},
             classifications={1: (StageName.PLANNING, "needs plan")},
-            open_prs=[
-                {"number": 66, "user": {"login": "alice", "type": "User"}},
-                {"number": 67, "user": {"login": "bob", "type": "User"}},
-                {"number": 68, "user": {"login": "alice", "type": "Bot"}},
-                {"number": 69, "user": {"login": "depbot", "type": "Bot"}},
-            ],
         )
-        monkeypatch.setattr(
-            pr_discovery_mod,
-            "_resolve_viewer_login",
-            lambda: "alice",
+        pr_pages = MagicMock(
+            side_effect=AssertionError("orphan PR cursor must not be queried or exhausted")
         )
-        repo_item.state = "DISCOVER"
-
-        RepoStage().step(repo_item, ctx)
-
-        assert "products" not in repo_item.payload
-        assert "_repo_issue_source" in repo_item.payload
-
-    def test_drive_green_all_skips_viewer_resolution_for_all_authors(
-        self,
-        repo_item: WorkItem,
-        tmp_path: Path,
-        make_ctx: Callable[..., Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        config = type(
-            "Cfg",
-            (),
-            {"drive_green_all": True, "include_all_authors": True, "dry_run": False},
-        )()
-        ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
-        self._patch_discovery(
-            monkeypatch,
-            meta=[],
-            facts={},
-            classifications={},
-            open_prs=[],
-        )
-        resolver = MagicMock(return_value="x")
-        monkeypatch.setattr(pr_discovery_mod, "_resolve_viewer_login", resolver)
-        repo_item.state = "DISCOVER"
-
-        RepoStage().step(repo_item, ctx)
-
-        resolver.assert_not_called()
-
-    def test_drive_green_all_pr_discovery_failure_finishes_fail(
-        self,
-        repo_item: WorkItem,
-        tmp_path: Path,
-        make_ctx: Callable[..., Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Orphan-PR discovery failures are visible, not successful empty runs."""
-        config = type(
-            "Cfg",
-            (),
-            {"drive_green_all": True, "include_all_authors": True, "dry_run": False},
-        )()
-        ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
-        self._patch_discovery(
-            monkeypatch,
-            meta=[{"number": 1, "labels": [], "title": "covered"}],
-            facts={1: _facts(1, pr=55, pr_open=True)},
-            classifications={1: (StageName.PR_REVIEW, "open PR")},
-        )
-        monkeypatch.setattr(
-            loop_repo_manager_mod,
-            "_iter_open_pr_meta",
-            lambda org, repo: (_ for _ in ()).throw(RuntimeError("pr list failed")),
-        )
+        monkeypatch.setattr(loop_repo_manager_mod, "_iter_open_pr_meta", pr_pages)
         repo_item.state = "DISCOVER"
 
         result = RepoStage().step(repo_item, ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition is Disposition.FINISH_FAIL
-        assert "discovery failed" in result.note
+        assert isinstance(result, Continue)
+        assert "products" not in repo_item.payload
+        assert "_repo_issue_source" in repo_item.payload
+        pr_pages.assert_not_called()
 
     def test_source_state_yields_to_the_coordinator(
         self, repo_item: WorkItem, repo_ctx: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -227,7 +227,7 @@ class TestDiscover:
             loop_repo_manager_mod, "_iter_open_issue_meta", lambda org, repo: iter(meta)
         )
         monkeypatch.setattr(
-            loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: open_prs or []
+            loop_repo_manager_mod, "_iter_open_pr_meta", lambda org, repo: iter(open_prs or [])
         )
         monkeypatch.setattr(seeding_mod, "seed_issue", lambda num: facts[num])
         monkeypatch.setattr(seeding_mod, "seed_issue_from_github", lambda num, github: facts[num])
@@ -275,7 +275,7 @@ class TestDiscover:
                 [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}]
             ),
         )
-        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: [])
+        monkeypatch.setattr(loop_repo_manager_mod, "_iter_open_pr_meta", lambda org, repo: iter([]))
         monkeypatch.setattr(
             seeding_mod,
             "seed_issue",
@@ -504,7 +504,7 @@ class TestDiscover:
         )
         monkeypatch.setattr(
             loop_repo_manager_mod,
-            "_list_open_pr_meta",
+            "_iter_open_pr_meta",
             lambda org, repo: (_ for _ in ()).throw(RuntimeError("pr list failed")),
         )
         repo_item.state = "DISCOVER"

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -1,9 +1,9 @@
 """RepoStage tests: label ensure, clone, discovery walk, epic-tag order (#1817).
 
 Doc section "1. repo" is the binding contract: ENTER -> CLONE_WAIT ->
-DISCOVER -> SEEDED; budget clone=2; epics tagged ``state:skip`` [durable]
-BEFORE exclusion; orphan PRs without a linked issue are skipped; the repo item
-is terminal (FINISH_PASS ``seeded:N``).
+DISCOVER -> SOURCE; budget clone=2.  The stage initializes only a bounded
+metadata cursor; the coordinator owns one-at-a-time classification, epic
+tagging, and terminal completion.
 """
 
 from __future__ import annotations
@@ -223,7 +223,9 @@ class TestDiscover:
     ) -> list[int]:
         """Patch the repo-stage read seams; returns the classify-call order."""
         classified: list[int] = []
-        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_issue_meta", lambda org, repo: meta)
+        monkeypatch.setattr(
+            loop_repo_manager_mod, "_iter_open_issue_meta", lambda org, repo: iter(meta)
+        )
         monkeypatch.setattr(
             loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: open_prs or []
         )
@@ -237,7 +239,7 @@ class TestDiscover:
         monkeypatch.setattr(seeding_mod, "classify_issue", fake_classify)
         return classified
 
-    def test_discover_classifies_through_repo_scoped_github(
+    def test_discover_initializes_source_without_eager_issue_reads(
         self,
         repo_item: WorkItem,
         tmp_path: Path,
@@ -268,8 +270,10 @@ class TestDiscover:
         ctx = make_ctx(github=github, paths=_RepoPaths(tmp_path))
         monkeypatch.setattr(
             loop_repo_manager_mod,
-            "_list_open_issue_meta",
-            lambda org, repo: [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}],
+            "_iter_open_issue_meta",
+            lambda org, repo: iter(
+                [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}]
+            ),
         )
         monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: [])
         monkeypatch.setattr(
@@ -282,11 +286,10 @@ class TestDiscover:
         result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
-        assert github.issue_reads == [8]
-        # Issue-level implementation-go on an open PR is a legacy compatibility
-        # label (#2140): post-#2280 it routes back to review, not merge_wait.
-        assert repo_item.payload["products"][0]["stage"] is StageName.PR_REVIEW
-        assert repo_item.payload["products"][0]["pr"] == 44
+        assert result.next_state == "SOURCE"
+        assert github.issue_reads == []
+        assert "products" not in repo_item.payload
+        assert "_repo_issue_source" in repo_item.payload
 
     def test_discover_failure_finishes_fail(
         self,
@@ -297,7 +300,7 @@ class TestDiscover:
         """Discovery failures are not converted into a successful empty run."""
         monkeypatch.setattr(
             loop_repo_manager_mod,
-            "_list_open_issue_meta",
+            "_iter_open_issue_meta",
             lambda org, repo: (_ for _ in ()).throw(RuntimeError("gh failed")),
         )
         repo_item.state = "DISCOVER"
@@ -308,13 +311,13 @@ class TestDiscover:
         assert result.disposition is Disposition.FINISH_FAIL
         assert "discovery failed" in result.note
 
-    def test_discover_classifies_dedups_and_stages_products(
+    def test_discover_retains_only_a_metadata_cursor(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """N issues (with a duplicate) classify into entry-queue products."""
+        """Discovery does not classify/dedup into an unbounded product list."""
         meta = [
             {"number": 1, "labels": [], "title": "one"},
             {"number": 2, "labels": ["state:plan-go"], "title": "two"},
@@ -333,20 +336,18 @@ class TestDiscover:
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, Continue) and result.next_state == "SEEDED"
-        assert classified == [1, 2]  # dedup: issue 1 classified once
-        products = repo_item.payload["products"]
-        stages = {p["number"]: p["stage"] for p in products}
-        assert stages == {1: StageName.PLANNING, 2: StageName.IMPLEMENTATION}
-        assert repo_item.payload["seeded_count"] == 2
+        assert isinstance(result, Continue) and result.next_state == "SOURCE"
+        assert classified == []
+        assert "products" not in repo_item.payload
+        assert "seeded_count" not in repo_item.payload
 
-    def test_epics_tagged_durably_before_exclusion(
+    def test_discover_does_not_mutate_before_source_consumption(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The skip_epics write lands BEFORE the epic is excluded (order test)."""
+        """The source owns the later durable epic-tagging side effect."""
         meta = [
             {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
             {"number": 6, "labels": [], "title": "real work"},
@@ -362,22 +363,17 @@ class TestDiscover:
 
         RepoStage().step(repo_item, repo_ctx)
 
-        # Durable tag written through the sanctioned chokepoint...
-        assert ("skip_epics", ((5,),)) in gh.mutation_log
-        assert "state:skip" in gh.labels[5]
-        # ...BEFORE the exclusion was materialized: the epic never reached
-        # the classifier, and its product records the exclusion.
-        assert classified == [6]
-        epic_products = [p for p in repo_item.payload["products"] if p["number"] == 5]
-        assert epic_products[0]["stage"] is None
+        assert gh.mutation_log == []
+        assert classified == []
+        assert "products" not in repo_item.payload
 
-    def test_skip_epics_failure_blocks_exclusion_until_reseed(
+    def test_discover_defers_epic_tag_failure_to_source_consumption(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A failed skip write leaves no excluded product; a reseed retries it."""
+        """Source setup is read-only, even when the eventual write would fail."""
         meta = [
             {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
             {"number": 6, "labels": [], "title": "real work"},
@@ -399,37 +395,25 @@ class TestDiscover:
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition is Disposition.FINISH_FAIL
+        assert isinstance(result, Continue)
         assert "products" not in repo_item.payload
         assert classified == []
         assert 5 not in gh.labels
-
         monkeypatch.setattr(gh, "skip_epics", original_skip_epics)
-        reseed_item = WorkItem(
-            repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO, state="DISCOVER"
-        )
-
-        reseed = RepoStage().step(reseed_item, repo_ctx)
-
-        assert isinstance(reseed, Continue) and reseed.next_state == "SEEDED"
-        assert "state:skip" in gh.labels[5]
-        assert [p["number"] for p in reseed_item.payload["products"]] == [5, 6]
 
     @pytest.mark.parametrize(
-        ("include_bot_prs", "include_all_authors", "expected"),
+        ("include_bot_prs", "include_all_authors"),
         [
-            pytest.param(True, False, [], id="viewer-only-including-bots"),
-            pytest.param(False, False, [], id="viewer-only-without-bots"),
-            pytest.param(True, True, [], id="all-authors-including-bots"),
-            pytest.param(False, True, [], id="all-authors-without-bots"),
+            pytest.param(True, False, id="viewer-only-including-bots"),
+            pytest.param(False, False, id="viewer-only-without-bots"),
+            pytest.param(True, True, id="all-authors-including-bots"),
+            pytest.param(False, True, id="all-authors-without-bots"),
         ],
     )
     def test_drive_green_all_honors_author_and_bot_filters(
         self,
         include_bot_prs: bool,
         include_all_authors: bool,
-        expected: list[int],
         repo_item: WorkItem,
         tmp_path: Path,
         make_ctx: Callable[..., Any],
@@ -467,8 +451,8 @@ class TestDiscover:
 
         RepoStage().step(repo_item, ctx)
 
-        orphan = [p for p in repo_item.payload["products"] if p.get("kind") == "pr"]
-        assert [p["number"] for p in orphan] == expected
+        assert "products" not in repo_item.payload
+        assert "_repo_issue_source" in repo_item.payload
 
     def test_drive_green_all_skips_viewer_resolution_for_all_authors(
         self,
@@ -531,23 +515,16 @@ class TestDiscover:
         assert result.disposition is Disposition.FINISH_FAIL
         assert "discovery failed" in result.note
 
-    def test_seeded_finishes_pass_with_cached_count(
+    def test_source_state_yields_to_the_coordinator(
         self, repo_item: WorkItem, repo_ctx: Any
     ) -> None:
-        """Terminal: FINISH_PASS(seeded:N) uses the cached discovery count."""
-        repo_item.state = "SEEDED"
-        repo_item.payload["products"] = [
-            {"number": 1, "stage": StageName.PLANNING, "reason": "r"},
-            {"number": 2, "stage": None, "reason": "excluded"},
-            {"number": 3, "stage": StageName.PR_REVIEW, "reason": "r"},
-        ]
-        repo_item.payload["seeded_count"] = 1
+        """SOURCE is a non-spinning yield point for coordinator source pull."""
+        repo_item.state = "SOURCE"
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition is Disposition.FINISH_PASS
-        assert result.note == "seeded:1"
+        assert isinstance(result, Continue)
+        assert result.next_state == "SOURCE"
 
     def test_unknown_state_finishes_failed(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         repo_item.state = "BOGUS"

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -1,0 +1,94 @@
+"""Coordinator-wide queue-capacity and admission-limit contracts (#2399)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from queue import Queue
+from threading import Event
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _RecordingWorkerPool:
+    """Worker-pool stand-in that records the coordinator's production wiring."""
+
+    def __init__(
+        self,
+        size: int,
+        shutdown: Event,
+        completion_q: Any,
+        lock_dir: Path | None = None,
+    ) -> None:
+        del lock_dir
+        self.size = size
+        self.shutdown_event = shutdown
+        self.completion_q = completion_q
+
+
+def _config(tmp_path: Path, *, parallel_repos: int = 2, max_workers: int = 3) -> PipelineConfig:
+    """Build a configuration whose global work capacity is easy to inspect."""
+    return PipelineConfig(
+        org="org",
+        repos=["repo-a", "repo-b"],
+        parallel_repos=parallel_repos,
+        max_workers=max_workers,
+        projects_dir=tmp_path,
+    )
+
+
+def test_coordinator_uses_one_capacity_for_all_queues_and_worker_pool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every coordinator-owned queue and its worker pool use C exactly."""
+    from hephaestus.automation.pipeline import worker_pool as worker_pool_mod
+
+    monkeypatch.setattr(worker_pool_mod, "WorkerPool", _RecordingWorkerPool)
+    config = _config(tmp_path)
+    capacity = config.parallel_repos * config.max_workers
+
+    coordinator = Coordinator(config, github=FakeStageGitHub(), install_signals=False)
+
+    assert {queue.capacity for queue in coordinator.queues.values()} == {capacity}
+    assert coordinator.completion_q.maxsize == capacity
+    assert coordinator.pool.size == capacity
+    assert coordinator.pool.completion_q is coordinator.completion_q
+
+
+def test_admission_rejects_when_global_worker_capacity_is_live(tmp_path: Path) -> None:
+    """A fifth cross-repo job cannot enter a four-worker executor backlog."""
+    coordinator = object.__new__(Coordinator)
+    coordinator.config = _config(tmp_path, parallel_repos=2, max_workers=2)
+    live_repos = ("repo-a", "repo-b", "repo-c", "repo-d")
+    coordinator.in_flight = {
+        object(): WorkItem(repo=repo, kind=ItemKind.ISSUE, issue=index)
+        for index, repo in enumerate(live_repos, start=1)
+    }
+    coordinator.inflight_per_repo = Counter(dict.fromkeys(live_repos, 1))
+
+    assert coordinator._admit(WorkItem(repo="repo-e", kind=ItemKind.ISSUE, issue=5)) is False
+
+
+def test_coordinator_rejects_injected_completion_queue_with_wrong_capacity(
+    tmp_path: Path,
+) -> None:
+    """An injected completion queue cannot weaken the coordinator's C bound."""
+    config = _config(tmp_path, parallel_repos=2, max_workers=2)
+    incompatible_pool = _RecordingWorkerPool(
+        size=4,
+        shutdown=Event(),
+        completion_q=Queue(maxsize=5),
+    )
+
+    with pytest.raises(ValueError):
+        Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=incompatible_pool,
+            install_signals=False,
+        )

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -92,3 +92,23 @@ def test_coordinator_rejects_injected_completion_queue_with_wrong_capacity(
             pool=incompatible_pool,
             install_signals=False,
         )
+
+
+def test_coordinator_replaces_an_injected_unbounded_completion_queue(tmp_path: Path) -> None:
+    """A zero-maxsize test double cannot silently bypass the global C bound."""
+    config = _config(tmp_path, parallel_repos=2, max_workers=2)
+    unbounded_pool = _RecordingWorkerPool(
+        size=4,
+        shutdown=Event(),
+        completion_q=Queue(),
+    )
+
+    coordinator = Coordinator(
+        config,
+        github=FakeStageGitHub(),
+        pool=unbounded_pool,
+        install_signals=False,
+    )
+
+    assert coordinator.completion_q.maxsize == 4
+    assert unbounded_pool.completion_q is coordinator.completion_q

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -6,11 +6,12 @@ from collections import Counter
 from pathlib import Path
 from queue import Queue
 from threading import Event
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import JobHandle
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -66,7 +67,7 @@ def test_admission_rejects_when_global_worker_capacity_is_live(tmp_path: Path) -
     coordinator.config = _config(tmp_path, parallel_repos=2, max_workers=2)
     live_repos = ("repo-a", "repo-b", "repo-c", "repo-d")
     coordinator.in_flight = {
-        object(): WorkItem(repo=repo, kind=ItemKind.ISSUE, issue=index)
+        cast(JobHandle, object()): WorkItem(repo=repo, kind=ItemKind.ISSUE, issue=index)
         for index, repo in enumerate(live_repos, start=1)
     }
     coordinator.inflight_per_repo = Counter(dict.fromkeys(live_repos, 1))

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -145,6 +145,67 @@ def test_repo_issue_source_is_lossless_and_ordered_at_capacity_one(
     assert coordinator._all_idle()
 
 
+def test_repo_entries_are_source_pulled_in_order_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C+1 repositories wait at one FIFO cursor instead of being dropped.
+
+    A repository source holds the sole REPO-stage lease through its bounded
+    issue cursor.  The next configured repository is therefore admitted only
+    after that source has drained, preserving source order without creating an
+    unbounded list of repo ``WorkItem`` instances.
+    """
+    events: list[tuple[str, int]] = []
+    metadata = {
+        "repo-a": [{"number": 101, "labels": ["state:needs-plan"], "title": "first"}],
+        "repo-b": [{"number": 201, "labels": ["state:needs-plan"], "title": "second"}],
+    }
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(
+        loop_repo_manager,
+        "_iter_open_issue_meta",
+        lambda _org, repo: iter(metadata[repo]),
+    )
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a", "repo-b"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+
+    assert events == [
+        ("classify", 101),
+        ("complete", 101),
+        ("classify", 201),
+        ("complete", 201),
+    ]
+    assert [item.repo for item in coordinator.items if item.kind is ItemKind.REPO] == [
+        "repo-a",
+        "repo-b",
+    ]
+    assert [item.issue for item in coordinator.items if item.kind is ItemKind.ISSUE] == [101, 201]
+    assert coordinator.live_work_count == 0
+    assert coordinator._all_idle()
+
+
 def test_repo_source_tags_epic_before_exclusion_and_next_issue_admission(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -1,0 +1,141 @@
+"""Repository-discovery source-pull regression coverage for bounded queues (#2399)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation import loop_repo_manager
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.stages.base import Continue
+from hephaestus.automation.pipeline.stages.repo import RepoStage
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _ImmediatePassStage:
+    """Finish planning synchronously so source admission order is observable."""
+
+    def __init__(self, events: list[tuple[str, int]]) -> None:
+        self._events = events
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del ctx
+        assert item.issue is not None
+        self._events.append(("complete", item.issue))
+        return StageOutcome(Disposition.FINISH_PASS, f"completed #{item.issue}")
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        del item, result, ctx
+        raise AssertionError("source-pull test must not submit a worker job")
+
+
+def _facts(issue: int) -> IssueFacts:
+    """Return one eligible, planning-entry issue classification."""
+    return IssueFacts(
+        number=issue,
+        title=f"Issue {issue}",
+        body="",
+        is_epic=False,
+        labels={"state:needs-plan"},
+        pr_number=None,
+        pr_is_open=False,
+        pr_is_merged=False,
+    )
+
+
+def test_repo_discovery_never_materializes_an_unbounded_products_spill(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A repo source must retain a cursor, not all C+1 classified products.
+
+    The bounded pipeline's only work-holding queues are coordinator-owned.
+    Discovery metadata may be read one page at a time, but the repo WorkItem
+    cannot turn every eligible issue into a ``payload["products"]`` spill list
+    before the planning queue has made capacity.
+    """
+    repo_item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO, state="DISCOVER")
+    ctx = type(
+        "Context",
+        (),
+        {
+            "org": "org",
+            "github": FakeStageGitHub(labels=["state:needs-plan"]),
+            "config": type("Config", (), {"drive_green_all": False})(),
+        },
+    )()
+    metadata = [
+        {"number": 101, "labels": ["state:needs-plan"], "title": "first"},
+        {"number": 102, "labels": ["state:needs-plan"], "title": "second"},
+    ]
+    monkeypatch.setattr(loop_repo_manager, "_list_open_issue_meta", lambda _org, _repo: metadata)
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", lambda issue, _github: _facts(issue))
+
+    result = RepoStage().step(repo_item, ctx)
+
+    assert isinstance(result, Continue)
+    assert "products" not in repo_item.payload
+
+
+def test_repo_issue_source_is_lossless_and_ordered_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C+1 discovered issues classify only as C=1 capacity becomes available.
+
+    The first issue may enter and finish before the second is classified.  No
+    internal saturation is a shutdown/fatal error, every issue finishes once,
+    and source order remains stable across the admission boundary.
+    """
+    events: list[tuple[str, int]] = []
+    metadata = [
+        {"number": 101, "labels": ["state:needs-plan"], "title": "first"},
+        {"number": 102, "labels": ["state:needs-plan"], "title": "second"},
+    ]
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(loop_repo_manager, "_list_open_issue_meta", lambda _org, _repo: metadata)
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+
+    assert events == [
+        ("classify", 101),
+        ("complete", 101),
+        ("classify", 102),
+        ("complete", 102),
+    ]
+    discovered = [item for item in coordinator.items if item.kind is ItemKind.ISSUE]
+    assert [item.issue for item in discovered] == [101, 102]
+    assert all(item.result is not None and item.result.passed for item in discovered)
+    assert coordinator.shutdown.is_set() is False
+    assert coordinator._fatal is False
+    assert coordinator._all_idle()

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -197,13 +197,69 @@ def test_repo_entries_are_source_pulled_in_order_at_capacity_one(
         ("classify", 201),
         ("complete", 201),
     ]
-    assert [item.repo for item in coordinator.items if item.kind is ItemKind.REPO] == [
-        "repo-a",
-        "repo-b",
-    ]
     assert [item.issue for item in coordinator.items if item.kind is ItemKind.ISSUE] == [101, 201]
+    assert all(item.kind is not ItemKind.REPO for item in coordinator.items)
     assert coordinator.live_work_count == 0
     assert coordinator._all_idle()
+
+
+def test_repo_sources_round_robin_across_repositories_at_capacity_two(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C=2 admits one source item from A and B before either gets a second turn."""
+    events: list[tuple[str, int]] = []
+    metadata = {
+        "repo-a": [
+            {"number": 101, "labels": ["state:needs-plan"], "title": "first A"},
+            {"number": 102, "labels": ["state:needs-plan"], "title": "second A"},
+        ],
+        "repo-b": [
+            {"number": 201, "labels": ["state:needs-plan"], "title": "first B"},
+            {"number": 202, "labels": ["state:needs-plan"], "title": "second B"},
+        ],
+    }
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(
+        loop_repo_manager,
+        "_iter_open_issue_meta",
+        lambda _org, repo: iter(metadata[repo]),
+    )
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a", "repo-b"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=2,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+
+    assert events == [
+        ("classify", 101),
+        ("classify", 201),
+        ("complete", 101),
+        ("complete", 201),
+        ("classify", 102),
+        ("classify", 202),
+        ("complete", 102),
+        ("complete", 202),
+    ]
+    assert coordinator._all_idle()
+    assert coordinator.live_work_count == 0
 
 
 def test_repo_source_tags_epic_before_exclusion_and_next_issue_admission(

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -203,6 +203,41 @@ def test_repo_entries_are_source_pulled_in_order_at_capacity_one(
     assert coordinator._all_idle()
 
 
+def test_resettable_org_repo_source_pulls_only_one_repository_at_capacity_one(
+    tmp_path: Path,
+) -> None:
+    """The coordinator, not the loop wrapper, advances the org repository source."""
+    pulls: list[str] = []
+    factories: list[object] = []
+
+    def source_factory() -> Any:
+        factories.append(object())
+        for repo in ("repo-a", "repo-b", "repo-c"):
+            pulls.append(repo)
+            yield repo
+
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=[],
+            repo_source_factory=source_factory,
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+
+    assert coordinator._seed_pass() == 1
+    assert len(factories) == 1
+    assert pulls == ["repo-a"]
+    assert [item.repo for item in coordinator.queues[StageName.REPO].snapshot()] == ["repo-a"]
+
+
 def test_repo_sources_round_robin_across_repositories_at_capacity_two(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -260,6 +295,52 @@ def test_repo_sources_round_robin_across_repositories_at_capacity_two(
     ]
     assert coordinator._all_idle()
     assert coordinator.live_work_count == 0
+
+
+def test_repo_setup_reserves_a_future_source_slot_before_registry_is_full(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C+1 repositories cannot strand a setup lease at a full cursor registry."""
+    metadata = {
+        # Keep A active long enough for the registry to have one free slot
+        # while C and D are eligible for REPO setup.  The coordinator must
+        # admit only C, reserving the other slot for that in-flight setup.
+        "a": [
+            {"number": number, "labels": ["epic"], "title": f"Epic {number}"}
+            for number in range(1, 6)
+        ],
+        "b": [{"number": 10, "labels": ["epic"], "title": "Epic B"}],
+        "c": [],
+        "d": [],
+    }
+    monkeypatch.setattr(
+        loop_repo_manager,
+        "_iter_open_issue_meta",
+        lambda _org, repo: iter(metadata[repo]),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["a", "b", "c", "d"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=2,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+
+    assert coordinator.run() == 0
+    assert coordinator._all_idle()
+    assert coordinator.live_work_count == 0
+    assert not coordinator._leases
+    activations = [
+        event[1] for event in coordinator.event_log if event[0] == "repo_source_activate"
+    ]
+    assert activations == ["a", "b", "c", "d"]
 
 
 def test_repo_source_reseed_drains_second_pass_before_zero_work_convergence(

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -262,6 +262,99 @@ def test_repo_sources_round_robin_across_repositories_at_capacity_two(
     assert coordinator.live_work_count == 0
 
 
+def test_repo_source_reseed_drains_second_pass_before_zero_work_convergence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh repo cursor keeps loop two alive until it classifies its issue.
+
+    The first pass fails and the second succeeds for the same discovered
+    issue.  A repository source begins with no classified work, so returning
+    from reseed based only on ``_pass_work_count`` would exit immediately and
+    strand the second cursor.
+    """
+    events: list[tuple[str, int]] = []
+
+    class _FailThenPassStage:
+        def on_enter(self, item: WorkItem, ctx: Any) -> None:
+            del item, ctx
+
+        def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+            del ctx
+            assert item.issue == 101
+            if not any(kind == "fail" for kind, _number in events):
+                events.append(("fail", item.issue))
+                return StageOutcome(Disposition.FINISH_FAIL, "first pass failed")
+            events.append(("pass", item.issue))
+            return StageOutcome(Disposition.FINISH_PASS, "replacement passed")
+
+        def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+            del item, result, ctx
+            raise AssertionError("the deterministic stage must not submit a job")
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(
+        loop_repo_manager,
+        "_iter_open_issue_meta",
+        lambda _org, _repo: iter(
+            [{"number": 101, "labels": ["state:needs-plan"], "title": "retry"}]
+        ),
+    )
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=2,
+            parallel_repos=1,
+            max_workers=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _FailThenPassStage()
+
+    assert coordinator.run() == 0
+
+    assert events == [
+        ("classify", 101),
+        ("fail", 101),
+        ("classify", 101),
+        ("pass", 101),
+    ]
+    assert coordinator._loops_run == 2
+    assert coordinator._terminal_summary.dispositions == {"pass": 1}
+
+
+def test_empty_repo_source_still_converges_after_one_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A drained source with no actionable issue does not cause a reseed loop."""
+    monkeypatch.setattr(loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(()))
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=3,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+
+    assert coordinator.run() == 0
+    assert coordinator._loops_run == 1
+    assert coordinator._all_idle()
+
+
 def test_repo_source_tags_epic_before_exclusion_and_next_issue_admission(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -77,7 +77,9 @@ def test_repo_discovery_never_materializes_an_unbounded_products_spill(
         {"number": 101, "labels": ["state:needs-plan"], "title": "first"},
         {"number": 102, "labels": ["state:needs-plan"], "title": "second"},
     ]
-    monkeypatch.setattr(loop_repo_manager, "_list_open_issue_meta", lambda _org, _repo: metadata)
+    monkeypatch.setattr(
+        loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(metadata)
+    )
     monkeypatch.setattr(seeding_mod, "seed_issue_from_github", lambda issue, _github: _facts(issue))
 
     result = RepoStage().step(repo_item, ctx)
@@ -106,7 +108,9 @@ def test_repo_issue_source_is_lossless_and_ordered_at_capacity_one(
         events.append(("classify", issue))
         return _facts(issue)
 
-    monkeypatch.setattr(loop_repo_manager, "_list_open_issue_meta", lambda _org, _repo: metadata)
+    monkeypatch.setattr(
+        loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(metadata)
+    )
     monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
 
     coordinator = Coordinator(
@@ -139,3 +143,49 @@ def test_repo_issue_source_is_lossless_and_ordered_at_capacity_one(
     assert coordinator.shutdown.is_set() is False
     assert coordinator._fatal is False
     assert coordinator._all_idle()
+
+
+def test_repo_source_tags_epic_before_exclusion_and_next_issue_admission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An epic is durably excluded before the cursor advances to live work."""
+    events: list[tuple[str, int]] = []
+    metadata = [
+        {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
+        {"number": 6, "labels": ["state:needs-plan"], "title": "implementation"},
+    ]
+
+    class _RecordingGitHub(FakeStageGitHub):
+        def skip_epics(self, epics_labels: dict[int, list[str]]) -> None:
+            events.extend(("tag", number) for number in epics_labels)
+            super().skip_epics(epics_labels)
+
+    def classify(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return _facts(issue)
+
+    monkeypatch.setattr(
+        loop_repo_manager, "_iter_open_issue_meta", lambda _org, _repo: iter(metadata)
+    )
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    github = _RecordingGitHub(labels=["state:needs-plan"])
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=github,
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+    assert events == [("tag", 5), ("classify", 6), ("complete", 6)]
+    assert "state:skip" in github.labels[5]

--- a/tests/unit/automation/pipeline/test_backpressure_seeding.py
+++ b/tests/unit/automation/pipeline/test_backpressure_seeding.py
@@ -1,0 +1,116 @@
+"""Direct-scope source-pull regression coverage for bounded queues (#2399)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.queues import StageQueue
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.work_item import WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _ImmediatePassStage:
+    """A no-I/O planning stage that makes admission progress observable."""
+
+    def __init__(self, events: list[tuple[str, int]]) -> None:
+        """Record stage progress alongside the seed-classification trace."""
+        self._events = events
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        """Leave the item ready for its deterministic one-step completion."""
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        """Complete one seeded issue without submitting a worker job."""
+        del ctx
+        assert item.issue is not None
+        self._events.append(("complete", item.issue))
+        return StageOutcome(Disposition.FINISH_PASS, f"completed #{item.issue}")
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        """Reject a worker path; this test exercises only queue admission."""
+        del item, result, ctx
+        raise AssertionError("the deterministic stage must not submit a job")
+
+
+def test_direct_issue_seeds_are_source_pulled_and_lossless_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C+1 direct issues wait at a bounded source cursor until each prior item drains.
+
+    ``--issues`` is an operator-provided source, not permission to build an
+    unbounded admission buffer.  With C=1, the second classification must
+    happen only after the first item has made pipeline progress; both issues
+    must then finish exactly once without turning internal saturation into a
+    shutdown or fatal run.
+    """
+    events: list[tuple[str, int]] = []
+    observed_occupancies: list[int] = []
+    original_offer = StageQueue.offer
+
+    def record_offer(self: StageQueue, item: WorkItem) -> bool:
+        accepted = original_offer(self, item)
+        observed_occupancies.append(self.occupancy)
+        return accepted
+
+    def classify_direct_issue(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return IssueFacts(
+            number=issue,
+            title=f"Issue {issue}",
+            body="",
+            is_epic=False,
+            labels={"state:needs-plan"},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+
+    monkeypatch.setattr(StageQueue, "offer", record_offer)
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify_direct_issue)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: issues,
+    )
+
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[101, 102],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+
+    assert events == [
+        ("classify", 101),
+        ("complete", 101),
+        ("classify", 102),
+        ("complete", 102),
+    ]
+    assert [item.issue for item in coordinator.items] == [101, 102]
+    assert all(item.result is not None and item.result.passed for item in coordinator.items)
+    assert coordinator.shutdown.is_set() is False
+    assert coordinator._fatal is False
+    assert coordinator._all_idle()
+    assert observed_occupancies
+    assert max(observed_occupancies) <= 1

--- a/tests/unit/automation/pipeline/test_backpressure_seeding.py
+++ b/tests/unit/automation/pipeline/test_backpressure_seeding.py
@@ -12,7 +12,7 @@ from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConf
 from hephaestus.automation.pipeline.queues import StageQueue
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.seeding import IssueFacts
-from hephaestus.automation.pipeline.work_item import WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -166,3 +166,43 @@ def test_direct_issue_source_restarts_for_each_configured_loop(
     ]
     assert coordinator._loops_run == 2
     assert len(coordinator.ledger) == 2
+
+
+def test_direct_pr_seeds_are_source_pulled_and_lossless_at_capacity_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C+1 explicit PRs wait for admission instead of being silently dropped."""
+    events: list[tuple[str, int]] = []
+
+    class _DirectPrGitHub(FakeStageGitHub):
+        def find_issue_for_pr(self, pr_number: int) -> int | None:
+            events.append(("classify", pr_number))
+            return pr_number + 1000
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            prs=[701, 702],
+            loops=1,
+            parallel_repos=1,
+            max_workers=1,
+            projects_dir=tmp_path,
+        ),
+        github=_DirectPrGitHub(pr_impl_state=(True, False)),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.MERGE_WAIT] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+
+    assert events == [
+        ("classify", 701),
+        ("complete", 1701),
+        ("classify", 702),
+        ("complete", 1702),
+    ]
+    assert [item.pr for item in coordinator.items if item.kind is ItemKind.PR] == [701, 702]
+    assert coordinator._all_idle()

--- a/tests/unit/automation/pipeline/test_backpressure_seeding.py
+++ b/tests/unit/automation/pipeline/test_backpressure_seeding.py
@@ -114,3 +114,55 @@ def test_direct_issue_seeds_are_source_pulled_and_lossless_at_capacity_one(
     assert coordinator._all_idle()
     assert observed_occupancies
     assert max(observed_occupancies) <= 1
+
+
+def test_direct_issue_source_restarts_for_each_configured_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bounded cursor is recreated, rather than exhausted, on re-seeding."""
+    events: list[tuple[str, int]] = []
+
+    def classify_direct_issue(issue: int, github: Any) -> IssueFacts:
+        del github
+        events.append(("classify", issue))
+        return IssueFacts(
+            number=issue,
+            title=f"Issue {issue}",
+            body="",
+            is_epic=False,
+            labels={"state:needs-plan"},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify_direct_issue)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: issues,
+    )
+
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[101],
+            loops=2,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage(events)
+
+    assert coordinator.run() == 0
+    assert events == [
+        ("classify", 101),
+        ("complete", 101),
+        ("classify", 101),
+        ("complete", 101),
+    ]
+    assert coordinator._loops_run == 2
+    assert len(coordinator.ledger) == 2

--- a/tests/unit/automation/pipeline/test_backpressure_transitions.py
+++ b/tests/unit/automation/pipeline/test_backpressure_transitions.py
@@ -1,0 +1,132 @@
+"""RED coordinator contract for a full next-stage queue transition (#2399).
+
+The queue object already exposes capacity-reserving leases.  This test pins
+the coordinator-level use of that contract: a completed stage action must not
+be run again, dropped, or treated as an interrupt merely because its next
+stage is temporarily full.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _AdvanceAfterJob:
+    """Run one durable side effect after a synthetic worker completion."""
+
+    def __init__(self, cwd: Path) -> None:
+        self._cwd = cwd
+        self._submitted = False
+        self.side_effects = 0
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        del item, result, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> JobRequest | StageOutcome:
+        del ctx
+        if not self._submitted:
+            self._submitted = True
+            return JobRequest(
+                AgentJob(
+                    repo=item.repo,
+                    issue=item.issue or 0,
+                    agent="codex",
+                    model="stub",
+                    prompt_builder=lambda: "stub",
+                    cwd=self._cwd,
+                    timeout_s=1,
+                ),
+                "AFTER_JOB",
+            )
+        self.side_effects += 1
+        return StageOutcome(Disposition.ADVANCE, "durable side effect complete")
+
+
+class _FinishStage:
+    """Make the destination runnable if it is drained after a retry."""
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        del item, result, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del item, ctx
+        return StageOutcome(Disposition.FINISH_PASS, "destination consumed")
+
+
+def _issue(issue: int, stage: StageName) -> WorkItem:
+    """Build an item whose identity is stable in coordinator event assertions."""
+    return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=stage)
+
+
+def test_full_next_stage_retains_completed_transition_until_retry(tmp_path: Path) -> None:
+    """A full destination retains a completed ADVANCE without replaying its side effect."""
+    source_stage = _AdvanceAfterJob(tmp_path)
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            parallel_repos=1,
+            max_workers=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        stages={
+            StageName.PLANNING: source_stage,
+            StageName.PLAN_REVIEW: _FinishStage(),
+        },
+        install_signals=False,
+    )
+    source = _issue(1, StageName.PLANNING)
+    blocker = _issue(2, StageName.PLAN_REVIEW)
+
+    # Dispatch source normally so the coordinator owns its source-stage slot.
+    coordinator._push_item(source, StageName.PLANNING, enter=True)
+    coordinator._drain_queues()
+    assert len(coordinator.in_flight) == 1
+
+    # A different completion can occupy the next stage while source is in flight.
+    coordinator._push_item(blocker, StageName.PLAN_REVIEW, enter=True)
+    destination = coordinator.queues[StageName.PLAN_REVIEW]
+    source_queue = coordinator.queues[StageName.PLANNING]
+    assert destination.snapshot() == [blocker]
+
+    coordinator._drain_completions()
+
+    # The completed side effect cannot be dropped, replayed, or turned into an interrupt.
+    assert source_stage.side_effects == 1
+    assert source.result is None
+    assert not coordinator.shutdown.is_set()
+    assert not coordinator._fatal
+    assert destination.snapshot() == [blocker]
+    assert source_queue.occupancy == source_queue.capacity == 1
+
+    # Once the next stage opens, the coordinator retries the retained transition exactly once.
+    assert destination.pop() is blocker
+    coordinator._drain_queues()
+
+    target_pushes = [
+        event
+        for event in coordinator.event_log
+        if event == ("push", StageName.PLAN_REVIEW.value, "repo-a#1")
+    ]
+    assert target_pushes == [("push", StageName.PLAN_REVIEW.value, "repo-a#1")]
+    assert source_stage.side_effects == 1
+    assert source_queue.occupancy == 0
+    assert not coordinator.shutdown.is_set()
+    assert not coordinator._fatal

--- a/tests/unit/automation/pipeline/test_backpressure_transitions.py
+++ b/tests/unit/automation/pipeline/test_backpressure_transitions.py
@@ -69,6 +69,46 @@ class _FinishStage:
         return StageOutcome(Disposition.FINISH_PASS, "destination consumed")
 
 
+class _AlwaysJob:
+    """Submit a worker job for every item without completing it inline."""
+
+    def __init__(self, cwd: Path) -> None:
+        self._cwd = cwd
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        del item, result, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> JobRequest:
+        del ctx
+        return JobRequest(
+            AgentJob(
+                repo=item.repo,
+                issue=item.issue or 0,
+                agent="codex",
+                model="stub",
+                prompt_builder=lambda: "stub",
+                cwd=self._cwd,
+                timeout_s=1,
+            ),
+            "AFTER_JOB",
+        )
+
+
+class _PendingPool(FakeWorkerPool):
+    """Record submissions while deliberately withholding completions."""
+
+    def submit(self, job: Any, on_done_state: StageName, **kwargs: Any) -> Any:
+        from hephaestus.automation.pipeline.jobs import JobHandle
+
+        handle = JobHandle(job=job, on_done_state=on_done_state)
+        self.submitted.append(handle)
+        self.submitted_claims.append((kwargs.get("claim_key", ""), kwargs.get("claim_stage", "")))
+        return handle
+
+
 def _issue(issue: int, stage: StageName) -> WorkItem:
     """Build an item whose identity is stable in coordinator event assertions."""
     return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=stage)
@@ -137,3 +177,32 @@ def test_full_next_stage_retains_completed_transition_until_retry(tmp_path: Path
     assert source_queue.occupancy == 0
     assert not coordinator.shutdown.is_set()
     assert not coordinator._fatal
+
+
+def test_stage_leases_allow_parallel_worker_submissions_up_to_capacity(tmp_path: Path) -> None:
+    """Two ready items dispatch before either completion when C is two."""
+    pool = _PendingPool()
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            parallel_repos=1,
+            max_workers=2,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=pool,
+        stages={StageName.PLANNING: _AlwaysJob(tmp_path)},
+        install_signals=False,
+    )
+    first = _issue(1, StageName.PLANNING)
+    second = _issue(2, StageName.PLANNING)
+    coordinator._push_item(first, StageName.PLANNING, enter=True)
+    coordinator._push_item(second, StageName.PLANNING, enter=True)
+
+    coordinator._drain_queues()
+
+    assert len(pool.submitted) == 2
+    assert len(coordinator.in_flight) == 2
+    assert not coordinator.queues[StageName.PLANNING].snapshot()
+    assert {id(lease.item) for lease in coordinator._leases.values()} == {id(first), id(second)}

--- a/tests/unit/automation/pipeline/test_backpressure_transitions.py
+++ b/tests/unit/automation/pipeline/test_backpressure_transitions.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
+from hephaestus.automation.pipeline.queues import StageQueue
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.stages.base import JobRequest
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
@@ -81,7 +82,12 @@ def test_full_next_stage_retains_completed_transition_until_retry(tmp_path: Path
             org="org",
             repos=["repo-a"],
             parallel_repos=1,
-            max_workers=1,
+            # Two valid live items are needed for this targeted full-next-stage
+            # fallback. Production queues have capacity C, so replace only the
+            # destination below with a smaller test double to exercise the
+            # defensive handoff path that remains lossless under an unexpected
+            # downstream capacity reduction.
+            max_workers=2,
             projects_dir=tmp_path,
         ),
         github=FakeStageGitHub(),
@@ -94,6 +100,7 @@ def test_full_next_stage_retains_completed_transition_until_retry(tmp_path: Path
     )
     source = _issue(1, StageName.PLANNING)
     blocker = _issue(2, StageName.PLAN_REVIEW)
+    coordinator.queues[StageName.PLAN_REVIEW] = StageQueue(capacity=1)
 
     # Dispatch source normally so the coordinator owns its source-stage slot.
     coordinator._push_item(source, StageName.PLANNING, enter=True)
@@ -114,7 +121,7 @@ def test_full_next_stage_retains_completed_transition_until_retry(tmp_path: Path
     assert not coordinator.shutdown.is_set()
     assert not coordinator._fatal
     assert destination.snapshot() == [blocker]
-    assert source_queue.occupancy == source_queue.capacity == 1
+    assert source_queue.occupancy == 1
 
     # Once the next stage opens, the coordinator retries the retained transition exactly once.
     assert destination.pop() is blocker

--- a/tests/unit/automation/pipeline/test_backpressure_transitions.py
+++ b/tests/unit/automation/pipeline/test_backpressure_transitions.py
@@ -164,7 +164,8 @@ def test_full_next_stage_retains_completed_transition_until_retry(tmp_path: Path
     assert source_queue.occupancy == 1
 
     # Once the next stage opens, the coordinator retries the retained transition exactly once.
-    assert destination.pop() is blocker
+    popped_blocker = destination.pop()
+    assert popped_blocker is blocker
     coordinator._drain_queues()
 
     target_pushes = [

--- a/tests/unit/automation/pipeline/test_bounded_diagnostics.py
+++ b/tests/unit/automation/pipeline/test_bounded_diagnostics.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from collections import deque
 from pathlib import Path
+from typing import Any
 
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
-from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import SeedEntry
 from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
@@ -73,3 +79,52 @@ def test_coordinator_bounds_diagnostics_and_keeps_full_terminal_aggregates(
     assert coordinator._terminal_summary.total == 4
     assert coordinator._terminal_summary.dispositions == {"fail": 1, "pass": 3}
     assert coordinator._exit_code() == 1
+
+
+class _TerminalStage:
+    """Return one terminal outcome per re-seeded planning item."""
+
+    def __init__(self, *outcomes: StageOutcome) -> None:
+        self._outcomes = deque(outcomes)
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+        return None
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del item, ctx
+        return self._outcomes.popleft()
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        del item, result, ctx
+
+
+def test_terminal_summary_uses_only_the_latest_reseed_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful replacement must supersede an earlier failed loop outcome."""
+    passes = deque(
+        [
+            [SeedEntry(kind="issue", identifier=7, stage=StageName.PLANNING, reason="first")],
+            [SeedEntry(kind="issue", identifier=7, stage=StageName.PLANNING, reason="second")],
+        ]
+    )
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_from_cli",
+        lambda _repos, _issues, _prs: list(passes.popleft()) if passes else [],
+    )
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo-a"], loops=2, projects_dir=tmp_path),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _TerminalStage(
+        StageOutcome(Disposition.FINISH_FAIL, "first failed"),
+        StageOutcome(Disposition.FINISH_PASS, "replacement passed"),
+    )
+
+    assert coordinator.run() == 0
+    assert coordinator._terminal_summary.total == 1
+    assert coordinator._terminal_summary.dispositions == {"pass": 1}

--- a/tests/unit/automation/pipeline/test_bounded_diagnostics.py
+++ b/tests/unit/automation/pipeline/test_bounded_diagnostics.py
@@ -1,0 +1,75 @@
+"""Bounded in-process diagnostics and terminal summary retention (#2399)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _coordinator(tmp_path: Path) -> Coordinator:
+    """Create a C=1 coordinator with deliberately small diagnostic bounds."""
+    config = PipelineConfig(
+        org="org",
+        repos=["repo-a"],
+        projects_dir=tmp_path,
+        metrics_port=9123,
+        event_log_capacity=3,
+        terminal_detail_capacity=2,
+    )
+    return Coordinator(
+        config,
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+
+
+def _finished_item(issue: int, *, passed: bool) -> WorkItem:
+    """Build one terminal item for the coordinator-owned finished sink."""
+    return WorkItem(
+        repo="repo-a",
+        kind=ItemKind.ISSUE,
+        issue=issue,
+        stage=StageName.FINISHED,
+        result=ItemResult(
+            passed=passed,
+            reason="ok" if passed else "failed",
+            final_stage=StageName.FINISHED,
+        ),
+    )
+
+
+def test_coordinator_bounds_diagnostics_and_keeps_full_terminal_aggregates(
+    tmp_path: Path,
+) -> None:
+    """Metric ticks, repo contexts, and old terminal detail cannot grow with an org."""
+    coordinator = _coordinator(tmp_path)
+
+    for _ in range(5):
+        coordinator._emit_observability_tick()
+    assert len(coordinator.event_log) == 3
+    assert all(event[0] == "metrics_snapshot" for event in coordinator.event_log)
+
+    for repo in ("repo-a", "repo-b", "repo-c"):
+        coordinator._ctx_for_repo(repo)
+    assert list(coordinator._ctx_cache) == ["repo-c"]
+
+    for issue in range(1, 5):
+        item = _finished_item(issue, passed=issue != 2)
+        assert coordinator._push_item(item, StageName.FINISHED, enter=True)
+        coordinator._drain_queues()
+
+    # The diagnostic rings retain only recent data, including generated metric
+    # events, while the terminal aggregate still reflects all four outcomes.
+    assert len(coordinator.event_log) == 3
+    assert len(coordinator._ctx_cache) == 1
+    assert [item.issue for item in coordinator.items] == [3, 4]
+    assert [result.reason for result in coordinator.ledger] == ["ok", "ok"]
+    assert coordinator._terminal_summary.total == 4
+    assert coordinator._terminal_summary.dispositions == {"fail": 1, "pass": 3}
+    assert coordinator._exit_code() == 1

--- a/tests/unit/automation/pipeline/test_completion_safety.py
+++ b/tests/unit/automation/pipeline/test_completion_safety.py
@@ -1,0 +1,69 @@
+"""Completion-channel saturation and signal-wake safety contracts (#2399)."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import JobResult
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _coordinator(tmp_path: Path) -> tuple[Coordinator, FakeWorkerPool]:
+    """Return a one-slot coordinator with a synchronous worker-pool stand-in."""
+    pool = FakeWorkerPool()
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            max_workers=1,
+            parallel_repos=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=pool,
+        install_signals=False,
+    )
+    return coordinator, pool
+
+
+def test_signal_wake_never_blocks_on_a_full_completion_queue(tmp_path: Path) -> None:
+    """Signal wake-up is a latch, not a queue write that can deadlock a handler."""
+    coordinator, _pool = _coordinator(tmp_path)
+    occupied = (object(), JobResult(ok=True, value="already queued"))
+    coordinator.completion_q.put_nowait(occupied)
+    callback = threading.Thread(target=coordinator._wake_completion_wait)
+
+    callback.start()
+    callback.join(timeout=0.2)
+    blocked = callback.is_alive()
+    try:
+        still_queued = coordinator.completion_q.get_nowait()
+    finally:
+        if callback.is_alive():
+            callback.join(timeout=1)
+
+    assert not blocked
+    assert still_queued is occupied
+    assert coordinator.completion_q.empty()
+    assert coordinator._completion_wakeup.is_set()
+
+
+def test_completion_saturation_exits_failed_without_claiming_signal_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An internal completion fault is exit 1, never an exit-130 cancellation."""
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda _repos, _issues, _prs: [])
+    coordinator, pool = _coordinator(tmp_path)
+    coordinator._completion_saturation.set()
+
+    assert coordinator.run() == 1
+    assert coordinator._fatal is True
+    assert not coordinator.shutdown.is_set()
+    assert pool.shutdown_calls == 1

--- a/tests/unit/automation/pipeline/test_completion_safety.py
+++ b/tests/unit/automation/pipeline/test_completion_safety.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import json
+import queue
 import threading
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline import admission as admission_mod, seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
-from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline.worker_pool import WorkerPool
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -67,3 +75,141 @@ def test_completion_saturation_exits_failed_without_claiming_signal_interrupt(
     assert coordinator._fatal is True
     assert not coordinator.shutdown.is_set()
     assert pool.shutdown_calls == 1
+
+
+class _BlockingWorkerPool(WorkerPool):
+    """Real callback path with test-controlled worker completion."""
+
+    def __init__(self, release: threading.Event, finished: threading.Event) -> None:
+        super().__init__(size=1, shutdown=threading.Event(), completion_q=queue.Queue())
+        self._release = release
+        self._finished = finished
+
+    def _run(self, job: Any, claim_key: str = "", claim_stage: str = "") -> JobResult:
+        del job, claim_key, claim_stage
+        assert self._release.wait(timeout=2)
+        self._finished.set()
+        return JobResult(ok=True)
+
+
+class _OneBlockingJobStage:
+    """Submit exactly one inert job so WorkerPool owns its real callback."""
+
+    def __init__(self, cwd: Path) -> None:
+        self._cwd = cwd
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        del item, result, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> JobRequest:
+        del ctx
+        return JobRequest(
+            AgentJob(
+                repo=item.repo,
+                issue=item.issue or 0,
+                agent="codex",
+                model="stub",
+                prompt_builder=lambda: "stub",
+                cwd=self._cwd,
+                timeout_s=1,
+            ),
+            "AFTER_JOB",
+        )
+
+
+class _PassStage:
+    """Complete a freshly reseeded item without submitting an external job."""
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        del item, result, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del ctx
+        return StageOutcome(Disposition.FINISH_PASS, "fresh source recovery")
+
+
+def test_real_worker_saturation_is_durable_resumable_and_recoverable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A C=1 callback overflow fails safely and a fresh source can resume work."""
+    release = threading.Event()
+    finished = threading.Event()
+    pool = _BlockingWorkerPool(release, finished)
+    event_log = tmp_path / "events.jsonl"
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=[],
+            parallel_repos=1,
+            max_workers=1,
+            event_log_path=event_log,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=pool,
+        stages={StageName.PLANNING: _OneBlockingJobStage(tmp_path)},
+        install_signals=False,
+    )
+    item = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=71, stage=StageName.PLANNING)
+    coordinator._push_item(item, StageName.PLANNING, enter=True)
+    coordinator._drain_queues()
+    assert len(coordinator.in_flight) == 1
+
+    # Consume the only C=1 completion slot with an unrelated stale payload,
+    # then let the real WorkerPool callback attempt publication.
+    active_handle = next(iter(coordinator.in_flight))
+    stale_handle = JobHandle(job=active_handle.job, on_done_state=active_handle.on_done_state)
+    coordinator.completion_q.put_nowait((stale_handle, JobResult(ok=True)))
+    release.set()
+    assert finished.wait(timeout=1)
+    assert coordinator._completion_saturation.wait(timeout=1)
+
+    assert coordinator.run() == 1
+    assert not coordinator.shutdown.is_set()
+    assert item.result is not None
+    assert item.result.reason == "resumable at planning"
+    records = [json.loads(line) for line in event_log.read_text(encoding="utf-8").splitlines()]
+    assert {record["event"] for record in records} >= {"completion_saturation", "resumable"}
+
+    monkeypatch.setattr(
+        seeding_mod,
+        "seed_issue_from_github",
+        lambda issue, _github: IssueFacts(
+            number=issue,
+            title="recover",
+            body="",
+            is_epic=False,
+            labels={"state:needs-plan"},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        ),
+    )
+    monkeypatch.setattr(admission_mod, "_filter_open_issues", lambda _repo, issues: list(issues))
+    recovered = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[71],
+            parallel_repos=1,
+            max_workers=1,
+            dry_run=True,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=["state:needs-plan"]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    recovered.stages[StageName.PLANNING] = _PassStage()
+
+    assert recovered.run() == 0
+    assert any(
+        candidate.issue == 71 and candidate.result and candidate.result.passed
+        for candidate in recovered.items
+    )

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -160,9 +160,7 @@ class TestQuiescence:
         monkeypatch.setattr(server_mod, "MetricsHTTPServer", FakeMetricsServer)
         monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
         coordinator = Coordinator(
-            PipelineConfig(
-                org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path, metrics_port=9123
-            ),
+            PipelineConfig(org="org", repos=[], loops=1, projects_dir=tmp_path, metrics_port=9123),
             github=FakeStageGitHub(),
             pool=FakeWorkerPool(),
             install_signals=False,

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -600,23 +600,33 @@ class TestAdmission:
     def test_global_work_window_defers_second_repo_item(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The global work window caps in-flight jobs across repositories."""
+        """The global work window caps jobs across repositories and stage queues.
+
+        Each source queue has capacity one here.  Put the work in distinct
+        stages so the assertion exercises global worker admission instead of
+        attempting to bypass the first item's capacity-reserving source lease.
+        """
         coordinator, pool, _ = make_coordinator(
             tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=1
         )
-        coordinator.stages[StageName.PLANNING] = StubStage(
+        coordinator.stages[StageName.MERGE_WAIT] = StubStage(
             JobRequest(_agent_job(repo="repo-a", issue=1), on_done_state="V"),
+        )
+        coordinator.stages[StageName.PR_REVIEW] = StubStage(
             JobRequest(_agent_job(repo="repo-b", issue=2), on_done_state="V"),
         )
-        coordinator._push_item(_issue_item(1, repo="repo-a"), StageName.PLANNING, enter=True)
-        coordinator._drain_queues()
-        coordinator._push_item(_issue_item(2, repo="repo-b"), StageName.PLANNING, enter=True)
+        coordinator._push_item(
+            _issue_item(1, repo="repo-a"), StageName.MERGE_WAIT, enter=True
+        )
+        coordinator._push_item(
+            _issue_item(2, repo="repo-b"), StageName.PR_REVIEW, enter=True
+        )
         coordinator._drain_queues()
 
         assert len(pool.submitted) == 1
         assert coordinator.inflight_per_repo["repo-a"] == 1
         assert coordinator.inflight_per_repo["repo-b"] == 0
-        queued_repos = [item.repo for item in coordinator.queues[StageName.PLANNING].snapshot()]
+        queued_repos = [item.repo for item in coordinator.queues[StageName.PR_REVIEW].snapshot()]
         assert queued_repos == ["repo-b"]
 
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -97,6 +97,7 @@ def make_coordinator(
     seed_entries: list[list[SeedEntry]] | None = None,
     loops: int = 1,
     max_workers: int = 1,
+    parallel_repos: int = 1,
     dry_run: bool = False,
     serialize_file_overlap: bool = True,
     github: FakeStageGitHub | None = None,
@@ -108,6 +109,7 @@ def make_coordinator(
         repos=repos if repos is not None else ["repo-a"],
         loops=loops,
         max_workers=max_workers,
+        parallel_repos=parallel_repos,
         dry_run=dry_run,
         serialize_file_overlap=serialize_file_overlap,
         projects_dir=tmp_path,
@@ -302,7 +304,9 @@ class TestQuiescence:
             SeedEntry(kind="issue", identifier=1, stage=StageName.PLANNING, reason="poison"),
             SeedEntry(kind="issue", identifier=2, stage=StageName.PLAN_REVIEW, reason="ok"),
         ]
-        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, seed_entries=[seed])
+        coordinator, _, _ = make_coordinator(
+            tmp_path, monkeypatch, seed_entries=[seed], parallel_repos=2
+        )
 
         class PoisonStage(StubStage):
             def step(self, item: WorkItem, ctx: Any) -> Any:
@@ -577,7 +581,9 @@ class TestAdmission:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """max_workers=1: the second same-repo item is not admitted."""
-        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=1)
+        coordinator, pool, _ = make_coordinator(
+            tmp_path, monkeypatch, max_workers=1, parallel_repos=2
+        )
         coordinator.stages[StageName.PLANNING] = StubStage(
             JobRequest(_agent_job(issue=1), on_done_state="VERIFY"),
             JobRequest(_agent_job(issue=2), on_done_state="VERIFY"),
@@ -591,10 +597,10 @@ class TestAdmission:
         assert coordinator.inflight_per_repo["repo-a"] == 1
         assert len(coordinator.queues[StageName.PLANNING]) == 1
 
-    def test_cap_is_per_repo_not_global(
+    def test_global_work_window_defers_second_repo_item(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Items of different repos are admitted independently."""
+        """The global work window caps in-flight jobs across repositories."""
         coordinator, pool, _ = make_coordinator(
             tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=1
         )
@@ -603,13 +609,15 @@ class TestAdmission:
             JobRequest(_agent_job(repo="repo-b", issue=2), on_done_state="V"),
         )
         coordinator._push_item(_issue_item(1, repo="repo-a"), StageName.PLANNING, enter=True)
+        coordinator._drain_queues()
         coordinator._push_item(_issue_item(2, repo="repo-b"), StageName.PLANNING, enter=True)
-
         coordinator._drain_queues()
 
-        assert len(pool.submitted) == 2
+        assert len(pool.submitted) == 1
         assert coordinator.inflight_per_repo["repo-a"] == 1
-        assert coordinator.inflight_per_repo["repo-b"] == 1
+        assert coordinator.inflight_per_repo["repo-b"] == 0
+        queued_repos = [item.repo for item in coordinator.queues[StageName.PLANNING].snapshot()]
+        assert queued_repos == ["repo-b"]
 
 
 class TestRateBudget:
@@ -932,7 +940,9 @@ class TestImplementationAdmission:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """3+ copies of one issue: first dispatches, ALL later copies terminalize (#2057)."""
-        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path, monkeypatch, max_workers=2, parallel_repos=2
+        )
         ran: list[int] = []
 
         class RecordingStage(StubStage):
@@ -1700,7 +1710,12 @@ class TestPipelineScopeWiring:
         )
 
     def _scoped_config(
-        self, tmp_path: Path, *, issues: list[int], force: bool = False
+        self,
+        tmp_path: Path,
+        *,
+        issues: list[int],
+        force: bool = False,
+        parallel_repos: int = 1,
     ) -> PipelineConfig:
 
         return PipelineConfig(
@@ -1708,6 +1723,7 @@ class TestPipelineScopeWiring:
             repos=["repo-a"],
             issues=issues,
             loops=1,
+            parallel_repos=parallel_repos,
             projects_dir=tmp_path,
             scope=PipelineScope(frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})),
             force=force,
@@ -1790,7 +1806,7 @@ class TestPipelineScopeWiring:
             "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
             fake_filter,
         )
-        config = self._scoped_config(tmp_path, issues=[1, 2, 3])
+        config = self._scoped_config(tmp_path, issues=[1, 2, 3], parallel_repos=2)
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
         assert coordinator._seed_pass() == 2

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -888,10 +888,14 @@ class TestImplementationAdmission:
         implementation = StubStage(StageOutcome(Disposition.ADVANCE, "PR opened"))
         coordinator.stages[StageName.IMPLEMENTATION] = implementation
 
-        blocker = _issue_item(22, StageName.PR_REVIEW)
         item = _issue_item(21, StageName.IMPLEMENTATION)
-        coordinator._push_item(blocker, StageName.PR_REVIEW, enter=True)
         coordinator._push_item(item, StageName.IMPLEMENTATION, enter=True)
+        # The global C=1 invariant prevents ordinary admission of both the
+        # implementation item and a review blocker.  Inject a stale full
+        # destination to exercise the defensive lossless-handoff path: it
+        # must retain the source lease rather than poison a completed action.
+        blocker = _issue_item(22, StageName.PR_REVIEW)
+        coordinator.queues[StageName.PR_REVIEW].push(blocker)
 
         coordinator._drain_implementation()
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -874,6 +874,69 @@ class TestFailBackRouting:
 class TestImplementationAdmission:
     """Topological order + file-overlap reuse for the implementation queue."""
 
+    def test_full_downstream_retains_implementation_lease_until_handoff(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """C=1 keeps a completed implementation item leased when review is full.
+
+        Implementation has its own topological drain, so it must claim through
+        the same lease protocol as every other stage.  Popping the source queue
+        directly drops that ownership: a full PR-review queue then turns an
+        already-completed implementation action into a poisoned terminal item.
+        """
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch)
+        implementation = StubStage(StageOutcome(Disposition.ADVANCE, "PR opened"))
+        coordinator.stages[StageName.IMPLEMENTATION] = implementation
+
+        blocker = _issue_item(22, StageName.PR_REVIEW)
+        item = _issue_item(21, StageName.IMPLEMENTATION)
+        coordinator._push_item(blocker, StageName.PR_REVIEW, enter=True)
+        coordinator._push_item(item, StageName.IMPLEMENTATION, enter=True)
+
+        coordinator._drain_implementation()
+
+        assert implementation.calls == [("enter", 21), ("step", 21)]
+        assert coordinator.queues[StageName.PR_REVIEW].snapshot() == [blocker]
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 0
+        assert coordinator.queues[StageName.IMPLEMENTATION].occupancy == 1
+        assert coordinator._leases[id(item)].item is item
+        assert coordinator._pending_handoffs[id(item)].target is StageName.PR_REVIEW
+        assert item.result is None
+
+        # Re-draining while the destination remains full must not re-run the
+        # completed implementation action.
+        coordinator._drain_implementation()
+        assert implementation.calls == [("enter", 21), ("step", 21)]
+
+        coordinator.queues[StageName.PR_REVIEW].pop()
+        coordinator._drain_pending_handoffs()
+
+        assert coordinator.queues[StageName.PR_REVIEW].snapshot() == [item]
+        assert id(item) not in coordinator._leases
+        assert id(item) not in coordinator._pending_handoffs
+        assert item.stage is StageName.PR_REVIEW
+
+    def test_retry_and_overlap_deferral_preserve_implementation_fifo_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A source retry remains ahead of a later overlap-deferred item."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        coordinator.stages[StageName.IMPLEMENTATION] = StubStage(
+            StageOutcome(Disposition.RETRY, "retry next tick")
+        )
+        retrying = _issue_item(21, StageName.IMPLEMENTATION)
+        deferred = _issue_item(22, StageName.IMPLEMENTATION)
+        coordinator._push_item(retrying, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(deferred, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._select_non_overlapping",
+            lambda issues, repo_of=None: (issues[:1], issues[1:]),
+        )
+
+        coordinator._drain_implementation()
+
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [retrying, deferred]
+
     def test_duplicate_issue_numbers_collapse_to_first_queued(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1275,6 +1338,7 @@ class TestDurableEventLog:
             PipelineConfig(
                 org="org",
                 repos=["repo-a"],
+                max_workers=2,
                 projects_dir=tmp_path,
                 metrics_port=9123,
             ),

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -215,7 +215,11 @@ class TestQuiescence:
     ) -> None:
         """A repo seed's products traverse their entry stages into the ledger."""
         seed = [SeedEntry(kind="repo", identifier="repo-a", stage=StageName.REPO, reason="seed")]
-        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, seed_entries=[seed])
+        # The repo item and its one actionable product are both live until
+        # each reaches the finished sink.
+        coordinator, pool, _ = make_coordinator(
+            tmp_path, monkeypatch, seed_entries=[seed], max_workers=2
+        )
 
         class ProducingRepoStage(StubStage):
             def step(self, item: WorkItem, ctx: Any) -> Any:
@@ -549,7 +553,10 @@ class TestDrainOrder:
 
     def test_downstream_first(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """merge_wait drains before review, planning, and repo."""
-        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        # This test intentionally fills four distinct stages before draining;
+        # the coordinator-wide permit budget must be large enough to admit
+        # that four-item fixture.
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, max_workers=4)
         for stage in (
             StageName.PLANNING,
             StageName.MERGE_WAIT,
@@ -602,9 +609,9 @@ class TestAdmission:
     ) -> None:
         """The global work window caps jobs across repositories and stage queues.
 
-        Each source queue has capacity one here.  Put the work in distinct
-        stages so the assertion exercises global worker admission instead of
-        attempting to bypass the first item's capacity-reserving source lease.
+        With C=1, a second item in a different stage cannot be admitted while
+        the first is in flight. The global permit rejects it before the worker
+        admission check, rather than allowing one item per stage queue.
         """
         coordinator, pool, _ = make_coordinator(
             tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=1
@@ -615,19 +622,20 @@ class TestAdmission:
         coordinator.stages[StageName.PR_REVIEW] = StubStage(
             JobRequest(_agent_job(repo="repo-b", issue=2), on_done_state="V"),
         )
-        coordinator._push_item(
-            _issue_item(1, repo="repo-a"), StageName.MERGE_WAIT, enter=True
+        assert (
+            coordinator._push_item(_issue_item(1, repo="repo-a"), StageName.MERGE_WAIT, enter=True)
+            is True
         )
-        coordinator._push_item(
-            _issue_item(2, repo="repo-b"), StageName.PR_REVIEW, enter=True
+        assert (
+            coordinator._push_item(_issue_item(2, repo="repo-b"), StageName.PR_REVIEW, enter=True)
+            is False
         )
         coordinator._drain_queues()
 
         assert len(pool.submitted) == 1
         assert coordinator.inflight_per_repo["repo-a"] == 1
         assert coordinator.inflight_per_repo["repo-b"] == 0
-        queued_repos = [item.repo for item in coordinator.queues[StageName.PR_REVIEW].snapshot()]
-        assert queued_repos == ["repo-b"]
+        assert coordinator.queues[StageName.PR_REVIEW].snapshot() == []
 
 
 class TestRateBudget:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -269,13 +269,16 @@ class TestInterruptSemantics:
         assert coordinator.shutdown.is_set()
         assert coordinator._grace_deadline is not None
         assert coordinator._immediate is False
-        assert not coordinator.completion_q.empty()
+        assert coordinator._completion_wakeup.is_set()
+        assert coordinator.completion_q.empty()
         coordinator._drain_completions()
         assert coordinator.completion_q.empty()
+        assert not coordinator._completion_wakeup.is_set()
 
         handler(signal_mod.SIGTERM, None)
         assert coordinator._immediate is True
-        assert not coordinator.completion_q.empty()
+        assert coordinator._completion_wakeup.is_set()
+        assert coordinator.completion_q.empty()
 
 
 class TestNormalTeardownExitSemantics:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -149,7 +149,11 @@ def _coordinator(
     install_signals: bool = False,
 ) -> Coordinator:
     config = PipelineConfig(
-        org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path, grace_s=grace_s
+        org="org",
+        repos=["repo-a"] if seed else [],
+        loops=1,
+        projects_dir=tmp_path,
+        grace_s=grace_s,
     )
     monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: list(seed or []))
     coordinator = Coordinator(
@@ -288,7 +292,7 @@ class TestNormalTeardownExitSemantics:
     def _default_pool_coordinator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Coordinator:
         monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
         return Coordinator(
-            PipelineConfig(org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path),
+            PipelineConfig(org="org", repos=[], loops=1, projects_dir=tmp_path),
             github=FakeStageGitHub(),
             install_signals=False,
         )

--- a/tests/unit/automation/pipeline/test_global_live_work_permits.py
+++ b/tests/unit/automation/pipeline/test_global_live_work_permits.py
@@ -1,0 +1,111 @@
+"""Coordinator-wide live-work permit regression coverage (#2399)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import GitJob
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _coordinator(tmp_path: Path) -> Coordinator:
+    """Build a coordinator with a deliberately minimal global capacity."""
+    return Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            parallel_repos=1,
+            max_workers=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+
+
+def _issue(number: int, stage: StageName) -> WorkItem:
+    """Create one distinct live issue item."""
+    return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=number, stage=stage)
+
+
+def _complete_finished_item(coordinator: Coordinator, item: WorkItem) -> None:
+    """Drive a finished item through its terminal coordinator release path."""
+    assert coordinator._claim_item(StageName.FINISHED) is item
+    coordinator._route(item, StageOutcome(Disposition.FINISH_PASS, "recorded"))
+
+
+def test_global_permit_refuses_c_plus_one_across_distinct_stage_queues(tmp_path: Path) -> None:
+    """C=1 applies across stages, not once independently to each stage queue.
+
+    Before the permit pool, the two ``StageQueue(capacity=1)`` instances
+    accepted one item each.  That made two nonterminal WorkItems live even
+    though the configured work window was one.
+    """
+    coordinator = _coordinator(tmp_path)
+    first = _issue(1, StageName.PLANNING)
+    second = _issue(2, StageName.PLAN_REVIEW)
+
+    assert coordinator._push_item(first, StageName.PLANNING, enter=True) is True
+    assert coordinator.live_work_count == 1
+
+    assert coordinator._push_item(second, StageName.PLAN_REVIEW, enter=True) is False
+    assert coordinator.queues[StageName.PLANNING].snapshot() == [first]
+    assert coordinator.queues[StageName.PLAN_REVIEW].snapshot() == []
+    assert coordinator.live_work_count == 1
+    assert id(second) not in coordinator._seen_item_ids
+
+    # Routing to the finished sink retains the permit: cleanup/ledger work is
+    # still nonterminal. Only the sink's terminal outcome makes a slot free.
+    assert coordinator._claim_item(StageName.PLANNING) is first
+    coordinator._finish(first, passed=True, reason="done")
+    assert coordinator.live_work_count == 1
+    _complete_finished_item(coordinator, first)
+    assert coordinator.live_work_count == 0
+
+    assert coordinator._push_item(second, StageName.PLAN_REVIEW, enter=True) is True
+    assert coordinator.live_work_count == 1
+
+
+def test_global_permit_survives_a_lease_and_timer_park(tmp_path: Path) -> None:
+    """A timer-parked item keeps its permit until terminal completion."""
+    coordinator = _coordinator(tmp_path)
+    parked = _issue(1, StageName.PLANNING)
+    later = _issue(2, StageName.PR_REVIEW)
+
+    assert coordinator._push_item(parked, StageName.PLANNING, enter=True) is True
+    assert coordinator._claim_item(StageName.PLANNING) is parked
+    coordinator._timer_park(parked, delay_s=60)
+
+    assert coordinator.queues[StageName.PLANNING].snapshot() == []
+    assert [entry[2] for entry in coordinator.timers] == [parked]
+    assert coordinator.live_work_count == 1
+    assert coordinator._push_item(later, StageName.PR_REVIEW, enter=True) is False
+    assert coordinator.live_work_count == 1
+
+
+def test_global_permit_survives_an_inflight_job(tmp_path: Path) -> None:
+    """An item remains globally live while its completion is outstanding."""
+    coordinator = _coordinator(tmp_path)
+    in_flight = _issue(1, StageName.PLANNING)
+    later = _issue(2, StageName.MERGE_WAIT)
+
+    assert coordinator._push_item(in_flight, StageName.PLANNING, enter=True) is True
+    assert coordinator._claim_item(StageName.PLANNING) is in_flight
+    coordinator._submit(
+        in_flight,
+        JobRequest(
+            GitJob(repo="repo-a", op="push", timeout_s=1),
+            on_done_state="AFTER_JOB",
+        ),
+    )
+
+    assert len(coordinator.in_flight) == 1
+    assert coordinator.live_work_count == 1
+    assert coordinator._push_item(later, StageName.MERGE_WAIT, enter=True) is False
+    assert coordinator.live_work_count == 1

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -114,7 +114,7 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
 
 
 def test_drive_green_all_maps_all_authors_and_bots(dispatch: dict[str, MagicMock]) -> None:
-    """The legacy drive-green-all flag keeps its broad discovery scope."""
+    """The legacy drive-green-all flag preserves its configuration mapping."""
     loop_runner.main(["--drive-green-all", "--dry-run"])
 
     (config,) = dispatch["run_pipeline"].call_args.args

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -43,8 +43,8 @@ class TestStageQueueLeases:
         assert source.occupancy == source.capacity == 2
         assert source.offer(replacement) is False
 
-    def test_restore_returns_claimed_item_without_opening_admission_slot(self) -> None:
-        """Restoring a lease keeps the claimed item and FIFO-ready work lossless."""
+    def test_restore_preserves_claimed_item_and_uses_remaining_capacity(self) -> None:
+        """A lease reserves its item but does not serialize unused capacity."""
         source = StageQueue(capacity=2)
         claimed_item = _item("claimed")
         source.push(claimed_item)
@@ -52,15 +52,15 @@ class TestStageQueueLeases:
         lease = source.claim()
 
         assert lease is not None
-        assert source.offer(_item("must-not-enter-before-restore")) is False
+        later = _item("may-enter-before-restore")
+        assert source.offer(later) is True
         lease.restore()
 
-        assert source.occupancy == 1
-        assert source.snapshot() == [claimed_item]
-        assert source.offer(_item("may-enter-after-restore")) is True
+        assert source.occupancy == 2
+        assert source.snapshot() == [claimed_item, later]
 
-    def test_claim_serializes_held_lease_to_preserve_fifo_order(self) -> None:
-        """A second claim cannot overtake a lease that may restore to the front."""
+    def test_concurrent_claims_restore_in_original_fifo_order(self) -> None:
+        """Multiple active claims retain capacity and restore by original order."""
         source = StageQueue(capacity=3)
         first = _item("first")
         second = _item("second")
@@ -69,14 +69,17 @@ class TestStageQueueLeases:
         source.push(second)
         source.push(third)
 
-        lease = source.claim()
+        first_lease = source.claim()
+        second_lease = source.claim()
 
-        assert lease is not None
-        assert lease.item is first
-        assert source.claim() is None
-        assert source.snapshot() == [second, third]
+        assert first_lease is not None
+        assert second_lease is not None
+        assert first_lease.item is first
+        assert second_lease.item is second
+        assert source.snapshot() == [third]
 
-        lease.restore()
+        second_lease.restore()
+        first_lease.restore()
 
         assert source.snapshot() == [first, second, third]
 
@@ -94,8 +97,11 @@ class TestStageQueueLeases:
         assert lease is not None
         assert lease.item is selected
         assert source.snapshot() == [first, third]
-        assert source.claim() is None
+        first_lease = source.claim()
+        assert first_lease is not None
+        assert first_lease.item is first
 
+        first_lease.restore()
         lease.restore()
 
         assert source.snapshot() == [first, selected, third]

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -1,0 +1,108 @@
+"""RED contract tests for lossless, bounded ``StageQueue`` handoffs.
+
+The lease API specified here is intentionally small and public:
+
+* ``StageQueue.claim()`` returns a lease for the FIFO-ready item, or ``None``
+  when the queue has no ready work.
+* A claimed item remains part of the source queue's ``occupancy`` while its
+  lease is outstanding, so it cannot create an admission slot by itself.
+* ``lease.restore()`` puts the item back at the front of its source queue.
+* ``lease.handoff(destination)`` atomically reserves the destination and then
+  releases the source reservation.  It returns ``False`` without losing the
+  source item when the destination is full; callers can retry that same lease.
+
+The production queue currently exposes only push/offer/pop.  These tests are
+deliberately RED until the bounded lease protocol is implemented.
+"""
+
+from hephaestus.automation.pipeline import ItemKind, StageQueue, WorkItem
+
+
+def _item(name: str) -> WorkItem:
+    """Create a distinct valid pipeline item for queue identity assertions."""
+    return WorkItem(repo=name, kind=ItemKind.REPO)
+
+
+class TestStageQueueLeases:
+    """Lossless handoff behavior for a bounded source and destination queue."""
+
+    def test_claim_reserves_capacity_and_blocks_new_source_offer(self) -> None:
+        """Claiming ready work keeps a full source occupied until it is released."""
+        source = StageQueue(capacity=2)
+        claimed_item = _item("claimed")
+        still_ready = _item("still-ready")
+        replacement = _item("replacement")
+        source.push(claimed_item)
+        source.push(still_ready)
+
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.item is claimed_item
+        assert source.snapshot() == [still_ready]
+        assert source.occupancy == source.capacity == 2
+        assert source.offer(replacement) is False
+
+    def test_restore_returns_claimed_item_without_opening_admission_slot(self) -> None:
+        """Restoring a lease keeps the claimed item and FIFO-ready work lossless."""
+        source = StageQueue(capacity=2)
+        claimed_item = _item("claimed")
+        source.push(claimed_item)
+
+        lease = source.claim()
+
+        assert lease is not None
+        assert source.offer(_item("must-not-enter-before-restore")) is False
+        lease.restore()
+
+        assert source.occupancy == 1
+        assert source.snapshot() == [claimed_item]
+        assert source.offer(_item("may-enter-after-restore")) is True
+
+    def test_successful_handoff_releases_source_and_enqueues_item_once(self) -> None:
+        """A successful handoff frees only the source reservation it transfers."""
+        source = StageQueue(capacity=1)
+        destination = StageQueue(capacity=1)
+        item = _item("handoff")
+        replacement = _item("replacement")
+        source.push(item)
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.handoff(destination) is True
+
+        assert source.occupancy == 0
+        assert source.offer(replacement) is True
+        assert destination.occupancy == 1
+        assert destination.snapshot() == [item]
+        assert destination.pop() is item
+        assert destination.occupancy == 0
+
+    def test_full_destination_retains_source_lease_for_later_handoff(self) -> None:
+        """A failed handoff neither drops nor spills work, and can be retried."""
+        source = StageQueue(capacity=1)
+        destination = StageQueue(capacity=1)
+        item = _item("source-item")
+        destination_item = _item("destination-item")
+        source.push(item)
+        destination.push(destination_item)
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.handoff(destination) is False
+        assert source.occupancy == source.capacity == 1
+        assert source.offer(_item("must-not-enter-while-leased")) is False
+        assert destination.snapshot() == [destination_item]
+
+        assert destination.pop() is destination_item
+        assert lease.handoff(destination) is True
+        assert source.occupancy == 0
+        assert destination.snapshot() == [item]
+        assert destination.pop() is item
+        assert destination.occupancy == 0
+
+    def test_empty_claim_is_explicit(self) -> None:
+        """An empty source queue reports no lease instead of raising or inventing work."""
+        source = StageQueue(capacity=1)
+
+        assert source.claim() is None

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -41,7 +41,8 @@ class TestStageQueueLeases:
         assert lease.item is claimed_item
         assert source.snapshot() == [still_ready]
         assert source.occupancy == source.capacity == 2
-        assert source.offer(replacement) is False
+        replacement_offered = source.offer(replacement)
+        assert replacement_offered is False
 
     def test_restore_preserves_claimed_item_and_uses_remaining_capacity(self) -> None:
         """A lease reserves its item but does not serialize unused capacity."""
@@ -53,7 +54,8 @@ class TestStageQueueLeases:
 
         assert lease is not None
         later = _item("may-enter-before-restore")
-        assert source.offer(later) is True
+        later_offered = source.offer(later)
+        assert later_offered is True
         lease.restore()
 
         assert source.occupancy == 2
@@ -132,13 +134,16 @@ class TestStageQueueLeases:
         lease = source.claim()
 
         assert lease is not None
-        assert lease.handoff(destination) is True
+        handoff_succeeded = lease.handoff(destination)
+        assert handoff_succeeded is True
 
         assert source.occupancy == 0
-        assert source.offer(replacement) is True
+        replacement_offered = source.offer(replacement)
+        assert replacement_offered is True
         assert destination.occupancy == 1
         assert destination.snapshot() == [item]
-        assert destination.pop() is item
+        popped_item = destination.pop()
+        assert popped_item is item
         assert destination.occupancy == 0
 
     def test_full_destination_retains_source_lease_for_later_handoff(self) -> None:
@@ -152,20 +157,26 @@ class TestStageQueueLeases:
         lease = source.claim()
 
         assert lease is not None
-        assert lease.handoff(destination) is False
+        handoff_succeeded = lease.handoff(destination)
+        assert handoff_succeeded is False
         assert source.occupancy == source.capacity == 1
-        assert source.offer(_item("must-not-enter-while-leased")) is False
+        rejected_offer = source.offer(_item("must-not-enter-while-leased"))
+        assert rejected_offer is False
         assert destination.snapshot() == [destination_item]
 
-        assert destination.pop() is destination_item
-        assert lease.handoff(destination) is True
+        popped_destination_item = destination.pop()
+        assert popped_destination_item is destination_item
+        handoff_succeeded = lease.handoff(destination)
+        assert handoff_succeeded is True
         assert source.occupancy == 0
         assert destination.snapshot() == [item]
-        assert destination.pop() is item
+        popped_item = destination.pop()
+        assert popped_item is item
         assert destination.occupancy == 0
 
     def test_empty_claim_is_explicit(self) -> None:
         """An empty source queue reports no lease instead of raising or inventing work."""
         source = StageQueue(capacity=1)
 
-        assert source.claim() is None
+        lease = source.claim()
+        assert lease is None

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -59,6 +59,27 @@ class TestStageQueueLeases:
         assert source.snapshot() == [claimed_item]
         assert source.offer(_item("may-enter-after-restore")) is True
 
+    def test_claim_serializes_held_lease_to_preserve_fifo_order(self) -> None:
+        """A second claim cannot overtake a lease that may restore to the front."""
+        source = StageQueue(capacity=3)
+        first = _item("first")
+        second = _item("second")
+        third = _item("third")
+        source.push(first)
+        source.push(second)
+        source.push(third)
+
+        lease = source.claim()
+
+        assert lease is not None
+        assert lease.item is first
+        assert source.claim() is None
+        assert source.snapshot() == [second, third]
+
+        lease.restore()
+
+        assert source.snapshot() == [first, second, third]
+
     def test_successful_handoff_releases_source_and_enqueues_item_once(self) -> None:
         """A successful handoff frees only the source reservation it transfers."""
         source = StageQueue(capacity=1)

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -80,6 +80,42 @@ class TestStageQueueLeases:
 
         assert source.snapshot() == [first, second, third]
 
+    def test_selected_claim_restores_the_original_queue_position(self) -> None:
+        """Topo scheduling may lease a non-head item without reordering a retry."""
+        source = StageQueue(capacity=3)
+        first = _item("first")
+        selected = _item("selected")
+        third = _item("third")
+        for item in (first, selected, third):
+            source.push(item)
+
+        lease = source.claim_at(1)
+
+        assert lease is not None
+        assert lease.item is selected
+        assert source.snapshot() == [first, third]
+        assert source.claim() is None
+
+        lease.restore()
+
+        assert source.snapshot() == [first, selected, third]
+
+    def test_selected_claim_release_does_not_remove_the_queue_head(self) -> None:
+        """A timer can take selected work without accidentally popping a peer."""
+        source = StageQueue(capacity=2)
+        first = _item("first")
+        selected = _item("selected")
+        source.push(first)
+        source.push(selected)
+
+        lease = source.claim_at(1)
+
+        assert lease is not None
+        lease.release()
+
+        assert source.snapshot() == [first]
+        assert source.occupancy == 1
+
     def test_successful_handoff_releases_source_and_enqueues_item_once(self) -> None:
         """A successful handoff frees only the source reservation it transfers."""
         source = StageQueue(capacity=1)

--- a/tests/unit/automation/pipeline/test_queues.py
+++ b/tests/unit/automation/pipeline/test_queues.py
@@ -97,11 +97,14 @@ class TestStageQueue:
         second = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=2)
         overflow = WorkItem(repo="repo3", kind=ItemKind.PR, pr=3)
 
-        assert q.offer(first) is True
-        assert q.offer(second) is True
+        first_offered = q.offer(first)
+        second_offered = q.offer(second)
+        assert first_offered is True
+        assert second_offered is True
         assert q.occupancy == 2
 
-        assert q.offer(overflow) is False
+        overflow_offered = q.offer(overflow)
+        assert overflow_offered is False
         assert q.occupancy == 2
         assert q.snapshot() == [first, second]
 
@@ -113,13 +116,19 @@ class TestStageQueue:
         rejected = WorkItem(repo="repo3", kind=ItemKind.PR, pr=3)
         admitted_later = WorkItem(repo="repo4", kind=ItemKind.REPO)
 
-        assert q.offer(first) is True
-        assert q.offer(second) is True
-        assert q.offer(rejected) is False
-        assert q.pop() == first
+        first_offered = q.offer(first)
+        second_offered = q.offer(second)
+        rejected_offered = q.offer(rejected)
+        assert first_offered is True
+        assert second_offered is True
+        assert rejected_offered is False
+        popped_first = q.pop()
+        assert popped_first == first
 
-        assert q.offer(admitted_later) is True
-        assert [q.pop(), q.pop()] == [second, admitted_later]
+        later_offered = q.offer(admitted_later)
+        assert later_offered is True
+        popped_items = [q.pop(), q.pop()]
+        assert popped_items == [second, admitted_later]
 
 
 class TestCompletionQueue:

--- a/tests/unit/automation/pipeline/test_queues.py
+++ b/tests/unit/automation/pipeline/test_queues.py
@@ -16,13 +16,21 @@ class TestStageQueue:
     """Tests for StageQueue (FIFO, not thread-safe)."""
 
     def test_stage_queue_creation(self) -> None:
-        """Create an empty StageQueue."""
-        q = StageQueue()
+        """Create an empty StageQueue with observable bounds."""
+        q = StageQueue(capacity=3)
         assert len(q) == 0
+        assert q.capacity == 3
+        assert q.occupancy == 0
+
+    @pytest.mark.parametrize("capacity", (0, -1))
+    def test_stage_queue_rejects_non_positive_capacity(self, capacity: int) -> None:
+        """A stage queue must have a positive, explicit capacity."""
+        with pytest.raises(ValueError, match="capacity"):
+            StageQueue(capacity=capacity)
 
     def test_stage_queue_push_pop(self) -> None:
         """Push and pop items in FIFO order."""
-        q = StageQueue()
+        q = StageQueue(capacity=3)
         item1 = WorkItem(repo="repo1", kind=ItemKind.REPO)
         item2 = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=1)
 
@@ -38,13 +46,13 @@ class TestStageQueue:
 
     def test_stage_queue_pop_empty_raises(self) -> None:
         """Popping from empty queue raises IndexError."""
-        q = StageQueue()
+        q = StageQueue(capacity=1)
         with pytest.raises(IndexError):
             q.pop()
 
     def test_stage_queue_snapshot(self) -> None:
         """snapshot() returns a list copy of all items."""
-        q = StageQueue()
+        q = StageQueue(capacity=3)
         item1 = WorkItem(repo="repo1", kind=ItemKind.REPO)
         item2 = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=1)
         item3 = WorkItem(repo="repo3", kind=ItemKind.PR, pr=2)
@@ -59,7 +67,7 @@ class TestStageQueue:
 
     def test_stage_queue_snapshot_returns_copy(self) -> None:
         """Mutating snapshot() does not affect the queue."""
-        q = StageQueue()
+        q = StageQueue(capacity=1)
         item = WorkItem(repo="repo", kind=ItemKind.REPO)
         q.push(item)
 
@@ -71,7 +79,7 @@ class TestStageQueue:
 
     def test_stage_queue_len_tracking(self) -> None:
         """len() tracks the queue size accurately."""
-        q = StageQueue()
+        q = StageQueue(capacity=5)
         assert len(q) == 0
 
         for i in range(5):
@@ -81,6 +89,37 @@ class TestStageQueue:
         for i in range(5, 0, -1):
             q.pop()
             assert len(q) == i - 1
+
+    def test_stage_queue_refuses_offer_above_capacity_without_mutation(self) -> None:
+        """A full queue refuses another item without evicting accepted work."""
+        q = StageQueue(capacity=2)
+        first = WorkItem(repo="repo1", kind=ItemKind.REPO)
+        second = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=2)
+        overflow = WorkItem(repo="repo3", kind=ItemKind.PR, pr=3)
+
+        assert q.offer(first) is True
+        assert q.offer(second) is True
+        assert q.occupancy == 2
+
+        assert q.offer(overflow) is False
+        assert q.occupancy == 2
+        assert q.snapshot() == [first, second]
+
+    def test_stage_queue_retains_fifo_after_temporary_full_condition(self) -> None:
+        """A rejected offer does not reorder later admitted work."""
+        q = StageQueue(capacity=2)
+        first = WorkItem(repo="repo1", kind=ItemKind.REPO)
+        second = WorkItem(repo="repo2", kind=ItemKind.ISSUE, issue=2)
+        rejected = WorkItem(repo="repo3", kind=ItemKind.PR, pr=3)
+        admitted_later = WorkItem(repo="repo4", kind=ItemKind.REPO)
+
+        assert q.offer(first) is True
+        assert q.offer(second) is True
+        assert q.offer(rejected) is False
+        assert q.pop() == first
+
+        assert q.offer(admitted_later) is True
+        assert [q.pop(), q.pop()] == [second, admitted_later]
 
 
 class TestCompletionQueue:

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -77,10 +77,16 @@ class TestTimerHeap:
             pool=FakeWorkerPool(),
             install_signals=False,
         )
-        blocker = _item(2)
         waiting = _item(1)
-        coordinator._push_item(blocker, StageName.PR_REVIEW, enter=True)
+        # Park a genuinely admitted item so it owns the sole global permit.
+        # Inject the blocker directly to model a stale/corrupt full stage:
+        # normal permit accounting cannot create a second live item at C=1,
+        # but timer re-entry must still retain ownership instead of losing it.
+        coordinator._push_item(waiting, StageName.PR_REVIEW, enter=True)
+        assert coordinator._claim_item(StageName.PR_REVIEW) is waiting
         coordinator._timer_park(waiting, 0.0)
+        blocker = _item(2)
+        coordinator.queues[StageName.PR_REVIEW].push(blocker)
 
         coordinator._wake_timers()
 

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -46,7 +46,7 @@ def clocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Coordinato
         SimpleNamespace(monotonic=clock.monotonic, time=lambda: clock.now),
     )
     monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
-    config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+    config = PipelineConfig(org="org", repos=["repo-a"], parallel_repos=3, projects_dir=tmp_path)
     coordinator = Coordinator(
         config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
     )

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -60,6 +60,40 @@ def _item(issue: int, stage: StageName = StageName.PR_REVIEW) -> WorkItem:
 class TestTimerHeap:
     """Ordering, seq tie-break, and expiry-only waking."""
 
+    def test_expired_timer_keeps_ownership_until_full_stage_accepts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """C=1 does not drop an expired timer when its source stage is full."""
+        clock = FakeClock()
+        monkeypatch.setattr(
+            coordinator_mod,
+            "time",
+            SimpleNamespace(monotonic=clock.monotonic, time=lambda: clock.now),
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        blocker = _item(2)
+        waiting = _item(1)
+        coordinator._push_item(blocker, StageName.PR_REVIEW, enter=True)
+        coordinator._timer_park(waiting, 0.0)
+
+        coordinator._wake_timers()
+
+        # The timer remains its owner; no overflow, loss, or duplicate occurs.
+        assert [entry[2] for entry in coordinator.timers] == [waiting]
+        assert coordinator.queues[StageName.PR_REVIEW].snapshot() == [blocker]
+
+        coordinator.queues[StageName.PR_REVIEW].pop()
+        coordinator._wake_timers()
+
+        assert coordinator.timers == []
+        assert coordinator.queues[StageName.PR_REVIEW].snapshot() == [waiting]
+
     def test_earliest_timer_wakes_first(self, clocked: tuple[Coordinator, FakeClock]) -> None:
         """Wake order follows wake_ts, not insertion order."""
         coordinator, clock = clocked

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -112,6 +112,77 @@ def test_shutdown_can_reap_without_marking_interrupted(
 class TestWorkerPoolSubmitComplete:
     """Tests for basic submit/complete workflow."""
 
+    def test_completion_callback_notifies_after_delivering_one_result(
+        self,
+        shutdown_event: threading.Event,
+        tmp_path: Path,
+    ) -> None:
+        """A completed future delivers one result and wakes its coordinator."""
+        completion_q: CompletionQueue = queue.Queue(maxsize=1)
+        pool = WorkerPool(
+            size=1,
+            shutdown=shutdown_event,
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
+        wakeup = threading.Event()
+        saturation = threading.Event()
+        pool.set_completion_notifiers(wakeup=wakeup, saturation=saturation)
+        future: Future[JobResult] = Future()
+        result = JobResult(ok=True, value="done")
+        future.set_result(result)
+        handle = JobHandle(job=_agent_job(), on_done_state=StageName.PLANNING)
+
+        try:
+            pool._on_future_done(handle, future)
+            delivered_handle, delivered_result = completion_q.get_nowait()
+        finally:
+            pool.shutdown(mark_interrupted=False)
+
+        assert delivered_handle is handle
+        assert delivered_result is result
+        assert wakeup.is_set()
+        assert not saturation.is_set()
+
+    def test_full_completion_queue_reports_saturation_without_blocking_callback(
+        self,
+        shutdown_event: threading.Event,
+        tmp_path: Path,
+    ) -> None:
+        """An impossible completion overflow faults the run rather than deadlocking a worker."""
+        completion_q: CompletionQueue = queue.Queue(maxsize=1)
+        occupied = (object(), JobResult(ok=True, value="already queued"))
+        completion_q.put_nowait(occupied)
+        pool = WorkerPool(
+            size=1,
+            shutdown=shutdown_event,
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
+        wakeup = threading.Event()
+        saturation = threading.Event()
+        pool.set_completion_notifiers(wakeup=wakeup, saturation=saturation)
+        future: Future[JobResult] = Future()
+        future.set_result(JobResult(ok=True, value="would overflow"))
+        handle = JobHandle(job=_agent_job(), on_done_state=StageName.PLANNING)
+        callback = threading.Thread(target=pool._on_future_done, args=(handle, future))
+
+        try:
+            callback.start()
+            callback.join(timeout=1)
+            still_queued = completion_q.get_nowait()
+        finally:
+            if callback.is_alive():
+                completion_q.get_nowait()
+                callback.join(timeout=1)
+            pool.shutdown(mark_interrupted=False)
+
+        assert not callback.is_alive()
+        assert still_queued is occupied
+        assert saturation.is_set()
+        assert wakeup.is_set()
+        assert not shutdown_event.is_set()
+
     def test_submit_agent_job_propagates_prompt_dir_override_to_worker_thread(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
@@ -44,7 +44,7 @@ VERSION_HELP = "show program's version number and exit"
 
 @dataclass(frozen=True)
 class ActionSpec:
-    """Stable subset of argparse action configuration relevant to CLI parity."""
+    """Stable executable argparse action configuration relevant to CLI parity."""
 
     option_strings: tuple[str, ...]
     dest: str
@@ -53,7 +53,10 @@ class ActionSpec:
     required: bool
     nargs: Any
     choices: tuple[Any, ...] | None
-    help: str | None
+    # Help prose is deliberately excluded from equality. It is operator-facing
+    # documentation, not a parser behavior contract; pinning wording here
+    # makes harmless documentation edits fail the executable test suite.
+    help: str | None = field(compare=False)
 
 
 def _action_spec(

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -398,8 +398,8 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             nargs="+",
             help_text=(
                 "Scope to these issue numbers' PRs. Requires at least one issue number when given. "
-                "Omit the flag entirely to drive every open PR discovered via gh "
-                "(issue-linked PRs plus bot-authored PRs)."
+                "Omit the flag to use bounded linked-issue discovery; unrelated open PRs are not "
+                "enumerated."
             ),
         ),
         _action_spec(
@@ -430,17 +430,16 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             True,
             nargs=0,
             help_text=(
-                "Exclude open bot-authored PRs (Dependabot, github-actions, etc.) from "
-                "the no-scope discovery sweep. Bot-authored PRs are included by default "
-                "so they are not architecturally invisible (#848)."
+                "Compatibility option retained for the retired open-PR sweep. No-scope discovery "
+                "is linked-issue based, so unrelated bot PRs remain out of scope; use --prs to "
+                "select a PR explicitly."
             ),
         ),
         _store_true(
             "--all",
             "include_all_authors",
-            "Include PRs opened by other actors (teammates and bots). Without this flag, "
-            "no-scope discovery drives only PRs authored by the authenticated viewer "
-            "(`gh api user`) (#821). Explicit --issues and --prs scopes are processed "
+            "Compatibility option retained for the retired author-filtered open-PR sweep. It does "
+            "not widen linked-issue discovery; explicit --issues and --prs scopes are processed "
             "regardless of author.",
         ),
         _timeout_spec(
@@ -647,9 +646,9 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
         _store_true(
             "--drive-green-all",
             "drive_green_all",
-            "Pass --all to the drive-green phase: drive every open PR, including those "
-            "opened by teammates and bots. By default drive-green operates only on PRs "
-            "authored by the authenticated viewer (#821).",
+            "Compatibility option for the retired broad drive-green sweep. Repository discovery "
+            "remains linked-issue based and never scans unrelated open PRs; use --prs for an "
+            "explicit PR scope.",
         ),
         _store_true(
             "--run-pre-pr-tests",

--- a/tests/unit/automation/test_ci_driver_main.py
+++ b/tests/unit/automation/test_ci_driver_main.py
@@ -100,7 +100,7 @@ def test_main_prs_scope_disables_drive_green_all() -> None:
 
 
 def test_main_discovery_mode_enables_drive_green_all() -> None:
-    """No --issues/--prs enables the coordinator's repo-wide PR sweep."""
+    """No --issues/--prs retains the linked-issue discovery compatibility flag."""
     captured = _run_main_capturing_config(["--dry-run"])
 
     config = captured["config"]
@@ -126,7 +126,7 @@ def test_main_discovery_mode_enables_drive_green_all() -> None:
 def test_main_threads_drive_green_filter_flags(
     argv: list[str], include_bot_prs: bool, include_all_authors: bool
 ) -> None:
-    """CLI discovery flags reach the pipeline configuration unchanged."""
+    """CLI compatibility fields reach the pipeline configuration unchanged."""
     config = _run_main_capturing_config(argv)["config"]
 
     assert config.include_bot_prs is include_bot_prs

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -92,31 +92,53 @@ class TestListOpenPrMeta:
 class TestListOpenIssueMeta:
     """Tests for uncapped open-issue metadata discovery."""
 
-    def test_flattens_all_paginated_issue_pages_beyond_five_hundred(self) -> None:
-        """All-open mode must not silently truncate a repository at 500 issues."""
+    def test_yields_page_at_a_time_without_paginate_or_slurp(self) -> None:
+        """The cursor pulls the next page only after the current page is consumed."""
         pages = [
             [
                 {"number": number, "labels": [{"name": "bug"}], "title": f"Issue {number}"}
-                for number in range(1, 501)
+                for number in range(1, 101)
             ],
-            [{"number": 501, "labels": [], "title": "Issue 501"}],
+            [{"number": 101, "labels": [], "title": "Issue 101"}],
         ]
         with patch(
             "hephaestus.automation.loop_repo_manager.gh_call",
-            return_value=MagicMock(stdout=json.dumps(pages)),
+            side_effect=[MagicMock(stdout=json.dumps(page)) for page in pages],
         ) as mock_gh:
-            result = loop_repo_manager._list_open_issue_meta("acme", "widget")
+            result = loop_repo_manager._iter_open_issue_meta("acme", "widget")
+            first = [next(result) for _ in range(100)]
+            assert mock_gh.call_count == 1
+            tail = list(result)
 
-        assert [entry["number"] for entry in result] == list(range(1, 502))
-        assert result[0] == {"number": 1, "labels": ["bug"], "title": "Issue 1"}
-        assert result[-1] == {"number": 501, "labels": [], "title": "Issue 501"}
-        assert mock_gh.call_args.args[0] == [
+        assert [entry["number"] for entry in first + tail] == list(range(1, 102))
+        assert first[0] == {"number": 1, "labels": ["bug"], "title": "Issue 1"}
+        assert tail[-1] == {"number": 101, "labels": [], "title": "Issue 101"}
+        assert mock_gh.call_args_list[0].args[0] == [
             "api",
-            "/repos/acme/widget/issues?state=open&per_page=100",
-            "--paginate",
-            "--slurp",
+            "/repos/acme/widget/issues?state=open&per_page=100&sort=created&direction=asc&page=1",
         ]
-        assert mock_gh.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+        assert mock_gh.call_args_list[1].args[0] == [
+            "api",
+            "/repos/acme/widget/issues?state=open&per_page=100&sort=created&direction=asc&page=2",
+        ]
+        assert all(call.kwargs["timeout"] == NETWORK_TIMEOUT for call in mock_gh.call_args_list)
+
+    @pytest.mark.parametrize(
+        "page",
+        [
+            {"not": "a list"},
+            [{"number": "not-an-int", "labels": [], "title": "broken"}],
+            [{"number": 1, "labels": ["not-an-object"], "title": "broken"}],
+        ],
+    )
+    def test_fails_closed_on_malformed_page(self, page: object) -> None:
+        """A malformed page cannot masquerade as an empty repository."""
+        with patch(
+            "hephaestus.automation.loop_repo_manager.gh_call",
+            return_value=MagicMock(stdout=json.dumps(page)),
+        ):
+            with pytest.raises(RuntimeError, match="failed to list open issues"):
+                list(loop_repo_manager._iter_open_issue_meta("acme", "widget"))
 
 
 class TestDetectCwdRepo:
@@ -421,7 +443,7 @@ class TestListOpenIssueNumbersEpicTagging:
             {"number": 82, "title": "Fix bug", "labels": ["bug"]},
         ]
         with (
-            patch.object(loop_repo_manager, "_list_open_issue_meta", return_value=meta),
+            patch.object(loop_repo_manager, "_list_open_issue_meta", return_value=iter(meta)),
             patch.object(loop_repo_manager, "skip_epics") as mock_skip,
         ):
             kept = loop_repo_manager._list_open_issue_numbers("MyOrg", "Proteus")
@@ -431,7 +453,7 @@ class TestListOpenIssueNumbersEpicTagging:
     def test_no_epics_means_no_label_write(self) -> None:
         meta = [{"number": 82, "title": "Fix bug", "labels": ["bug"]}]
         with (
-            patch.object(loop_repo_manager, "_list_open_issue_meta", return_value=meta),
+            patch.object(loop_repo_manager, "_list_open_issue_meta", return_value=iter(meta)),
             patch.object(loop_repo_manager, "skip_epics") as mock_skip,
         ):
             kept = loop_repo_manager._list_open_issue_numbers("MyOrg", "Proteus")

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -28,6 +28,49 @@ from hephaestus.automation.loop_repo_manager import (
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 
+class TestOrgRepoSource:
+    """Bounded organization-repository source contracts."""
+
+    def test_pages_are_fetched_only_when_the_prior_page_is_consumed(self) -> None:
+        first_page = [
+            {"name": f"repo-{number:03d}", "fork": False, "archived": False}
+            for number in range(100)
+        ]
+        second_page = [{"name": "repo-100", "fork": False, "archived": False}]
+        with patch(
+            "hephaestus.automation.loop_repo_manager.gh_call",
+            side_effect=[
+                MagicMock(stdout=json.dumps(first_page)),
+                MagicMock(stdout=json.dumps(second_page)),
+            ],
+        ) as mock_gh:
+            source = loop_repo_manager._iter_gh_repos("acme")
+            first = [next(source) for _ in range(100)]
+            assert mock_gh.call_count == 1
+            tail = list(source)
+
+        assert first + tail == [f"repo-{number:03d}" for number in range(100)] + ["repo-100"]
+        assert mock_gh.call_args_list[1].args[0][-1].endswith("page=2")
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"name": "missing-flags"},
+            {"name": "not-a-bool", "fork": "false", "archived": False},
+            {"name": "not-a-bool", "fork": False, "archived": 0},
+        ],
+    )
+    def test_rejects_malformed_rest_repository_flags(self, entry: dict[str, object]) -> None:
+        with (
+            patch(
+                "hephaestus.automation.loop_repo_manager.gh_call",
+                return_value=MagicMock(stdout=json.dumps([entry])),
+            ),
+            pytest.raises(RuntimeError, match="malformed flags"),
+        ):
+            list(loop_repo_manager._iter_gh_repos("acme"))
+
+
 class TestListOpenPrMeta:
     """Tests for open pull-request metadata discovery."""
 

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -89,6 +89,36 @@ class TestListOpenPrMeta:
             loop_repo_manager._list_open_pr_meta("acme", "widget")
 
 
+class TestListOpenIssueMeta:
+    """Tests for uncapped open-issue metadata discovery."""
+
+    def test_flattens_all_paginated_issue_pages_beyond_five_hundred(self) -> None:
+        """All-open mode must not silently truncate a repository at 500 issues."""
+        pages = [
+            [
+                {"number": number, "labels": [{"name": "bug"}], "title": f"Issue {number}"}
+                for number in range(1, 501)
+            ],
+            [{"number": 501, "labels": [], "title": "Issue 501"}],
+        ]
+        with patch(
+            "hephaestus.automation.loop_repo_manager.gh_call",
+            return_value=MagicMock(stdout=json.dumps(pages)),
+        ) as mock_gh:
+            result = loop_repo_manager._list_open_issue_meta("acme", "widget")
+
+        assert [entry["number"] for entry in result] == list(range(1, 502))
+        assert result[0] == {"number": 1, "labels": ["bug"], "title": "Issue 1"}
+        assert result[-1] == {"number": 501, "labels": [], "title": "Issue 501"}
+        assert mock_gh.call_args.args[0] == [
+            "api",
+            "/repos/acme/widget/issues?state=open&per_page=100",
+            "--paginate",
+            "--slurp",
+        ]
+        assert mock_gh.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+
+
 class TestDetectCwdRepo:
     """Tests for _detect_cwd_repo URL parsing logic."""
 

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -31,14 +31,15 @@ from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 class TestListOpenPrMeta:
     """Tests for open pull-request metadata discovery."""
 
-    def test_returns_sorted_author_metadata_from_paginated_rows(self) -> None:
-        pages = [
-            [{"number": 9, "user": {"login": "depbot", "type": "Bot"}}],
-            [{"number": 3, "user": {"login": "alice", "type": "User"}}],
+    def test_returns_sorted_author_metadata_from_compatibility_wrapper(self) -> None:
+        """The legacy list wrapper preserves its sorted materialized contract."""
+        page = [
+            {"number": 9, "user": {"login": "depbot", "type": "Bot"}},
+            {"number": 3, "user": {"login": "alice", "type": "User"}},
         ]
         with patch(
             "hephaestus.automation.loop_repo_manager.gh_call",
-            return_value=MagicMock(stdout=json.dumps(pages)),
+            return_value=MagicMock(stdout=json.dumps(page)),
         ) as mock_gh:
             result = loop_repo_manager._list_open_pr_meta("acme", "widget")
 
@@ -58,17 +59,15 @@ class TestListOpenPrMeta:
         ]
         assert mock_gh.call_args.args[0] == [
             "api",
-            "/repos/acme/widget/pulls?state=open&per_page=100",
-            "--paginate",
-            "--slurp",
+            "/repos/acme/widget/pulls?state=open&per_page=100&sort=created&direction=asc&page=1",
         ]
         assert mock_gh.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
 
     def test_normalizes_malformed_user_metadata(self) -> None:
-        pages = [[{"number": 7, "user": "unexpected"}, {"number": 8, "user": None}]]
+        page = [{"number": 7, "user": "unexpected"}, {"number": 8, "user": None}]
         with patch(
             "hephaestus.automation.loop_repo_manager.gh_call",
-            return_value=MagicMock(stdout=json.dumps(pages)),
+            return_value=MagicMock(stdout=json.dumps(page)),
         ):
             result = loop_repo_manager._list_open_pr_meta("acme", "widget")
 
@@ -87,6 +86,35 @@ class TestListOpenPrMeta:
             pytest.raises(RuntimeError, match="failed to list open PRs"),
         ):
             loop_repo_manager._list_open_pr_meta("acme", "widget")
+
+    def test_iterator_reads_following_page_only_after_consuming_first(self) -> None:
+        """Runtime PR discovery never asks gh to prefetch/slurp all pages."""
+        pages = [
+            [
+                {"number": number, "user": {"login": "alice", "type": "User"}}
+                for number in range(1, 101)
+            ],
+            [{"number": 101, "user": {"login": "bob", "type": "User"}}],
+        ]
+        with patch(
+            "hephaestus.automation.loop_repo_manager.gh_call",
+            side_effect=[MagicMock(stdout=json.dumps(page)) for page in pages],
+        ) as mock_gh:
+            result = loop_repo_manager._iter_open_pr_meta("acme", "widget")
+            first = [next(result) for _ in range(100)]
+            assert mock_gh.call_count == 1
+            tail = list(result)
+
+        assert [entry["number"] for entry in first + tail] == list(range(1, 102))
+        assert mock_gh.call_args_list[0].args[0] == [
+            "api",
+            "/repos/acme/widget/pulls?state=open&per_page=100&sort=created&direction=asc&page=1",
+        ]
+        assert mock_gh.call_args_list[1].args[0] == [
+            "api",
+            "/repos/acme/widget/pulls?state=open&per_page=100&sort=created&direction=asc&page=2",
+        ]
+        assert all(call.kwargs["timeout"] == NETWORK_TIMEOUT for call in mock_gh.call_args_list)
 
 
 class TestListOpenIssueMeta:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -10,6 +10,7 @@ seams that remain here.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -229,8 +230,9 @@ def test_gh_list_repos_filters_forks_and_archived() -> None:
     # Odysseus is included — no name-based filtering (issue #814).
     assert sorted(names) == ["Odysseus", "keep"]
     invoked_argv = mock_gh_call.call_args[0][0]
-    assert "--no-archived" in invoked_argv
-    assert "name,isArchived,isFork" in invoked_argv
+    assert invoked_argv[0] == "api"
+    assert "per_page=100" in invoked_argv[1]
+    assert "type=all" in invoked_argv[1]
 
 
 def test_gh_list_repos_passes_network_timeout() -> None:
@@ -241,6 +243,40 @@ def test_gh_list_repos_passes_network_timeout() -> None:
         )
         loop_runner._gh_list_repos("MyOrg")
     assert mock_gh_call.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+
+
+def test_gh_list_repos_pages_beyond_the_former_two_hundred_cap() -> None:
+    """Organization discovery reads bounded pages without silently truncating."""
+    first_page = [
+        {"name": f"repo-{number:03d}", "isFork": False, "isArchived": False}
+        for number in range(100)
+    ]
+    second_page = [
+        {"name": "repo-100", "isFork": False, "isArchived": False},
+        {"name": "fork", "isFork": True, "isArchived": False},
+    ]
+    with patch(
+        "hephaestus.automation.loop_repo_manager.gh_call",
+        side_effect=[
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(first_page), stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(second_page), stderr=""
+            ),
+        ],
+    ) as mock_gh_call:
+        names = loop_runner._gh_list_repos("MyOrg")
+
+    assert names == [f"repo-{number:03d}" for number in range(100)] + ["repo-100"]
+    assert mock_gh_call.call_args_list[0].args[0] == [
+        "api",
+        "/orgs/MyOrg/repos?per_page=100&type=all&sort=full_name&direction=asc&page=1",
+    ]
+    assert mock_gh_call.call_args_list[1].args[0] == [
+        "api",
+        "/orgs/MyOrg/repos?per_page=100&type=all&sort=full_name&direction=asc&page=2",
+    ]
 
 
 def test_gh_list_repos_timeout_raises_systemexit() -> None:
@@ -335,6 +371,27 @@ def test_resolve_org_and_repos_org_named() -> None:
     assert org == "ExplicitOrg"
     assert repos == ["x"]
     mock_detect.assert_not_called()
+
+
+def test_resolve_org_and_repos_org_preserves_discovery_order_without_issue_scan() -> None:
+    """--org passes repository names to the coordinator without backlog sorting."""
+    args = loop_runner._parse_args(["--org", "ExplicitOrg"])
+    with (
+        patch(
+            "hephaestus.automation.loop_runner._gh_list_repos",
+            return_value=["alpha", "beta"],
+        ),
+        patch(
+            "hephaestus.automation.loop_runner._sort_repos_by_open_count",
+            side_effect=AssertionError("--org must not enumerate each repo's issue metadata"),
+        ) as mock_sort,
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+
+    assert err is None
+    assert org == "ExplicitOrg"
+    assert repos == ["alpha", "beta"]
+    mock_sort.assert_not_called()
 
 
 def test_resolve_org_and_repos_dry_run_never_tags_discovered_epics() -> None:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -248,8 +248,7 @@ def test_gh_list_repos_passes_network_timeout() -> None:
 def test_gh_list_repos_pages_beyond_the_former_two_hundred_cap() -> None:
     """Organization discovery reads bounded pages without silently truncating."""
     first_page = [
-        {"name": f"repo-{number:03d}", "fork": False, "archived": False}
-        for number in range(100)
+        {"name": f"repo-{number:03d}", "fork": False, "archived": False} for number in range(100)
     ]
     second_page = [
         {"name": "repo-100", "fork": False, "archived": False},

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -379,6 +379,47 @@ def test_resolve_org_and_repos_org_defers_discovery_without_issue_scan() -> None
     mock_sort.assert_not_called()
 
 
+@pytest.mark.parametrize("scope", [("--issues", "42"), ("--prs", "42")])
+def test_resolve_org_and_repos_rejects_numeric_scope_without_concrete_repo(
+    scope: tuple[str, str],
+) -> None:
+    """Org-wide direct numeric scopes must not materialize or pick a repo."""
+    args = loop_runner._parse_args(["--org", "ExplicitOrg", *scope])
+    with patch("hephaestus.automation.loop_runner._gh_list_repos") as mock_list:
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+
+    assert org == "ExplicitOrg"
+    assert repos == []
+    assert err == "--org with --issues/--prs requires exactly one --repos REPO scope."
+    mock_list.assert_not_called()
+
+
+@pytest.mark.parametrize("scope", [("--issues", "42"), ("--prs", "42")])
+def test_resolve_org_and_repos_rejects_multi_repo_numeric_scope(
+    scope: tuple[str, str],
+) -> None:
+    """A direct numeric target has one unambiguous repository owner."""
+    args = loop_runner._parse_args(["--org", "ExplicitOrg", "--repos", "a,b", *scope])
+
+    org, repos, err = loop_runner._resolve_org_and_repos(args)
+
+    assert org == ""
+    assert repos == []
+    assert err == "--issues/--prs require exactly one repository via --repos REPO."
+
+
+@pytest.mark.parametrize("scope", [("--issues", "42"), ("--prs", "42")])
+def test_resolve_org_and_repos_accepts_single_repo_numeric_scope(
+    scope: tuple[str, str],
+) -> None:
+    """One explicit repository preserves the direct numeric-scope contract."""
+    args = loop_runner._parse_args(["--org", "ExplicitOrg", "--repos", "target", *scope])
+
+    org, repos, err = loop_runner._resolve_org_and_repos(args)
+
+    assert (org, repos, err) == ("ExplicitOrg", ["target"], None)
+
+
 def test_resolve_org_and_repos_dry_run_never_tags_discovered_epics() -> None:
     """Organization discovery stays read-only when the loop is a dry run."""
     args = loop_runner._parse_args(["--org", "ExplicitOrg", "--dry-run"])

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -212,15 +212,15 @@ def test_repos_argparse_rejects_space_separated() -> None:
 
 
 def test_gh_list_repos_filters_forks_and_archived() -> None:
-    """``isFork: true`` and ``isArchived: true`` entries are excluded.
+    """REST ``fork: true`` and ``archived: true`` entries are excluded.
 
-    Repo names are NOT filtered — only isArchived/isFork status gates inclusion.
+    Repo names are NOT filtered — only archived/fork status gates inclusion.
     """
     payload = (
-        '[{"name":"keep","isFork":false,"isArchived":false},'
-        '{"name":"drop-fork","isFork":true,"isArchived":false},'
-        '{"name":"drop-archived","isFork":false,"isArchived":true},'
-        '{"name":"Odysseus","isFork":false,"isArchived":false}]'
+        '[{"name":"keep","fork":false,"archived":false},'
+        '{"name":"drop-fork","fork":true,"archived":false},'
+        '{"name":"drop-archived","fork":false,"archived":true},'
+        '{"name":"Odysseus","fork":false,"archived":false}]'
     )
     with patch("hephaestus.automation.loop_repo_manager.gh_call") as mock_gh_call:
         mock_gh_call.return_value = subprocess.CompletedProcess(
@@ -248,12 +248,12 @@ def test_gh_list_repos_passes_network_timeout() -> None:
 def test_gh_list_repos_pages_beyond_the_former_two_hundred_cap() -> None:
     """Organization discovery reads bounded pages without silently truncating."""
     first_page = [
-        {"name": f"repo-{number:03d}", "isFork": False, "isArchived": False}
+        {"name": f"repo-{number:03d}", "fork": False, "archived": False}
         for number in range(100)
     ]
     second_page = [
-        {"name": "repo-100", "isFork": False, "isArchived": False},
-        {"name": "fork", "isFork": True, "isArchived": False},
+        {"name": "repo-100", "fork": False, "archived": False},
+        {"name": "fork", "fork": True, "archived": False},
     ]
     with patch(
         "hephaestus.automation.loop_repo_manager.gh_call",
@@ -314,7 +314,7 @@ def test_resolve_org_and_repos_errors_when_no_scope_and_not_git() -> None:
 
 
 def test_resolve_org_and_repos_org_no_arg_autodetects() -> None:
-    """``--org`` with no value → detect org from cwd, enumerate."""
+    """``--org`` with no value resolves a streamed organization source."""
     args = loop_runner._parse_args(["--org"])
     assert args.org is loop_runner._ORG_AUTODETECT
     with (
@@ -322,20 +322,13 @@ def test_resolve_org_and_repos_org_no_arg_autodetects() -> None:
             "hephaestus.automation.loop_runner._detect_cwd_repo",
             return_value=("DetectedOrg", "AnyRepo"),
         ),
-        patch(
-            "hephaestus.automation.loop_runner._gh_list_repos",
-            return_value=["a", "b"],
-        ) as mock_list,
-        patch(
-            "hephaestus.automation.loop_runner._sort_repos_by_open_count",
-            side_effect=lambda _org, r: r,
-        ),
+        patch("hephaestus.automation.loop_runner._gh_list_repos") as mock_list,
     ):
         org, repos, err = loop_runner._resolve_org_and_repos(args)
     assert err is None
     assert org == "DetectedOrg"
-    assert repos == ["a", "b"]
-    mock_list.assert_called_once_with("DetectedOrg")
+    assert repos == []
+    mock_list.assert_not_called()
 
 
 def test_resolve_org_and_repos_org_no_arg_errors_when_not_git() -> None:
@@ -351,36 +344,27 @@ def test_resolve_org_and_repos_org_no_arg_errors_when_not_git() -> None:
 
 
 def test_resolve_org_and_repos_org_named() -> None:
-    """``--org NAME`` enumerates the named org without cwd detection."""
+    """``--org NAME`` streams the named org without cwd detection."""
     args = loop_runner._parse_args(["--org", "ExplicitOrg"])
     with (
         patch(
             "hephaestus.automation.loop_runner._detect_cwd_repo",
         ) as mock_detect,
-        patch(
-            "hephaestus.automation.loop_runner._gh_list_repos",
-            return_value=["x"],
-        ),
-        patch(
-            "hephaestus.automation.loop_runner._sort_repos_by_open_count",
-            side_effect=lambda _org, r: r,
-        ),
+        patch("hephaestus.automation.loop_runner._gh_list_repos") as mock_list,
     ):
         org, repos, err = loop_runner._resolve_org_and_repos(args)
     assert err is None
     assert org == "ExplicitOrg"
-    assert repos == ["x"]
+    assert repos == []
     mock_detect.assert_not_called()
+    mock_list.assert_not_called()
 
 
-def test_resolve_org_and_repos_org_preserves_discovery_order_without_issue_scan() -> None:
-    """--org passes repository names to the coordinator without backlog sorting."""
+def test_resolve_org_and_repos_org_defers_discovery_without_issue_scan() -> None:
+    """--org does not enumerate repos before the bounded coordinator source."""
     args = loop_runner._parse_args(["--org", "ExplicitOrg"])
     with (
-        patch(
-            "hephaestus.automation.loop_runner._gh_list_repos",
-            return_value=["alpha", "beta"],
-        ),
+        patch("hephaestus.automation.loop_runner._gh_list_repos") as mock_list,
         patch(
             "hephaestus.automation.loop_runner._sort_repos_by_open_count",
             side_effect=AssertionError("--org must not enumerate each repo's issue metadata"),
@@ -390,7 +374,8 @@ def test_resolve_org_and_repos_org_preserves_discovery_order_without_issue_scan(
 
     assert err is None
     assert org == "ExplicitOrg"
-    assert repos == ["alpha", "beta"]
+    assert repos == []
+    mock_list.assert_not_called()
     mock_sort.assert_not_called()
 
 
@@ -399,10 +384,7 @@ def test_resolve_org_and_repos_dry_run_never_tags_discovered_epics() -> None:
     args = loop_runner._parse_args(["--org", "ExplicitOrg", "--dry-run"])
     epic = {"number": 81, "title": "Epic: roadmap", "labels": ["epic"]}
     with (
-        patch(
-            "hephaestus.automation.loop_runner._gh_list_repos",
-            return_value=["Proteus"],
-        ),
+        patch("hephaestus.automation.loop_runner._gh_list_repos") as mock_list,
         patch(
             "hephaestus.automation.loop_repo_manager._list_open_issue_meta",
             return_value=[epic],
@@ -413,7 +395,8 @@ def test_resolve_org_and_repos_dry_run_never_tags_discovered_epics() -> None:
 
     assert err is None
     assert org == "ExplicitOrg"
-    assert repos == ["Proteus"]
+    assert repos == []
+    mock_list.assert_not_called()
     mock_skip.assert_not_called()
 
 
@@ -634,6 +617,18 @@ def test_main_disables_phase_timeout_when_zero(monkeypatch: pytest.MonkeyPatch) 
     assert config.phase_timeout_s is None  # type: ignore[attr-defined]
 
 
+def test_main_passes_org_discovery_as_a_resettable_pipeline_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An org-wide run never materializes repository names in PipelineConfig."""
+    config = _capture_main_config(
+        ["--org", "Org", "--dry-run", "--loops", "1", "--agent", "codex"], monkeypatch
+    )
+
+    assert config.repos == []  # type: ignore[attr-defined]
+    assert callable(config.repo_source_factory)  # type: ignore[attr-defined]
+
+
 @pytest.mark.parametrize("port", [0, 65535])
 def test_metrics_port_parser_accepts_tcp_port_range(port: int) -> None:
     """The opt-in local metrics endpoint accepts every valid TCP port."""
@@ -829,7 +824,7 @@ def test_main_errors_on_empty_repo_list() -> None:
         patch.object(loop_runner, "resolve_agent", return_value="claude"),
         patch.object(loop_runner, "_resolve_org_and_repos", return_value=("Org", [], None)),
     ):
-        rc = main(["--org", "Org"])
+        rc = main([])
     assert rc == 1
 
 

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -82,8 +82,10 @@ def test_architecture_md_documents_bounded_queue_and_restart_authority() -> None
     assert "C = max(1, parallel_repos × max_workers)" in text
     assert "StageQueueLease" in text
     assert "FIFO round-robin" in text
-    assert "REST pages of at most 100 rows" in text
+    assert "linked-issue metadata use REST pages of at most 100 rows" in normalized
     assert "`gh ... --limit 500` discovery cap" in text
+    assert "does not pre-scan open-PR pages" in text
+    assert "An orphan PR has no issue requirements" in text
     assert "not durable routing authority" in text
     assert "GitHub labels, comments, and PR state remain the only restart authority" in normalized
 

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -74,22 +74,6 @@ def test_architecture_md_documents_concurrency_pool_size_section_2() -> None:
     assert "Pool size = `parallel_repos × max_workers`" in text
 
 
-def test_architecture_md_documents_bounded_queue_and_restart_authority() -> None:
-    """The #2399 capacity contract must not regress to eager/spill semantics."""
-    text = _arch_text()
-    normalized = " ".join(text.split())
-
-    assert "C = max(1, parallel_repos × max_workers)" in text
-    assert "StageQueueLease" in text
-    assert "FIFO round-robin" in text
-    assert "linked-issue metadata use REST pages of at most 100 rows" in normalized
-    assert "`gh ... --limit 500` discovery cap" in text
-    assert "does not pre-scan open-PR pages" in text
-    assert "An orphan PR has no issue requirements" in text
-    assert "not durable routing authority" in text
-    assert "GitHub labels, comments, and PR state remain the only restart authority" in normalized
-
-
 def test_architecture_md_has_glossary_section_13() -> None:
     """Section 13 'Glossary' must remain."""
     text = _arch_text()

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -74,6 +74,20 @@ def test_architecture_md_documents_concurrency_pool_size_section_2() -> None:
     assert "Pool size = `parallel_repos × max_workers`" in text
 
 
+def test_architecture_md_documents_bounded_queue_and_restart_authority() -> None:
+    """The #2399 capacity contract must not regress to eager/spill semantics."""
+    text = _arch_text()
+    normalized = " ".join(text.split())
+
+    assert "C = max(1, parallel_repos × max_workers)" in text
+    assert "StageQueueLease" in text
+    assert "FIFO round-robin" in text
+    assert "REST pages of at most 100 rows" in text
+    assert "`gh ... --limit 500` discovery cap" in text
+    assert "not durable routing authority" in text
+    assert "GitHub labels, comments, and PR state remain the only restart authority" in normalized
+
+
 def test_architecture_md_has_glossary_section_13() -> None:
     """Section 13 'Glossary' must remain."""
     text = _arch_text()


### PR DESCRIPTION
## Summary

- bound every queue and source cursor by one global live-work capacity
- preserve lossless, FIFO stage admission and restart authority in GitHub
- remove eager repository discovery and unbounded diagnostic retention
- keep drive-green scoped to linked issues; orphan PRs require explicit selection

## Verification

- full pre-push test suite (6,744 tests)
- mypy, Ruff, focused backpressure/source/reseed/docs regression suites

Closes #2399