### PR TITLE
fix(automation): bound plan-loop revision context

### DIFF
--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -74,7 +74,7 @@ from hephaestus.automation.protocol import (
 )
 from hephaestus.automation.review_journal import (
     IssueComment,
-    history_projection,
+    current_plan_context,
     journal_snapshot,
     parse_plan_review_state,
     render_current_review,
@@ -153,8 +153,8 @@ def _current_revision(comments: Sequence[IssueComment | str]) -> int:
 
 
 def _plan_history(comments: Sequence[IssueComment | str]) -> str:
-    """Render tracked comments in logical revision order for the next agent."""
-    return history_projection(comments)
+    """Return a bounded prior-plan excerpt for a resumed planner amendment."""
+    return current_plan_context(comments)
 
 
 def _confirm_pending_amendment_transition(
@@ -419,7 +419,10 @@ class PlanReviewStage(Stage):
                     "iteration": round_index,
                     "prior_review": item.payload.get("prior_review") or None,
                     "advise_findings": item.payload.get("advise_findings", ""),
-                    "plan_history": _plan_history(ctx.github.issue_comments(item.issue)),
+                    # The reviewer already receives the complete current plan
+                    # and direct prior critique; superseded journal entries
+                    # would only duplicate stale feedback.
+                    "plan_history": "",
                 },
                 parse=parse_plan_review_verdict,  # verdict parsed in-worker
                 descr="review",

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -42,7 +42,7 @@ from hephaestus.automation.protocol import PLAN_REVIEW_CANONICAL_MARKER, PLAN_RE
 from hephaestus.automation.review_journal import (
     IssueComment,
     JournalSnapshot,
-    history_projection,
+    current_revision_context,
     is_pending_review,
     journal_snapshot,
     render_current_plan,
@@ -124,8 +124,8 @@ def build_plan_prompt(
 
 
 def _planning_history(comments: Sequence[IssueComment | str]) -> str:
-    """Return every ordered plan/review journal iteration."""
-    return history_projection(comments)
+    """Return only current rejected-revision context for a resumed planner."""
+    return current_revision_context(comments)
 
 
 def _normalize_plan_comment(plan: str, *, revision: int | None = None) -> str:

--- a/hephaestus/automation/review_journal.py
+++ b/hephaestus/automation/review_journal.py
@@ -34,6 +34,10 @@ PLAN_REVIEW_STATES: Final[frozenset[str]] = frozenset(
 )
 
 MAX_AGENT_HISTORY_CHARS: Final[int] = 48_000
+#: Planning/review prompts receive the current plan and/or latest review in
+#: dedicated fields.  Keep the restart-only current-revision context bounded
+#: so append-only superseded artifacts cannot compete with active feedback.
+MAX_CURRENT_REVISION_CONTEXT_CHARS: Final[int] = 12_000
 MAX_REVIEW_SUMMARY_CHARS: Final[int] = 800
 
 _OLD_PLAN_PAYLOAD = "<!-- hephaestus-plan-history:old-plan -->"
@@ -492,3 +496,70 @@ def history_projection(
         rendered += f"{separator}{heading}\n\n{excerpt}"
         remaining -= len(excerpt)
     return rendered
+
+
+def current_plan_context(
+    comments: Sequence[IssueComment | str],
+    *,
+    max_chars: int = MAX_CURRENT_REVISION_CONTEXT_CHARS,
+) -> str:
+    """Return a bounded canonical-plan excerpt without superseded revisions.
+
+    The append-only journal remains the durable recovery and audit record.
+    This projection is only supplemental agent context for a resumed planner,
+    which already receives the immediate NOGO critique separately.
+    """
+    if max_chars <= 0:
+        return ""
+    snapshot = journal_snapshot(comments)
+    if not snapshot.current_plan:
+        return ""
+    plan = render_current_plan(snapshot.current_plan, revision=snapshot.revision)
+    return _bounded_excerpt(plan, max_chars)
+
+
+def current_revision_context(
+    comments: Sequence[IssueComment | str],
+    *,
+    max_chars: int = MAX_CURRENT_REVISION_CONTEXT_CHARS,
+) -> str:
+    """Return bounded current plan context while preserving its paired review.
+
+    Superseded plan/review artifacts are deliberately excluded: they remain
+    durable on GitHub but can contain stale, mutually incompatible critique.
+    When space is constrained, preserve the current review in full whenever
+    possible and spend the remaining budget on a deterministic plan excerpt.
+    """
+    if max_chars <= 0:
+        return ""
+    snapshot = journal_snapshot(comments)
+    plan = (
+        render_current_plan(snapshot.current_plan, revision=snapshot.revision)
+        if snapshot.current_plan
+        else ""
+    )
+    review = (
+        render_current_review(snapshot.current_review, revision=snapshot.revision)
+        if snapshot.current_review
+        and snapshot.current_review_revision is not None
+        and snapshot.current_review_revision >= snapshot.revision
+        else ""
+    )
+    if not plan:
+        return _bounded_excerpt(review, max_chars)
+    if not review:
+        return _bounded_excerpt(plan, max_chars)
+
+    plan_heading = "## Current rejected plan\n\n"
+    review_heading = "## Current review\n\n"
+    separator = "\n\n---\n\n"
+    fixed_size = len(plan_heading) + len(review_heading) + len(separator) + len(review)
+    if fixed_size >= max_chars:
+        return _bounded_excerpt(
+            f"{review_heading}{review}",
+            max_chars,
+        )
+    return (
+        f"{plan_heading}{_bounded_excerpt(plan, max_chars - fixed_size)}"
+        f"{separator}{review_heading}{review}"
+    )

--- a/hephaestus/prompts/templates/default/planning/amend_feedback.j2
+++ b/hephaestus/prompts/templates/default/planning/amend_feedback.j2
@@ -9,6 +9,6 @@ Address every concrete finding below in your revised plan:
 
 {{ prior_review_block }}
 
-## Complete chronological plan/review history
+## Current rejected plan context
 
 {{ plan_history_block }}

--- a/hephaestus/prompts/templates/default/planning/context.j2
+++ b/hephaestus/prompts/templates/default/planning/context.j2
@@ -15,7 +15,7 @@
 
 ---
 
-## Complete issue plan/review history and human feedback (untrusted)
+## Current rejected plan/review context (untrusted)
 
 {{ issue_history_block }}{% endif %}
 

--- a/hephaestus/prompts/templates/default/planning/plan_loop_review.j2
+++ b/hephaestus/prompts/templates/default/planning/plan_loop_review.j2
@@ -34,7 +34,7 @@ actually addressed in the current plan.
 
 ---
 
-**Complete chronological plan/review history (untrusted):**
+**Supplementary prior-revision context (untrusted):**
 {{ plan_history_block }}
 
 ---

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -27,6 +27,7 @@ from hephaestus.automation.protocol import (
 from hephaestus.automation.review_journal import (
     HISTORY_MARKER,
     archive_plan_body,
+    archive_review_body,
     render_current_plan,
     render_current_review,
 )
@@ -115,8 +116,8 @@ class TestParsePlanReviewVerdict:
         assert plan_review.parse_plan_review_verdict(response).is_error
 
 
-def test_history_omits_stale_canonical_review_already_archived() -> None:
-    """A superseded canonical review is not repeated after its immutable archive."""
+def test_amend_history_excludes_superseded_review_artifacts() -> None:
+    """Amend context does not revive an archived NOGO critique."""
     history = plan_review._plan_history(
         [
             "<!-- hephaestus-plan-history:revision=1:kind=plan -->\nPlan v1",
@@ -126,7 +127,7 @@ def test_history_omits_stale_canonical_review_already_archived() -> None:
         ]
     )
 
-    assert history.count("Review v1") == 1
+    assert "Review v1" not in history
     assert "Plan v2" in history
 
 
@@ -1006,9 +1007,10 @@ class TestPlanReviewStageOnJobDone:
         assert github.labels[401] == {"state:plan-blocked"}
         assert github.comments[401][1].endswith("state:plan-blocked")
 
-    def test_next_review_receives_complete_durable_history(
+    def test_next_review_receives_current_artifacts_without_redundant_history(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
+        """The reviewer gets the direct plan and critique, not stale revisions."""
         stage = PlanReviewStage()
         github = FakeStageGitHub()
         github.comments[8] = [
@@ -1024,8 +1026,33 @@ class TestPlanReviewStageOnJobDone:
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
+        assert result.job.prompt_kwargs["plan_text"] == "Plan v2"
+        assert result.job.prompt_kwargs["plan_history"] == ""
+
+    def test_amendment_receives_only_current_plan_context(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An amendment retains its prior plan but not superseded critique."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        github.comments[8] = [
+            archive_plan_body(1, "Plan v1", "Plan v2"),
+            archive_review_body(1, "Review v1\n\nstate:plan-no-go"),
+            render_current_plan("Plan v2", revision=2),
+            render_current_review("Review v2\n\nstate:plan-no-go", revision=2),
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=8, state="AMEND_WAIT")
+        item.payload["prior_review"] = "Review v2\n\nstate:plan-no-go"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
         history = result.job.prompt_kwargs["plan_history"]
-        assert history.index("Plan v1") < history.index("Review v1") < history.index("Plan v2")
+        assert "Plan v2" in history
+        assert "Plan v1" not in history
+        assert "Review v1" not in history
+        assert "Review v2" not in history
 
     def test_failed_result_is_not_stored(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed job result is logged and never stored."""

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -348,10 +348,10 @@ class TestPlanningStageEnter:
         assert STATE_PLAN_GO not in github.labels[20]
         assert STATE_NEEDS_PLAN not in github.labels[20]
 
-    def test_normal_no_go_replan_receives_complete_ordered_history(
+    def test_normal_no_go_replan_receives_current_rejected_revision_context(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """Every rejected-plan iteration gets plan then review context, without human feedback."""
+        """A replan gets its current rejected plan/review pair for recovery."""
         stage = PlanningStage()
         github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO], has_plan=True)
         github.comments[29] = [
@@ -370,6 +370,29 @@ class TestPlanningStageEnter:
         assert isinstance(request, JobRequest)
         assert isinstance(request.job, AgentJob)
         assert request.job.prompt_kwargs["issue_history"] == history
+
+    def test_normal_no_go_replan_excludes_superseded_revision_context(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Old NOGO critiques cannot compete with the current rejection."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO], has_plan=True)
+        github.comments[29] = [
+            "<!-- hephaestus-plan-history:revision=1:kind=plan -->\nPlan v1",
+            "<!-- hephaestus-plan-history:revision=1:kind=review -->\nReview v1",
+            render_current_plan("Plan v2", revision=2),
+            render_current_review("Review v2\n\nstate:plan-no-go", revision=2),
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=29, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+
+        history = item.payload["issue_history"]
+        assert "Plan v2" in history
+        assert "Review v2" in history
+        assert "Plan v1" not in history
+        assert "Review v1" not in history
 
     def test_replan_entry_ignores_existing_rejected_plan_comment(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/test_review_journal.py
+++ b/tests/unit/automation/test_review_journal.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from hephaestus.automation.review_journal import (
     HISTORY_MARKER,
     MAX_AGENT_HISTORY_CHARS,
+    MAX_CURRENT_REVISION_CONTEXT_CHARS,
     IssueComment,
     archive_plan_body,
     archive_review_body,
     blocked_audit_recovery_body,
+    current_plan_context,
+    current_revision_context,
     history_projection,
     journal_snapshot,
     plan_fingerprint,
@@ -140,6 +143,65 @@ def test_projection_indexes_the_plan_belonging_to_each_revision() -> None:
 
     revision_one = next(line for line in projection.splitlines() if "Revision 1:" in line)
     assert f"plan_sha={plan_fingerprint('Plan one')}" in revision_one
+
+
+def test_current_revision_context_excludes_superseded_plan_and_review_artifacts() -> None:
+    """Restart context keeps only the current rejected revision's instructions."""
+    comments = [
+        _owned(archive_plan_body(1, "Plan v1", "Plan v2")),
+        _owned(archive_review_body(1, "Review v1\n\nstate:plan-no-go")),
+        _owned(render_current_plan("Plan v2", revision=2)),
+        _owned(render_current_review("Review v2\n\nstate:plan-no-go", revision=2)),
+    ]
+
+    context = current_revision_context(comments)
+
+    assert "Plan v2" in context
+    assert "Review v2" in context
+    assert "Plan v1" not in context
+    assert "Review v1" not in context
+
+
+def test_current_revision_context_preserves_latest_review_when_plan_is_oversized() -> None:
+    """A long plan cannot crowd out the immediate reviewer critique."""
+    comments = [
+        _owned(render_current_plan("x" * 50_000, revision=7)),
+        _owned(render_current_review("Latest finding\n\nstate:plan-no-go", revision=7)),
+    ]
+
+    context = current_revision_context(comments)
+
+    assert len(context) <= MAX_CURRENT_REVISION_CONTEXT_CHARS
+    assert "Latest finding" in context
+    assert "state:plan-no-go" in context
+
+
+def test_current_plan_context_excludes_current_review_and_superseded_revisions() -> None:
+    """Amendments receive the last plan separately from the direct critique."""
+    comments = [
+        _owned(archive_plan_body(1, "Plan v1", "Plan v2")),
+        _owned(archive_review_body(1, "Review v1\n\nstate:plan-no-go")),
+        _owned(render_current_plan("Plan v2", revision=2)),
+        _owned(render_current_review("Review v2\n\nstate:plan-no-go", revision=2)),
+    ]
+
+    context = current_plan_context(comments)
+
+    assert "Plan v2" in context
+    assert "Plan v1" not in context
+    assert "Review v1" not in context
+    assert "Review v2" not in context
+
+
+def test_current_plan_context_honors_its_explicit_size_budget() -> None:
+    """An oversized previous plan cannot expand an amendment prompt unboundedly."""
+    context = current_plan_context(
+        [_owned(render_current_plan("x" * 2_000, revision=2))],
+        max_chars=128,
+    )
+
+    assert len(context) <= 128
+    assert "artifact excerpt truncated" in context
 
 
 def test_projection_respects_tiny_explicit_budget() -> None:


### PR DESCRIPTION
Summary: The #2403 pilot exhausted two plan cycles after append-only history was injected alongside the current plan and direct NOGO critique. Its 18-comment journal was 744,543 characters, so stale revisions competed with active instructions. This change keeps the complete GitHub journal for audit and recovery, while resumed planning receives only the bounded current rejected plan/review, plan review receives its direct current plan and critique without redundant history, and amendments receive the bounded current plan plus direct critique. Verification: full unit suite 6,433 passed / 6 skipped at 85.20 percent coverage; full unit-plus-integration suite 6,806 passed / 6 skipped at 85.22 percent coverage; focused suite 230 passed; targeted mypy, Ruff, and formatting checks passed. Scope: This fixes planning-loop context amplification only. It does not complete #2403 or bypass plan-review, label, or merge gates.