### PR TITLE
fix(automation): conditionally merge reviewed PR heads

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -493,7 +493,7 @@ jobs:
 
           state=$(jq -r '.autoMergeRequest' pr.json)
           if [ "$state" != "null" ] && [ -n "$state" ]; then
-            echo "::notice::Auto-merge is armed by the automation loop."
+            echo "::notice::Auto-merge is present and external to the automation loop."
             exit 0
           fi
           echo "OK: auto-merge is currently disabled"

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -456,7 +456,7 @@ jobs:
   auto-merge-policy:
     name: auto-merge-policy
     # Advisory (NOT a required check): the automation loop owns review,
-    # approval labeling, and merge arming. This job reports observable PR
+    # approval labeling, and conditional merging. This job reports observable PR
     # state but never authorizes the loop or substitutes for that process.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,8 +350,8 @@ The required CI gate `pr-policy` and the PR reviewer enforce:
 `pr-policy` blocks PRs that fail those checks. The queue runs
 `$athena:pr-review` in its normal default profile when available, then applies
 `state:implementation-go` on GO. `merge_wait` verifies the process-local
-reviewed-head proof and stands by pending #2419; no queue stage mutates
-auto-merge.
+reviewed-head proof and conditionally squash-merges that exact head; no queue
+stage mutates native auto-merge.
 Normal review may collect CI/CD evidence and incorporate it into its binary
 verdict, but the loop does not change CI/CD. CI workflows and external
 artifacts never independently grant that authority. Branch protection and
@@ -375,8 +375,7 @@ gh pr create \
   --body "$(printf 'Summary of change.\n\nCloses #<issue-number>\n')"
 
 # 5. Do not use --admin or bypass branch protection. Queue stages do not mutate
-#    auto-merge; merge_wait verifies the reviewed-head proof and stands by
-#    pending #2419.
+#    native auto-merge; merge_wait uses a SHA-conditional normal merge.
 ```
 
 ### Commit Message Format
@@ -538,8 +537,8 @@ fallback. It posts inline findings and a final grade/GO-NOGO review; a GO
 applies `state:implementation-go`. Normal review may collect CI/CD evidence
 and incorporate it into its binary verdict, but the loop does not change CI/CD
 and no workflow, status, artifact, or lease independently authorizes it.
-`merge_wait` verifies the process-local reviewed-head proof and stands by
-pending #2419; no queue stage mutates auto-merge.
+`merge_wait` verifies the process-local reviewed-head proof and conditionally
+merges that exact head; no queue stage mutates native auto-merge.
 
 | Queue stage | Module | Purpose |
 |-------------|--------|---------|
@@ -548,7 +547,7 @@ pending #2419; no queue stage mutates auto-merge.
 | plan_review | `hephaestus.automation.pipeline.stages.plan_review` | Strict plan review, amendment, and plan labels |
 | implementation | `hephaestus.automation.pipeline.stages.implementation` | Worktree creation, implementation, tests, commit/push, and PR creation |
 | pr_review | `hephaestus.automation.pipeline.stages.pr_review` | Inline PR review, validation, comment addressing, and implementation labels |
-| merge_wait | `hephaestus.automation.pipeline.stages.merge_wait` | Verifies the reviewed-head proof, stands by pending #2419, and preserves post-merge learning |
+| merge_wait | `hephaestus.automation.pipeline.stages.merge_wait` | Conditionally merges the exact reviewed head and preserves post-merge learning |
 | finished | `hephaestus.automation.pipeline.stages.finished` | Terminal ledger and worktree cleanup/preservation |
 
 Console scripts preserve their historical names. Stage-scoped wrappers are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ links to the full section below.
    body, and keep auto-merge disabled. After an unconditional independent
    current-head `$athena:pr-review` GO, the loop applies
    `state:implementation-go`; `merge_wait` then revalidates the in-memory
-   reviewed-head proof and safely stands by without mutating auto-merge.
+   reviewed-head proof and conditionally squash-merges that exact head without
+   mutating native auto-merge.
    Normal review may collect CI/CD evidence and incorporate it into its binary
    verdict, but the loop does not change CI/CD and CI itself never
    independently authorizes it. Do not enable auto-merge manually.
@@ -285,9 +286,9 @@ valid issue reference, signed commits, or DCO sign-offs:
 Do not enable auto-merge manually. The queue applies
 `state:implementation-go` only after `$athena:pr-review` for the PR's current
 head. `merge_wait` consumes the loop-owned label together with its in-memory
-reviewed-head proof and safely stands by; it does not create, disable, adopt,
-or poll an auto-merge request. A restart has no proof and returns the PR to
-review only after a confirmed-unarmed read permits stale-label revocation.
+reviewed-head proof and conditionally squash-merges that exact head; it does
+not create, disable, adopt, or poll an auto-merge request. A restart has no
+proof and returns the PR to review without mutating labels.
 Normal review may collect CI/CD evidence and incorporate it into its binary
 verdict, but the loop does not change CI/CD and no CI check independently
 authorizes it; the advisory `auto-merge-policy` is not the authorization

--- a/README.md
+++ b/README.md
@@ -456,8 +456,9 @@ hephaestus-check-complexity --help
 The `main` branch is protected; all changes go through a pull request. CI blocks
 PRs that fail its issue-reference, signature, and DCO checks. The loop runs
 `$athena:pr-review` and then writes `state:implementation-go` for the reviewed
-head. `merge_wait` revalidates the current-process proof and safely stands by;
-it does not create, disable, adopt, or poll an auto-merge request. Normal
+head. `merge_wait` revalidates the current-process proof and conditionally
+squash-merges that exact head; it does not create, disable, adopt, or poll an
+auto-merge request. Normal
 review may collect CI/CD evidence and incorporate it into its binary verdict,
 but the loop does not change CI/CD and no CI workflow independently authorizes
 it. The `auto-merge-policy` check is advisory.
@@ -470,8 +471,8 @@ it. The `auto-merge-policy` check is advisory.
 4. Open a pull request whose body contains the literal line `Closes #123`
    (capital `C`, no colon, on its own line — `Fixes`/`Resolves` are **not** accepted).
 5. Do not enable auto-merge manually. The automation loop's review, label, and
-   `merge_wait` stages preserve the head-bound approval boundary but currently
-   do not mutate auto-merge.
+   `merge_wait` preserves the head-bound approval boundary with a
+   SHA-conditional normal merge and never mutates native auto-merge.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -14,7 +14,7 @@ A piece of work is **done** when every item below is true.
 | 1 | Branch named `<issue-number>-<description>` | Convention (PR reviewer) |
 | 2 | PR body contains the literal line `Closes #<issue-number>` (capital C, no colon, on its own line) | CI gate `pr-policy` (`.github/workflows/_required.yml`) |
 | 3 | Every commit on the branch is cryptographically signed and DCO-signed (`git commit -S -s`) | CI gate `pr-policy` |
-| 4 | `pr_review` writes loop-owned `state:implementation-go` only after `$athena:pr-review` (or the inline fallback) and a current-process reviewed-head proof. `merge_wait` revalidates that proof against a confirmed-unarmed PR and stands by; pending #2419, no queue stage mutates auto-merge. | Queue gate; advisory `auto-merge-policy` and human review |
+| 4 | `pr_review` writes loop-owned `state:implementation-go` only after `$athena:pr-review` (or the inline fallback) and a current-process reviewed-head proof. `merge_wait` revalidates that proof against an open `main`, confirmed-unarmed PR with an exclusive GO label, then performs one SHA-conditional ordinary squash merge. No queue stage mutates native auto-merge. | Queue gate; advisory `auto-merge-policy` and human review |
 | 5 | Commit messages follow Conventional Commits (`type(scope): description`) | CI gate `pr-policy` (Check 3) + local `commit-msg` hook `conventional-commit-msg` |
 | 6 | `uv run ruff check hephaestus/ tests/` passes | CI job `lint` |
 | 7 | `uv run ruff format --check hephaestus/ tests/` passes (no files would be reformatted) | CI job `lint` |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -5,8 +5,9 @@
 > *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
 > prepare. 0.10.0's headline change is the queue pipeline's reviewed-head review
 > interlock: `pr_review` writes `state:implementation-go` only for the current
