### PR TITLE
fix(automation): sync explicit scopes before classification

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -650,6 +650,13 @@ Repo intake discovers candidate work through a bounded source, records
 exclusions, and routes each eligible issue or pull request to the stage implied
 by its durable state.
 
+Before it reads a direct `--issues` / `--prs` scope, performs a label mutation,
+or dispatches an agent, repo intake proves its reusable checkout is the
+expected repository, clean, on the remote default branch, and fast-forwarded
+to that branch's fetched head. A missing checkout is cloned and then subjected
+to the same synchronization proof. Any failure is terminal for that scope; it
+never falls through to an ambient or stale checkout.
+
 #### Boundary diagram
 
 ```mermaid
@@ -685,6 +692,9 @@ stateDiagram-v2
 Architectural contract:
 
 - Exclusions become durable before excluded work leaves the queue.
+- Label-vocabulary setup and source classification occur only after the
+  checkout proof succeeds. Explicit scopes use the same bounded direct cursors
+  after that gate; they do not bypass it or widen their selected stage scope.
 - Discovery never writes planning, review, implementation, or merge verdicts.
 - Failure of the repository item does not fabricate outcomes for its issues.
 - Runtime repository discovery does not eagerly build `products` or downstream

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -173,6 +173,13 @@ _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05
 
+#: Payload marker for the internal setup item that gates an explicit
+#: ``--issues`` / ``--prs`` cursor.  It is intentionally not a pipeline stage:
+#: a scoped invocation may omit REPO from its work stages, but it must still
+#: prove that the one reusable checkout is a clean default branch before any
+#: source read, label mutation, or agent job starts.
+_DIRECT_SCOPE_BOOTSTRAP_KEY = "_direct_scope_bootstrap"
+
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
 #: finished sink drains first of all so results are recorded promptly).
@@ -525,6 +532,7 @@ class Coordinator:
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self._direct_issue_source: _DirectIssueSource | None = None
         self._direct_pr_source: _DirectPrSource | None = None
+        self._direct_scope_bootstrap_pending = False
         self._repo_entry_source: _RepoEntrySource | None = None
         self._repo_issue_sources: deque[_ActiveRepoIssueSource] = deque()
         # A StageQueue's capacity only bounds that one stage.  This permit
@@ -1868,6 +1876,9 @@ class Coordinator:
 
     def _route(self, item: WorkItem, outcome: StageOutcome) -> None:
         """Apply the Disposition -> action table (plan #1817)."""
+        if item.stage is StageName.REPO and item.payload.get(_DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+            self._route_direct_scope_bootstrap(item, outcome)
+            return
         route = self._routes.get(item.stage)
         if route is None:
             # A stage absent from this run's (possibly scope-trimmed) route
@@ -1925,6 +1936,51 @@ class Coordinator:
         # FINISH_FAIL (exhaustive over Disposition)
         self._finish(item, passed=False, reason=outcome.note or "fail")
 
+    def _route_direct_scope_bootstrap(self, item: WorkItem, outcome: StageOutcome) -> None:
+        """Activate direct cursors only after their checkout proof succeeds.
+
+        A partial pipeline scope deliberately omits ``REPO`` from its route
+        table.  This internal setup item therefore has its own tiny terminal
+        protocol instead of widening the operator-selected stage scope.  It
+        never reaches an agent-capable stage unless the repo stage completed
+        clone-plus-sync and then prepared the label vocabulary.
+        """
+        if outcome.disposition is Disposition.RETRY:
+            self._route_retry(item, outcome)
+            return
+        if outcome.disposition is not Disposition.FINISH_PASS:
+            self._direct_scope_bootstrap_pending = False
+            self._finish(
+                item,
+                passed=False,
+                reason=outcome.note or "direct scope checkout preparation failed",
+            )
+            return
+
+        try:
+            self._begin_direct_pr_source(item.repo)
+            self._begin_direct_issue_source(item.repo)
+        except Exception as exc:
+            self._direct_scope_bootstrap_pending = False
+            logger.warning(
+                "direct scope for %s could not initialize after sync: %s", item.repo, exc
+            )
+            self._finish(item, passed=False, reason=f"direct scope initialization failed: {exc}")
+            return
+
+        # A successful bootstrap is coordinator plumbing, not an issue/repo
+        # result.  Free its sole bounded slot before admitting the first
+        # direct entry, mirroring successful REPO-source externalization.
+        self._release_source_lease(item)
+        self._release_work_permit(item)
+        self._direct_scope_bootstrap_pending = False
+        self._seen_item_ids.discard(id(item))
+        with suppress(ValueError):
+            self.items.remove(item)
+        self._record_event("direct_scope_ready", item.repo)
+        self._drain_direct_pr_source()
+        self._drain_direct_issue_source()
+
     def _route_retry(self, item: WorkItem, outcome: StageOutcome) -> None:
         """Apply the RETRY row: heap-park on a recorded delay, else next tick.
 
@@ -1974,6 +2030,8 @@ class Coordinator:
 
     def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
         """Set the item's result and hand it to the finished sink."""
+        if item.stage is StageName.REPO and item.payload.get(_DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+            self._direct_scope_bootstrap_pending = False
         if item.stage is StageName.FINISHED:
             # Poisoned inside the sink: record directly, never re-queue.
             item.result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
@@ -2118,7 +2176,8 @@ class Coordinator:
         # unbounded logical-identity map in the terminal aggregate.
         self._terminal_summary.reset()
         self._pass_work_count = 0
-        discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
+        has_direct_scope = bool(self.config.issues or self.config.prs)
+        discovery_repos = [] if has_direct_scope else self.config.repos
         # Repository discovery is a source, not a list of pre-built
         # ``SeedEntry``/``WorkItem`` values.  Keep the legacy empty call so
         # direct test seams and any non-repository synthetic entries retain
@@ -2126,8 +2185,6 @@ class Coordinator:
         entries = _seeding.seed_from_cli([], [], [])
         self._begin_repo_entry_source(discovery_repos if not entries else [])
         default_repo = self.config.repos[0] if self.config.repos else ""
-        self._begin_direct_pr_source(default_repo)
-        self._begin_direct_issue_source(default_repo)
         pushed = 0
         for entry in entries:
             if entry.stage is None:
@@ -2147,12 +2204,33 @@ class Coordinator:
                 )
             if self._push_item(item, item.stage, enter=True):
                 pushed += 1
+        if has_direct_scope:
+            pushed += self._begin_direct_scope_bootstrap(default_repo)
+        else:
+            self._begin_direct_pr_source(default_repo)
+            self._begin_direct_issue_source(default_repo)
         return (
             pushed
             + self._drain_repo_entry_source()
-            + self._drain_direct_pr_source()
-            + self._drain_direct_issue_source()
+            + (0 if has_direct_scope else self._drain_direct_pr_source())
+            + (0 if has_direct_scope else self._drain_direct_issue_source())
         )
+
+    def _begin_direct_scope_bootstrap(self, repo: str) -> int:
+        """Enqueue the one checkout proof required by an explicit CLI scope."""
+        self._direct_scope_bootstrap_pending = True
+        if not repo:
+            self._direct_scope_bootstrap_pending = False
+            item = WorkItem(repo="", kind=ItemKind.REPO, stage=StageName.FINISHED)
+            item.result = ItemResult(
+                passed=False,
+                reason="explicit --issues/--prs scope requires exactly one repository",
+                final_stage=StageName.FINISHED,
+            )
+            return int(self._push_item(item, StageName.FINISHED, enter=True))
+        item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.REPO)
+        item.payload[_DIRECT_SCOPE_BOOTSTRAP_KEY] = True
+        return int(self._push_item(item, StageName.REPO, enter=True))
 
     def _begin_repo_entry_source(self, repos: list[str]) -> None:
         """Initialize one FIFO source for this pass's repository discovery.
@@ -2601,6 +2679,7 @@ class Coordinator:
                 bool(self._repo_issue_sources),
                 self._direct_issue_source is not None,
                 self._direct_pr_source is not None,
+                self._direct_scope_bootstrap_pending,
             )
         )
 

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -2,18 +2,19 @@
 
 Binding contract: docs/architecture.md §5.1 "repo".
 
-States: ENTER -> CLONE_WAIT -> DISCOVER -> SOURCE.
+States: ENTER -> CLONE_WAIT -> LABELS -> DISCOVER -> SOURCE.
 
 Steps:
 
-1. [M] ``on_enter``: ``ctx.github.ensure_state_labels()`` — idempotent label
-   vocabulary setup.
-2. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing, or
-   ``GitJob(op="sync_checkout")`` when it already exists. Synchronization
-   validates the expected remote and fast-forwards only a clean default-branch
-   checkout. Both operations are logged-skipped under dry-run — the
+1. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing, then
+   ``GitJob(op="sync_checkout")``; or ``GitJob(op="sync_checkout")`` directly
+   when it already exists. Synchronization validates the expected remote and
+   fast-forwards only a clean default-branch checkout. Both operations are
+   logged-skipped under dry-run — the
    coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
+2. [M] LABELS: ``ctx.github.ensure_state_labels()`` only after checkout
+   synchronization succeeds.
 3. [M] DISCOVER: initialize one page-at-a-time metadata cursor. It never
    materializes a list of classified products.
 4. [M] SOURCE: the coordinator transfers the bounded cursor to its fair
@@ -88,7 +89,7 @@ class RepoStage(Stage):
     kind = StageName.REPO
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
-        """Ensure the state-label vocabulary exists (idempotent, durable).
+        """Proceed to checkout preparation before any durable label work.
 
         Args:
             item: The repo work item.
@@ -98,7 +99,7 @@ class RepoStage(Stage):
             None to proceed with step().
 
         """
-        ctx.github.ensure_state_labels()
+        del item, ctx
         return None
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
@@ -118,6 +119,15 @@ class RepoStage(Stage):
         if item.state == "CLONE_WAIT":
             return self._clone_or_skip(item, ctx)
 
+        if item.state == "LABELS":
+            ctx.github.ensure_state_labels()
+            if item.payload.get("_direct_scope_bootstrap", False):
+                return StageOutcome(
+                    Disposition.FINISH_PASS,
+                    note="direct scope checkout synchronized",
+                )
+            return Continue(next_state="DISCOVER")
+
         if item.state == "DISCOVER":
             return self._discover(item, ctx)
 
@@ -131,8 +141,9 @@ class RepoStage(Stage):
 
     def _clone_or_skip(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Prepare a checkout by cloning or safely synchronizing it."""
-        # Clone failure handling (budget clone=2): on_job_done recorded the
-        # failure; classify it here so retry re-submits and exhaustion fails.
+        # Checkout preparation failure handling (budget clone=2): on_job_done
+        # records the failure while retaining CLONE_WAIT, so retry cannot fall
+        # through into label work or discovery after a failed fetch.
         if item.payload.pop("clone_failed", False):
             if item.attempts.get("clone", 0) >= ctx.budget("clone"):
                 return StageOutcome(
@@ -146,15 +157,19 @@ class RepoStage(Stage):
                 ctx.budget("clone"),
             )
 
+        if item.payload.pop("checkout_verified", False):
+            return Continue(next_state="LABELS")
+
         dest = _repo_checkout_path(item, ctx)
         if ctx.dry_run:
             if dest.exists():
                 logger.info("[dry-run] would synchronize %s/%s at %s", ctx.org, item.repo, dest)
-                return Continue(next_state="DISCOVER")
+                return Continue(next_state="LABELS")
             logger.info("[dry-run] would clone %s/%s to %s", ctx.org, item.repo, dest)
-            return Continue(next_state="DISCOVER")
+            return Continue(next_state="LABELS")
 
-        if dest.exists():
+        if item.payload.pop("checkout_cloned", False) or dest.exists():
+            item.payload["checkout_op"] = "sync_checkout"
             job = GitJob(
                 repo=item.repo,
                 op="sync_checkout",
@@ -162,8 +177,9 @@ class RepoStage(Stage):
                 kwargs={"repo": f"{ctx.org}/{item.repo}", "dest": str(dest)},
                 descr=f"synchronize {ctx.org}/{item.repo}",
             )
-            return JobRequest(job=job, on_done_state="DISCOVER")
+            return JobRequest(job=job, on_done_state="CLONE_WAIT")
 
+        item.payload["checkout_op"] = "clone"
         job = GitJob(
             repo=item.repo,
             op="clone",
@@ -173,7 +189,7 @@ class RepoStage(Stage):
             kwargs={"repo": f"{ctx.org}/{item.repo}", "dest": str(dest)},
             descr=f"clone {ctx.org}/{item.repo}",
         )
-        return JobRequest(job=job, on_done_state="DISCOVER")
+        return JobRequest(job=job, on_done_state="CLONE_WAIT")
 
     def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """[M] Initialize a bounded metadata source; do not classify eagerly."""
@@ -204,7 +220,17 @@ class RepoStage(Stage):
         if item.state != "CLONE_WAIT":
             return
         if result.ok:
-            logger.info("repo:%s: checkout preparation completed", item.repo)
+            operation = item.payload.get("checkout_op")
+            if operation == "clone":
+                item.payload["checkout_cloned"] = True
+                logger.info("repo:%s: clone completed; verifying checkout", item.repo)
+            elif operation == "sync_checkout":
+                item.payload["checkout_verified"] = True
+                logger.info("repo:%s: checkout preparation completed", item.repo)
+            else:  # pragma: no cover - every checkout JobRequest records its operation
+                item.payload["clone_failed"] = True
+                item.attempts["clone"] = item.attempts.get("clone", 0) + 1
+                logger.warning("repo:%s: checkout operation identity missing", item.repo)
             return
         item.attempts["clone"] = item.attempts.get("clone", 0) + 1
         item.payload["clone_failed"] = True

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -72,13 +72,21 @@ def _facts(
 
 
 class TestOnEnterAndCloneStates:
-    """Steps 1-2: ensure_state_labels [M], clone [W:G] with budget 2."""
+    """Checkout proof precedes label setup and discovery."""
 
-    def test_on_enter_ensures_state_labels(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+    def test_labels_are_deferred_until_checkout_is_verified(
+        self, repo_item: WorkItem, repo_ctx: Any
+    ) -> None:
         stage = RepoStage()
 
         assert stage.on_enter(repo_item, repo_ctx) is None
+        assert repo_ctx.github.mutation_log == []
 
+        repo_item.state = "LABELS"
+        result = stage.step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DISCOVER"
         assert ("ensure_state_labels", ()) in repo_ctx.github.mutation_log
 
     def test_enter_state_advances_to_clone_wait(self, repo_item: WorkItem, repo_ctx: Any) -> None:
@@ -102,7 +110,7 @@ class TestOnEnterAndCloneStates:
             "repo": "test-org/repo-a",
             "dest": str(tmp_path / "repo-a"),
         }
-        assert result.on_done_state == "DISCOVER"
+        assert result.on_done_state == "CLONE_WAIT"
 
     def test_existing_checkout_submits_sync_job_before_discovery(
         self, repo_item: WorkItem, repo_ctx: Any, tmp_path: Path
@@ -120,7 +128,30 @@ class TestOnEnterAndCloneStates:
             "repo": "test-org/repo-a",
             "dest": str(tmp_path / "repo-a"),
         }
-        assert result.on_done_state == "DISCOVER"
+        assert result.on_done_state == "CLONE_WAIT"
+
+    def test_successful_clone_requires_follow_up_sync_before_labels(
+        self, repo_item: WorkItem, repo_ctx: Any
+    ) -> None:
+        """A new clone cannot reach labels or discovery without a sync proof."""
+        repo_item.state = "CLONE_WAIT"
+        stage = RepoStage()
+
+        clone = stage.step(repo_item, repo_ctx)
+        assert isinstance(clone, JobRequest)
+        assert isinstance(clone.job, GitJob)
+        assert clone.job.op == "clone"
+
+        stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
+        sync = stage.step(repo_item, repo_ctx)
+        assert isinstance(sync, JobRequest)
+        assert isinstance(sync.job, GitJob)
+        assert sync.job.op == "sync_checkout"
+
+        stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
+        ready = stage.step(repo_item, repo_ctx)
+        assert isinstance(ready, Continue)
+        assert ready.next_state == "LABELS"
 
     def test_explicit_existing_repo_root_submits_sync_job(
         self, repo_item: WorkItem, tmp_path: Path, make_ctx: Callable[..., Any]
@@ -152,7 +183,7 @@ class TestOnEnterAndCloneStates:
         result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
-        assert result.next_state == "DISCOVER"
+        assert result.next_state == "LABELS"
 
     def test_existing_checkout_is_not_synchronized_in_dry_run(
         self,
@@ -170,7 +201,7 @@ class TestOnEnterAndCloneStates:
         result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
-        assert result.next_state == "DISCOVER"
+        assert result.next_state == "LABELS"
         assert "[dry-run] would synchronize test-org/repo-a" in caplog.text
 
     def test_clone_failure_retries_within_budget(self, repo_item: WorkItem, repo_ctx: Any) -> None:
@@ -201,11 +232,13 @@ class TestOnEnterAndCloneStates:
     def test_clone_success_records_nothing(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         stage = RepoStage()
         repo_item.state = "CLONE_WAIT"
+        repo_item.payload["checkout_op"] = "sync_checkout"
 
         stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
 
         assert repo_item.attempts["clone"] == 0
         assert "clone_failed" not in repo_item.payload
+        assert repo_item.payload["checkout_verified"] is True
 
 
 class TestDiscover:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1780,7 +1780,10 @@ class TestPipelineScopeWiring:
         config = self._scoped_config(tmp_path, issues=[1, 2, 3], parallel_repos=2)
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
-        assert coordinator._seed_pass() == 2
+        assert coordinator._seed_pass() == 1
+        coordinator._drain_queues()
+        coordinator._drain_completions()
+        coordinator._drain_completions()
         assert [item.issue for item in coordinator.items] == [1, 3]
         assert gh.issue_json_calls == [1, 3]
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -90,6 +90,14 @@ def _item(issue: int = 1, stage: StageName = StageName.PLANNING) -> WorkItem:
     return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=stage, state="ENTER")
 
 
+def _complete_direct_scope_bootstrap(coordinator: Coordinator) -> None:
+    """Advance the clone-plus-sync gate before inspecting direct entries."""
+    coordinator._seed_pass()
+    coordinator._drain_queues()
+    coordinator._drain_completions()
+    coordinator._drain_completions()
+
+
 class TestWiring:
     """Constructor and run_pipeline production wiring."""
 
@@ -701,7 +709,7 @@ class TestSeedingEdges:
         )
         coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
 
-        coordinator._seed_pass()
+        _complete_direct_scope_bootstrap(coordinator)
 
         assert created == [("target-repo", tmp_path / "target-repo")]
         item = coordinator.queues[StageName.MERGE_WAIT].snapshot()[0]
@@ -745,7 +753,7 @@ class TestSeedingEdges:
         )
         coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
 
-        coordinator._seed_pass()
+        _complete_direct_scope_bootstrap(coordinator)
 
         assert created == [("target-repo", tmp_path / "target-repo")]
         item = coordinator.queues[StageName.MERGE_WAIT].snapshot()[0]
@@ -783,7 +791,7 @@ class TestSeedingEdges:
         )
         coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
 
-        coordinator._seed_pass()
+        _complete_direct_scope_bootstrap(coordinator)
 
         item = coordinator.queues[StageName.PR_REVIEW].snapshot()[0]
         assert item.repo == "target-repo"

--- a/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
+++ b/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
@@ -1,0 +1,159 @@
+"""Regression coverage for explicit CLI scope checkout synchronization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
+from hephaestus.automation.pipeline.routing import (
+    Disposition,
+    PipelineScope,
+    StageName,
+    StageOutcome,
+)
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.work_item import WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _ImmediatePassStage:
+    """Finish a seeded issue without an agent job."""
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del item, ctx
+        return StageOutcome(Disposition.FINISH_PASS, "complete")
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        del item, result, ctx
+        raise AssertionError("the deterministic stage does not submit jobs")
+
+
+class _RecordingPool(FakeWorkerPool):
+    """Record the synchronization submission in the shared event trace."""
+
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self._events = events
+
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
+        if isinstance(job, GitJob) and job.op == "sync_checkout":
+            self._events.append("sync")
+        return super().submit(job, on_done_state, **kwargs)
+
+
+class _RecordingGitHub(FakeStageGitHub):
+    """Record the first label mutation relative to direct classification."""
+
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(labels=["state:needs-plan"])
+        self._events = events
+
+    def ensure_state_labels(self) -> None:
+        self._events.append("labels")
+        super().ensure_state_labels()
+
+
+def _facts(issue: int) -> IssueFacts:
+    return IssueFacts(
+        number=issue,
+        title=f"Issue {issue}",
+        body="",
+        is_epic=False,
+        labels={"state:needs-plan"},
+        pr_number=None,
+        pr_is_open=False,
+        pr_is_merged=False,
+    )
+
+
+def test_explicit_scope_syncs_before_labels_and_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scoped run gates direct source admission on a clean-main sync job."""
+    events: list[str] = []
+    checkout = tmp_path / "repo-a"
+    checkout.mkdir()
+    pool = _RecordingPool(events)
+    github = _RecordingGitHub(events)
+
+    def classify(issue: int, github_arg: Any) -> IssueFacts:
+        del github_arg
+        events.append("classify")
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: list(issues),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[101],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})),
+        ),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage()
+
+    assert coordinator.run() == 0
+    assert events[:3] == ["sync", "labels", "classify"]
+
+
+def test_explicit_scope_sync_failure_blocks_labels_sources_and_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed explicit-scope fetch never falls through to stale checkout work."""
+    checkout = tmp_path / "repo-a"
+    checkout.mkdir()
+    classifications: list[int] = []
+    pool = FakeWorkerPool()
+    pool.script(
+        JobResult(ok=False, error="fetch unavailable"),
+        JobResult(ok=False, error="fetch unavailable"),
+    )
+    github = FakeStageGitHub(labels=["state:needs-plan"])
+
+    def classify(issue: int, github_arg: Any) -> IssueFacts:
+        del github_arg
+        classifications.append(issue)
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: list(issues),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo-a"], issues=[101], projects_dir=tmp_path),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage()
+
+    assert coordinator.run() == 1
+    assert classifications == []
+    assert github.mutation_log == []
+    assert [handle.job.op for handle in pool.submitted if isinstance(handle.job, GitJob)] == [
+        "sync_checkout",
+        "sync_checkout",
+    ]
+    assert not any(isinstance(handle.job, AgentJob) for handle in pool.submitted)
+    assert len(coordinator.ledger) == 1
+    assert "clone exhausted" in coordinator.ledger[0].reason

--- a/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
+++ b/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
@@ -53,13 +53,17 @@ class _RecordingPool(FakeWorkerPool):
 class _RecordingGitHub(FakeStageGitHub):
     """Record the first label mutation relative to direct classification."""
 
-    def __init__(self, events: list[str]) -> None:
-        super().__init__(labels=["state:needs-plan"])
+    def __init__(self, events: list[str], **kwargs: Any) -> None:
+        super().__init__(labels=["state:needs-plan"], **kwargs)
         self._events = events
 
     def ensure_state_labels(self) -> None:
         self._events.append("labels")
         super().ensure_state_labels()
+
+    def find_issue_for_pr(self, pr_number: int) -> int | None:
+        self._events.append("classify-pr")
+        return super().find_issue_for_pr(pr_number)
 
 
 def _facts(issue: int) -> IssueFacts:
@@ -114,17 +118,49 @@ def test_explicit_scope_syncs_before_labels_and_classification(
     assert events[:3] == ["sync", "labels", "classify"]
 
 
-def test_explicit_scope_sync_failure_blocks_labels_sources_and_agents(
+def test_explicit_pr_scope_syncs_before_labels_and_pr_classification(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A failed explicit-scope fetch never falls through to stale checkout work."""
+    """An explicit PR follows the same checkout proof before its first read."""
+    events: list[str] = []
+    (tmp_path / "repo-a").mkdir()
+    pool = _RecordingPool(events)
+    github = _RecordingGitHub(events, pr_issue=101, pr_impl_state=(True, False))
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            prs=[77],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.MERGE_WAIT})),
+        ),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.MERGE_WAIT] = _ImmediatePassStage()
+
+    assert coordinator.run() == 0
+    assert events[:3] == ["sync", "labels", "classify-pr"]
+
+
+@pytest.mark.parametrize(
+    "sync_error",
+    ["fetch unavailable", "checkout is dirty", "cannot fast-forward checkout"],
+)
+def test_explicit_scope_sync_failure_blocks_labels_sources_and_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sync_error: str
+) -> None:
+    """Fetch, dirty, or stale checkout failures cannot enter a scoped run."""
     checkout = tmp_path / "repo-a"
     checkout.mkdir()
     classifications: list[int] = []
     pool = FakeWorkerPool()
     pool.script(
-        JobResult(ok=False, error="fetch unavailable"),
-        JobResult(ok=False, error="fetch unavailable"),
+        JobResult(ok=False, error=sync_error),
+        JobResult(ok=False, error=sync_error),
     )
     github = FakeStageGitHub(labels=["state:needs-plan"])
 


### PR DESCRIPTION
## Summary

Closes #2452

- Gate explicit `--issues` and `--prs` runs through clone-plus-synchronization before label reads, source classification, or agent dispatch.
- Require even a newly cloned checkout to pass the remote/default-branch synchronization proof.
- Keep checkout preparation failures terminal and preserve the requested partial stage scope.

## Verification

- `uv run --all-extras --locked pytest tests/unit/automation/pipeline/stages/test_stage_repo.py tests/unit/automation/pipeline/test_coordinator.py tests/unit/automation/pipeline/test_coordinator_edges.py tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py -q --override-ini=addopts=` (138 passed)
- Ruff, formatting, mypy, and `git diff --check`
- Repository-required full pre-push suite completed before branch publication