### PR TITLE
fix(automation): seed direct reviews without mutable diffs

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -2532,7 +2532,6 @@ class Coordinator:
                         issue_number=issue_number,
                         issue_title=issue_facts.title,
                         issue_body=issue_facts.body,
-                        pr_diff=review_context["pr_diff"],
                         pr_description=review_context["pr_description"],
                         passed=passed,
                     )
@@ -2567,7 +2566,6 @@ class Coordinator:
             )
             item.payload["issue_title"] = entry.issue_title
             item.payload["issue_body"] = entry.issue_body
-            item.payload["pr_diff"] = entry.pr_diff
             item.payload["pr_description"] = entry.pr_description
         else:
             item = WorkItem(

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -141,7 +141,6 @@ class SeedEntry:
             planner/reviewer/implementer prompts.
         issue_body: Issue body copied into the issue WorkItem payload for
             planner/reviewer/implementer prompts.
-        pr_diff: Complete PR diff copied into a direct PR review payload.
         pr_description: PR body copied into a direct PR review payload.
         passed: Terminal result for entries clamped directly to ``finished``.
         skip_tag_obligation: Durable write that must complete before this
@@ -157,7 +156,6 @@ class SeedEntry:
     issue_number: int | None = None
     issue_title: str = ""
     issue_body: str = ""
-    pr_diff: str = ""
     pr_description: str = ""
     passed: bool = True
     skip_tag_obligation: EpicSkipTagObligation | None = None

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -144,9 +144,9 @@ class FakeStageGitHub(FakeGitHub):
             pr_review_context
             if pr_review_context is not None
             else {
-                "pr_diff": "diff --git a/a.py b/a.py\n+@@ -1 +1 @@\n-old\n+new\n",
                 "pr_description": "Closes #1",
                 "pr_head_sha": "a" * 40,
+                "pr_base_branch": "main",
             }
         )
         self._learn_terminal = learn_terminal

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -382,17 +382,18 @@ class TestQuiescence:
         assert entries[0].passed is False
         assert "no linked issue" in entries[0].reason
 
-    def test_direct_pr_with_linked_issue_preserves_full_review_context(
+    def test_direct_pr_metadata_context_enters_checkout_bound_review(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A real resolved issue remains available to the downstream gates."""
+        """A direct seed needs metadata, not an unverified remote diff."""
         github = FakeStageGitHub(
             pr_issue=700,
             issue_title="Review the migration",
             issue_body="Preserve the requirements context.",
             pr_review_context={
-                "pr_diff": "diff --git a/a.py b/a.py\n+@@ -1 +1 @@\n-old\n+new\n",
                 "pr_description": "Closes #700\n\nCarry review inputs.",
+                "pr_head_sha": "a" * 40,
+                "pr_base_branch": "main",
             },
         )
         config = PipelineConfig(org="org", repos=["repo-a"], prs=[701], projects_dir=tmp_path)
@@ -407,8 +408,8 @@ class TestQuiescence:
         assert item.issue == 700
         assert item.payload["issue_title"] == "Review the migration"
         assert item.payload["issue_body"] == "Preserve the requirements context."
-        assert item.payload["pr_diff"].startswith("diff --git")
         assert item.payload["pr_description"].startswith("Closes #700")
+        assert "pr_diff" not in item.payload
 
 
 def _fake_in_flight_item(coordinator: Coordinator, item: WorkItem) -> JobHandle:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -404,6 +404,8 @@ class TestQuiescence:
         entries = coordinator._seed_direct_scope("repo-a")
         item = coordinator._entry_to_item(entries[0], "repo-a")
 
+        assert entries[0].stage is StageName.PR_REVIEW
+        assert item.stage is StageName.PR_REVIEW
         assert item.pr == 701
         assert item.issue == 700
         assert item.payload["issue_title"] == "Review the migration"


### PR DESCRIPTION
## Summary
- remove the obsolete direct-seed pr_diff payload field
- retain PR metadata only until the SHA-bound checkout stage derives the diff
- align direct-PR test fixtures with the production review-context contract

## Root cause
PR #2428 intentionally stopped returning a mutable remote diff from pr_review_context(), but direct PR seeding still indexed that retired key. Direct --prs runs therefore failed before queuing review work.

## Validation
- uv run --all-extras --locked pytest tests/unit/automation/pipeline -q --no-cov
- uv run --all-extras --locked pytest tests/unit/automation/test_pipeline_github.py -q --no-cov
- uv run --all-extras --locked ruff check hephaestus/automation/pipeline/coordinator.py hephaestus/automation/pipeline/seeding.py tests/unit/automation/pipeline/test_coordinator.py tests/unit/automation/pipeline/stages/conftest.py
- pre-push: uv run --all-extras --locked pytest -q (6798 passed, 6 skipped; 85.20% coverage)

Closes #2448