-> process's reviewed head, and `merge_wait` revalidates that proof before standing by
-> on a confirmed-unarmed PR. No queue stage arms auto-merge pending #2419. There are **no breaking changes
+> process's reviewed head, and `merge_wait` revalidates that proof before one
+> SHA-conditional normal squash merge on a confirmed-unarmed PR. No queue stage
+> arms native auto-merge. There are **no breaking changes
 > to the documented public API** from 0.9.x: upgrading requires no code changes for
 > code that uses only the documented public API in
 > [`COMPATIBILITY.md`](../COMPATIBILITY.md). Operators of the automation loop should

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,8 +13,8 @@ Remediation of the strict 2026-05-28 audit findings (`audit-finding` issues) con
 2. **Automation Pipeline Hardening** — Stabilizing the queue-based
    plan → implement → review pipeline (Epic #1809): drive-green loop
    behavior, linked-issue PR recovery, epic/skip-tag scoping, and restoring
-   the reviewed-head interlock while `merge_wait` safely stands by on a
-   confirmed-unarmed PR pending the separately reviewed #2419 merge path.
+   the reviewed-head interlock and bounded SHA-conditional normal merge in
+   `merge_wait` for a confirmed-unarmed PR.
 
 3. **CLI Tool Coverage Expansion** — Expanding the CLI entry point test suite from 13 of 47 declared tools to full coverage, ensuring all command-line interfaces are properly validated.
 

--- a/docs/adr/0009-head-bound-strict-review-merge-gate.md
+++ b/docs/adr/0009-head-bound-strict-review-merge-gate.md
@@ -46,3 +46,15 @@ the current head, and must fail closed if it cannot revoke stale eligibility.
   administrator bypass.
 - Artifact, head-race, identity, byte-limit, and read-only-worker behavior are
   regression-tested as security boundaries.
+
+## Superseding clarification (2026-07-25)
+
+The arming and disable-containment language above records the accepted
+historical design; it is not the active implementation. Issue #2419 found
+that GitHub exposes no conditional disable operation or durable ownership token
+for an auto-merge request, so a read-then-disable protocol can disable an
+external replacement. The active merge-wait contract therefore never creates
+or mutates native auto-merge. After #2423's process-local reviewed-head proof,
+it performs one ordinary repo-scoped REST squash merge conditional on that
+exact SHA, with fresh open/`main`/unarmed/exclusive-GO admission and bounded
+reconciliation of the result.

--- a/docs/adr/0009-head-bound-strict-review-merge-gate.md
+++ b/docs/adr/0009-head-bound-strict-review-merge-gate.md
@@ -46,15 +46,3 @@ the current head, and must fail closed if it cannot revoke stale eligibility.
   administrator bypass.
 - Artifact, head-race, identity, byte-limit, and read-only-worker behavior are
   regression-tested as security boundaries.
-
-## Superseding clarification (2026-07-25)
-
-The arming and disable-containment language above records the accepted
-historical design; it is not the active implementation. Issue #2419 found
-that GitHub exposes no conditional disable operation or durable ownership token
-for an auto-merge request, so a read-then-disable protocol can disable an
-external replacement. The active merge-wait contract therefore never creates
-or mutates native auto-merge. After #2423's process-local reviewed-head proof,
-it performs one ordinary repo-scoped REST squash merge conditional on that
-exact SHA, with fresh open/`main`/unarmed/exclusive-GO admission and bounded
-reconciliation of the result.

--- a/docs/adr/0012-loop-owned-pr-review-approval.md
+++ b/docs/adr/0012-loop-owned-pr-review-approval.md
@@ -57,3 +57,11 @@ it belongs in that stage rather than in GitHub Actions.
   automation loop does not change CI/CD and it never independently authorizes
   the loop.
 - The retired policy no longer appears as an active contract.
+
+## Superseding clarification (2026-07-25)
+
+The pending #2419 wording above is historical. The active `merge_wait`
+implementation now uses one repo-scoped ordinary REST squash merge conditional
+on the process-local reviewed SHA after fresh open/`main`/unarmed/exclusive-GO
+admission. It still never creates, disables, adopts, or polls native
+auto-merge, and stale proof returns to review with zero label mutation.

--- a/docs/adr/0012-loop-owned-pr-review-approval.md
+++ b/docs/adr/0012-loop-owned-pr-review-approval.md
@@ -57,11 +57,3 @@ it belongs in that stage rather than in GitHub Actions.
   automation loop does not change CI/CD and it never independently authorizes
   the loop.
 - The retired policy no longer appears as an active contract.
-
-## Superseding clarification (2026-07-25)
-
-The pending #2419 wording above is historical. The active `merge_wait`
-implementation now uses one repo-scoped ordinary REST squash merge conditional
-on the process-local reviewed SHA after fresh open/`main`/unarmed/exclusive-GO
-admission. It still never creates, disables, adopts, or polls native
-auto-merge, and stale proof returns to review with zero label mutation.

--- a/docs/adr/0014-conditional-normal-merge.md
+++ b/docs/adr/0014-conditional-normal-merge.md
@@ -1,0 +1,76 @@
+# ADR-0014: Conditional normal merge after loop-owned review
+
+- Status: Accepted
+- Date: 2026-07-25
+- Tracks: #2419
+- Supersedes: ADR-0012
+- Clarifies: ADR-0009
+
+## Context
+
+ADR-0012 established that `pr_review` is the loop's sole implementation
+approval authority and that the current process carries its reviewed-head
+proof. Its temporary merge-wait policy deliberately stood by while #2419 was
+reviewed. ADR-0009 describes an earlier native auto-merge arming protocol.
+
+Neither a read-then-disable sequence nor a durable local arming record can
+prove ownership of GitHub's mutable native auto-merge request. A later actor
+can replace that request between reads, so containment could disable another
+actor's arm. GitHub does, however, offer a normal merge endpoint conditional
+on the PR head SHA. That condition can make the merge mutation itself prove
+that the reviewed head did not change before the request was accepted.
+
+## Decision
+
+1. `merge_wait` is the only queue stage permitted to request a merge. It first
+   reads final admission facts: the PR is open against `main`, has no native
+   auto-merge request, has an exclusive `state:implementation-go` label, and
+   has the exact in-process reviewed-head proof for its current head.
+2. After final admission it makes at most one repository-scoped REST request:
+   `PUT /repos/{owner}/{repo}/pulls/{number}/merge`, with only the reviewed
+   `sha` and `merge_method=squash`. It never invokes `gh pr merge`, native
+   auto-merge, a merge queue, an administrator bypass, or a retrying mutation
+   helper.
+3. A `200` response succeeds only after a fresh lifecycle read reports
+   `MERGED`. A `409` is reconciled with a fresh state read; head drift returns
+   to review without label mutation, while an externally armed request blocks
+   without mutation. A `405` performs a fresh readiness read: `CONFLICTING`
+   and `DIRTY` are terminal, while explicitly retryable readiness states may
+   use a bounded timer retry.
+4. A transport ambiguity is never assumed to have failed. `merge_wait` first
+   re-reads lifecycle state. It succeeds if the PR is merged, and retries only
+   when the PR remains open on the same reviewed head, is unarmed, retains the
+   exclusive GO label, and has budget remaining. The retry is timer-delayed;
+   unreadable or changed state is terminal or returns to review as appropriate.
+5. The reviewed-head proof is process-local. A restart cannot reconstruct it
+   from labels or a work item, so merge-wait returns the item to review with
+   zero label writes. No queue stage creates, disables, adopts, or polls
+   native auto-merge.
+
+## Alternatives considered
+
+- **Continue native auto-merge arming and containment.** Rejected: GitHub
+  exposes no conditional ownership token for a disable, so an external arm can
+  be modified accidentally.
+- **Use `gh pr merge --auto` or a merge queue.** Rejected: both delegate the
+  final merge to a mutable asynchronous mechanism rather than binding it to
+  this process's reviewed SHA.
+- **Retry uncertain merge mutations immediately.** Rejected: a transport
+  failure can conceal a successful merge; immediate retry risks duplicate or
+  unauthorized mutation.
+- **Treat a durable GO label as restart-safe proof.** Rejected: labels are not
+  bound to a session or exact review snapshot.
+
+## Consequences
+
+- Merge authority remains local to one reviewed process and one exact SHA.
+- The only queue merge write is auditable as a single conditional REST PUT
+  with a fixed squash method and no privilege escalation.
+- Ambiguous network outcomes are slower when the PR is still eligible, but
+  bounded delayed reconciliation prevents duplicate in-step requests.
+- Native auto-merge remains an external-ownership boundary. Operators retain
+  normal GitHub branch protection and manual merge authority independent of
+  the loop.
+- Regression tests cover 200 confirmation, transport ambiguity, unreadable
+  state, restart, exhaustion, 409 external ownership, conflicting readiness,
+  and timer re-entry/attempt counting.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,6 @@ numbered, and listed here.
 | [0009](0009-head-bound-strict-review-merge-gate.md) | Head-bound strict review controls queue-owned merge eligibility | Accepted (historical; superseded by 0012) |
 | [0010](0010-trusted-strict-review-proof.md) | Trusted strict-review proof context | Superseded by 0012 (historical) |
 | [0011](0011-mcp-integration-posture.md) | MCP is optional project-scoped agent tooling | Accepted |
-| [0012](0012-loop-owned-pr-review-approval.md) | Loop-owned Athena PR-review approval | Accepted |
+| [0012](0012-loop-owned-pr-review-approval.md) | Loop-owned Athena PR-review approval | Accepted (historical; superseded by 0014) |
 | [0013](0013-backup-and-disaster-recovery-policy.md) | Tiered backup and disaster-recovery policy | Accepted |
 | [0014](0014-conditional-normal-merge.md) | Conditional normal merge after loop-owned review | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ numbered, and listed here.
 | [0011](0011-mcp-integration-posture.md) | MCP is optional project-scoped agent tooling | Accepted |
 | [0012](0012-loop-owned-pr-review-approval.md) | Loop-owned Athena PR-review approval | Accepted |
 | [0013](0013-backup-and-disaster-recovery-policy.md) | Tiered backup and disaster-recovery policy | Accepted |
+| [0014](0014-conditional-normal-merge.md) | Conditional normal merge after loop-owned review | Accepted |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,15 +58,16 @@ in §5.1, which tags `state:skip` on epics before any other durable mutation.
  into the same queue and the loop reconverges
  ([`_park_resumable`](hephaestus/automation/pipeline/coordinator.py),
  [`_finalize_resumable`](hephaestus/automation/pipeline/coordinator.py)).
-- **Reviewed-head proof, no queue merge mutation.** `state:implementation-go`
+- **Reviewed-head proof, conditional queue merge.** `state:implementation-go`
  is applied only by `pr_review._eval`, which is the sole stage authorized to
  write the label. Before the reviewer runs, `pr_review` snapshots the GitHub
  review inputs and its head SHA, then requires a clean local checkout at that
  exact SHA. The resulting in-memory proof is rechecked against a confirmed,
  unarmed live PR before the label is written. `merge_wait` consumes that proof
- but currently stands by; no queue stage creates, disables, adopts, or polls
- an auto-merge request pending the separately reviewed #2419 conditional
- merge path ([`pr_review.py`](hephaestus/automation/pipeline/stages/pr_review.py),
+ only after fresh open/`main`/unarmed/exclusive-GO admission, then issues one
+ SHA-conditional ordinary squash merge. No queue stage creates, disables,
+ adopts, or polls an auto-merge request
+ ([`pr_review.py`](hephaestus/automation/pipeline/stages/pr_review.py),
  [`worker_pool.py`](hephaestus/automation/pipeline/worker_pool.py),
  [`merge_wait.py`](hephaestus/automation/pipeline/stages/merge_wait.py)).
 - **Globally bounded budgets.** Stages count retries on `_on_job_done` so
@@ -589,10 +590,10 @@ state:skip : NO RANK (excluded from rank compare)
 
 A label alone never authorizes merge. `merge_wait` requires both the
 `state:implementation-go` label and a matching in-memory reviewed-head proof
-on a confirmed, unarmed live PR. A missing or drifted proof is contained by
-returning to review only after a fresh unarmed read permits stale-label
-revocation; a matching proof currently reaches a safe standby outcome pending
-issue #2419 ([`merge_wait.py`](hephaestus/automation/pipeline/stages/merge_wait.py)).
+on an open `main`, confirmed-unarmed live PR with an exclusive GO label. A
+missing or drifted proof returns to review without a label mutation; a matching
+proof permits one SHA-conditional ordinary squash merge
+([`merge_wait.py`](hephaestus/automation/pipeline/stages/merge_wait.py)).
 
 Plan-review labels are the sole durable authority. Review comments explain and
 audit a decision but never authorize a transition, block a stage, or backfill a
@@ -951,20 +952,21 @@ Architectural contract:
 ### 5.6 Merge wait
 
 Merge wait verifies a still-valid implementation approval against its
-in-memory reviewed-head proof and then stands by. Until #2419 supplies a
-separately reviewed conditional normal-merge path, it does not create,
-disable, adopt, or poll an auto-merge request. An existing request is treated
-as external ownership and is left untouched.
+in-memory reviewed-head proof, then issues one ordinary REST squash merge
+conditional on that SHA. Admission requires an open `main` PR, an explicitly
+unarmed record, and an exclusive implementation-GO label. It does not create,
+disable, adopt, or poll an auto-merge request; an existing request is external
+ownership and is left untouched.
 
 #### Boundary diagram
 
 ```mermaid
 flowchart LR
     Approved["Approval label + reviewed-head proof"] --> Verify
-    Verify --> StandBy["Safe standby pending #2419"]
+    Verify --> Merge["Conditional SHA squash merge"]
     Verify --> Review["Missing or drifted proof"]
     Verify --> Operator["External or ambiguous ownership"]
-    Merged --> Learn["Optional learning"] --> Finished
+    Merge --> Merged --> Learn["Optional learning"] --> Finished
 ```
 
 #### State machine
@@ -977,11 +979,14 @@ stateDiagram-v2
     Inspect --> OperatorOwned: externally armed
     Inspect --> PRReview: approval missing
     Inspect --> Verify: approval label present
-    Verify --> StandBy: matching reviewed head and unarmed PR
-    Verify --> PRReview: missing or drifted proof after safe label revocation
+    Verify --> Merge: matching reviewed head, main, unarmed exclusive GO
+    Verify --> PRReview: missing or drifted proof
     Verify --> OperatorOwned: externally armed or ownership ambiguous
     Verify --> Failed: incomplete or unavailable state
-    StandBy --> [*]
+    Merge --> Complete: 200 merged and lifecycle confirms
+    Merge --> PRReview: 409 or ambiguous lifecycle head drift
+    Merge --> Retry: 405 readiness or safe ambiguous retry
+    Retry --> Merge: timer and budget available
     Learn --> Complete: disabled or recorded
     Learn --> Failed: durable outcome ambiguous
     Complete --> [*]
@@ -994,10 +999,10 @@ Architectural contract:
 
 - A current-process review proof is bound to the reviewed head commit.
 - Existing external merge ownership is preserved.
-- Missing or drifted proof returns approval to PR review only after a fresh,
-  confirmed-unarmed read permits label revocation.
-- A matching proof stands by pending the #2419 conditional merge path.
-- Ambiguous merge or learning state stops for operator inspection.
+- Missing or drifted proof returns approval to PR review with zero label writes.
+- A matching proof can submit exactly one SHA-conditional normal merge request.
+- HTTP 409, 405 readiness, and ambiguous transport responses are reconciled
+  with fresh lifecycle reads and the per-item merge budget.
 
 ### 5.7 `finished`
 
@@ -1053,7 +1058,7 @@ budgets. Every `routes.py` row and every doc row MUST agree.
 | `plan_review` | `IMPLEMENTATION` | `nogo` → `PLANNING`; `plan_cycles_exhausted` → `FINISHED`; `*` → `PLANNING` | `plan_review_iter = 3`, `plan_cycles = 2` |
 | `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `test_fix = 1` |
 | `pr_review` | `MERGE_WAIT` | `agent_error` → `IMPLEMENTATION`; `human_blocked` → `FINISHED`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
-| `merge_wait` | `FINISHED` | `not_implementation_go`, `reviewed_head_missing`, or `reviewed_head_drift` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | — (no queue-stage budget) |
+| `merge_wait` | `FINISHED` | `not_implementation_go`, `reviewed_head_missing`, or `reviewed_head_drift` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | `merge = 5` |
 | `finished` | `FINISHED` | — (terminal) | — |
 
 Budget provenance (cross-check):
@@ -1074,8 +1079,7 @@ Budget provenance (cross-check):
  [`loop_runner.py LoopConfig.drive_green_loops`](hephaestus/automation/loop_runner.py).
 - `merge = 5` (CLI default for `--drive-green-loops`,
  [`DEFAULT_DRIVE_GREEN_LOOPS`](hephaestus/automation/pipeline/routing.py))
- is retained routing compatibility metadata for the legacy drive-green CLI;
- the queue `merge_wait` stage does not poll or consume this budget.
+ bounds queue `merge_wait` conditional requests and timer retries.
 All per-item-lifetime counters live in
 [`WorkItem.attempts`](hephaestus/automation/pipeline/work_item.py);
 they are NEVER reset when an item re-enters a stage, so cross-stage
@@ -1166,8 +1170,8 @@ The queue is in-memory: a restart re-seeds normally through the ordinary
 [`classifier`](hephaestus/automation/pipeline/seeding.py) and does not recover
 the process-local reviewed-head proof. A direct PR seed or restart therefore
 cannot use a durable implementation-GO label by itself: merge wait first
-requires a confirmed-unarmed read, then returns the PR to review after safely
-revoking a stale label. Other-run auto-merge requests are
+requires a confirmed-unarmed read, then returns the PR to review without
+mutating its labels. Other-run auto-merge requests are
 [blocked without adoption or mutation](hephaestus/automation/pipeline/stages/merge_wait.py)
 and require operator handling.
 
@@ -1516,8 +1520,8 @@ Exit-code priority is:
  matching the live `headRefOid` of the PR. `pr_review` creates its
  process-local proof only after a GitHub snapshot and a clean checkout agree
  on that SHA; it rechecks the proof before writing the GO label. `merge_wait`
- compares that proof with the confirmed-unarmed live PR and stands by pending
- #2419 rather than arming or polling auto-merge.
+ compares that proof with the confirmed-unarmed live PR and issues a normal
+ SHA-conditional merge rather than arming or polling auto-merge.
 - **Skip-reason marker** — the `<!-- hephaestus-state-skip-reason -->` HTML-comment marker ([`SKIP_REASON_MARKER`](hephaestus/automation/state_labels.py)) that prefixes every `state:skip` reason-comment body produced by [`format_skip_reason_comment`](hephaestus/automation/state_labels.py), so a repo reader can deterministically trace the automated skip reason.
 - **File-system loader** — the Jinja `FileSystemLoader` resolved from `__file__`-relative paths in [`prompts/catalog.py`](hephaestus/prompts/catalog.py); deliberately NOT `PackageLoader` to avoid importlib editable-install staleness (#2308).
 - **Conflict-resolution request** — the [`ConflictResolutionRequest`](hephaestus/automation/_review_conflict_resolver.py) immutable context consumed by the cohesive [`ReviewConflictResolver`](hephaestus/automation/_review_conflict_resolver.py) unit split out of `_review_phase.py` (#2209).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -501,9 +501,6 @@ Key fields:
 - `result` ([`ItemResult`](hephaestus/automation/pipeline/work_item.py)) —
  final `passed / reason / final_stage` written by
  [`_finish`](hephaestus/automation/pipeline/coordinator.py).
-- `armed` — compatibility field retained on the work item. The current
- [`merge_wait`](hephaestus/automation/pipeline/stages/merge_wait.py) stage
- does not set it because the queue does not arm auto-merge.
 - `worktree`, `branch` — populated by [`implementation`](hephaestus/automation/pipeline/stages/implementation.py).
 
 ### [§`StageName`](hephaestus/automation/pipeline/routing.py)

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -11,7 +11,8 @@ GitHub Actions validates repository code independently. Normal
 its binary verdict, but the automation loop does not change checks, workflows,
 statuses, artifacts, leases, or `pull_request_target` events. After the review
 returns a current-head GO, the loop applies `state:implementation-go`;
-`merge_wait` consumes that loop-owned label, while restarted labels re-enter
+`merge_wait` consumes that loop-owned label with its process-local reviewed
+head proof and conditionally merges only that SHA; restarted labels re-enter
 merge-wait. CI/CD never independently produces or validates authorization.
 
 ## Current required contexts

--- a/docs/runbooks/ci-driver-stall.md
+++ b/docs/runbooks/ci-driver-stall.md
@@ -2,9 +2,9 @@
 
 Use this runbook when a PR carries loop-owned `state:implementation-go` and
 remains blocked. The current queue verifies the label only with its
-current-process reviewed-head proof, then `merge_wait` stands by; it does not
-create, disable, adopt, or poll auto-merge pending the separately reviewed
-issue #2419 conditional merge path. CI/CD is outside the loop.
+current-process reviewed-head proof, then `merge_wait` makes one ordinary
+SHA-conditional squash-merge attempt. It does not create, disable, adopt, or
+poll native auto-merge. CI/CD is outside the loop.
 
 ## Containment
 
@@ -24,9 +24,9 @@ manually as a substitute for the queue's review proof.
 
 Confirm the PR has `state:implementation-go`, then rerun the bounded
 drive-green scope. A direct run or restart has no durable reviewed-head proof,
-so merge wait safely revokes the stale label only after a confirmed-unarmed
-read and returns the PR to review. A proof created during the current review
-cycle reaches safe standby rather than an auto-merge mutation:
+so merge wait returns the PR to review without mutating labels. A proof
+created during the current review cycle permits one bounded SHA-conditional
+normal merge rather than an auto-merge mutation:
 
 ```bash
 uv run hephaestus-automation-loop --prs <N> --loops 1 --max-workers 1

--- a/hephaestus/automation/auto_merge_coordinator.py
+++ b/hephaestus/automation/auto_merge_coordinator.py
@@ -240,7 +240,7 @@ class AutoMergeCoordinator:
         )
 
     def enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:
-        """Refuse legacy automatic arming while queue auto-merge is unavailable.
+        """Refuse legacy automatic arming; merge-wait owns conditional merging.
 
         The queue pipeline is the production entry point, but compatibility
         callers must be fail-closed too: a stale implementation-GO label must
@@ -252,7 +252,7 @@ class AutoMergeCoordinator:
             return False
         logger.error(
             "Refusing legacy auto-merge arm for PR #%s; "
-            "queue handling is unavailable pending #2419",
+            "native auto-merge is prohibited and merge-wait uses a conditional normal merge",
             pr_number,
         )
         return False

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -52,7 +52,8 @@ logger = logging.getLogger(__name__)
 
 #: Contiguous stage subset the historical drive-green CLI runs. Direct PRs
 #: first receive the normal PR review, then merge-wait verifies the proof and
-#: safely stands by without mutating auto-merge.
+#: conditionally merges only an admitted reviewed head without mutating native
+#: auto-merge.
 _CI_DRIVER_SCOPE_STAGES: frozenset[StageName] = frozenset(
     {StageName.PR_REVIEW, StageName.MERGE_WAIT}
 )

--- a/hephaestus/automation/github_api/prs.py
+++ b/hephaestus/automation/github_api/prs.py
@@ -260,7 +260,8 @@ def gh_pr_create(
         title: PR title
         body: PR description
         auto_merge: Deprecated compatibility flag; ignored.  Queue
-            automatic-merge handling is unavailable pending #2419.
+        native auto-merge is prohibited; merge-wait conditionally merges
+        reviewed heads after final admission.
         base: Base branch to compare against for signed-commit validation
 
     Returns:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -193,7 +193,7 @@ Examples:
     parser.add_argument(
         "--no-auto-merge",
         action="store_true",
-        help="(Deprecated, ignored) queue auto-merge handling is unavailable pending #2419",
+        help="(Deprecated, ignored) native auto-merge is not used; merge-wait conditionally merges",
     )
     parser.add_argument(
         "--no-learn",

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -200,8 +200,9 @@ class LoopConfig:
     # into the blocking drive-green by default.
     phases: tuple[str, ...] = ALL_PHASES
     # Compatibility bound retained for the historical drive-green CLI. The
-    # current merge-wait stage safely stands by and does not arm or poll
-    # auto-merge; the default remains 5 for stable CLI/config compatibility.
+    # current merge-wait stage conditionally merges only a freshly admitted
+    # reviewed head and never manages native auto-merge; the default remains 5
+    # for stable CLI/config compatibility.
     drive_green_loops: int = 5
     # When True (default), never dispatch two issues whose plans touch the same
     # file concurrently — defer the later one (#1623).
@@ -272,7 +273,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=5,
         help=(
             "Compatibility iteration bound for the historical drive-green CLI; current "
-            "merge-wait safely stands by and does not arm or poll auto-merge "
+            "merge-wait conditionally merges reviewed heads and does not manage native auto-merge "
             "(default: 5; replaces --max-merge-attempts)."
         ),
     )

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -272,9 +272,9 @@ def classify_issue(facts: IssueFacts) -> Classification:
     if facts.pr_is_open:
         # The loop-owned approval label records review eligibility, not durable
         # merge authority.  A restart sends it to merge_wait, which confirms an
-        # unarmed PR before revoking a stale label and returning to review; a
-        # matching current-process proof stands by.  Pending #2419, no queue
-        # stage creates, disables, adopts, or polls automatic merge.
+        # unarmed PR before returning to review; a matching current-process
+        # proof attempts one ordinary conditional merge. No queue stage
+        # creates, disables, adopts, or polls automatic merge.
         if facts.pr_has_implementation_go:
             return (
                 StageName.MERGE_WAIT,

--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -6,6 +6,7 @@ stage-local state machine. The base protocol and step-result types live in
 """
 
 from .base import (
+    ConditionalMergeResult,
     Continue,
     JobRequest,
     Stage,
@@ -23,6 +24,7 @@ from .pr_review import PrReviewStage
 from .repo import RepoStage
 
 __all__ = [
+    "ConditionalMergeResult",
     "Continue",
     "FinishedStage",
     "ImplementationStage",

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -74,6 +74,7 @@ __all__ = [
     "AgentJob",
     "BuildTestJob",
     "CompactJob",
+    "ConditionalMergeResult",
     "Continue",
     "Disposition",
     "GitJob",
@@ -103,6 +104,23 @@ GIT_JOB_TIMEOUT_S = 600
 
 #: Poll backoff cap in seconds (legacy ``min(2**attempt, 60)`` — shared by
 #: every stage that uses the legacy exponential poll delay.
+
+
+@dataclass(frozen=True)
+class ConditionalMergeResult:
+    """Outcome of one SHA-conditional normal GitHub merge request.
+
+    ``status`` and ``body`` preserve the server's response for merge-wait to
+    classify. ``transport_error`` means the server outcome is unknown, while
+    ``malformed`` means the response was received but could not be safely
+    interpreted. The adapter never retries this mutation itself.
+    """
+
+    status: int | None
+    body: dict[str, Any] | None
+    transport_error: bool = False
+    malformed: bool = False
+    dry_run: bool = False
 
 
 @runtime_checkable
@@ -320,6 +338,14 @@ class StageGitHub(Protocol):
         head OID and classify merged, closed, and open lifecycle states.
         """
         ...
+
+    def gh_pr_merge_readiness(self, pr_number: int) -> dict[str, Any] | None:
+        """Read operational normal-merge readiness after an HTTP 405 response."""
+        pass
+
+    def merge_pr_if_head(self, pr_number: int, reviewed_sha: str) -> ConditionalMergeResult:
+        """Perform one immediate normal merge conditional on ``reviewed_sha``."""
+        pass
 
     def drive_green_learn_terminal(self, issue_number: int) -> bool:
         """Return True when the post-merge ``/learn`` is already terminal.

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -1,29 +1,16 @@
-"""Merge-wait: reviewed-head interlock and post-merge learning.
+"""Merge-wait: final head-bound admission and one conditional normal merge.
 
-``pr_review`` owns the only automated GO/NOGO decision and writes the
-loop-owned ``state:implementation-go`` label.  It consumes an in-memory
-reviewed-head proof only when it matches the live, confirmed-unarmed PR head.
-Until #2419 supplies a separately reviewed conditional normal-merge path, a
-matching proof stands down safely: this stage never creates, disables, adopts,
-or polls an auto-merge request.
-
-The implemented mini-state graph is:
-
-- Open PR: ENTER -> ARM -> FINISH_FAIL(``merge_wait_standing_by``) after
-  reviewed-head and confirmed-unarmed checks.
-- Already-merged PR: ENTER -> ARM -> LEARN_WAIT -> MW_FINISH,
-  preserving the exactly-once post-merge learning contract through
-  ``ctx.github.drive_green_learn_terminal``.
-
-The persistent approval label is deliberately insufficient after a restart or
-direct ``--prs`` seed because the reviewed-head proof is process-local.  Those
-paths revoke the stale label only after a fresh confirmed-unarmed state read
-and return to review; merge-wait-only scope consequently terminates safely.
+``pr_review`` owns the loop's source-review decision. This stage may perform
+one ordinary REST squash merge only after it observes the exact active-run
+reviewed head, an exclusive implementation-GO label, an open ``main`` PR, and
+an explicitly absent auto-merge request. It never enables, disables, adopts,
+or polls native auto-merge.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from hephaestus.automation.agent_config import implementer_model, learn_claude_timeout
 from hephaestus.automation.learn import build_learn_prompt
@@ -51,11 +38,13 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 ENTER = "ENTER"
-ARM = "ARM"
-POLL = "POLL"
+MERGE = "MERGE"
 LEARN_WAIT = "LEARN_WAIT"
 MW_FINISH = "MW_FINISH"
 FINISH = MW_FINISH
+
+_RETRYABLE_READINESS = frozenset({"BEHIND", "BLOCKED", "HAS_HOOKS", "UNKNOWN", "UNSTABLE"})
+_CONFLICTING_READINESS = frozenset({"CONFLICTING", "DIRTY"})
 
 
 def build_drive_green_learn_prompt(issue_number: int, pr_number: int) -> str:
@@ -68,10 +57,10 @@ def build_drive_green_learn_prompt(issue_number: int, pr_number: int) -> str:
 
 
 class MergeWaitStage(Stage):
-    """Verify a reviewed approval without creating persistent merge authority."""
+    """Attempt a bounded SHA-conditional merge after final live admission."""
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
-        """Reject an unscoped PR without altering any operator-owned arm."""
+        """Reject an unscoped PR without touching any GitHub state."""
         del ctx
         if item.issue is None:
             logger.warning(
@@ -83,13 +72,11 @@ class MergeWaitStage(Stage):
         return None
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Execute the current merge-wait mini-state."""
+        """Execute the merge-wait state machine."""
         if item.state == ENTER:
-            return Continue(next_state=ARM)
-        if item.state == ARM:
-            return self._arm(item, ctx)
-        if item.state == POLL:
-            return self._poll(item, ctx)
+            return Continue(next_state=MERGE)
+        if item.state == MERGE:
+            return self._merge(item, ctx)
         if item.state == LEARN_WAIT:
             return self._request_learn(item, ctx)
         if item.state == MW_FINISH:
@@ -99,93 +86,137 @@ class MergeWaitStage(Stage):
         logger.warning("merge_wait:%s: unknown state %r", item.issue, item.state)
         return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
 
-    def _arm(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Consume only a matching current-review proof, then stand down."""
+    def _merge(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Read final admission facts, then make at most one conditional request."""
+        admitted = self._admit(item, ctx)
+        if not isinstance(admitted, tuple):
+            return admitted
+        pr_state, reviewed_head = admitted
+        del pr_state
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
-        pr_state, terminal = self._read_confirmed_open_unarmed(item, ctx)
-        if terminal is not None:
-            return terminal
-        if pr_state is None:
-            return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
-        has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
-        if not has_go:
-            return StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
-        head_sha = str(pr_state.get("headRefOid") or "")
-        if not head_sha:
-            logger.warning(
-                "merge_wait: PR #%d has no readable head; operator action required", item.pr
-            )
-            return StageOutcome(Disposition.FINISH_FAIL, "missing_pr_head")
-        reviewed_head = str(item.payload.get("reviewed_pr_head_sha") or "")
-        if reviewed_head != head_sha:
-            return self._revoke_stale_reviewed_head(item, ctx, reviewed_head)
-        return StageOutcome(Disposition.FINISH_FAIL, "merge_wait_standing_by")
+        if item.attempts["merge"] >= ctx.budget("merge"):
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
+        item.attempts["merge"] += 1
+        result = ctx.github.merge_pr_if_head(item.pr, reviewed_head)
+        if result.dry_run:
+            return StageOutcome(Disposition.FINISH_FAIL, "conditional_merge_dry_run")
+        if result.malformed:
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_result_malformed")
+        if result.transport_error or result.status is None:
+            return self._reconcile_transport_ambiguity(item, ctx)
+        if result.status == 200:
+            if result.body is not None and result.body.get("merged") is True:
+                return self._reconcile_successful_merge(item, ctx)
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_not_merged")
+        if result.status == 409:
+            return self._reconcile_head_conflict(item, ctx)
+        if result.status == 405:
+            return self._reconcile_not_ready(item, ctx)
+        if result.status in {403, 404, 422}:
+            return StageOutcome(Disposition.FINISH_FAIL, f"merge_http_{result.status}")
+        return StageOutcome(Disposition.FINISH_FAIL, f"merge_http_{result.status}")
 
-    def _poll(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Stand down when a live unarmed PR reaches the retired poll state."""
+    def _admit(self, item: WorkItem, ctx: StageContext) -> tuple[dict[str, Any], str] | StepResult:
+        """Return the complete final-admission facts or a safe terminal route."""
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
-        _pr_state, terminal = self._read_confirmed_open_unarmed(item, ctx)
-        if terminal is not None:
-            return terminal
-        return StageOutcome(Disposition.FINISH_FAIL, "merge_wait_standing_by")
-
-    def _read_confirmed_open_unarmed(
-        self, item: WorkItem, ctx: StageContext
-    ) -> tuple[dict[str, object] | None, StepResult | None]:
-        """Read one PR state and return it only when it is complete, open, and unarmed."""
-        if item.pr is None:
-            return None, StageOutcome(Disposition.FINISH_FAIL, "no_pr")
         pr_state = ctx.github.gh_pr_state(item.pr)
         terminal = _terminal_pr_outcome(pr_state, item.pr)
         if terminal is not None:
-            result = (
-                self._route_merged(item, ctx)
-                if terminal.disposition is Disposition.FINISH_PASS
-                else terminal
-            )
-            return None, result
+            if terminal.disposition is Disposition.FINISH_PASS:
+                return self._route_merged(item, ctx)
+            return terminal
         if pr_state is None:
-            logger.warning(
-                "merge_wait: PR #%d state unavailable; operator action required", item.pr
-            )
-            return None, StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
+            return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
         if pr_state.get("autoMergeRequest") is not None:
-            logger.warning(
-                "merge_wait: PR #%d is already armed; leaving it to the operator", item.pr
-            )
-            return None, StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+            return StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
         if not _is_confirmed_open_unarmed(pr_state):
-            return None, StageOutcome(Disposition.FINISH_FAIL, "pr_state_unverified")
-        return pr_state, None
+            return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unverified")
+        if pr_state.get("baseRefName") != "main":
+            return StageOutcome(Disposition.FINISH_FAIL, "non_main_base")
+        has_go, has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
+        if not has_go or has_no_go:
+            return StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
+        head = str(pr_state.get("headRefOid") or "")
+        if not head:
+            return StageOutcome(Disposition.FINISH_FAIL, "missing_pr_head")
+        reviewed_head = str(item.payload.get("reviewed_pr_head_sha") or "")
+        if reviewed_head != head:
+            return self._revoke_stale_reviewed_head(item, ctx, reviewed_head)
+        return pr_state, reviewed_head
 
     def _revoke_stale_reviewed_head(
         self, item: WorkItem, ctx: StageContext, reviewed_head: str
-    ) -> StepResult:
-        """Re-read before revoking a stale label and return to review if still stale."""
-        if item.pr is None:
-            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
-        current_state, terminal = self._read_confirmed_open_unarmed(item, ctx)
-        if terminal is not None:
-            return terminal
-        if current_state is None:
-            return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
-        current_head = str(current_state.get("headRefOid") or "")
-        if not current_head:
-            return StageOutcome(Disposition.FINISH_FAIL, "missing_pr_head")
-        if reviewed_head == current_head:
-            return StageOutcome(Disposition.FINISH_FAIL, "merge_wait_standing_by")
-        try:
-            ctx.github.mark_pr_implementation_no_go(item.pr)
-        except Exception as exc:
-            logger.warning(
-                "merge_wait: could not revoke stale approval on PR #%d (%s)", item.pr, exc
-            )
-            return StageOutcome(Disposition.FINISH_FAIL, "implementation_no_go_label_failed")
+    ) -> StageOutcome:
+        """Discard stale process-local proof without relabelling a live PR.
+
+        A final read cannot prove this process owns a future label: an external
+        arm or newer GO can arrive immediately afterward. Fresh review owns any
+        subsequent state decision, so this method performs zero mutations.
+        """
+        del item, ctx
         if not reviewed_head:
             return StageOutcome(Disposition.FAIL_BACK, "reviewed_head_missing")
         return StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
+
+    def _reconcile_successful_merge(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Require a fresh terminal lifecycle observation after HTTP 200."""
+        if item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        state = ctx.github.gh_pr_state(item.pr)
+        terminal = _terminal_pr_outcome(state, item.pr)
+        if terminal is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_not_merged")
+        if terminal.disposition is Disposition.FINISH_PASS:
+            return self._route_merged(item, ctx)
+        return terminal
+
+    def _reconcile_head_conflict(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Classify a conditional-SHA conflict using fresh live lifecycle state."""
+        admitted = self._admit(item, ctx)
+        if not isinstance(admitted, tuple):
+            return admitted
+        return StageOutcome(Disposition.FINISH_FAIL, "merge_409_without_head_drift")
+
+    def _reconcile_not_ready(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Use operational readiness to distinguish retryable 405 from conflict."""
+        if item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        readiness = ctx.github.gh_pr_merge_readiness(item.pr)
+        terminal = _terminal_pr_outcome(readiness, item.pr)
+        if terminal is not None:
+            if terminal.disposition is Disposition.FINISH_PASS:
+                return self._route_merged(item, ctx)
+            return terminal
+        if readiness is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_readiness_unavailable")
+        if readiness.get("autoMergeRequest") is not None:
+            return StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+        admitted = self._admit(item, ctx)
+        if not isinstance(admitted, tuple):
+            return admitted
+        status = str(readiness.get("mergeStateStatus") or "").upper()
+        if status in _CONFLICTING_READINESS:
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_conflicting")
+        if status not in _RETRYABLE_READINESS:
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_readiness_unknown")
+        return self._retry(item, ctx)
+
+    def _reconcile_transport_ambiguity(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Re-read lifecycle before deciding whether an unknown request may retry."""
+        admitted = self._admit(item, ctx)
+        if not isinstance(admitted, tuple):
+            return admitted
+        return self._retry(item, ctx)
+
+    @staticmethod
+    def _retry(item: WorkItem, ctx: StageContext) -> StageOutcome:
+        """Timer-park a bounded retry without issuing another merge in this step."""
+        if item.attempts["merge"] >= ctx.budget("merge"):
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
+        item.payload["retry_delay_s"] = float(min(2 ** max(0, item.attempts["merge"] - 1), 60))
+        return StageOutcome(Disposition.RETRY, "merge_not_ready")
 
     def _route_merged(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Dispatch the existing deduplicated post-merge learning step."""

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -49,7 +49,7 @@ contract):
   ``_write_go`` performs one final human-thread live-read, requires a
   confirmed-unarmed live PR, and applies ``state:implementation-go``.
   The checkout GitJob-proven reviewed head accompanies that label;
-  ``merge_wait`` verifies it and stands by pending #2419. Every
+  ``merge_wait`` verifies it before one SHA-conditional normal merge. Every
   real non-GO round durably writes ``state:implementation-no-go`` (doc
   section 5 owned label, "NOGO verdict, before retry/regress"; legacy
   ``_apply_impl_review_verdict`` -> ``mark_pr_implementation_no_go``

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -85,7 +85,6 @@ class WorkItem:
     labels_cache: dict[str, bool] = field(default_factory=dict)
     payload: dict[str, Any] = field(default_factory=dict)
     result: ItemResult | None = None
-    armed: bool = False
 
     def add_history_event(self, stage: StageName, state: str, note: str = "") -> None:
         """Record a stage transition in the history (capped at HISTORY_CAP events)."""

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -41,6 +41,7 @@ from hephaestus.automation.arming_state import (
     ArmingStateStore,
 )
 from hephaestus.automation.git_utils import issue_auto_impl_branch_name
+from hephaestus.automation.pipeline.stages.base import ConditionalMergeResult
 from hephaestus.automation.prompts.pr_review import (
     BLOCKING_SEVERITIES,
     SEVERITY_MARKER_PREFIX,
@@ -77,6 +78,35 @@ from hephaestus.utils.file_lock import file_lock
 logger = logging.getLogger(__name__)
 
 _CLOSES_ISSUE_LINE_RE = re.compile(r"^Closes #(\d+)\s*$", re.MULTILINE)
+_HTTP_STATUS_RE = re.compile(r"^HTTP/\S+\s+(\d{3})\b", re.MULTILINE)
+
+
+def _parse_included_http_response(
+    stdout: str,
+) -> tuple[int | None, dict[str, Any] | None, bool]:
+    """Parse the final status and JSON object from ``gh api --include`` output.
+
+    A missing HTTP status means the CLI did not provide enough evidence to
+    classify the request. A received non-object or invalid body is explicitly
+    malformed so callers fail closed rather than treating it as transport
+    ambiguity.
+    """
+    matches = list(_HTTP_STATUS_RE.finditer(stdout))
+    if not matches:
+        return None, None, False
+    status = int(matches[-1].group(1))
+    headers_end = re.search(r"\r?\n\r?\n", stdout[matches[-1].start() :])
+    if headers_end is None:
+        return status, None, True
+    body_start = matches[-1].start() + headers_end.end()
+    body = stdout[body_start:].strip()
+    if not body:
+        return status, None, True
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return status, None, True
+    return (status, parsed, False) if isinstance(parsed, dict) else (status, None, True)
 
 
 def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
@@ -862,6 +892,67 @@ class PipelineGitHub:
         except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
             logger.warning("PR #%s: gh_pr_state read failed: %s", pr_number, exc)
             return None
+
+    def gh_pr_merge_readiness(self, pr_number: int) -> dict[str, Any] | None:
+        """Read operational readiness after a conditional normal merge returns 405.
+
+        This read classifies whether GitHub declined an otherwise valid merge
+        because the PR is not ready, rather than treating CI/CD state as a
+        separate source of merge authority.
+        """
+        try:
+            result = self._gh(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "state,headRefOid,mergedAt,baseRefName,autoMergeRequest,mergeable,mergeStateStatus",
+                ]
+            )
+            data = json.loads(result.stdout or "{}")
+            return data if isinstance(data, dict) else None
+        except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+            logger.warning("PR #%s: merge readiness read failed: %s", pr_number, exc)
+            return None
+
+    def merge_pr_if_head(self, pr_number: int, reviewed_sha: str) -> ConditionalMergeResult:
+        """Attempt one immediate squash merge conditional on the reviewed SHA.
+
+        The request deliberately avoids the GitHub CLI PR-merge subcommand,
+        native auto-merge, merge queues, administrator flags, and retries. A
+        stage-owned lifecycle read decides whether an ambiguous request may be
+        retried later.
+        """
+        if pr_number <= 0 or not re.fullmatch(r"[0-9a-fA-F]{40}", reviewed_sha):
+            return ConditionalMergeResult(status=None, body=None, malformed=True)
+        owner, name = self._owner_name()
+        if self._skip(f"conditionally squash merge PR #{pr_number} at {reviewed_sha}"):
+            return ConditionalMergeResult(status=None, body=None, dry_run=True)
+        try:
+            result = gh_call(
+                [
+                    "api",
+                    "--method",
+                    "PUT",
+                    "--include",
+                    f"/repos/{owner}/{name}/pulls/{pr_number}/merge",
+                    "-f",
+                    f"sha={reviewed_sha}",
+                    "-f",
+                    "merge_method=squash",
+                ],
+                check=False,
+                retry_on_rate_limit=False,
+                max_retries=1,
+            )
+        except (subprocess.SubprocessError, RuntimeError, OSError) as exc:
+            logger.warning("PR #%s: conditional merge transport failure: %s", pr_number, exc)
+            return ConditionalMergeResult(status=None, body=None, transport_error=True)
+        status, body, malformed = _parse_included_http_response(result.stdout or "")
+        if status is None:
+            return ConditionalMergeResult(status=None, body=None, transport_error=True)
+        return ConditionalMergeResult(status=status, body=body, malformed=malformed)
 
     def drive_green_learn_terminal(self, issue_number: int) -> bool:
         """Return True when the post-merge ``/learn`` is already terminal.

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -733,11 +733,11 @@ def pr_has_implementation_state_label(pr_number: int) -> tuple[bool, bool]:
 
 
 def enable_auto_merge_after_implementation_go(pr_number: int) -> None:
-    """Refuse legacy direct arming while queue auto-merge is unavailable."""
+    """Refuse legacy direct arming; merge-wait owns conditional merging."""
     ensure_pr_auto_merge_deferred(pr_number)
     raise RuntimeError(
         f"refusing to arm auto-merge for PR #{pr_number}: "
-        "queue auto-merge handling is unavailable pending #2419"
+        "native auto-merge is prohibited; merge-wait uses a conditional normal merge"
     )
 
 
@@ -929,8 +929,8 @@ def ensure_pr_created(
         issue_number: Issue number
         branch_name: Git branch name
         worktree_path: Path to worktree
-        auto_merge: Deprecated compatibility flag; ignored.  Queue
-            automatic-merge handling is unavailable pending #2419.
+        auto_merge: Deprecated compatibility flag; ignored. Native auto-merge
+            is prohibited; merge-wait conditionally merges reviewed heads.
         status_tracker: StatusTracker instance for slot updates (optional)
         slot_id: Worker slot ID for status updates
         agent: Selected implementation agent for generated PR metadata.
@@ -1037,8 +1037,8 @@ def create_pr(
     Args:
         issue_number: Issue number
         branch_name: Git branch name
-        auto_merge: Deprecated compatibility flag; ignored.  Queue
-            automatic-merge handling is unavailable pending #2419.
+        auto_merge: Deprecated compatibility flag; ignored. Native auto-merge
+            is prohibited; merge-wait conditionally merges reviewed heads.
         agent: Selected implementation agent for generated PR metadata.
         base: Base branch used for changed-file and commit context.
         worktree_path: Optional worktree path used to invoke the lightweight

--- a/hephaestus/prompts/templates/default/implementation/implementation.j2
+++ b/hephaestus/prompts/templates/default/implementation/implementation.j2
@@ -95,5 +95,7 @@ After you return, the orchestrator will:
 
 Missing `Closes #N` or signed-commit policy is enforced outside the automation
 loop. Only the queue's `pr_review` stage may publish implementation approval.
-Pending #2419, no queue stage manages automatic merge. This policy applies to
-every PR — no exceptions.
+After that approval, `merge_wait` independently revalidates the exact reviewed
+head and may perform one SHA-conditional normal squash merge. Agents must not
+enable, disable, adopt, or otherwise manage native auto-merge. This policy
+applies to every PR — no exceptions.

--- a/hephaestus/prompts/templates/default/pr_review/analysis.j2
+++ b/hephaestus/prompts/templates/default/pr_review/analysis.j2
@@ -34,8 +34,9 @@ Analyze PR #{{ pr_number }} using {{ review_context_kind }} #{{ issue_number }} 
 > `CONDITIONAL GO` or any no-go result is `NOGO`.
 > If it is unavailable, perform the equivalent review
 > directly using this prompt. In either case, this review is the loop's sole
-> GO/NOGO decision; `merge_wait` verifies the reviewed-head proof and stands by
-> while automatic-merge handling remains unavailable pending #2419.
+> GO/NOGO decision; `merge_wait` independently verifies the reviewed-head
+> proof and may perform its own one-shot SHA-conditional normal merge. Never
+> ask an agent to enable, disable, adopt, or otherwise manage native auto-merge.
 
 **Assume the code is WRONG; your job is to prove it right.** Do not review for
 plausibility — review for falsification: trace each changed execution path,

--- a/hephaestus/validation/doc_policy.py
+++ b/hephaestus/validation/doc_policy.py
@@ -11,7 +11,7 @@ Policies enforced:
 - ``gh pr create`` must NOT include ``--label``
 - ``git commit`` must NOT use ``--no-verify``
 - ``gh pr merge`` must use manual ``--squash`` without ``--auto`` (not ``--merge``
-  or ``--rebase``; queue automatic-merge handling is unavailable pending #2419)
+  or ``--rebase``; native auto-merge remains forbidden to queue agents)
 - ``git push`` must NOT push directly to ``main``/``master``
 
 Excluded paths (archived / test-fixture content that is not authoritative):
@@ -118,7 +118,8 @@ _RAW_RULES: list[tuple[str, Severity, str, str]] = [
         # Flag any ``gh pr merge`` invocation that carries ``--auto`` or a
         # rejected strategy flag, or that omits the required manual squash
         # strategy. Docs must not instruct an agent to arm a merge autonomously.
-        # Pending #2419, no queue stage owns automatic-merge handling.
+        # `merge_wait` owns the one-shot SHA-conditional REST path; this
+        # guard continues to forbid native automatic-merge instructions.
         r"gh\s+pr\s+merge\b"
         r"(?:"
         r"(?=.*--auto\b)|"

--- a/scripts/choose_merge_flag.sh
+++ b/scripts/choose_merge_flag.sh
@@ -7,7 +7,8 @@
 #   # After a human-approved manual merge decision:
 #   gh pr merge "$PR" "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
 # Legacy consumers choose a permitted manual merge strategy with this helper.
-# Queue automatic-merge handling is unavailable pending #2419.
+# Native automatic-merge remains disabled: queue merge-wait uses a separate
+# SHA-conditional normal merge and never arms GitHub auto-merge.
 #
 # Preference order: rebase (linear history) -> squash -> merge commit.
 # Exit codes:

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -17,6 +17,7 @@ import pytest
 from hephaestus.automation.pipeline.events import StageEvent
 from hephaestus.automation.pipeline.routing import ROUTES, StageName
 from hephaestus.automation.pipeline.stages import (
+    ConditionalMergeResult,
     StageContext,
     StageGitHub,
 )
@@ -361,6 +362,17 @@ class FakeStageGitHub(FakeGitHub):
         """Mirror ci_driver.CIDriver._gh_pr_state (canned answer)."""
         del pr_number  # single canned answer; not per-PR keyed
         return self._pr_state
+
+    def gh_pr_merge_readiness(self, pr_number: int) -> dict[str, Any] | None:
+        """Mirror the post-405 operational readiness lookup."""
+        del pr_number
+        return dict(self._pr_state) if isinstance(self._pr_state, dict) else self._pr_state
+
+    def merge_pr_if_head(self, pr_number: int, reviewed_sha: str) -> ConditionalMergeResult:
+        """Mirror one successful SHA-conditional normal merge request."""
+        self._log("merge_pr_if_head", pr_number, reviewed_sha)
+        self._pr_state = {"state": "MERGED"}
+        return ConditionalMergeResult(status=200, body={"merged": True})
 
     def drive_green_learn_terminal(self, issue_number: int) -> bool:
         """Mirror ci_driver._learn_record_terminal over the arming record.

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from hephaestus.automation.pipeline.routing import Disposition, StageName
 from hephaestus.automation.pipeline.stages import ConditionalMergeResult, Continue, StageOutcome
 from hephaestus.automation.pipeline.stages.merge_wait import MergeWaitStage
@@ -225,6 +227,71 @@ def test_ambiguous_transport_head_drift_fails_back_without_label_mutation(
     assert github.mutation_log == []
 
 
+def test_ambiguous_transport_retries_only_after_delayed_same_head_read(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A same-head ambiguity earns one timer retry, never an in-step re-PUT."""
+    github = _ConditionalGitHub(
+        states=[_open_pr(), _open_pr()],
+        merge_results=[
+            ConditionalMergeResult(
+                status=None,
+                body=None,
+                transport_error=True,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+    item = _reviewed_item(make_work_item)
+
+    result = MergeWaitStage().step(item, make_ctx(github=github, budget_fn=lambda _route: 2))
+
+    assert result == StageOutcome(Disposition.RETRY, "merge_not_ready")
+    assert item.attempts["merge"] == 1
+    assert item.payload["retry_delay_s"] == 1.0
+    assert github.merge_attempts == [(12, "a" * 40)]
+    assert github.mutation_log == []
+
+
+def test_ambiguous_transport_with_unreadable_reconciliation_is_terminal(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A transport ambiguity cannot retry when the confirming read is unavailable."""
+    github = _ConditionalGitHub(
+        states=[_open_pr(), None],
+        merge_results=[
+            ConditionalMergeResult(
+                status=None,
+                body=None,
+                transport_error=True,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
+    assert github.merge_attempts == [(12, "a" * 40)]
+    assert github.mutation_log == []
+
+
+def test_restarted_merge_without_process_local_proof_fails_back_without_put(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A restarted process never reconstructs authority from durable labels alone."""
+    github = _ConditionalGitHub(states=[_open_pr()])
+    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=MERGE)
+
+    result = MergeWaitStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_missing")
+    assert github.merge_attempts == []
+    assert github.mutation_log == []
+
+
 def test_409_head_drift_fails_back_without_label_mutation(
     make_ctx: Any, make_work_item: Any
 ) -> None:
@@ -272,6 +339,63 @@ def test_405_retry_is_timer_parked_only_while_merge_budget_remains(
     assert result == StageOutcome(Disposition.RETRY, "merge_not_ready")
     assert item.payload["retry_delay_s"] == 1.0
     assert github.merge_attempts == [(12, "a" * 40)]
+
+
+@pytest.mark.parametrize("merge_state_status", ["CONFLICTING", "DIRTY"])
+def test_405_conflicting_or_dirty_readiness_is_terminal(
+    make_ctx: Any, make_work_item: Any, merge_state_status: str
+) -> None:
+    """Conflict-like GitHub readiness states are not retried as transient readiness."""
+    github = _ConditionalGitHub(
+        states=[_open_pr()],
+        merge_results=[
+            ConditionalMergeResult(
+                status=405,
+                body={"message": "not ready"},
+                transport_error=False,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+        readiness={
+            "state": "OPEN",
+            "headRefOid": "a" * 40,
+            "autoMergeRequest": None,
+            "baseRefName": "main",
+            "mergeable": "CONFLICTING",
+            "mergeStateStatus": merge_state_status,
+        },
+    )
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_conflicting")
+    assert github.merge_attempts == [(12, "a" * 40)]
+    assert github.mutation_log == []
+
+
+def test_409_reconciliation_external_arm_blocks_without_label_mutation(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A fresh external arm after a 409 blocks the run without trying to revoke it."""
+    github = _ConditionalGitHub(
+        states=[_open_pr(), _open_pr(auto_merge_request={"enabledAt": "external"})],
+        merge_results=[
+            ConditionalMergeResult(
+                status=409,
+                body={"message": "head changed"},
+                transport_error=False,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+    assert github.merge_attempts == [(12, "a" * 40)]
+    assert github.mutation_log == []
 
 
 def test_label_loss_or_non_main_base_prevents_the_conditional_request(

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -1,314 +1,349 @@
-"""Tests for the intentionally simple label-only merge-wait stage."""
+"""Tests for the conditional, head-bound merge-wait stage."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from hephaestus.automation.pipeline.routing import Disposition, StageName
-from hephaestus.automation.pipeline.stages import StageOutcome
-from hephaestus.automation.pipeline.stages.merge_wait import ARM, POLL, MergeWaitStage
+from hephaestus.automation.pipeline.stages import ConditionalMergeResult, Continue, StageOutcome
+from hephaestus.automation.pipeline.stages.merge_wait import MergeWaitStage
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
-
-class _ArmingGitHub(FakeStageGitHub):
-    def __init__(self, *, labels: tuple[bool, bool] = (True, False)) -> None:
-        super().__init__(
-            pr_impl_state=labels,
-            pr_state={"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
-        )
+MERGE = "MERGE"
 
 
-def test_matching_reviewed_head_stands_down_without_creating_auto_merge(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """#2423 holds a reviewed PR safely pending the later normal merge path."""
-    github = _ArmingGitHub()
-    item = make_work_item(
-        stage=StageName.MERGE_WAIT,
-        pr=12,
-        state=ARM,
-        payload={"reviewed_pr_head_sha": "a" * 40},
-    )
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_wait_standing_by")
-    assert github.mutation_log == []
-    assert item.armed is False
-
-
-def test_existing_auto_merge_is_blocked_and_left_to_the_operator(
-    make_ctx: Any, make_work_item: Any, caplog: Any
-) -> None:
-    """An arm observed before this run never triggers recovery or re-arming."""
-    github = _ArmingGitHub()
-    github._pr_state = {
+def _open_pr(
+    head: str = "a" * 40,
+    *,
+    auto_merge_request: object | None = None,
+    base: str = "main",
+) -> dict[str, object]:
+    """Return a complete open lifecycle record for a merge admission test."""
+    return {
         "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "elsewhere"},
+        "headRefOid": head,
+        "autoMergeRequest": auto_merge_request,
+        "baseRefName": base,
     }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=ARM)
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert not any(action == "arm_auto_merge" for action, _ in github.mutation_log)
-    assert item.attempts["merge"] == 0
-    assert "already armed" in caplog.text
 
 
-def test_missing_reviewed_head_revokes_go_and_returns_to_review(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """Restarted merge-wait has no durable review proof and must fail back."""
-    github = _ArmingGitHub()
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=ARM)
+class _ConditionalGitHub(FakeStageGitHub):
+    """Stage fake with scripted atomic-merge and lifecycle responses."""
 
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_missing")
-    assert github.mutation_log == [("mark_pr_implementation_no_go", (12,))]
-
-
-def test_poll_of_an_unarmed_pr_stands_by_without_retrying(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """Merge wait no longer tracks or retries an auto-merge arm."""
-    github = _ArmingGitHub()
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    github._pr_state = {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None}
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_wait_standing_by")
-    assert github.mutation_log == []
-
-
-def test_closed_pr_stops_without_mutating_or_consuming_merge_budget(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """A closed-unmerged PR is terminal before merge-arm handling."""
-    github = _ArmingGitHub()
-    github._pr_state = {"state": "CLOSED"}
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    item.armed = True
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "closed")
-    assert github.mutation_log == []
-    assert item.attempts["merge"] == 0
-
-
-def test_unavailable_pr_state_stops_without_mutating_or_consuming_merge_budget(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """An API/read failure is terminal before merge-arm handling."""
-    github = _ArmingGitHub()
-    github._pr_state = None
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    item.armed = True
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
-    assert github.mutation_log == []
-    assert item.attempts["merge"] == 0
-
-
-def test_merge_wait_rejects_a_partial_unarmed_state_without_label_mutation(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """A missing auto-merge field is ambiguous, not proof of an unarmed PR."""
-    github = _ArmingGitHub()
-    github._pr_state = {"state": "OPEN", "headRefOid": "a" * 40}
-    item = make_work_item(
-        stage=StageName.MERGE_WAIT,
-        pr=12,
-        state=ARM,
-        payload={"reviewed_pr_head_sha": "a" * 40},
-    )
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "pr_state_unverified")
-    assert github.mutation_log == []
-
-
-def test_stale_proof_re_read_that_matches_stands_down_without_revoking_go(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """A remote head moving back to the reviewed commit invalidates the stale decision."""
-
-    class FlippingStateGitHub(_ArmingGitHub):
-        def __init__(self) -> None:
-            super().__init__()
-            self._states = [
-                {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None},
-                {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
+    def __init__(
+        self,
+        *,
+        labels: tuple[bool, bool] = (True, False),
+        states: list[dict[str, object] | None] | None = None,
+        merge_results: list[ConditionalMergeResult] | None = None,
+        readiness: dict[str, object] | None = None,
+    ) -> None:
+        scripted_states = states or [_open_pr()]
+        super().__init__(pr_impl_state=labels, pr_state=scripted_states[-1])
+        self._states = list(scripted_states)
+        self._merge_results = list(
+            merge_results
+            or [
+                ConditionalMergeResult(
+                    status=200,
+                    body={"merged": True},
+                    transport_error=False,
+                    malformed=False,
+                    dry_run=False,
+                )
             ]
+        )
+        self._readiness = readiness or {
+            "state": "OPEN",
+            "headRefOid": "a" * 40,
+            "autoMergeRequest": None,
+            "baseRefName": "main",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BEHIND",
+        }
+        self.merge_attempts: list[tuple[int, str]] = []
 
-        def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
-            del pr_number
+    def gh_pr_state(self, pr_number: int) -> dict[str, object] | None:
+        del pr_number
+        if len(self._states) > 1:
             return self._states.pop(0)
+        return self._states[0]
 
-    github = FlippingStateGitHub()
-    item = make_work_item(
+    def merge_pr_if_head(self, pr_number: int, reviewed_sha: str) -> ConditionalMergeResult:
+        self.merge_attempts.append((pr_number, reviewed_sha))
+        return self._merge_results.pop(0)
+
+    def gh_pr_merge_readiness(self, pr_number: int) -> dict[str, object] | None:
+        del pr_number
+        return dict(self._readiness)
+
+
+def _reviewed_item(make_work_item: Any, *, head: str = "a" * 40) -> Any:
+    return make_work_item(
         stage=StageName.MERGE_WAIT,
         pr=12,
-        state=ARM,
-        payload={"reviewed_pr_head_sha": "a" * 40},
+        state=MERGE,
+        payload={"reviewed_pr_head_sha": head},
     )
 
-    result = MergeWaitStage().step(item, make_ctx(github=github))
 
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_wait_standing_by")
-    assert github.mutation_log == []
-
-
-def test_poll_external_auto_merge_is_blocked_without_consuming_merge_budget(
-    make_ctx: Any, make_work_item: Any, caplog: Any
-) -> None:
-    """A POLL restart never claims an arm it did not create."""
-    github = _ArmingGitHub()
-    github._pr_state = {
-        "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "elsewhere"},
-    }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert github.mutation_log == []
-    assert item.attempts["merge"] == 0
-    assert "retry_delay_s" not in item.payload
-    assert "already armed" in caplog.text
-
-
-def test_poll_external_auto_merge_without_approval_remains_blocked(
+def test_conditional_merge_succeeds_only_after_lifecycle_confirms_merged(
     make_ctx: Any, make_work_item: Any
 ) -> None:
-    """An external arm remains operator-owned even after its approval changes."""
-    github = _ArmingGitHub(labels=(False, False))
-    github._pr_state = {
-        "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "elsewhere"},
-    }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert github.mutation_log == []
-    assert item.attempts["merge"] == 0
-    assert "retry_delay_s" not in item.payload
-
-
-def test_poll_treats_any_observed_arm_as_external(make_ctx: Any, make_work_item: Any) -> None:
-    """No in-process arm ownership remains after #2423."""
-    github = _ArmingGitHub()
-    github._pr_state = {
-        "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "this-run"},
-    }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    item.armed = True
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert item.attempts["merge"] == 0
-    assert "retry_delay_s" not in item.payload
-
-
-def test_poll_arm_does_not_consume_a_merge_budget(make_ctx: Any, make_work_item: Any) -> None:
-    """An operator-owned arm is never retried by the pipeline."""
-    github = _ArmingGitHub()
-    github._pr_state = {
-        "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "this-run"},
-    }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    item.armed = True
-    result = MergeWaitStage().step(item, make_ctx(github=github, budget_fn=lambda _name: 1))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert item.attempts["merge"] == 0
-    assert "retry_delay_s" not in item.payload
-
-
-def test_missing_implementation_go_returns_to_review(make_ctx: Any, make_work_item: Any) -> None:
-    """A normal absent approval still returns to the loop-owned review stage."""
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=ARM)
-
-    result = MergeWaitStage().step(item, make_ctx(github=_ArmingGitHub(labels=(False, False))))
-
-    assert result == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
-
-
-def test_external_arm_without_approval_remains_blocked(make_ctx: Any, make_work_item: Any) -> None:
-    """External arms take priority over missing labels and receive no mutation."""
-    github = _ArmingGitHub(labels=(False, False))
-    github._pr_state = {
-        "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "this-run"},
-    }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    item.armed = True
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert github.mutation_log == []
-    assert item.attempts["merge"] == 0
-    assert "retry_delay_s" not in item.payload
-
-
-def test_external_arm_never_invokes_the_removed_defer_path(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """The safe operator stand-down has no disable/reconciliation operation."""
-    github = _ArmingGitHub(labels=(False, False))
-    github._pr_state = {
-        "state": "OPEN",
-        "headRefOid": "a" * 40,
-        "autoMergeRequest": {"enabledAt": "this-run"},
-    }
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    item.armed = True
-
-    result = MergeWaitStage().step(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
-    assert github.mutation_log == []
-    assert item.attempts["merge"] == 0
-    assert "retry_delay_s" not in item.payload
-
-
-def test_orphan_pr_finishes_without_mutating_an_operator_owned_arm(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """Missing requirements context cannot arm or disarm a PR."""
-    github = _ArmingGitHub()
-    item = make_work_item(issue=None, stage=StageName.MERGE_WAIT, pr=12, state=ARM)
-
-    result = MergeWaitStage().on_enter(item, make_ctx(github=github))
-
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_wait_orphan")
-    assert github.mutation_log == []
-
-
-def test_merged_pr_completes_without_learn_when_disabled(
-    make_ctx: Any, make_work_item: Any
-) -> None:
-    """A merged PR remains a normal terminal success."""
-    item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=POLL)
-    ctx = make_ctx(github=FakeStageGitHub(pr_state={"state": "MERGED"}))
+    """A 200 response is insufficient until the terminal lifecycle read is merged."""
+    github = _ConditionalGitHub(states=[_open_pr(), {"state": "MERGED"}])
+    ctx = make_ctx(github=github)
     ctx.config.enable_learn = False
 
-    assert MergeWaitStage().step(item, ctx) == StageOutcome(Disposition.FINISH_PASS, "merged")
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), ctx)
+
+    assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert github.merge_attempts == [(12, "a" * 40)]
+
+
+def test_external_arm_blocks_conditional_merge_without_any_mutation(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """An arm observed at final admission belongs to an external actor."""
+    github = _ConditionalGitHub(states=[_open_pr(auto_merge_request={"enabledAt": "elsewhere"})])
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
+    assert github.merge_attempts == []
+    assert github.mutation_log == []
+
+
+def test_stale_proof_fails_back_without_revoking_a_label(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A stale process owns no later label and must only request fresh review."""
+    github = _ConditionalGitHub(states=[_open_pr("b" * 40)])
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
+    assert github.merge_attempts == []
+    assert github.mutation_log == []
+
+
+def test_revoke_stale_reviewed_head_never_writes_after_external_interleaving(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A new arm/GO may arrive after the final read, so stale runs never relabel."""
+
+    class InterleavingGitHub(_ConditionalGitHub):
+        def mark_pr_implementation_no_go(self, pr_number: int) -> None:
+            self._pr_state = _open_pr(
+                "c" * 40,
+                auto_merge_request={"enabledAt": "external-after-read"},
+            )
+            self._pr_impl_state = (True, False)
+            super().mark_pr_implementation_no_go(pr_number)
+
+    github = InterleavingGitHub(states=[_open_pr("b" * 40)])
+    item = _reviewed_item(make_work_item)
+
+    result = MergeWaitStage()._revoke_stale_reviewed_head(item, make_ctx(github=github), "a" * 40)
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
+    assert github.mutation_log == []
+
+
+def test_already_merged_retry_never_attempts_a_second_merge(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A retry that observes terminal merged state is a success without a PUT."""
+    github = _ConditionalGitHub(states=[{"state": "MERGED"}])
+    ctx = make_ctx(github=github)
+    ctx.config.enable_learn = False
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), ctx)
+
+    assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert github.merge_attempts == []
+
+
+def test_already_merged_retry_preserves_post_merge_learning(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A retry that discovers a merge keeps the existing exactly-once learn path."""
+    github = _ConditionalGitHub(states=[{"state": "MERGED"}])
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == Continue(next_state="LEARN_WAIT")
+    assert github.merge_attempts == []
+
+
+def test_ambiguous_transport_reconciles_a_merged_pr_without_duplicate_put(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """An unknown transport outcome is reconciled before any retry is considered."""
+    github = _ConditionalGitHub(
+        states=[_open_pr(), {"state": "MERGED"}],
+        merge_results=[
+            ConditionalMergeResult(
+                status=None,
+                body=None,
+                transport_error=True,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+    ctx = make_ctx(github=github)
+    ctx.config.enable_learn = False
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), ctx)
+
+    assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert github.merge_attempts == [(12, "a" * 40)]
+
+
+def test_ambiguous_transport_head_drift_fails_back_without_label_mutation(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A transport retry cannot carry a review proof across a changed head."""
+    github = _ConditionalGitHub(
+        states=[_open_pr(), _open_pr("b" * 40)],
+        merge_results=[
+            ConditionalMergeResult(
+                status=None,
+                body=None,
+                transport_error=True,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
+    assert github.merge_attempts == [(12, "a" * 40)]
+    assert github.mutation_log == []
+
+
+def test_409_head_drift_fails_back_without_label_mutation(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """The conditional SHA conflict cannot revoke an actor-owned later label."""
+    github = _ConditionalGitHub(
+        states=[_open_pr(), _open_pr("b" * 40)],
+        merge_results=[
+            ConditionalMergeResult(
+                status=409,
+                body={"message": "head changed"},
+                transport_error=False,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
+    assert github.merge_attempts == [(12, "a" * 40)]
+    assert github.mutation_log == []
+
+
+def test_405_retry_is_timer_parked_only_while_merge_budget_remains(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """Not-ready protections retry later instead of issuing a second PUT in-step."""
+    github = _ConditionalGitHub(
+        states=[_open_pr()],
+        merge_results=[
+            ConditionalMergeResult(
+                status=405,
+                body={"message": "not ready"},
+                transport_error=False,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+    )
+    item = _reviewed_item(make_work_item)
+
+    result = MergeWaitStage().step(item, make_ctx(github=github, budget_fn=lambda _route: 2))
+
+    assert result == StageOutcome(Disposition.RETRY, "merge_not_ready")
+    assert item.payload["retry_delay_s"] == 1.0
+    assert github.merge_attempts == [(12, "a" * 40)]
+
+
+def test_label_loss_or_non_main_base_prevents_the_conditional_request(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """Final authorization facts are all required immediately before the PUT."""
+    label_lost = _ConditionalGitHub(labels=(False, False), states=[_open_pr()])
+    wrong_base = _ConditionalGitHub(states=[_open_pr(base="release")])
+
+    assert MergeWaitStage().step(
+        _reviewed_item(make_work_item), make_ctx(github=label_lost)
+    ) == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
+    assert MergeWaitStage().step(
+        _reviewed_item(make_work_item), make_ctx(github=wrong_base)
+    ) == StageOutcome(Disposition.FINISH_FAIL, "non_main_base")
+    assert label_lost.merge_attempts == []
+    assert wrong_base.merge_attempts == []
+
+
+def test_200_without_merged_true_is_terminal(make_ctx: Any, make_work_item: Any) -> None:
+    """A successful transport does not imply the PR was merged."""
+    github = _ConditionalGitHub(
+        merge_results=[
+            ConditionalMergeResult(
+                status=200,
+                body={"merged": False},
+                transport_error=False,
+                malformed=False,
+                dry_run=False,
+            )
+        ]
+    )
+
+    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_not_merged")
+
+
+def test_405_readiness_exhaustion_is_terminal_and_does_not_duplicate_attempts(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A bounded readiness retry stops once the merge budget has been consumed."""
+    github = _ConditionalGitHub(
+        states=[_open_pr()],
+        merge_results=[
+            ConditionalMergeResult(
+                status=405,
+                body={"message": "not ready"},
+                transport_error=False,
+                malformed=False,
+                dry_run=False,
+            )
+        ],
+        readiness={
+            "state": "OPEN",
+            "headRefOid": "a" * 40,
+            "autoMergeRequest": None,
+            "baseRefName": "main",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BEHIND",
+        },
+    )
+    item = _reviewed_item(make_work_item)
+    item.attempts["merge"] = 2
+
+    result = MergeWaitStage().step(item, make_ctx(github=github, budget_fn=lambda _route: 2))
+
+    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
+    assert github.merge_attempts == []
+    assert "retry_delay_s" not in item.payload
+
+
+def test_stage_github_exposes_a_conditional_merge_adapter(make_ctx: Any) -> None:
+    """The stage contract has an explicit adapter rather than a CLI merge escape hatch."""
+    assert callable(getattr(make_ctx().github, "merge_pr_if_head", None))

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -877,7 +877,7 @@ class TestEvalVerdicts:
     def test_go_with_zero_threads_marks_implementation_go_and_advances_to_merge_wait(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """The PR-review gate marks GO; merge_wait later verifies and stands by."""
+        """The PR-review gate marks GO; merge_wait later verifies the exact head."""
         stage = PrReviewStage()
         github = FakeStageGitHub(unresolved=[(0, 0)])
         ctx = make_ctx(github=github)

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -707,6 +707,7 @@ class TestFailBackRouting:
             pr_state={
                 "state": "OPEN",
                 "headRefOid": "a" * 40,
+                "baseRefName": "main",
                 "autoMergeRequest": None,
             },
         )
@@ -722,7 +723,7 @@ class TestFailBackRouting:
         )
         item = _issue_item(3, StageName.MERGE_WAIT)
         item.pr = 12
-        item.state = "ARM"
+        item.state = "MERGE"
 
         coordinator._push_item(item, StageName.MERGE_WAIT, enter=False)
         coordinator._drain_queues()
@@ -741,13 +742,14 @@ class TestFailBackRouting:
             pr_state={
                 "state": "OPEN",
                 "headRefOid": "a" * 40,
+                "baseRefName": "main",
                 "autoMergeRequest": {"enabledAt": "elsewhere"},
             },
         )
         coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, github=github)
         item = _issue_item(3, StageName.MERGE_WAIT)
         item.pr = 12
-        item.state = "POLL"
+        item.state = "MERGE"
 
         coordinator._push_item(item, StageName.MERGE_WAIT, enter=False)
         coordinator._drain_queues()
@@ -772,7 +774,7 @@ class TestFailBackRouting:
         coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, github=github)
         item = _issue_item(3, StageName.MERGE_WAIT)
         item.pr = 12
-        item.state = "ARM"
+        item.state = "MERGE"
 
         coordinator._push_item(item, StageName.MERGE_WAIT, enter=False)
         coordinator._drain_queues()

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -248,6 +248,62 @@ class TestRetryDelayConsumption:
         coordinator._drain_queues()
         assert github.puts == 2
 
+    def test_merge_wait_transport_ambiguity_timer_reentry_is_bounded(
+        self, clocked: tuple[Coordinator, FakeClock]
+    ) -> None:
+        """An unknown PUT result gets delayed retries and exactly consumes the budget."""
+
+        class AmbiguousGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(
+                    pr_impl_state=(True, False),
+                    learn_terminal=True,
+                    pr_state={
+                        "state": "OPEN",
+                        "headRefOid": "a" * 40,
+                        "baseRefName": "main",
+                        "autoMergeRequest": None,
+                    },
+                )
+                self.puts = 0
+
+            def merge_pr_if_head(self, pr_number: int, reviewed_sha: str) -> ConditionalMergeResult:
+                self.puts += 1
+                return ConditionalMergeResult(status=None, body=None, transport_error=True)
+
+        coordinator, clock = clocked
+        github = AmbiguousGitHub()
+        coordinator.github = github
+        coordinator._ctx_cache.clear()
+        coordinator.config.budget_overrides["merge"] = 2
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=89,
+            pr=12,
+            stage=StageName.MERGE_WAIT,
+            state="MERGE",
+            payload={"reviewed_pr_head_sha": "a" * 40},
+        )
+
+        coordinator._run_item(item)
+
+        assert github.puts == 1
+        assert item.attempts["merge"] == 1
+        assert len(coordinator.timers) == 1
+        clock.now += 2.0
+        coordinator._wake_timers()
+        coordinator._drain_queues()
+
+        assert github.puts == 2
+        assert item.attempts["merge"] == 2
+        assert item.result is not None
+        assert item.result.reason == "merge_attempts_exhausted"
+        assert coordinator.timers == []
+        coordinator._wake_timers()
+        coordinator._drain_queues()
+        assert github.puts == 2
+
 
 class TestStepWatchdog:
     """WARN when a stage.step breaches the <~15s protocol contract."""

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -21,6 +21,7 @@ from hephaestus.automation.pipeline.coordinator import (
     PipelineConfig,
 )
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.stages.base import ConditionalMergeResult
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
@@ -182,6 +183,70 @@ class TestRetryDelayConsumption:
         assert item.stage is StageName.PR_REVIEW
         assert item.state == "POLL"
         assert item.payload.get("_enter_pending") is not True
+
+    def test_merge_wait_timer_reentry_is_bounded_without_duplicate_puts(
+        self, clocked: tuple[Coordinator, FakeClock]
+    ) -> None:
+        """Each timer wake earns one new attempt and exhaustion parks no duplicate."""
+
+        class NotReadyGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(
+                    pr_impl_state=(True, False),
+                    learn_terminal=True,
+                    pr_state={
+                        "state": "OPEN",
+                        "headRefOid": "a" * 40,
+                        "baseRefName": "main",
+                        "autoMergeRequest": None,
+                    },
+                )
+                self.puts = 0
+
+            def merge_pr_if_head(self, pr_number: int, reviewed_sha: str) -> ConditionalMergeResult:
+                self.puts += 1
+                return ConditionalMergeResult(status=405, body={"message": "not ready"})
+
+            def gh_pr_merge_readiness(self, pr_number: int) -> dict[str, Any] | None:
+                return {
+                    "state": "OPEN",
+                    "headRefOid": "a" * 40,
+                    "baseRefName": "main",
+                    "autoMergeRequest": None,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "BEHIND",
+                }
+
+        coordinator, clock = clocked
+        github = NotReadyGitHub()
+        coordinator.github = github
+        coordinator._ctx_cache.clear()
+        coordinator.config.budget_overrides["merge"] = 2
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=88,
+            pr=12,
+            stage=StageName.MERGE_WAIT,
+            state="MERGE",
+            payload={"reviewed_pr_head_sha": "a" * 40},
+        )
+
+        coordinator._run_item(item)
+
+        assert github.puts == 1
+        assert len(coordinator.timers) == 1
+        clock.now += 2.0
+        coordinator._wake_timers()
+        coordinator._drain_queues()
+
+        assert github.puts == 2
+        assert item.result is not None
+        assert item.result.reason == "merge_attempts_exhausted"
+        assert coordinator.timers == []
+        coordinator._wake_timers()
+        coordinator._drain_queues()
+        assert github.puts == 2
 
 
 class TestStepWatchdog:

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -505,7 +505,7 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
         _store_true(
             "--no-auto-merge",
             "no_auto_merge",
-            "(Deprecated, ignored) queue auto-merge handling is unavailable pending #2419",
+            "(Deprecated, ignored) native auto-merge is not used; merge-wait conditionally merges",
         ),
         _dry_run_spec(
             _dry_help("Suppress GitHub mutations and git pushes (no PR creation, no commits).")

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -581,7 +581,8 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             5,
             help_text=(
                 "Compatibility iteration bound for the historical drive-green CLI; current "
-                "merge-wait safely stands by and does not arm or poll auto-merge "
+                "merge-wait conditionally merges reviewed heads and does not manage "
+                "native auto-merge "
                 "(default: 5; replaces --max-merge-attempts)."
             ),
         ),

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -67,6 +67,92 @@ def test_adapter_satisfies_stage_github_protocol(adapter: pg.PipelineGitHub) -> 
     assert isinstance(adapter, StageGitHub)
 
 
+class TestConditionalMerge:
+    """The conditional REST merge seam preserves the server's exact outcome."""
+
+    def test_uses_only_sha_and_squash_method_in_repo_scoped_put(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The atomic SHA condition replaces every native auto-merge path."""
+        adapter.repo = "repo"
+        call_mock = MagicMock(
+            return_value=SimpleNamespace(
+                stdout='HTTP/2.0 200 OK\ncontent-type: application/json\n\n{"merged": true}',
+                returncode=0,
+            )
+        )
+        monkeypatch.setattr(pg, "gh_call", call_mock)
+
+        result = adapter.merge_pr_if_head(7, "a" * 40)
+
+        assert result.status == 200
+        assert result.body == {"merged": True}
+        call_mock.assert_called_once_with(
+            [
+                "api",
+                "--method",
+                "PUT",
+                "--include",
+                "/repos/org/repo/pulls/7/merge",
+                "-f",
+                f"sha={'a' * 40}",
+                "-f",
+                "merge_method=squash",
+            ],
+            check=False,
+            retry_on_rate_limit=False,
+            max_retries=1,
+        )
+
+    def test_preserves_a_409_response_for_stage_level_head_drift_handling(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The adapter does not collapse an expected SHA conflict into transport failure."""
+        adapter.repo = "repo"
+        monkeypatch.setattr(
+            pg,
+            "gh_call",
+            MagicMock(
+                return_value=SimpleNamespace(
+                    stdout='HTTP/2.0 409 Conflict\n\n{"message": "head changed"}', returncode=1
+                )
+            ),
+        )
+
+        result = adapter.merge_pr_if_head(7, "a" * 40)
+
+        assert result.status == 409
+        assert result.body == {"message": "head changed"}
+        assert result.transport_error is False
+
+    def test_transport_exception_is_explicit_and_never_retried_by_adapter(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only merge-wait's lifecycle reconciliation may choose a bounded retry."""
+        adapter.repo = "repo"
+        call_mock = MagicMock(side_effect=OSError("connection reset"))
+        monkeypatch.setattr(pg, "gh_call", call_mock)
+
+        result = adapter.merge_pr_if_head(7, "a" * 40)
+
+        assert result.transport_error is True
+        assert result.status is None
+        call_mock.assert_called_once()
+
+    def test_dry_run_returns_a_non_mutating_result_without_calling_github(
+        self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dry-run may report the intended merge but cannot issue the PUT."""
+        dry_adapter.repo = "repo"
+        call_mock = MagicMock()
+        monkeypatch.setattr(pg, "gh_call", call_mock)
+
+        result = dry_adapter.merge_pr_if_head(7, "a" * 40)
+
+        assert result.dry_run is True
+        call_mock.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Mutator mapping matrix: (method, args, patch-owner, underlying-name)
 # 'module' = a function bound into pipeline_github's namespace at import.

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -561,7 +561,7 @@ class TestCreatePR:
             "_gh_call",
             side_effect=lambda *_args, **_kwargs: next(responses),
         ):
-            with pytest.raises(RuntimeError, match="queue auto-merge handling is unavailable"):
+            with pytest.raises(RuntimeError, match="native auto-merge is prohibited"):
                 pr_manager.enable_auto_merge_after_implementation_go(42)
 
     def test_invokes_gh_pr_create(self) -> None:


### PR DESCRIPTION
## Summary

- replace merge-wait standby and legacy ARM/POLL ownership with a single repo-scoped REST squash merge conditional on the active reviewed SHA
- require final open/main/unarmed/exclusive-GO/exact-reviewed-head admission and preserve external auto-merge requests without mutation
- reconcile 409 drift, 405 readiness, terminal HTTP outcomes, and ambiguous transport safely with bounded timer retries and post-merge learning
- add race, lifecycle, adapter, timer re-entry, and documentation regressions; retain historical ADR text with append-only clarifications

## Validation

- `uv run --all-extras --locked pytest tests/unit --override-ini='addopts=' -q` (6,384 passed, 6 skipped)
- `uv run --all-extras --locked pre-commit run --all-files`
- mandatory pre-push `uv run --all-extras --locked pytest -q` (6,756 passed, 6 skipped; 85.08% coverage)

Closes #2419