### PR TITLE
fix(automation): bound plan-loop revision context

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -695,18 +695,19 @@ Architectural contract:
 ### 5.2 Planning
 
 Planning produces one canonical implementation plan from the issue and its
-durable chronological journal. The GitHub journal remains complete; agent
-prompts receive the complete sequence while it fits the context budget, then
-an ordered revision index plus the latest complete plan and review. A blocked
-plan is an automation stop: only an external actor may resolve the dependency
-and replace `state:plan-blocked` with exactly one next plan-state label.
+durable chronological journal. The GitHub journal remains complete for audit
+and recovery. A resumed rejected plan receives only bounded context for its
+current canonical plan and paired current review; superseded revisions do not
+compete with the active critique. A blocked plan is an automation stop: only
+an external actor may resolve the dependency and replace `state:plan-blocked`
+with exactly one next plan-state label.
 
 #### Boundary diagram
 
 ```mermaid
 flowchart LR
     Issue["Issue text"] --> Context
-    History["Plan and review history"] --> Context
+    History["Current rejected plan/review"] --> Context
     Context --> Planner --> Canonical["Canonical plan comment"]
     Canonical --> PlanReview["Plan review"]
 ```
@@ -737,9 +738,9 @@ Architectural contract:
 
 - The first automation journal role is the canonical implementation plan,
   identified by an opaque marker and updated only by its owning GitHub actor.
-- Every iteration receives the ordered issue → plan → review → revision
-  sequence, with a bounded index projection only when the complete journal is
-  too large for an agent prompt.
+- A restarted rejected plan receives only its bounded current canonical plan
+  and paired current review. Superseded revision comments remain audit and
+  recovery artifacts and are not active planner context.
 - Journal ingestion is bounded by both comment count and body bytes. If either
   limit is exceeded, automation stops with an explicit manual-recovery error
   instead of silently dropping old plan/review revisions.
