### PR TITLE
fix(automation): serialize active implementation plans

### DIFF
--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from hephaestus.automation.dependency_resolver import CyclicDependencyError, DependencyResolver
 from hephaestus.automation.github_api import (
@@ -52,6 +52,11 @@ LOG = logging.getLogger(__name__)
 # concurrently, falling back to pre-#1623 behavior (acceptable tradeoff for regex tightness).
 _PLAN_FILE_RE = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)`")
 _PLAN_FILE_SECTION_RE = re.compile(r"^#{2,}\s+Files to (Modify|Create)\b", re.IGNORECASE)
+
+# A source path only conflicts with work in the same repository.  The
+# implementation queue is shared across repositories, so a bare path string
+# would incorrectly serialize independent ``repo-a`` and ``repo-b`` changes.
+PlanFileClaim: TypeAlias = tuple[tuple[str, str] | None, str]
 
 
 def _parse_planned_files(plan_body: str) -> set[str]:
@@ -110,17 +115,24 @@ def _fetch_planned_files(issue: int, repo: tuple[str, str] | None = None) -> set
 
 
 def _select_non_overlapping(
-    issues: list[int], repo_of: Mapping[int, tuple[str, str]] | None = None
+    issues: list[int],
+    repo_of: Mapping[int, tuple[str, str]] | None = None,
+    *,
+    initial_claims: set[PlanFileClaim] | None = None,
+    selected_claims: dict[int, set[PlanFileClaim]] | None = None,
 ) -> tuple[list[int], list[int]]:
     """Partition *issues* into (dispatch_now, defer_next_round).
 
     Greedy first-fit in the given order: an issue whose parsed plan file set
-    intersects the union of already-claimed files is deferred. Unknown file set
-    (no plan / parse failure) claims NO files and is always dispatched
-    (fail-open). The first issue always dispatches, so a whole batch can never
-    be deferred (liveness). Performs one serial GraphQL comment fetch per issue;
-    only invoked in multi-worker rounds (guarded at the call site), so the cost
-    is bounded by the issue count already being processed that round.
+    intersects the union of already-claimed files in the same repository is
+    deferred. ``initial_claims`` carries plans belonging to implementation
+    items that were dispatched by an earlier drain and are still in flight.
+    Unknown file set (no plan / parse failure) claims NO files and is always dispatched
+    (fail-open). When active work already owns a conflicting known path, every
+    queued item may defer until that work completes. Performs one serial
+    GraphQL comment fetch per issue; only invoked in multi-worker rounds
+    (guarded at the call site), so the cost is bounded by the issue count
+    already being processed that round.
 
     Args:
         issues: The issue numbers to partition, in dispatch-priority order.
@@ -129,27 +141,42 @@ def _select_non_overlapping(
             by stage rather than by repo, so one round can legitimately hold
             issues from several repositories. An issue missing from the mapping
             falls back to ambient-CWD resolution (#1795).
+        initial_claims: Repository-scoped plan-file claims owned by in-flight
+            implementation jobs.  They reserve paths before queued jobs are
+            considered, closing the gap between drain rounds.
+        selected_claims: Optional host-owned sink populated with the exact
+            plan snapshot that admitted each dispatched issue.  The
+            coordinator reuses those claims when submitting the job, so an
+            editable plan comment cannot change the reservation after the
+            overlap decision.
 
     Returns:
         A ``(dispatch, defer)`` tuple of issue-number lists (order preserved).
 
     """
     repo_of = repo_of or {}
-    claimed: set[str] = set()
+    claimed: set[PlanFileClaim] = set(initial_claims or ())
     dispatch: list[int] = []
     defer: list[int] = []
     for issue in issues:
-        planned = _fetch_planned_files(issue, repo=repo_of.get(issue))
-        if planned and (planned & claimed):
+        repo = repo_of.get(issue)
+        planned = _fetch_planned_files(issue, repo=repo)
+        claims = {(repo, path) for path in planned} if planned else set()
+        if claims and (claims & claimed):
             LOG.info(
                 "issue #%s deferred: plan files %s overlap in-flight peers",
                 issue,
-                sorted(planned & claimed),
+                sorted(path for _repo, path in claims & claimed),
             )
             defer.append(issue)
             continue
-        if planned:
-            claimed |= planned
+        if claims:
+            claimed |= claims
+        if selected_claims is not None:
+            # Preserve even an empty snapshot.  It proves this drain selected
+            # the issue fail-open and prevents submission from re-reading a
+            # mutable plan comment after the overlap decision.
+            selected_claims[issue] = set(claims)
         dispatch.append(issue)
     return dispatch, defer
 
@@ -228,6 +255,7 @@ def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
 
 
 __all__ = [
+    "PlanFileClaim",
     "_fetch_planned_files",
     "_filter_open_issues",
     "_parse_planned_files",

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -153,6 +153,11 @@ _IDLE_POLL_S = 1.0
 #: Number of fully stalled idle ticks before the coordinator force-runs work.
 _STALL_TICKS_BEFORE_FORCE = 3
 
+# Host-owned work-item payload key for the immutable plan-file snapshot that
+# admitted a queued implementation job.  It is consumed at submission and is
+# never sourced from GitHub content.
+_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD = "_implementation_file_claims"
+
 #: Upper bound on Continue-transitions per _run_item call (defensive: a stage
 #: that never yields a JobRequest/StageOutcome would otherwise spin forever).
 _MAX_STEPS_PER_TICK = 100
@@ -516,6 +521,10 @@ class Coordinator:
         }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
+        # Known implementation plans retain their repository-scoped file
+        # claims for the lifetime of the submitted job.  Never reconstruct
+        # this from mutable issue comments during later drain rounds (#2451).
+        self._inflight_implementation_claims: dict[JobHandle, set[_admission.PlanFileClaim]] = {}
         self.inflight_per_repo: Counter[str] = Counter()
         # A normal (non-implementation) drain claims instead of popping.  The
         # active lease reserves its source capacity while an item executes or
@@ -1262,6 +1271,7 @@ class Coordinator:
         """
         self._progress = True
         item = self.in_flight.pop(handle, None)
+        self._inflight_implementation_claims.pop(handle, None)
         if item is None:
             self._record_event(
                 "complete_unknown",
@@ -1602,9 +1612,9 @@ class Coordinator:
 
         REUSES :func:`admission.order_for_implementation` (dependencies
         first) and :func:`admission._select_non_overlapping` (defer plans
-        touching the same files while a peer is dispatched, #1623 — only
-        engaged when real parallelism is possible, mirroring the legacy
-        ``serialize_file_overlap`` gate).
+        touching the same files while a peer is queued or already executing,
+        #1623/#2451 — only engaged when real parallelism is possible,
+        mirroring the legacy ``serialize_file_overlap`` gate).
 
         The queue is STAGE-keyed, so one drain round can hold issues from
         several repos (#1795), and dependency ordering runs across the whole
@@ -1639,6 +1649,29 @@ class Coordinator:
                 return
 
         items = q.snapshot()
+        # A snapshot belongs only to the drain that selected it.  Anything
+        # still queued after an admission/capacity deferral is re-evaluated on
+        # its next drain, rather than carrying an unsubmitted old reservation.
+        for queued_item in items:
+            queued_item.payload.pop(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD, None)
+        dispatch_items, submission_claims = self._select_implementation_dispatch(items)
+        for item in dispatch_items:
+            if self.shutdown.is_set() or not self._admit(item):
+                continue
+            if not self._claim_selected_implementation_item(item):
+                continue
+            # Preserve the exact immutable snapshot used by the overlap gate.
+            # A plan comment can change between admission and submission, but
+            # it must not change the reservation that made this item eligible.
+            if (claims := submission_claims.get(id(item))) is not None:
+                item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(claims)
+            self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
+            self._run_item(item)
+
+    def _select_implementation_dispatch(
+        self, items: list[WorkItem]
+    ) -> tuple[list[WorkItem], dict[int, set[_admission.PlanFileClaim]]]:
+        """Order queued work and reserve immutable snapshots for this drain."""
         issue_items, ambiguous = self._index_issue_items(items)
         infos = [
             IssueInfo(
@@ -1650,7 +1683,8 @@ class Coordinator:
         ]
         ordered = _admission.order_for_implementation(infos)
         dispatch = ordered
-        if self.config.serialize_file_overlap and self.config.max_workers > 1 and len(ordered) > 1:
+        selected_claims: dict[int, set[_admission.PlanFileClaim]] = {}
+        if self.config.serialize_file_overlap and self.config.max_workers > 1 and ordered:
             # Resolve each issue's owning repo from its own WorkItem: the queue is
             # keyed by stage, so one round can hold issues from several repos (#1795).
             repo_of = {
@@ -1658,20 +1692,37 @@ class Coordinator:
                 for number, item in issue_items.items()
                 if item.repo
             }
-            dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
+            inflight_claims = self._active_implementation_file_claims()
+            selection_kwargs: dict[str, Any] = {
+                "repo_of": repo_of,
+                "selected_claims": selected_claims,
+            }
+            if inflight_claims:
+                selection_kwargs["initial_claims"] = inflight_claims
+            dispatch, deferred = _admission._select_non_overlapping(ordered, **selection_kwargs)
             for number in deferred:
                 logger.info("implementation #%s deferred (file overlap)", number)
-        # Cross-repo same-number items bypass the number-keyed gates and dispatch
-        # directly — they are distinct work that the ordering model cannot rank.
         dispatch_items = [issue_items[number] for number in dispatch]
-        dispatch_items.extend(it for group in ambiguous.values() for it in group)
-        for item in dispatch_items:
-            if self.shutdown.is_set() or not self._admit(item):
-                continue
-            if not self._claim_selected_implementation_item(item):
-                continue
-            self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
-            self._run_item(item)
+        submission_claims = {
+            id(issue_items[number]): set(claims) for number, claims in selected_claims.items()
+        }
+        # Cross-repo same-number items bypass only the number-keyed dependency
+        # ordering.  They still need their own repo-scoped overlap admission;
+        # otherwise a same-number collision could evade active reservations.
+        if self.config.serialize_file_overlap and self.config.max_workers > 1:
+            claimed = self._active_implementation_file_claims()
+            for claims in selected_claims.values():
+                claimed.update(claims)
+            ambiguous_items, ambiguous_claims = self._select_ambiguous_implementation_items(
+                ambiguous, claimed
+            )
+            dispatch_items.extend(ambiguous_items)
+            submission_claims.update(ambiguous_claims)
+        else:
+            # Cross-repo same-number items are distinct work even though the
+            # shared issue-number dependency model cannot rank them (#2057).
+            dispatch_items.extend(it for group in ambiguous.values() for it in group)
+        return dispatch_items, submission_claims
 
     @staticmethod
     def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
@@ -1687,6 +1738,61 @@ class Coordinator:
             else:
                 seen.add(key)
         return duplicates
+
+    def _active_implementation_file_claims(self) -> set[_admission.PlanFileClaim]:
+        """Return the immutable plan claims held by active implementation jobs."""
+        claims: set[_admission.PlanFileClaim] = set()
+        for active_claims in self._inflight_implementation_claims.values():
+            claims.update(active_claims)
+        return claims
+
+    def _select_ambiguous_implementation_items(
+        self,
+        ambiguous: dict[int, list[WorkItem]],
+        claimed: set[_admission.PlanFileClaim],
+    ) -> tuple[list[WorkItem], dict[int, set[_admission.PlanFileClaim]]]:
+        """Apply file-overlap admission to cross-repo same-number items.
+
+        Dependency order cannot represent these items under its number-only
+        keys, but file paths are repository-scoped and must still honour both
+        active reservations and earlier selections from this drain.
+        """
+        dispatch: list[WorkItem] = []
+        snapshots: dict[int, set[_admission.PlanFileClaim]] = {}
+        for group in ambiguous.values():
+            for item in group:
+                if item.issue is None:  # defensive: index construction excludes this case
+                    continue
+                repo = (self.config.org, item.repo)
+                planned = _admission._fetch_planned_files(item.issue, repo=repo)
+                item_claims = {(repo, path) for path in planned} if planned else set()
+                if item_claims and (item_claims & claimed):
+                    logger.info(
+                        "implementation %s#%s deferred (file overlap)", item.repo, item.issue
+                    )
+                    continue
+                claimed.update(item_claims)
+                # Preserve an empty snapshot too: unknown plans fail open,
+                # but must not be fetched again after being admitted.
+                snapshots[id(item)] = set(item_claims)
+                dispatch.append(item)
+        return dispatch, snapshots
+
+    def _capture_implementation_file_claims(self, item: WorkItem) -> set[_admission.PlanFileClaim]:
+        """Return the immutable claims reserved for an implementation submission.
+
+        The parallel admission gate places its exact selection snapshot in the
+        host-owned payload.  Serial and overlap-opt-out submissions retain the
+        established one-time, fail-open lookup behavior.
+        """
+        if item.stage is not StageName.IMPLEMENTATION or item.issue is None:
+            return set()
+        selected = item.payload.pop(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD, None)
+        if selected is not None:
+            return set(selected)
+        repo = (self.config.org, item.repo)
+        planned = _admission._fetch_planned_files(item.issue, repo=repo)
+        return {(repo, path) for path in planned} if planned else set()
 
     def _claim_selected_implementation_item(self, item: WorkItem) -> bool:
         """Claim *item* at its current position, preserving FIFO retry order."""
@@ -1841,6 +1947,7 @@ class Coordinator:
             if self.config.phase_timeout_s and self.config.phase_timeout_s > 0:
                 # --phase-timeout bounds each AGENT JOB, not a phase subprocess.
                 job = replace(job, timeout_s=int(self.config.phase_timeout_s))
+        implementation_claims = self._capture_implementation_file_claims(item)
         handle = self.pool.submit(
             job,
             request.on_done_state,
@@ -1848,6 +1955,8 @@ class Coordinator:
             claim_stage=item.stage.value,
         )
         self.in_flight[handle] = item
+        if implementation_claims:
+            self._inflight_implementation_claims[handle] = implementation_claims
         self.inflight_per_repo[item.repo] += 1
         self._record_event(
             "submit",
@@ -2684,6 +2793,7 @@ class Coordinator:
         for item in list(self.in_flight.values()):
             self._park_resumable(item)
         self.in_flight.clear()
+        self._inflight_implementation_claims.clear()
         self.inflight_per_repo.clear()
 
     def _finalize_resumable(self) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1266,8 +1266,12 @@ class TestImplementationAdmission:
                 return JobRequest(_agent_job(item.repo, item.issue or 0), StageName.IMPLEMENTATION)
 
         coordinator.stages[StageName.IMPLEMENTATION] = SubmittingStage()
-        coordinator._push_item(_issue_item(21, StageName.IMPLEMENTATION), StageName.IMPLEMENTATION)
-        coordinator._push_item(_issue_item(22, StageName.IMPLEMENTATION), StageName.IMPLEMENTATION)
+        coordinator._push_item(
+            _issue_item(21, StageName.IMPLEMENTATION), StageName.IMPLEMENTATION, enter=True
+        )
+        coordinator._push_item(
+            _issue_item(22, StageName.IMPLEMENTATION), StageName.IMPLEMENTATION, enter=True
+        )
         fetches: list[int] = []
 
         def _planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str] | None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -414,7 +414,12 @@ class TestQuiescence:
         assert "pr_diff" not in item.payload
 
 
-def _fake_in_flight_item(coordinator: Coordinator, item: WorkItem) -> JobHandle:
+def _fake_in_flight_item(
+    coordinator: Coordinator,
+    item: WorkItem,
+    *,
+    claimed_files: set[str] | None = None,
+) -> JobHandle:
     """Register *item* as in-flight under a synthetic handle (no real submit)."""
     handle = JobHandle(
         job=AgentJob(
@@ -429,6 +434,11 @@ def _fake_in_flight_item(coordinator: Coordinator, item: WorkItem) -> JobHandle:
         on_done_state=item.stage,
     )
     coordinator.in_flight[handle] = item
+    if claimed_files:
+        repo = (coordinator.config.org, item.repo)
+        coordinator._inflight_implementation_claims[handle] = {
+            (repo, path) for path in claimed_files
+        }
     coordinator.inflight_per_repo[item.repo] += 1
     return handle
 
@@ -947,7 +957,7 @@ class TestImplementationAdmission:
         coordinator._push_item(deferred, StageName.IMPLEMENTATION, enter=True)
         monkeypatch.setattr(
             "hephaestus.automation.pipeline.admission._select_non_overlapping",
-            lambda issues, repo_of=None: (issues[:1], issues[1:]),
+            lambda issues, repo_of=None, **_kwargs: (issues[:1], issues[1:]),
         )
 
         coordinator._drain_implementation()
@@ -1183,7 +1193,9 @@ class TestImplementationAdmission:
         seen_repo_of: dict[int, tuple[str, str]] = {}
 
         def _fake_select(
-            issues: list[int], repo_of: dict[int, tuple[str, str]] | None = None
+            issues: list[int],
+            repo_of: dict[int, tuple[str, str]] | None = None,
+            **_kwargs: Any,
         ) -> tuple[list[int], list[int]]:
             seen_repo_of.update(repo_of or {})
             return issues[:1], issues[1:]  # defer everything but the first
@@ -1199,6 +1211,252 @@ class TestImplementationAdmission:
         assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
         # Each issue is scoped to the repo of ITS OWN WorkItem, not the ambient CWD.
         assert seen_repo_of == {21: ("org", "repo-a"), 22: ("org", "repo-b")}
+
+    def test_overlap_gate_reuses_admission_snapshot_at_parallel_submission(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mutable plan cannot change its claim after overlap admission."""
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+
+        class SubmittingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                return JobRequest(_agent_job(item.repo, item.issue or 0), StageName.IMPLEMENTATION)
+
+        coordinator.stages[StageName.IMPLEMENTATION] = SubmittingStage()
+        first = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        second = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-a")
+        coordinator._push_item(first, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(second, StageName.IMPLEMENTATION, enter=True)
+        fetches: list[int] = []
+
+        def _planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str]:
+            del repo
+            fetches.append(issue)
+            if fetches.count(issue) > 1:
+                raise AssertionError("submission must reuse the admission snapshot")
+            return {f"planned-{issue}.py"}
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            _planned_files,
+        )
+
+        coordinator._drain_implementation()
+
+        assert fetches == [21, 22]
+        assert len(pool.submitted) == 2
+        assert len(coordinator._inflight_implementation_claims) == 2
+        assert {
+            claim
+            for claims in coordinator._inflight_implementation_claims.values()
+            for claim in claims
+        } == {
+            (("org", "repo-a"), "planned-21.py"),
+            (("org", "repo-a"), "planned-22.py"),
+        }
+
+    def test_overlap_gate_reuses_empty_admission_snapshot_at_submission(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fail-open plan lookup is still an immutable submission snapshot."""
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+
+        class SubmittingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                return JobRequest(_agent_job(item.repo, item.issue or 0), StageName.IMPLEMENTATION)
+
+        coordinator.stages[StageName.IMPLEMENTATION] = SubmittingStage()
+        coordinator._push_item(_issue_item(21, StageName.IMPLEMENTATION), StageName.IMPLEMENTATION)
+        coordinator._push_item(_issue_item(22, StageName.IMPLEMENTATION), StageName.IMPLEMENTATION)
+        fetches: list[int] = []
+
+        def _planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str] | None:
+            del repo
+            fetches.append(issue)
+            if issue == 21:
+                if fetches.count(issue) > 1:
+                    raise AssertionError("unknown plan must not be re-fetched at submission")
+                return None
+            return {"shared.py"}
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            _planned_files,
+        )
+
+        coordinator._drain_implementation()
+
+        assert fetches == [21, 22]
+        assert len(pool.submitted) == 2
+
+    def test_overlap_gate_checks_ambiguous_numbers_against_active_claims(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cross-repo number collision cannot bypass same-repo reservations."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_repos: list[str] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_repos.append(item.repo)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        _fake_in_flight_item(
+            coordinator,
+            _issue_item(8, StageName.IMPLEMENTATION, repo="repo-a"),
+            claimed_files={"shared.py"},
+        )
+        repo_a = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-a")
+        repo_b = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(repo_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(repo_b, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"shared.py"} if repo == ("org", "repo-a") else {"other.py"},
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_repos == ["repo-b"]
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [repo_a]
+
+    def test_overlap_gate_defers_queued_work_that_conflicts_with_inflight_implementation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An active implementation claims its plan files before a later item runs."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        queued = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-a")
+        fetches: list[int] = []
+
+        def _planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str]:
+            del repo
+            fetches.append(issue)
+            if issue == 21 and fetches.count(21) > 1:
+                raise AssertionError("an active plan must not be fetched after submission")
+            return {"hephaestus/automation/pipeline/coordinator.py"}
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            _planned_files,
+        )
+        coordinator._submit(active, JobRequest(_agent_job("repo-a", 21), StageName.IMPLEMENTATION))
+        coordinator._push_item(queued, StageName.IMPLEMENTATION, enter=True)
+
+        coordinator._drain_implementation()
+
+        assert run_order == []
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [queued]
+        assert fetches == [21, 22]
+
+    def test_overlap_gate_releases_deferred_item_after_inflight_implementation_finishes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deferred overlap becomes eligible as soon as its active peer leaves the stage."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        active_handle = _fake_in_flight_item(
+            coordinator,
+            active,
+            claimed_files={"hephaestus/automation/pipeline/coordinator.py"},
+        )
+        queued = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-a")
+        coordinator._push_item(queued, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"hephaestus/automation/pipeline/coordinator.py"},
+        )
+
+        coordinator._drain_implementation()
+        coordinator._handle_completion(active_handle, JobResult(ok=True))
+        run_order.clear()  # active completion is not the queued-item dispatch under test
+        coordinator._drain_implementation()
+
+        assert run_order == [22]
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 0
+
+    def test_overlap_gate_keeps_same_paths_in_different_repositories_independent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path overlap is meaningful only inside the repository that owns it."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        _fake_in_flight_item(
+            coordinator,
+            active,
+            claimed_files={"hephaestus/automation/pipeline/coordinator.py"},
+        )
+        queued = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(queued, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"hephaestus/automation/pipeline/coordinator.py"},
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_order == [22]
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 0
+
+    def test_overlap_gate_opt_out_ignores_inflight_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The documented opt-out preserves intentionally concurrent dispatch."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path, monkeypatch, max_workers=2, serialize_file_overlap=False
+        )
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        _fake_in_flight_item(
+            coordinator,
+            active,
+            claimed_files={"hephaestus/automation/pipeline/coordinator.py"},
+        )
+        queued = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-a")
+        coordinator._push_item(queued, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: (_ for _ in ()).throw(
+                AssertionError("overlap lookup must be disabled")
+            ),
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_order == [22]
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 0
 
     def test_file_overlap_serialization_can_be_disabled(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Closes #2451

- Reserve repo-scoped planned-file claims for implementation jobs until completion or teardown.
- Gate queued work against active claims, including cross-repository issue-number collisions.
- Reuse the exact admission snapshot at submission, including an empty fail-open snapshot, so mutable plan comments cannot reopen the overlap race.

## Verification

- `uv run --all-extras --locked pytest tests/unit/automation/pipeline/test_coordinator.py tests/unit/automation/pipeline/test_admission.py -q --override-ini=addopts=`
- Ruff, formatting, mypy, and `git diff --check`
- Required pre-push suite: 6,805 passed, 6 skipped; 85.24% coverage
- Independent final source review: no material findings