@@ -767,7 +768,7 @@ an audit record and context source, never an authorization fallback.
 ```mermaid
 flowchart LR
     Plan["Canonical plan"] --> Review
-    History["Ordered plan/review history"] --> Review
+    History["Current plan and direct critique"] --> Review
     Review -->|"plan-go / plan-no-go"| CanonicalReview["Canonical review comment"]
     CanonicalReview --> Label["Confirmed GitHub plan-state label"]
     Review -->|"plan-blocked"| BlockLatch["Confirmed blocked label"]
@@ -823,6 +824,10 @@ Architectural contract:
 - The plan archive contains the next-plan recovery payload. On restart, a
   missing review archive or canonical update is completed idempotently before
   another agent runs.
+- Review receives the current plan and direct prior critique. An amendment
+  receives the bounded current canonical plan and direct critique; superseded
+  journal revisions remain durable audit and recovery artifacts, not prompt
+  context.
 - A blocked verdict states exactly what decision or dependency is required.
   Because BLOCKED is the safety latch, its label is confirmed before the
   fallible explanatory write; an audit-write failure can never leave the item

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -74,7 +74,7 @@ from hephaestus.automation.protocol import (
 )
 from hephaestus.automation.review_journal import (
     IssueComment,
-    history_projection,
+    current_plan_context,
     journal_snapshot,
     parse_plan_review_state,
     render_current_review,
@@ -153,8 +153,8 @@ def _current_revision(comments: Sequence[IssueComment | str]) -> int:
 
 
 def _plan_history(comments: Sequence[IssueComment | str]) -> str:
-    """Render tracked comments in logical revision order for the next agent."""
-    return history_projection(comments)
+    """Return a bounded prior-plan excerpt for a resumed planner amendment."""
+    return current_plan_context(comments)
 
 
 def _confirm_pending_amendment_transition(
@@ -419,7 +419,10 @@ class PlanReviewStage(Stage):
                     "iteration": round_index,
                     "prior_review": item.payload.get("prior_review") or None,
                     "advise_findings": item.payload.get("advise_findings", ""),
-                    "plan_history": _plan_history(ctx.github.issue_comments(item.issue)),
+                    # The reviewer already receives the complete current plan
+                    # and direct prior critique; superseded journal entries
+                    # would only duplicate stale feedback.
+                    "plan_history": "",
                 },
                 parse=parse_plan_review_verdict,  # verdict parsed in-worker
                 descr="review",

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -42,7 +42,7 @@ from hephaestus.automation.protocol import PLAN_REVIEW_CANONICAL_MARKER, PLAN_RE
 from hephaestus.automation.review_journal import (
     IssueComment,
     JournalSnapshot,
-    history_projection,
+    current_revision_context,
     is_pending_review,
     journal_snapshot,
     render_current_plan,
@@ -124,8 +124,8 @@ def build_plan_prompt(
 
 
 def _planning_history(comments: Sequence[IssueComment | str]) -> str:
-    """Return every ordered plan/review journal iteration."""
-    return history_projection(comments)
+    """Return only current rejected-revision context for a resumed planner."""
+    return current_revision_context(comments)
 
 
 def _normalize_plan_comment(plan: str, *, revision: int | None = None) -> str:

--- a/hephaestus/automation/review_journal.py
+++ b/hephaestus/automation/review_journal.py
@@ -33,16 +33,13 @@ PLAN_REVIEW_STATES: Final[frozenset[str]] = frozenset(
     {"state:plan-go", "state:plan-no-go", "state:plan-blocked"}
 )
 
-MAX_AGENT_HISTORY_CHARS: Final[int] = 48_000
-MAX_REVIEW_SUMMARY_CHARS: Final[int] = 800
+#: Planning/review prompts receive the current plan and/or latest review in
+#: dedicated fields. Keep the restart-only current-revision context bounded
+#: so append-only superseded artifacts cannot compete with active feedback.
+MAX_CURRENT_REVISION_CONTEXT_CHARS: Final[int] = 12_000
 
 _OLD_PLAN_PAYLOAD = "<!-- hephaestus-plan-history:old-plan -->"
 _NEW_PLAN_PAYLOAD = "<!-- hephaestus-plan-history:new-plan -->"
-_TRUNCATION_NOTICE = (
-    "<!-- hephaestus-history-projection:truncated -->\n"
-    "_Older complete artifacts remain in the GitHub issue journal; this prompt "
-    "contains their ordered index and the latest actionable artifacts._"
-)
 _TRUSTED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
 
@@ -362,60 +359,6 @@ def journal_snapshot(comments: Sequence[IssueComment | str]) -> JournalSnapshot:
     )
 
 
-def review_state(review: str) -> str:
-    """Return the final plan-state token without legacy free-text fallback."""
-    return parse_plan_review_state(review) or "unparseable"
-
-
-def _review_reason(review: str) -> str:
-    meaningful = [
-        line.strip()
-        for line in review.splitlines()
-        if line.strip() and not line.lstrip().startswith(("<!--", "##", "state:plan-", "Verdict:"))
-    ]
-    text = " ".join(meaningful)
-    if len(text) <= MAX_REVIEW_SUMMARY_CHARS:
-        return text
-    return f"{text[:MAX_REVIEW_SUMMARY_CHARS].rstrip()}…"
-
-
-def _history_index(snapshot: JournalSnapshot, *, max_chars: int) -> str:
-    """Render a compact, bounded index for superseded and current revisions."""
-    if max_chars <= 0:
-        return ""
-    lines = ["## Ordered revision index"]
-    by_revision: dict[int, dict[str, HistoryArtifact]] = {}
-    for artifact in snapshot.history:
-        by_revision.setdefault(artifact.revision, {})[artifact.kind] = artifact
-    for revision in sorted(by_revision):
-        pair = by_revision[revision]
-        plan = pair.get("plan")
-        review = pair.get("review")
-        old_plan = archived_old_plan(plan.body) if plan else ""
-        review_payload = extract_current_review(review.body) if review else ""
-        fingerprint = plan_fingerprint(old_plan) if old_plan else "missing"
-        review_reason = _review_reason(review_payload) or "none"
-        lines.append(
-            f"- Revision {revision}: plan_sha={fingerprint}; "
-            f"review={review_state(review_payload)}; "
-            f"reason={_bounded_excerpt(review_reason, 120)}"
-        )
-    if snapshot.current_plan:
-        current_review = (
-            snapshot.current_review
-            if snapshot.current_review_revision is not None
-            and snapshot.current_review_revision >= snapshot.revision
-            else ""
-        )
-        current_reason = _review_reason(current_review) or "none"
-        lines.append(
-            f"- Revision {snapshot.revision} (current): "
-            f"plan_sha={plan_fingerprint(snapshot.current_plan)}; "
-            f"review={review_state(current_review)}; reason={current_reason}"
-        )
-    return _bounded_excerpt("\n".join(lines), max_chars)
-
-
 def _bounded_excerpt(text: str, max_chars: int) -> str:
     """Return a deterministic head/tail excerpt that fits *max_chars*."""
     if max_chars <= 0:
@@ -431,64 +374,68 @@ def _bounded_excerpt(text: str, max_chars: int) -> str:
     return f"{text[:head]}{marker}{text[-tail:] if tail else ''}"
 
 
-def history_projection(
-    comments: Sequence[IssueComment | str], *, max_chars: int = MAX_AGENT_HISTORY_CHARS
+def current_plan_context(
+    comments: Sequence[IssueComment | str],
+    *,
+    max_chars: int = MAX_CURRENT_REVISION_CONTEXT_CHARS,
 ) -> str:
-    """Return chronological agent context while keeping the complete GitHub journal intact."""
+    """Return a bounded canonical-plan excerpt without superseded revisions.
+
+    The append-only journal remains the durable recovery and audit record.
+    This projection is only supplemental agent context for a resumed planner,
+    which already receives the immediate NOGO critique separately.
+    """
     if max_chars <= 0:
         return ""
     snapshot = journal_snapshot(comments)
-    full_parts = [artifact.body for artifact in snapshot.history]
-    if snapshot.current_plan:
-        full_parts.append(render_current_plan(snapshot.current_plan, revision=snapshot.revision))
-    if (
-        snapshot.current_review
-        and snapshot.current_review_revision is not None
-        and snapshot.current_review_revision >= snapshot.revision
-    ):
-        full_parts.append(
-            render_current_review(snapshot.current_review, revision=snapshot.revision)
-        )
-    full = "\n\n---\n\n".join(full_parts)
-    if len(full) <= max_chars:
-        return full
+    if not snapshot.current_plan:
+        return ""
+    plan = render_current_plan(snapshot.current_plan, revision=snapshot.revision)
+    return _bounded_excerpt(plan, max_chars)
 
-    current_parts: list[tuple[str, str]] = []
-    if snapshot.current_plan:
-        current_parts.append(
-            (
-                "## Current plan excerpt",
-                render_current_plan(snapshot.current_plan, revision=snapshot.revision),
-            )
-        )
-    if (
-        snapshot.current_review
+
+def current_revision_context(
+    comments: Sequence[IssueComment | str],
+    *,
+    max_chars: int = MAX_CURRENT_REVISION_CONTEXT_CHARS,
+) -> str:
+    """Return bounded current plan context while preserving its paired review.
+
+    Superseded plan/review artifacts are deliberately excluded: they remain
+    durable on GitHub but can contain stale, mutually incompatible critique.
+    When space is constrained, preserve the current review in full whenever
+    possible and spend the remaining budget on a deterministic plan excerpt.
+    """
+    if max_chars <= 0:
+        return ""
+    snapshot = journal_snapshot(comments)
+    plan = (
+        render_current_plan(snapshot.current_plan, revision=snapshot.revision)
+        if snapshot.current_plan
+        else ""
+    )
+    review = (
+        render_current_review(snapshot.current_review, revision=snapshot.revision)
+        if snapshot.current_review
         and snapshot.current_review_revision is not None
         and snapshot.current_review_revision >= snapshot.revision
-    ):
-        current_parts.append(
-            (
-                "## Current review excerpt",
-                render_current_review(snapshot.current_review, revision=snapshot.revision),
-            )
-        )
-    if max_chars <= len(_TRUNCATION_NOTICE):
-        return _bounded_excerpt(_TRUNCATION_NOTICE, max_chars)
-    index_budget = max_chars // 2
-    index = _history_index(snapshot, max_chars=index_budget)
-    prefix = f"{_TRUNCATION_NOTICE}\n\n{index}" if index else _TRUNCATION_NOTICE
+        else ""
+    )
+    if not plan:
+        return _bounded_excerpt(review, max_chars)
+    if not review:
+        return _bounded_excerpt(plan, max_chars)
+
+    plan_heading = "## Current rejected plan\n\n"
+    review_heading = "## Current review\n\n"
     separator = "\n\n---\n\n"
-    headings_size = sum(len(separator) + len(heading) + 2 for heading, _ in current_parts)
-    available = max_chars - len(prefix) - headings_size
-    if available < 0:
-        return _bounded_excerpt(prefix, max_chars)
-
-    rendered = prefix
-    remaining = available
-    for index_in_parts, (heading, artifact) in enumerate(current_parts):
-        parts_left = len(current_parts) - index_in_parts
-        excerpt_budget = remaining // parts_left
-        excerpt = _bounded_excerpt(artifact, excerpt_budget)
-        rendered += f"{separator}{heading}\n\n{excerpt}"
-        remaining -= len(excerpt)
-    return rendered
+    fixed_size = len(plan_heading) + len(review_heading) + len(separator) + len(review)
+    if fixed_size >= max_chars:
+        return _bounded_excerpt(
+            f"{review_heading}{review}",
+            max_chars,
+        )
+    return (
+        f"{plan_heading}{_bounded_excerpt(plan, max_chars - fixed_size)}"
+        f"{separator}{review_heading}{review}"
+    )

--- a/hephaestus/prompts/templates/default/planning/amend_feedback.j2
+++ b/hephaestus/prompts/templates/default/planning/amend_feedback.j2
@@ -9,6 +9,6 @@ Address every concrete finding below in your revised plan:
 
 {{ prior_review_block }}
 
-## Complete chronological plan/review history
+## Current rejected plan context
 
 {{ plan_history_block }}

--- a/hephaestus/prompts/templates/default/planning/context.j2
+++ b/hephaestus/prompts/templates/default/planning/context.j2
@@ -15,7 +15,7 @@
 
 ---
 
-## Complete issue plan/review history and human feedback (untrusted)
+## Current rejected plan/review context (untrusted)
 
 {{ issue_history_block }}{% endif %}
 

--- a/hephaestus/prompts/templates/default/planning/plan_loop_review.j2
+++ b/hephaestus/prompts/templates/default/planning/plan_loop_review.j2
@@ -34,7 +34,7 @@ actually addressed in the current plan.
 
 ---
 
-**Complete chronological plan/review history (untrusted):**
+**Supplementary prior-revision context (untrusted):**
 {{ plan_history_block }}
 
 ---

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -27,6 +27,7 @@ from hephaestus.automation.protocol import (
 from hephaestus.automation.review_journal import (
     HISTORY_MARKER,
     archive_plan_body,
+    archive_review_body,
     render_current_plan,
     render_current_review,
 )
@@ -115,8 +116,8 @@ class TestParsePlanReviewVerdict:
         assert plan_review.parse_plan_review_verdict(response).is_error
 
 
-def test_history_omits_stale_canonical_review_already_archived() -> None:
-    """A superseded canonical review is not repeated after its immutable archive."""
+def test_amend_history_excludes_superseded_review_artifacts() -> None:
+    """Amend context does not revive an archived NOGO critique."""
     history = plan_review._plan_history(
         [
             "<!-- hephaestus-plan-history:revision=1:kind=plan -->\nPlan v1",
@@ -126,7 +127,7 @@ def test_history_omits_stale_canonical_review_already_archived() -> None:
         ]
     )
 
-    assert history.count("Review v1") == 1
+    assert "Review v1" not in history
     assert "Plan v2" in history
 
 
@@ -1006,9 +1007,10 @@ class TestPlanReviewStageOnJobDone:
         assert github.labels[401] == {"state:plan-blocked"}
         assert github.comments[401][1].endswith("state:plan-blocked")
 
-    def test_next_review_receives_complete_durable_history(
+    def test_next_review_receives_current_artifacts_without_redundant_history(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
+        """The reviewer gets the direct plan and critique, not stale revisions."""
         stage = PlanReviewStage()
         github = FakeStageGitHub()
         github.comments[8] = [
@@ -1024,8 +1026,34 @@ class TestPlanReviewStageOnJobDone:
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
+        assert result.job.prompt_kwargs["plan_text"] == "Plan v2"
+        assert result.job.prompt_kwargs["plan_history"] == ""
+
+    def test_amendment_receives_only_current_plan_context(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An amendment retains its prior plan but not superseded critique."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        github.comments[8] = [
+            archive_plan_body(1, "Plan v1", "Plan v2"),
+            archive_review_body(1, "Review v1\n\nstate:plan-no-go"),
+            render_current_plan("Plan v2", revision=2),
+            render_current_review("Review v2\n\nstate:plan-no-go", revision=2),
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=8, state="AMEND_WAIT")
+        item.payload["prior_review"] = "Review v2\n\nstate:plan-no-go"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
         history = result.job.prompt_kwargs["plan_history"]
-        assert history.index("Plan v1") < history.index("Review v1") < history.index("Plan v2")
+        assert "Plan v2" in history
+        assert "Plan v1" not in history
+        assert "Review v1" not in history
+        assert "Review v2" not in history
 
     def test_failed_result_is_not_stored(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed job result is logged and never stored."""

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -348,10 +348,10 @@ class TestPlanningStageEnter:
         assert STATE_PLAN_GO not in github.labels[20]
         assert STATE_NEEDS_PLAN not in github.labels[20]
 
-    def test_normal_no_go_replan_receives_complete_ordered_history(
+    def test_normal_no_go_replan_receives_current_rejected_revision_context(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """Every rejected-plan iteration gets plan then review context, without human feedback."""
+        """A replan gets its current rejected plan/review pair for recovery."""
         stage = PlanningStage()
         github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO], has_plan=True)
         github.comments[29] = [
@@ -370,6 +370,29 @@ class TestPlanningStageEnter:
         assert isinstance(request, JobRequest)
         assert isinstance(request.job, AgentJob)
         assert request.job.prompt_kwargs["issue_history"] == history
+
+    def test_normal_no_go_replan_excludes_superseded_revision_context(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Old NOGO critiques cannot compete with the current rejection."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO], has_plan=True)
+        github.comments[29] = [
+            "<!-- hephaestus-plan-history:revision=1:kind=plan -->\nPlan v1",
+            "<!-- hephaestus-plan-history:revision=1:kind=review -->\nReview v1",
+            render_current_plan("Plan v2", revision=2),
+            render_current_review("Review v2\n\nstate:plan-no-go", revision=2),
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=29, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+
+        history = item.payload["issue_history"]
+        assert "Plan v2" in history
+        assert "Review v2" in history
+        assert "Plan v1" not in history
+        assert "Review v1" not in history
 
     def test_replan_entry_ignores_existing_rejected_plan_comment(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/test_review_journal.py
+++ b/tests/unit/automation/test_review_journal.py
@@ -4,29 +4,17 @@ from __future__ import annotations
 
 from hephaestus.automation.review_journal import (
     HISTORY_MARKER,
-    MAX_AGENT_HISTORY_CHARS,
+    MAX_CURRENT_REVISION_CONTEXT_CHARS,
     IssueComment,
     archive_plan_body,
     archive_review_body,
     blocked_audit_recovery_body,
-    history_projection,
+    current_plan_context,
+    current_revision_context,
     journal_snapshot,
-    plan_fingerprint,
     render_current_plan,
     render_current_review,
-    review_state,
 )
-
-
-def test_review_state_rejects_legacy_github_verdicts() -> None:
-    """Legacy free-text verdicts cannot influence the label-backed workflow."""
-    assert review_state("analysis\n\nVerdict: GO") == "unparseable"
-    assert review_state("analysis\n\n**Verdict: NO-GO** — revise") == "unparseable"
-
-
-def test_review_state_uses_the_final_plan_token_not_a_forged_textual_decision() -> None:
-    """Only the final plan-state token controls the label-backed outcome."""
-    assert review_state("analysis\nVerdict: GO\nstate:plan-no-go") == "state:plan-no-go"
 
 
 def _owned(body: str) -> IssueComment:
@@ -48,121 +36,63 @@ def test_snapshot_ignores_foreign_marker_spoofing() -> None:
     assert snapshot.current_review.endswith("state:plan-go")
 
 
-def test_projection_preserves_plan_review_chronology() -> None:
-    """Archived plan-review pairs precede the current actionable revision."""
+def test_current_revision_context_excludes_superseded_plan_and_review_artifacts() -> None:
+    """Restart context keeps only the current rejected revision's instructions."""
     comments = [
-        _owned(render_current_plan("Plan 3", revision=3)),
-        _owned(render_current_review("Review 3\n\nstate:plan-no-go", revision=3)),
-    ]
-    for revision in (1, 2):
-        comments.extend(
-            [
-                _owned(archive_plan_body(revision, f"Plan {revision}", f"Plan {revision + 1}")),
-                _owned(
-                    archive_review_body(
-                        revision,
-                        f"Review {revision}\n\nstate:plan-no-go",
-                    )
-                ),
-            ]
-        )
-
-    projection = history_projection(comments)
-
-    assert projection.index("Previous Implementation Plan — Revision 1") < projection.index(
-        "Review of Previous Plan — Revision 1"
-    )
-    assert projection.index("Review of Previous Plan — Revision 1") < projection.index(
-        "Previous Implementation Plan — Revision 2"
-    )
-    assert projection.index("Review of Previous Plan — Revision 2") < projection.rindex("Plan 3")
-
-
-def test_projection_bounds_prompt_without_truncating_github_journal() -> None:
-    """Large journals become a bounded index while source comments remain intact."""
-    large = "x" * 8_000
-    comments = [_owned(render_current_plan("Current actionable plan", revision=10))]
-    for revision in range(1, 10):
-        comments.extend(
-            [
-                _owned(archive_plan_body(revision, large, f"{large}{revision}")),
-                _owned(
-                    archive_review_body(
-                        revision,
-                        f"Review {revision}: {large}\n\nstate:plan-no-go",
-                    )
-                ),
-            ]
-        )
-
-    projection = history_projection(comments)
-
-    assert len(projection) <= MAX_AGENT_HISTORY_CHARS
-    assert "hephaestus-history-projection:truncated" in projection
-    assert "Ordered revision index" in projection
-    assert "Current actionable plan" in projection
-    assert len(comments) == 19
-
-
-def test_projection_compacts_many_revision_reasons_without_raising() -> None:
-    """The metadata index is bounded even after many verbose review rounds."""
-    comments = [_owned(render_current_plan("Current plan " + "x" * 50_000, revision=81))]
-    for revision in range(1, 81):
-        comments.extend(
-            [
-                _owned(archive_plan_body(revision, f"Plan {revision}", f"Plan {revision + 1}")),
-                _owned(
-                    archive_review_body(
-                        revision,
-                        f"Review {revision}: {'reason ' * 200}\n\nstate:plan-no-go",
-                    )
-                ),
-            ]
-        )
-
-    projection = history_projection(comments)
-
-    assert len(projection) <= MAX_AGENT_HISTORY_CHARS
-    assert "Revision 1" in projection
-    assert "Revision 80" in projection
-    assert "Current plan excerpt" in projection
-
-
-def test_projection_indexes_the_plan_belonging_to_each_revision() -> None:
-    """Revision N fingerprints its superseded plan, not revision N+1's recovery payload."""
-    comments = [
-        _owned(archive_plan_body(1, "Plan one", "Plan two")),
-        _owned(archive_review_body(1, "Needs work.\n\nstate:plan-no-go")),
-        _owned(render_current_plan("Plan two " + "x" * 2_000, revision=2)),
+        _owned(archive_plan_body(1, "Plan v1", "Plan v2")),
+        _owned(archive_review_body(1, "Review v1\n\nstate:plan-no-go")),
+        _owned(render_current_plan("Plan v2", revision=2)),
+        _owned(render_current_review("Review v2\n\nstate:plan-no-go", revision=2)),
     ]
 
-    projection = history_projection(comments, max_chars=1_000)
+    context = current_revision_context(comments)
 
-    revision_one = next(line for line in projection.splitlines() if "Revision 1:" in line)
-    assert f"plan_sha={plan_fingerprint('Plan one')}" in revision_one
+    assert "Plan v2" in context
+    assert "Review v2" in context
+    assert "Plan v1" not in context
+    assert "Review v1" not in context
 
 
-def test_projection_respects_tiny_explicit_budget() -> None:
-    """Even an operator-supplied tiny budget returns a bounded projection."""
-    projection = history_projection(
-        [_owned(render_current_plan("x" * 2_000, revision=1))],
-        max_chars=64,
+def test_current_revision_context_preserves_latest_review_when_plan_is_oversized() -> None:
+    """A long plan cannot crowd out the immediate reviewer critique."""
+    comments = [
+        _owned(render_current_plan("x" * 50_000, revision=7)),
+        _owned(render_current_review("Latest finding\n\nstate:plan-no-go", revision=7)),
+    ]
+
+    context = current_revision_context(comments)
+
+    assert len(context) <= MAX_CURRENT_REVISION_CONTEXT_CHARS
+    assert "Latest finding" in context
+    assert "state:plan-no-go" in context
+
+
+def test_current_plan_context_excludes_current_review_and_superseded_revisions() -> None:
+    """Amendments receive the last plan separately from the direct critique."""
+    comments = [
+        _owned(archive_plan_body(1, "Plan v1", "Plan v2")),
+        _owned(archive_review_body(1, "Review v1\n\nstate:plan-no-go")),
+        _owned(render_current_plan("Plan v2", revision=2)),
+        _owned(render_current_review("Review v2\n\nstate:plan-no-go", revision=2)),
+    ]
+
+    context = current_plan_context(comments)
+
+    assert "Plan v2" in context
+    assert "Plan v1" not in context
+    assert "Review v1" not in context
+    assert "Review v2" not in context
+
+
+def test_current_plan_context_honors_its_explicit_size_budget() -> None:
+    """An oversized previous plan cannot expand an amendment prompt unboundedly."""
+    context = current_plan_context(
+        [_owned(render_current_plan("x" * 2_000, revision=2))],
+        max_chars=128,
     )
 
-    assert len(projection) <= 64
-
-
-def test_oversized_current_plan_keeps_index_fingerprint_and_explicit_excerpt() -> None:
-    """A single oversized current artifact cannot tail-slice away its index."""
-    comments = [_owned(render_current_plan("x" * 50_000, revision=7))]
-
-    projection = history_projection(comments)
-
-    assert len(projection) <= MAX_AGENT_HISTORY_CHARS
-    assert "Ordered revision index" in projection
-    assert "Revision 7" in projection
-    assert "plan_sha=" in projection
-    assert "Current plan excerpt" in projection
+    assert len(context) <= 128
+    assert "artifact excerpt truncated" in context
 
 
 def test_history_markers_are_revision_and_kind_specific() -> None:


### PR DESCRIPTION
Summary: The staged automation pilot exhausted plan cycles after append-only historical plan and review artifacts were injected alongside the current plan and direct critique. This repair preserves the complete GitHub journal for audit and recovery but supplies bounded current-revision context only to resumed planning, avoids redundant context in plan review, and keeps the direct current critique separate for amendments. It also removes the unused full-history projection and updates the binding architecture contract. Verification: focused regression and prompt suite: 222 passed; full unit suite: 6,426 passed, 6 skipped, 85.19 percent coverage; changed-file pre-commit including mypy, Markdown lint, Gitleaks, and Bandit: passed; signed DCO commit; normal pre-push unit-plus-integration validation passed. Scope: fixes planning-loop context amplification only; it does not close issue 2403 or bypass review, label, or merge gates.

Closes #2442