### PR TITLE
fix(automation): pin direct scope checkout revisions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -650,6 +650,13 @@ Repo intake discovers candidate work through a bounded source, records
 exclusions, and routes each eligible issue or pull request to the stage implied
 by its durable state.
 
+Before it reads a direct `--issues` / `--prs` scope, performs a label mutation,
+or dispatches an agent, repo intake proves its reusable checkout is the
+expected repository, clean, on the remote default branch, and fast-forwarded
+to that branch's fetched head. A missing checkout is cloned and then subjected
+to the same synchronization proof. Any failure is terminal for that scope; it
+never falls through to an ambient or stale checkout.
+
 #### Boundary diagram
 
 ```mermaid
@@ -685,6 +692,9 @@ stateDiagram-v2
 Architectural contract:
 
 - Exclusions become durable before excluded work leaves the queue.
+- Label-vocabulary setup and source classification occur only after the
+  checkout proof succeeds. Explicit scopes use the same bounded direct cursors
+  after that gate; they do not bypass it or widen their selected stage scope.
 - Discovery never writes planning, review, implementation, or merge verdicts.
 - Failure of the repository item does not fabricate outcomes for its issues.
 - Runtime repository discovery does not eagerly build `products` or downstream

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1060,6 +1060,7 @@ stateDiagram-v2
     RECORD --> CLEANUP: result recorded
     CLEANUP --> DONE: remove passed workspace
     CLEANUP --> DONE: preserve failed workspace
+    CLEANUP --> DONE: non-forced direct no-op cleanup
     CLEANUP --> DONE: no workspace
     DONE --> [*]
 ```
@@ -1067,7 +1068,11 @@ stateDiagram-v2
 Architectural contract:
 
 - A terminal result is recorded once.
-- Failed workspaces are preserved for diagnosis.
+- Failed workspaces are preserved for diagnosis, except a direct-scope no-op
+  whose remote reservation was released: its known-clean worktree and local
+  branch receive a non-forced cleanup so a later direct run is not blocked by
+  stale deterministic state. A late dirty edit makes that cleanup fail and
+  preserves the worktree instead.
 - Successful temporary workspaces are removed when safe.
 - Cleanup failure never rewrites the underlying result.
 

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -286,6 +286,162 @@ def push_branch(branch_name: str, worktree_path: Path, *, timeout: int | None = 
         raise RuntimeError(f"Failed to push branch {branch_name}: {e}") from e
 
 
+def reserve_remote_branch_if_absent(
+    branch_name: str,
+    base_sha: str,
+    repo_root: Path,
+    *,
+    timeout: int | None = None,
+) -> None:
+    """Atomically create ``origin/<branch_name>`` at ``base_sha`` only when absent.
+
+    A direct CLI scope needs a server-side ownership proof before an agent can
+    begin writing its deterministic implementation branch.  An empty
+    ``--force-with-lease`` expectation makes the receive-pack reject a branch
+    that appeared after the caller's local inspection.
+    """
+    try:
+        run(
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/{branch_name}:",
+                "origin",
+                f"{base_sha}:refs/heads/{branch_name}",
+            ],
+            cwd=repo_root,
+            **_timeout_kw(timeout),
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to reserve direct-scope branch {branch_name}: {exc}") from exc
+
+
+def push_branch_if_remote_matches(
+    branch_name: str,
+    expected_remote_sha: str,
+    worktree_path: Path,
+    *,
+    timeout: int | None = None,
+) -> None:
+    """Push only an expected fast-forward of a direct-scope reservation.
+
+    The ancestry check prevents a locally rewritten branch from becoming a
+    forced update.  The explicit server-side lease then rejects any human or
+    competing writer that changed the reservation after admission.
+    """
+    ancestry = run(
+        ["git", "merge-base", "--is-ancestor", expected_remote_sha, "HEAD"],
+        cwd=worktree_path,
+        check=False,
+        **_timeout_kw(timeout),
+    )
+    if ancestry.returncode != 0:
+        raise RuntimeError(
+            f"Direct-scope branch {branch_name} is not a fast-forward of its reservation"
+        )
+    try:
+        run(
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/{branch_name}:{expected_remote_sha}",
+                "origin",
+                f"HEAD:refs/heads/{branch_name}",
+            ],
+            cwd=worktree_path,
+            **_timeout_kw(timeout),
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to publish direct-scope branch {branch_name}: {exc}") from exc
+
+
+def delete_reserved_branch_if_unchanged(
+    branch_name: str,
+    expected_remote_sha: str,
+    repo_root: Path,
+    *,
+    timeout: int | None = None,
+) -> bool:
+    """Delete an unused direct-scope reservation only while it remains ours.
+
+    A stale lease is expected when an external writer took ownership after the
+    reservation.  It is reported as ``False`` only after a follow-up ref read
+    confirms that the remote no longer points to our expected SHA.  Transport
+    and authentication failures raise so callers can retry rather than
+    mistaking an unreachable reservation for a safe ownership loss.
+    """
+    try:
+        run(
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/{branch_name}:{expected_remote_sha}",
+                "origin",
+                f":refs/heads/{branch_name}",
+            ],
+            cwd=repo_root,
+            **_timeout_kw(timeout),
+        )
+        return True
+    except subprocess.CalledProcessError as exc:
+        try:
+            observed = run(
+                ["git", "ls-remote", "--refs", "origin", f"refs/heads/{branch_name}"],
+                cwd=repo_root,
+                **_timeout_kw(timeout),
+            ).stdout.split()
+        except subprocess.CalledProcessError as probe_exc:
+            raise RuntimeError(
+                f"Failed to release direct-scope branch {branch_name}; "
+                "could not verify the remote reservation"
+            ) from probe_exc
+        if not observed or observed[0] != expected_remote_sha:
+            logger.warning(
+                "Direct-scope branch %s changed before its reservation could be released",
+                branch_name,
+            )
+            return False
+        raise RuntimeError(
+            f"Failed to release direct-scope branch {branch_name}; "
+            "remote reservation remains unchanged"
+        ) from exc
+
+
+def delete_local_branch_if_unchanged(
+    branch_name: str,
+    expected_sha: str,
+    repo_root: Path,
+    *,
+    timeout: int | None = None,
+) -> bool:
+    """Delete a local no-op branch only if it is still at ``expected_sha``.
+
+    The caller holds the shared worktree-metadata lock. It first verifies the
+    expected ref value, then uses ``git branch -d`` rather than plumbing ref
+    deletion: Git refuses to delete a branch attached to any worktree. A
+    changed, absent, or checked-out branch is a safe ``False`` result.
+    """
+    ref = f"refs/heads/{branch_name}"
+    observed = run(
+        ["git", "show-ref", "--verify", "--hash", ref],
+        cwd=repo_root,
+        check=False,
+        **_timeout_kw(timeout),
+    )
+    if observed.returncode == 1 or observed.stdout.strip() != expected_sha:
+        return False
+    try:
+        run(["git", "branch", "-d", branch_name], cwd=repo_root, **_timeout_kw(timeout))
+        return True
+    except subprocess.CalledProcessError as exc:
+        detail = f"{exc.stdout or ''}\n{exc.stderr or ''}".lower()
+        if "checked out" in detail or "not fully merged" in detail:
+            return False
+        raise RuntimeError(
+            f"Failed to release local direct-scope branch {branch_name}; ref remains unchanged"
+        ) from exc
+
+
 def push_head_to_branch(
     branch_name: str, worktree_path: Path, *, timeout: int | None = None
 ) -> None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -119,7 +119,13 @@ from hephaestus.automation.pipeline.stages import (
     StageGitHub,
 )
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
-from hephaestus.automation.pipeline.stages.repo import RepoIssueSource, product_to_work_item
+from hephaestus.automation.pipeline.stages.repo import (
+    DIRECT_SCOPE_BASE_SHA_KEY,
+    DIRECT_SCOPE_BOOTSTRAP_KEY,
+    RepoIssueSource,
+    is_full_commit_sha,
+    product_to_work_item,
+)
 from hephaestus.automation.pipeline.summary import (
     RunStats,
     TerminalSummary,
@@ -177,13 +183,6 @@ _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — rei
 _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05
-
-#: Payload marker for the internal setup item that gates an explicit
-#: ``--issues`` / ``--prs`` cursor.  It is intentionally not a pipeline stage:
-#: a scoped invocation may omit REPO from its work stages, but it must still
-#: prove that the one reusable checkout is a clean default branch before any
-#: source read, label mutation, or agent job starts.
-_DIRECT_SCOPE_BOOTSTRAP_KEY = "_direct_scope_bootstrap"
 
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
@@ -391,6 +390,7 @@ class _DirectIssueSource:
 
     repo: str
     issues: Iterator[int]
+    base_sha: str
 
 
 @dataclass
@@ -404,6 +404,7 @@ class _DirectPrSource:
 
     repo: str
     prs: Iterator[int]
+    base_sha: str
 
 
 @dataclass
@@ -1985,7 +1986,7 @@ class Coordinator:
 
     def _route(self, item: WorkItem, outcome: StageOutcome) -> None:
         """Apply the Disposition -> action table (plan #1817)."""
-        if item.stage is StageName.REPO and item.payload.get(_DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+        if item.stage is StageName.REPO and item.payload.get(DIRECT_SCOPE_BOOTSTRAP_KEY, False):
             self._route_direct_scope_bootstrap(item, outcome)
             return
         route = self._routes.get(item.stage)
@@ -2066,9 +2067,24 @@ class Coordinator:
             )
             return
 
+        base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+        if not is_full_commit_sha(base_sha):
+            if not self.config.dry_run:
+                self._direct_scope_bootstrap_pending = False
+                self._finish(
+                    item,
+                    passed=False,
+                    reason="direct scope checkout returned an invalid default-branch SHA",
+                )
+                return
+            # Dry-run never submits checkout or implementation jobs, so it
+            # cannot truthfully obtain an immutable checkout SHA. Do not
+            # attach a fake pin: direct items retain normal preview behavior
+            # while real runs still fail closed without the proof.
+            base_sha = ""
         try:
-            self._begin_direct_pr_source(item.repo)
-            self._begin_direct_issue_source(item.repo)
+            self._begin_direct_pr_source(item.repo, base_sha)
+            self._begin_direct_issue_source(item.repo, base_sha)
         except Exception as exc:
             self._direct_scope_bootstrap_pending = False
             logger.warning(
@@ -2139,7 +2155,7 @@ class Coordinator:
 
     def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
         """Set the item's result and hand it to the finished sink."""
-        if item.stage is StageName.REPO and item.payload.get(_DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+        if item.stage is StageName.REPO and item.payload.get(DIRECT_SCOPE_BOOTSTRAP_KEY, False):
             self._direct_scope_bootstrap_pending = False
         if item.stage is StageName.FINISHED:
             # Poisoned inside the sink: record directly, never re-queue.
@@ -2316,8 +2332,11 @@ class Coordinator:
         if has_direct_scope:
             pushed += self._begin_direct_scope_bootstrap(default_repo)
         else:
-            self._begin_direct_pr_source(default_repo)
-            self._begin_direct_issue_source(default_repo)
+            # No explicit cursor exists in an unscoped pass. Keep the calls
+            # for their established empty-source cleanup semantics without
+            # manufacturing a checkout pin outside the direct bootstrap.
+            self._begin_direct_pr_source(default_repo, "")
+            self._begin_direct_issue_source(default_repo, "")
         return (
             pushed
             + self._drain_repo_entry_source()
@@ -2338,7 +2357,7 @@ class Coordinator:
             )
             return int(self._push_item(item, StageName.FINISHED, enter=True))
         item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.REPO)
-        item.payload[_DIRECT_SCOPE_BOOTSTRAP_KEY] = True
+        item.payload[DIRECT_SCOPE_BOOTSTRAP_KEY] = True
         return int(self._push_item(item, StageName.REPO, enter=True))
 
     def _begin_repo_entry_source(self, repos: list[str]) -> None:
@@ -2389,19 +2408,27 @@ class Coordinator:
             pushed += 1
         return pushed
 
-    def _begin_direct_issue_source(self, repo: str) -> None:
+    def _begin_direct_issue_source(self, repo: str, base_sha: str) -> None:
         """Initialize one bounded cursor for this pass's ``--issues`` input."""
         self._direct_issue_source = None
         if not self.config.issues:
             return
         open_issues = _admission._filter_open_issues(repo, self.config.issues)
-        self._direct_issue_source = _DirectIssueSource(repo=repo, issues=iter(open_issues))
+        self._direct_issue_source = _DirectIssueSource(
+            repo=repo,
+            issues=iter(open_issues),
+            base_sha=base_sha,
+        )
 
-    def _begin_direct_pr_source(self, repo: str) -> None:
+    def _begin_direct_pr_source(self, repo: str, base_sha: str) -> None:
         """Initialize one bounded cursor for this pass's ``--prs`` input."""
         self._direct_pr_source = None
         if self.config.prs:
-            self._direct_pr_source = _DirectPrSource(repo=repo, prs=iter(self.config.prs))
+            self._direct_pr_source = _DirectPrSource(
+                repo=repo,
+                prs=iter(self.config.prs),
+                base_sha=base_sha,
+            )
 
     def _direct_issue_queues_can_accept(self) -> bool:
         """Return whether one direct issue can be classified and enqueued now."""
@@ -2440,6 +2467,8 @@ class Coordinator:
                 continue
 
             item = self._entry_to_item(entry, source.repo)
+            if is_full_commit_sha(source.base_sha):
+                item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = source.base_sha
             if item.stage not in (StageName.REPO, StageName.FINISHED):
                 self._pass_work_count += 1
             if item.stage is StageName.FINISHED and item.result is None:
@@ -2486,6 +2515,8 @@ class Coordinator:
                 continue
 
             item = self._entry_to_item(entry, source.repo)
+            if is_full_commit_sha(source.base_sha):
+                item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = source.base_sha
             if item.stage not in (StageName.REPO, StageName.FINISHED):
                 self._pass_work_count += 1
             if item.stage is StageName.FINISHED and item.result is None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -178,6 +178,13 @@ _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05
 
+#: Payload marker for the internal setup item that gates an explicit
+#: ``--issues`` / ``--prs`` cursor.  It is intentionally not a pipeline stage:
+#: a scoped invocation may omit REPO from its work stages, but it must still
+#: prove that the one reusable checkout is a clean default branch before any
+#: source read, label mutation, or agent job starts.
+_DIRECT_SCOPE_BOOTSTRAP_KEY = "_direct_scope_bootstrap"
+
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
 #: finished sink drains first of all so results are recorded promptly).
@@ -534,6 +541,7 @@ class Coordinator:
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self._direct_issue_source: _DirectIssueSource | None = None
         self._direct_pr_source: _DirectPrSource | None = None
+        self._direct_scope_bootstrap_pending = False
         self._repo_entry_source: _RepoEntrySource | None = None
         self._repo_issue_sources: deque[_ActiveRepoIssueSource] = deque()
         # A StageQueue's capacity only bounds that one stage.  This permit
@@ -1977,6 +1985,9 @@ class Coordinator:
 
     def _route(self, item: WorkItem, outcome: StageOutcome) -> None:
         """Apply the Disposition -> action table (plan #1817)."""
+        if item.stage is StageName.REPO and item.payload.get(_DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+            self._route_direct_scope_bootstrap(item, outcome)
+            return
         route = self._routes.get(item.stage)
         if route is None:
             # A stage absent from this run's (possibly scope-trimmed) route
@@ -2034,6 +2045,51 @@ class Coordinator:
         # FINISH_FAIL (exhaustive over Disposition)
         self._finish(item, passed=False, reason=outcome.note or "fail")
 
+    def _route_direct_scope_bootstrap(self, item: WorkItem, outcome: StageOutcome) -> None:
+        """Activate direct cursors only after their checkout proof succeeds.
+
+        A partial pipeline scope deliberately omits ``REPO`` from its route
+        table.  This internal setup item therefore has its own tiny terminal
+        protocol instead of widening the operator-selected stage scope.  It
+        never reaches an agent-capable stage unless the repo stage completed
+        clone-plus-sync and then prepared the label vocabulary.
+        """
+        if outcome.disposition is Disposition.RETRY:
+            self._route_retry(item, outcome)
+            return
+        if outcome.disposition is not Disposition.FINISH_PASS:
+            self._direct_scope_bootstrap_pending = False
+            self._finish(
+                item,
+                passed=False,
+                reason=outcome.note or "direct scope checkout preparation failed",
+            )
+            return
+
+        try:
+            self._begin_direct_pr_source(item.repo)
+            self._begin_direct_issue_source(item.repo)
+        except Exception as exc:
+            self._direct_scope_bootstrap_pending = False
+            logger.warning(
+                "direct scope for %s could not initialize after sync: %s", item.repo, exc
+            )
+            self._finish(item, passed=False, reason=f"direct scope initialization failed: {exc}")
+            return
+
+        # A successful bootstrap is coordinator plumbing, not an issue/repo
+        # result.  Free its sole bounded slot before admitting the first
+        # direct entry, mirroring successful REPO-source externalization.
+        self._release_source_lease(item)
+        self._release_work_permit(item)
+        self._direct_scope_bootstrap_pending = False
+        self._seen_item_ids.discard(id(item))
+        with suppress(ValueError):
+            self.items.remove(item)
+        self._record_event("direct_scope_ready", item.repo)
+        self._drain_direct_pr_source()
+        self._drain_direct_issue_source()
+
     def _route_retry(self, item: WorkItem, outcome: StageOutcome) -> None:
         """Apply the RETRY row: heap-park on a recorded delay, else next tick.
 
@@ -2083,6 +2139,8 @@ class Coordinator:
 
     def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
         """Set the item's result and hand it to the finished sink."""
+        if item.stage is StageName.REPO and item.payload.get(_DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+            self._direct_scope_bootstrap_pending = False
         if item.stage is StageName.FINISHED:
             # Poisoned inside the sink: record directly, never re-queue.
             item.result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
@@ -2227,7 +2285,8 @@ class Coordinator:
         # unbounded logical-identity map in the terminal aggregate.
         self._terminal_summary.reset()
         self._pass_work_count = 0
-        discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
+        has_direct_scope = bool(self.config.issues or self.config.prs)
+        discovery_repos = [] if has_direct_scope else self.config.repos
         # Repository discovery is a source, not a list of pre-built
         # ``SeedEntry``/``WorkItem`` values.  Keep the legacy empty call so
         # direct test seams and any non-repository synthetic entries retain
@@ -2235,8 +2294,6 @@ class Coordinator:
         entries = _seeding.seed_from_cli([], [], [])
         self._begin_repo_entry_source(discovery_repos if not entries else [])
         default_repo = self.config.repos[0] if self.config.repos else ""
-        self._begin_direct_pr_source(default_repo)
-        self._begin_direct_issue_source(default_repo)
         pushed = 0
         for entry in entries:
             if entry.stage is None:
@@ -2256,12 +2313,33 @@ class Coordinator:
                 )
             if self._push_item(item, item.stage, enter=True):
                 pushed += 1
+        if has_direct_scope:
+            pushed += self._begin_direct_scope_bootstrap(default_repo)
+        else:
+            self._begin_direct_pr_source(default_repo)
+            self._begin_direct_issue_source(default_repo)
         return (
             pushed
             + self._drain_repo_entry_source()
-            + self._drain_direct_pr_source()
-            + self._drain_direct_issue_source()
+            + (0 if has_direct_scope else self._drain_direct_pr_source())
+            + (0 if has_direct_scope else self._drain_direct_issue_source())
         )
+
+    def _begin_direct_scope_bootstrap(self, repo: str) -> int:
+        """Enqueue the one checkout proof required by an explicit CLI scope."""
+        self._direct_scope_bootstrap_pending = True
+        if not repo:
+            self._direct_scope_bootstrap_pending = False
+            item = WorkItem(repo="", kind=ItemKind.REPO, stage=StageName.FINISHED)
+            item.result = ItemResult(
+                passed=False,
+                reason="explicit --issues/--prs scope requires exactly one repository",
+                final_stage=StageName.FINISHED,
+            )
+            return int(self._push_item(item, StageName.FINISHED, enter=True))
+        item = WorkItem(repo=repo, kind=ItemKind.REPO, stage=StageName.REPO)
+        item.payload[_DIRECT_SCOPE_BOOTSTRAP_KEY] = True
+        return int(self._push_item(item, StageName.REPO, enter=True))
 
     def _begin_repo_entry_source(self, repos: list[str]) -> None:
         """Initialize one FIFO source for this pass's repository discovery.
@@ -2710,6 +2788,7 @@ class Coordinator:
                 bool(self._repo_issue_sources),
                 self._direct_issue_source is not None,
                 self._direct_pr_source is not None,
+                self._direct_scope_bootstrap_pending,
             )
         )
 

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -26,6 +26,7 @@ GIT_OPS: frozenset[str] = frozenset(
         "rebase",
         "push",
         "commit_push",
+        "release_branch_reservation",
     }
 )
 

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -37,8 +37,15 @@ from .base import (
     StepResult,
     WorkItem,
 )
+from .repo import (
+    DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY,
+    DIRECT_SCOPE_RESERVATION_KEY,
+    is_full_commit_sha,
+)
 
 logger = logging.getLogger(__name__)
+
+_RESERVATION_RELEASE_RETRY_CAP = 2
 
 
 class FinishedStage(Stage):
@@ -113,6 +120,50 @@ class FinishedStage(Stage):
 
     def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Clean or preserve the writer worktree."""
+        reservation = item.payload.get(DIRECT_SCOPE_RESERVATION_KEY)
+        if not item.payload.get("_direct_scope_reservation_release_attempted", False):
+            if isinstance(reservation, dict):
+                branch_name = reservation.get("branch")
+                base_sha = reservation.get("base_sha")
+                if isinstance(branch_name, str) and is_full_commit_sha(base_sha):
+                    # The branch contains no coordinator-published commit.
+                    # Release only if its remote ref is still the exact base
+                    # we reserved, so a later human/concurrent writer is
+                    # never deleted.  This also runs for failed items whose
+                    # writer worktree is deliberately preserved.
+                    attempts = int(
+                        item.payload.get("_direct_scope_reservation_release_attempts", 0)
+                    )
+                    if attempts < _RESERVATION_RELEASE_RETRY_CAP:
+                        item.payload["_direct_scope_reservation_release_attempts"] = attempts + 1
+                        item.payload["_direct_scope_reservation_release_inflight"] = True
+                        return JobRequest(
+                            job=GitJob(
+                                repo=item.repo,
+                                op="release_branch_reservation",
+                                timeout_s=GIT_JOB_TIMEOUT_S,
+                                kwargs={
+                                    "branch": branch_name,
+                                    "base_sha": base_sha,
+                                    "repo_root": str(ctx.paths.repo_root),
+                                },
+                                descr=f"release unused direct-scope branch {branch_name}",
+                            ),
+                            on_done_state="CLEANUP",
+                        )
+                    logger.warning(
+                        "finished:%s: could not release direct-scope reservation after %d attempts",
+                        item.issue or item.repo,
+                        attempts,
+                    )
+                else:
+                    logger.warning(
+                        "finished:%s: invalid direct-scope reservation receipt; "
+                        "not releasing branch",
+                        item.issue or item.repo,
+                    )
+            item.payload["_direct_scope_reservation_release_attempted"] = True
+
         if not item.worktree:
             return Continue(next_state="DONE")
 
@@ -132,17 +183,21 @@ class FinishedStage(Stage):
             logger.info("[dry-run] would remove worktree %s", item.worktree)
             return Continue(next_state="DONE")
 
+        kwargs: dict[str, object] = {
+            "worktree_path": item.worktree,
+            "repo_root": str(ctx.paths.repo_root),
+            "force": True,
+        }
+        local_cleanup = item.payload.get(DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY)
+        if isinstance(local_cleanup, dict):
+            kwargs["local_branch_cleanup"] = local_cleanup
         job = GitJob(
             repo=item.repo,
             op="remove_worktree",
             timeout_s=GIT_JOB_TIMEOUT_S,
             # Use the concrete worktree path: the cleanup worker constructs a
             # fresh WorktreeManager, so its in-memory issue map is empty.
-            kwargs={
-                "worktree_path": item.worktree,
-                "repo_root": str(ctx.paths.repo_root),
-                "force": True,
-            },
+            kwargs=kwargs,
             descr=f"remove worktree {item.worktree}",
         )
         return JobRequest(job=job, on_done_state="DONE")
@@ -156,9 +211,34 @@ class FinishedStage(Stage):
             ctx: Stage context.
 
         """
+        if item.payload.pop("_direct_scope_reservation_release_inflight", False):
+            if result.ok:
+                item.payload["_direct_scope_reservation_release_attempted"] = True
+                item.payload.pop(DIRECT_SCOPE_RESERVATION_KEY, None)
+                if result.value is False:
+                    logger.warning(
+                        "finished:%s: direct-scope reservation changed and was not released",
+                        item.issue or item.repo,
+                    )
+            elif (
+                item.payload.get("_direct_scope_reservation_release_attempts", 0)
+                >= _RESERVATION_RELEASE_RETRY_CAP
+            ):
+                item.payload["_direct_scope_reservation_release_attempted"] = True
+                logger.warning(
+                    "finished:%s: direct-scope reservation release failed after retries: %s",
+                    item.issue or item.repo,
+                    result.error,
+                )
+            return
         if not result.ok:
             logger.warning(
                 "finished:%s: worktree cleanup failed (non-fatal): %s",
                 item.issue or item.repo,
                 result.error,
+            )
+        elif isinstance(result.value, dict) and result.value.get("local_branch_deleted") is False:
+            logger.warning(
+                "finished:%s: local direct-scope branch changed and was not deleted",
+                item.issue or item.repo,
             )

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -11,7 +11,9 @@ Steps:
    and ledger ownership stay with the coordinator).
 2. [W:G] CLEANUP: remove the implementation worktree on pass; on fail, preserve that writer
    worktree for debugging and record it in the preserved list the end-of-run
-   summary prints.
+   summary prints. A direct-scope no-op is the exception: its remote reservation
+   has already been released, so cleanup attempts a non-forced removal of its
+   known-clean worktree and local branch; a late dirty edit is preserved.
 
 Verdicts: terminal — no outgoing routes (the coordinator drops the item
 when the sink emits its final outcome).
@@ -168,7 +170,14 @@ class FinishedStage(Stage):
             return Continue(next_state="DONE")
 
         passed = bool(item.result and item.result.passed)
-        if not passed:
+        local_cleanup = item.payload.get(DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY)
+        is_direct_noop = (
+            isinstance(local_cleanup, dict)
+            and isinstance(local_cleanup.get("branch"), str)
+            and bool(local_cleanup["branch"])
+            and is_full_commit_sha(local_cleanup.get("base_sha"))
+        )
+        if not passed and not is_direct_noop:
             entry = (item.repo, item.issue or item.pr or 0, item.worktree)
             if entry not in self._preserved:
                 self._preserved.append(entry)
@@ -186,11 +195,14 @@ class FinishedStage(Stage):
         kwargs: dict[str, object] = {
             "worktree_path": item.worktree,
             "repo_root": str(ctx.paths.repo_root),
-            "force": True,
+            # A no-op direct scope is known-clean at commit/push time, but a
+            # human may edit it before this terminal cleanup runs. Refuse to
+            # discard that late edit; on failure the worktree is preserved.
+            "force": not is_direct_noop,
         }
-        local_cleanup = item.payload.get(DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY)
-        if isinstance(local_cleanup, dict):
+        if is_direct_noop:
             kwargs["local_branch_cleanup"] = local_cleanup
+            item.payload["_direct_scope_noop_cleanup_inflight"] = True
         job = GitJob(
             repo=item.repo,
             op="remove_worktree",
@@ -232,6 +244,10 @@ class FinishedStage(Stage):
                 )
             return
         if not result.ok:
+            if item.payload.pop("_direct_scope_noop_cleanup_inflight", False):
+                entry = (item.repo, item.issue or item.pr or 0, item.worktree)
+                if entry not in self._preserved:
+                    self._preserved.append(entry)
             logger.warning(
                 "finished:%s: worktree cleanup failed (non-fatal): %s",
                 item.issue or item.repo,

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -116,6 +116,12 @@ from .base import (
     stage_model,
     write_skip_label,
 )
+from .repo import (
+    DIRECT_SCOPE_BASE_SHA_KEY,
+    DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY,
+    DIRECT_SCOPE_RESERVATION_KEY,
+    is_full_commit_sha,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -302,6 +308,9 @@ class ImplementationStage(Stage):
         issue = _issue_number(item)
         logger.info("implementation:%d: requesting worktree job", issue)
         adopted = bool(item.payload.get("existing_pr"))
+        direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+        if not adopted and direct_base_sha is not None and not is_full_commit_sha(direct_base_sha):
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_scope_base_pin_invalid")
         kwargs: dict[str, object] = {
             "issue_number": issue,
             "branch_name": item.branch,
@@ -311,9 +320,11 @@ class ImplementationStage(Stage):
             # remote head instead (the anti-clobber reset of
             # _prepare_worktree_for_existing_pr :649/:693, so re-running
             # never discards pushed commits). Values coordinator-vetted.
-            "refresh_base": not adopted,
+            "refresh_base": not adopted and direct_base_sha is None,
             "repo_root": str(ctx.paths.repo_root),
         }
+        if not adopted and direct_base_sha is not None:
+            kwargs["base_sha"] = direct_base_sha
         if adopted:
             kwargs["sync_to_remote"] = True
             kwargs["pr_number"] = item.pr
@@ -506,16 +517,22 @@ class ImplementationStage(Stage):
         if item.payload.get("tests_failed"):
             return Continue(next_state=TESTFIX_WAIT)
         logger.info("implementation:%d: requesting commit+push job", issue)
+        kwargs: dict[str, object] = {
+            "issue_number": issue,
+            "worktree_path": item.worktree,
+            "branch": item.branch,
+            "agent": agent_provider(ctx),
+        }
+        direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+        if direct_base_sha is not None:
+            if not is_full_commit_sha(direct_base_sha):
+                return StageOutcome(Disposition.FINISH_FAIL, "direct_scope_base_pin_invalid")
+            kwargs["expected_remote_sha"] = direct_base_sha
         push_job = GitJob(
             repo=item.repo,
             op="commit_push",
             timeout_s=GIT_JOB_TIMEOUT_S,
-            kwargs={
-                "issue_number": issue,
-                "worktree_path": item.worktree,
-                "branch": item.branch,
-                "agent": agent_provider(ctx),
-            },
+            kwargs=kwargs,
             descr="commit_push",
         )
         return JobRequest(push_job, on_done_state=PR_CREATE)
@@ -570,6 +587,18 @@ class ImplementationStage(Stage):
         if result.ok:
             if not bool(result.value):
                 item.payload["no_commits"] = True
+                # The worker's no-commit path conditionally released the
+                # remote branch.  Keep the exact receipt so Finished can
+                # remove the now-unused local branch after its worktree is
+                # detached; otherwise the next direct run would fail closed
+                # on that stale local ref.
+                reservation = item.payload.pop(DIRECT_SCOPE_RESERVATION_KEY, None)
+                if isinstance(reservation, dict):
+                    item.payload[DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY] = reservation
+            else:
+                # A published branch has real commits and must not be
+                # released by terminal cleanup.
+                item.payload.pop(DIRECT_SCOPE_RESERVATION_KEY, None)
             # A successful worker result ends the consecutive-git-failure
             # streak even when no commit was produced; PR_CREATE handles skip.
             item.payload.pop("git_error_retries", None)
@@ -618,6 +647,26 @@ class ImplementationStage(Stage):
         """
         if not result.ok:
             logger.warning("implementation:%s: worktree job failed: %s", item.issue, result.error)
+            direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+            reservation = (
+                result.value.get("direct_scope_reservation")
+                if isinstance(result.value, dict)
+                else None
+            )
+            if (
+                is_full_commit_sha(direct_base_sha)
+                and isinstance(reservation, dict)
+                and reservation.get("branch") == item.branch
+                and reservation.get("base_sha") == direct_base_sha
+            ):
+                # The worktree did not materialize, but a failed rollback
+                # left our server-side reservation at its base. Preserve the
+                # receipt so Finished can use its bounded, conditional release
+                # protocol if the retriable worktree job is exhausted.
+                item.payload[DIRECT_SCOPE_RESERVATION_KEY] = {
+                    "branch": item.branch,
+                    "base_sha": direct_base_sha,
+                }
             item.worktree = ""
             item.payload.pop("worktree_dirty", None)
             item.payload.pop("worktree_status", None)
@@ -632,6 +681,27 @@ class ImplementationStage(Stage):
             item.payload["worktree_dirty"] = bool(value.get("dirty"))
             item.payload["worktree_status"] = str(value.get("status", ""))
             item.payload["worktree_diff"] = str(value.get("diff", ""))
+            direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+            if direct_base_sha is not None:
+                reservation = value.get("direct_scope_reservation")
+                if (
+                    not is_full_commit_sha(direct_base_sha)
+                    or not isinstance(reservation, dict)
+                    or reservation.get("branch") != item.branch
+                    or reservation.get("base_sha") != direct_base_sha
+                ):
+                    logger.warning(
+                        "implementation:%s: direct worktree result omitted or corrupted its "
+                        "remote reservation receipt",
+                        item.issue,
+                    )
+                    item.worktree = ""
+                    item.payload["git_error"] = True
+                    return
+                item.payload[DIRECT_SCOPE_RESERVATION_KEY] = {
+                    "branch": item.branch,
+                    "base_sha": direct_base_sha,
+                }
         elif isinstance(value, str) and value:
             item.worktree = value
 

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -33,7 +33,7 @@ import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeGuard
 
 from hephaestus.automation import loop_repo_manager as _repo_manager
 
@@ -54,6 +54,30 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Direct CLI scopes bootstrap one reusable checkout before any source reads.
+# The SHA travels only with that bootstrap's cursors; normal repository
+# discovery retains per-issue fresh-trunk semantics.
+DIRECT_SCOPE_BOOTSTRAP_KEY = "_direct_scope_bootstrap"
+DIRECT_SCOPE_BASE_SHA_KEY = "_direct_scope_base_sha"
+# A direct-scope worker returns this receipt only after it has atomically
+# reserved the remote implementation branch.  It remains on the item until a
+# coordinator-owned push publishes a commit or the Finished stage releases the
+# still-unused reservation.
+DIRECT_SCOPE_RESERVATION_KEY = "_direct_scope_reservation"
+# The remote reservation is already released after a direct no-op.  Finished
+# uses this receipt to compare-and-delete the now-detached local branch only
+# after removing its worktree.
+DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY = "_direct_scope_local_branch_cleanup"
+
+
+def is_full_commit_sha(value: object) -> TypeGuard[str]:
+    """Return whether ``value`` is a full SHA-1 or SHA-256 commit id."""
+    return bool(
+        isinstance(value, str)
+        and len(value) in (40, 64)
+        and all(character in "0123456789abcdef" for character in value)
+    )
 
 
 def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
@@ -121,7 +145,7 @@ class RepoStage(Stage):
 
         if item.state == "LABELS":
             ctx.github.ensure_state_labels()
-            if item.payload.get("_direct_scope_bootstrap", False):
+            if item.payload.get(DIRECT_SCOPE_BOOTSTRAP_KEY, False):
                 return StageOutcome(
                     Disposition.FINISH_PASS,
                     note="direct scope checkout synchronized",
@@ -225,6 +249,16 @@ class RepoStage(Stage):
                 item.payload["checkout_cloned"] = True
                 logger.info("repo:%s: clone completed; verifying checkout", item.repo)
             elif operation == "sync_checkout":
+                if item.payload.get(DIRECT_SCOPE_BOOTSTRAP_KEY, False):
+                    if not is_full_commit_sha(result.value):
+                        item.attempts["clone"] = item.attempts.get("clone", 0) + 1
+                        item.payload["clone_failed"] = True
+                        logger.warning(
+                            "repo:%s: direct scope sync returned no validated default-branch SHA",
+                            item.repo,
+                        )
+                        return
+                    item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = result.value
                 item.payload["checkout_verified"] = True
                 logger.info("repo:%s: checkout preparation completed", item.repo)
             else:  # pragma: no cover - every checkout JobRequest records its operation

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -2,18 +2,19 @@
 
 Binding contract: docs/architecture.md §5.1 "repo".
 
-States: ENTER -> CLONE_WAIT -> DISCOVER -> SOURCE.
+States: ENTER -> CLONE_WAIT -> LABELS -> DISCOVER -> SOURCE.
 
 Steps:
 
-1. [M] ``on_enter``: ``ctx.github.ensure_state_labels()`` — idempotent label
-   vocabulary setup.
-2. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing, or
-   ``GitJob(op="sync_checkout")`` when it already exists. Synchronization
-   validates the expected remote and fast-forwards only a clean default-branch
-   checkout. Both operations are logged-skipped under dry-run — the
+1. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing, then
+   ``GitJob(op="sync_checkout")``; or ``GitJob(op="sync_checkout")`` directly
+   when it already exists. Synchronization validates the expected remote and
+   fast-forwards only a clean default-branch checkout. Both operations are
+   logged-skipped under dry-run — the
    coordinator's ``_submit`` asserts no job is ever submitted in dry-run.
    Budget ``clone`` = 2; exhaustion -> finished(fail).
+2. [M] LABELS: ``ctx.github.ensure_state_labels()`` only after checkout
+   synchronization succeeds.
 3. [M] DISCOVER: initialize one page-at-a-time metadata cursor. It never
    materializes a list of classified products.
 4. [M] SOURCE: the coordinator transfers the bounded cursor to its fair
@@ -88,7 +89,7 @@ class RepoStage(Stage):
     kind = StageName.REPO
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
-        """Ensure the state-label vocabulary exists (idempotent, durable).
+        """Proceed to checkout preparation before any durable label work.
 
         Args:
             item: The repo work item.
@@ -98,7 +99,7 @@ class RepoStage(Stage):
             None to proceed with step().
 
         """
-        ctx.github.ensure_state_labels()
+        del item, ctx
         return None
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
@@ -118,6 +119,15 @@ class RepoStage(Stage):
         if item.state == "CLONE_WAIT":
             return self._clone_or_skip(item, ctx)
 
+        if item.state == "LABELS":
+            ctx.github.ensure_state_labels()
+            if item.payload.get("_direct_scope_bootstrap", False):
+                return StageOutcome(
+                    Disposition.FINISH_PASS,
+                    note="direct scope checkout synchronized",
+                )
+            return Continue(next_state="DISCOVER")
+
         if item.state == "DISCOVER":
             return self._discover(item, ctx)
 
@@ -131,8 +141,9 @@ class RepoStage(Stage):
 
     def _clone_or_skip(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Prepare a checkout by cloning or safely synchronizing it."""
-        # Clone failure handling (budget clone=2): on_job_done recorded the
-        # failure; classify it here so retry re-submits and exhaustion fails.
+        # Checkout preparation failure handling (budget clone=2): on_job_done
+        # records the failure while retaining CLONE_WAIT, so retry cannot fall
+        # through into label work or discovery after a failed fetch.
         if item.payload.pop("clone_failed", False):
             if item.attempts.get("clone", 0) >= ctx.budget("clone"):
                 return StageOutcome(
@@ -146,15 +157,19 @@ class RepoStage(Stage):
                 ctx.budget("clone"),
             )
 
+        if item.payload.pop("checkout_verified", False):
+            return Continue(next_state="LABELS")
+
         dest = _repo_checkout_path(item, ctx)
         if ctx.dry_run:
             if dest.exists():
                 logger.info("[dry-run] would synchronize %s/%s at %s", ctx.org, item.repo, dest)
-                return Continue(next_state="DISCOVER")
+                return Continue(next_state="LABELS")
             logger.info("[dry-run] would clone %s/%s to %s", ctx.org, item.repo, dest)
-            return Continue(next_state="DISCOVER")
+            return Continue(next_state="LABELS")
 
-        if dest.exists():
+        if item.payload.pop("checkout_cloned", False) or dest.exists():
+            item.payload["checkout_op"] = "sync_checkout"
             job = GitJob(
                 repo=item.repo,
                 op="sync_checkout",
@@ -162,8 +177,9 @@ class RepoStage(Stage):
                 kwargs={"repo": f"{ctx.org}/{item.repo}", "dest": str(dest)},
                 descr=f"synchronize {ctx.org}/{item.repo}",
             )
-            return JobRequest(job=job, on_done_state="DISCOVER")
+            return JobRequest(job=job, on_done_state="CLONE_WAIT")
 
+        item.payload["checkout_op"] = "clone"
         job = GitJob(
             repo=item.repo,
             op="clone",
@@ -173,7 +189,7 @@ class RepoStage(Stage):
             kwargs={"repo": f"{ctx.org}/{item.repo}", "dest": str(dest)},
             descr=f"clone {ctx.org}/{item.repo}",
         )
-        return JobRequest(job=job, on_done_state="DISCOVER")
+        return JobRequest(job=job, on_done_state="CLONE_WAIT")
 
     def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """[M] Initialize a bounded metadata source; do not classify eagerly."""
@@ -204,7 +220,17 @@ class RepoStage(Stage):
         if item.state != "CLONE_WAIT":
             return
         if result.ok:
-            logger.info("repo:%s: checkout preparation completed", item.repo)
+            operation = item.payload.get("checkout_op")
+            if operation == "clone":
+                item.payload["checkout_cloned"] = True
+                logger.info("repo:%s: clone completed; verifying checkout", item.repo)
+            elif operation == "sync_checkout":
+                item.payload["checkout_verified"] = True
+                logger.info("repo:%s: checkout preparation completed", item.repo)
+            else:  # pragma: no cover - every checkout JobRequest records its operation
+                item.payload["clone_failed"] = True
+                item.attempts["clone"] = item.attempts.get("clone", 0) + 1
+                logger.warning("repo:%s: checkout operation identity missing", item.repo)
             return
         item.attempts["clone"] = item.attempts.get("clone", 0) + 1
         item.payload["clone_failed"] = True

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -21,6 +21,7 @@ from contextlib import ExitStack, contextmanager
 from contextvars import copy_context
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TypeGuard
 
 from hephaestus.agents.runtime import resolve_agent, resume_agent_session, run_agent_session
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
@@ -92,6 +93,15 @@ _TRUSTED_GH_CANDIDATES = (
     Path("/usr/bin/gh"),
 )
 _TRUSTED_GH_ROOTS = (Path("/opt/homebrew"), Path("/usr/local"), Path("/usr"))
+
+
+def _is_full_commit_sha(value: object) -> TypeGuard[str]:
+    """Return whether ``value`` is a full SHA-1 or SHA-256 commit id."""
+    return bool(
+        isinstance(value, str)
+        and len(value) in (40, 64)
+        and all(character in "0123456789abcdef" for character in value)
+    )
 
 
 def _controlled_git_env() -> dict[str, str]:
@@ -799,6 +809,29 @@ class WorkerPool:
         elif job.op == "commit_push":
             return self._git_commit_push(job)
 
+        elif job.op == "release_branch_reservation":
+            branch_name = str(job.kwargs.get("branch") or "")
+            base_sha = job.kwargs.get("base_sha")
+            repo_root_value = job.kwargs.get("repo_root")
+            repo_root = Path(str(repo_root_value)) if repo_root_value else None
+            if (
+                not branch_name
+                or not _is_full_commit_sha(base_sha)
+                or repo_root is None
+                or not repo_root.is_dir()
+            ):
+                return JobResult(
+                    ok=False,
+                    error="release_branch_reservation requires branch, base_sha, and repo_root",
+                )
+            released = git_utils.delete_reserved_branch_if_unchanged(
+                branch_name,
+                base_sha,
+                repo_root,
+                timeout=job.timeout_s,
+            )
+            return JobResult(ok=True, value=released)
+
         elif job.op == "clone":
             # gh repo clone <repo> <dest>
             repo = str(job.kwargs.get("repo") or "")
@@ -831,17 +864,36 @@ class WorkerPool:
         checkout = Path(dest)
         if not checkout.is_dir():
             return JobResult(ok=False, error=f"checkout does not exist: {checkout}")
-
-        # ``git config --list`` uses the effective repository configuration,
-        # including a linked worktree's ``config.worktree``.  It must precede
-        # origin/status because either command can observe a poisoned setting.
+        # This read-only security preflight must run before acquiring a lock
+        # below: creating a lock file can otherwise create ``.git`` in a
+        # malformed directory and change how the preflight probes it.
         if preflight_error := _checkout_preflight_error(checkout, job.timeout_s):
             return JobResult(ok=False, error=preflight_error)
 
+        metadata_lock = WorktreeManager.git_metadata_lock_path(checkout)
+        with _interruptible_file_lock(
+            metadata_lock,
+            shutdown=self._shutdown,
+            timeout_s=job.timeout_s,
+        ):
+            return self._sync_checkout_locked(
+                checkout=checkout,
+                expected_repo=expected_repo,
+                timeout_s=job.timeout_s,
+            )
+
+    def _sync_checkout_locked(
+        self,
+        *,
+        checkout: Path,
+        expected_repo: str,
+        timeout_s: int,
+    ) -> JobResult:
+        """Validate and synchronize one checkout while its metadata lock is held."""
         origin = git_utils.run(
             ["git", "remote", "get-url", "origin"],
             cwd=checkout,
-            timeout=job.timeout_s,
+            timeout=timeout_s,
             env=_controlled_git_env(),
         ).stdout.strip()
         normalized_origin = origin.rstrip("/").removesuffix(".git")
@@ -866,31 +918,29 @@ class WorkerPool:
                 "--untracked-files=all",
             ],
             cwd=checkout,
-            timeout=job.timeout_s,
+            timeout=timeout_s,
             env=_controlled_git_env(),
         )
         if status.stdout.strip():
             return JobResult(ok=False, error=f"checkout is dirty: {checkout}")
-
         branch_result = git_utils.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
             cwd=checkout,
             check=False,
             log_errors=False,
-            timeout=job.timeout_s,
+            timeout=timeout_s,
             env=_controlled_git_env(),
         )
         branch = branch_result.stdout.strip()
         if branch_result.returncode != 0 or not branch:
             return JobResult(ok=False, error=f"checkout is detached: {checkout}")
-
         gh_command = _trusted_gh_executable()
         if gh_command is None:
             return JobResult(ok=False, error="required GitHub executable is unavailable")
         default_branch = git_utils.run(
             [gh_command, "api", f"repos/{expected_repo}", "--jq", ".default_branch"],
             cwd=checkout,
-            timeout=job.timeout_s,
+            timeout=timeout_s,
             env=_controlled_git_env(),
         ).stdout.strip()
         if not default_branch:
@@ -899,23 +949,48 @@ class WorkerPool:
             return JobResult(
                 ok=False,
                 error=(
-                    f"checkout is not on its default branch {default_branch}: "
-                    f"currently on {branch or 'detached HEAD'}"
+                    f"checkout is not on its default branch {default_branch}: currently on {branch}"
                 ),
             )
+        return self._fast_forward_checkout(
+            checkout=checkout,
+            default_branch=default_branch,
+            gh_command=gh_command,
+            timeout_s=timeout_s,
+        )
 
-        metadata_lock = WorktreeManager.git_metadata_lock_path(checkout)
-        with _interruptible_file_lock(
-            metadata_lock,
-            shutdown=self._shutdown,
-            timeout_s=job.timeout_s,
-        ):
-            return self._fast_forward_checkout(
-                checkout=checkout,
-                default_branch=default_branch,
-                gh_command=gh_command,
-                timeout_s=job.timeout_s,
-            )
+    @staticmethod
+    def _checkout_state_error(*, checkout: Path, default_branch: str, timeout_s: int) -> str | None:
+        """Return the clean-default-branch validation error, if any."""
+        status = git_utils.run(
+            [
+                "git",
+                "-c",
+                "core.fsmonitor=false",
+                "status",
+                "--porcelain",
+                "--untracked-files=all",
+            ],
+            cwd=checkout,
+            timeout=timeout_s,
+            env=_controlled_git_env(),
+        )
+        if status.stdout.strip():
+            return f"checkout is dirty: {checkout}"
+        branch_result = git_utils.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            cwd=checkout,
+            check=False,
+            log_errors=False,
+            timeout=timeout_s,
+            env=_controlled_git_env(),
+        )
+        branch = branch_result.stdout.strip()
+        if branch_result.returncode != 0 or not branch:
+            return f"checkout is detached: {checkout}"
+        if branch != default_branch:
+            return f"checkout is not on its default branch {default_branch}: currently on {branch}"
+        return None
 
     @staticmethod
     def _fast_forward_checkout(
@@ -971,6 +1046,12 @@ class WorkerPool:
             timeout=timeout_s,
             env=_controlled_git_env(),
         )
+        if validation_error := WorkerPool._checkout_state_error(
+            checkout=checkout,
+            default_branch=default_branch,
+            timeout_s=timeout_s,
+        ):
+            return JobResult(ok=False, error=validation_error)
         relation = git_utils.run(
             [
                 "git",
@@ -1017,6 +1098,12 @@ class WorkerPool:
                 ok=False,
                 error=(f"checkout cannot fast-forward {default_branch} to origin/{default_branch}"),
             )
+        if validation_error := WorkerPool._checkout_state_error(
+            checkout=checkout,
+            default_branch=default_branch,
+            timeout_s=timeout_s,
+        ):
+            return JobResult(ok=False, error=validation_error)
         synced_heads = git_utils.run(
             ["git", "rev-parse", "HEAD", f"origin/{default_branch}"],
             cwd=checkout,
@@ -1028,7 +1115,13 @@ class WorkerPool:
                 ok=False,
                 error=f"checkout did not reach origin/{default_branch}: {checkout}",
             )
-        return JobResult(ok=True)
+        synced_head = synced_heads[0]
+        if not _is_full_commit_sha(synced_head):
+            return JobResult(
+                ok=False,
+                error=f"checkout returned malformed default-branch SHA: {checkout}",
+            )
+        return JobResult(ok=True, value=synced_head)
 
     def _git_create_worktree(self, job: GitJob) -> JobResult:
         """Create a worktree and optionally sync an adopted PR branch."""
@@ -1037,25 +1130,153 @@ class WorkerPool:
         pr_number = kwargs.pop("pr_number", None)
         repo_root_kwarg = kwargs.pop("repo_root", None)
         repo_root = Path(repo_root_kwarg) if repo_root_kwarg else get_repo_root()
+        direct_setup = self._prepare_direct_scope_worktree(
+            kwargs=kwargs,
+            sync_to_remote=sync_to_remote,
+            repo_root=repo_root,
+            timeout_s=job.timeout_s,
+        )
+        if isinstance(direct_setup, JobResult):
+            return direct_setup
+        base_sha, branch_name = direct_setup
         base_dir = repo_root / "build" / ".worktrees"
-        manager = WorktreeManager(base_dir=base_dir, repo_root=repo_root)
-        created = manager.create_worktree(**kwargs, timeout=job.timeout_s)
+        if isinstance(base_sha, str):
+            manager = WorktreeManager(
+                base_dir=base_dir,
+                base_branch=base_sha,
+                repo_root=repo_root,
+            )
+        else:
+            manager = WorktreeManager(base_dir=base_dir, repo_root=repo_root)
+        if base_sha is not None:
+            kwargs["base_sha"] = base_sha
+            kwargs["remote_branch_reserved"] = True
+        try:
+            created = manager.create_worktree(**kwargs, timeout=job.timeout_s)
+        except Exception as exc:
+            if base_sha is not None:
+                return self._rollback_direct_scope_reservation(
+                    branch_name=branch_name,
+                    base_sha=base_sha,
+                    repo_root=repo_root,
+                    timeout_s=job.timeout_s,
+                    error=f"worktree creation failed: {exc}",
+                )
+            raise
+        return self._finalize_created_worktree(
+            created=created,
+            base_sha=base_sha,
+            branch_name=branch_name,
+            repo_root=repo_root,
+            repo=job.repo,
+            sync_to_remote=sync_to_remote,
+            pr_number=pr_number,
+            timeout_s=job.timeout_s,
+        )
+
+    @staticmethod
+    def _release_direct_scope_reservation(
+        branch_name: str,
+        base_sha: str | None,
+        repo_root: Path,
+        *,
+        timeout_s: int,
+    ) -> bool:
+        """Conditionally release a direct reservation, or no-op for normal worktrees."""
+        return base_sha is None or git_utils.delete_reserved_branch_if_unchanged(
+            branch_name,
+            base_sha,
+            repo_root,
+            timeout=timeout_s,
+        )
+
+    def _rollback_direct_scope_reservation(
+        self,
+        *,
+        branch_name: str,
+        base_sha: str,
+        repo_root: Path,
+        timeout_s: int,
+        error: str,
+    ) -> JobResult:
+        """Release an early reservation or preserve its receipt for Finished."""
+        try:
+            released = self._release_direct_scope_reservation(
+                branch_name, base_sha, repo_root, timeout_s=timeout_s
+            )
+        except (RuntimeError, subprocess.TimeoutExpired) as exc:
+            return JobResult(
+                ok=False,
+                value={"direct_scope_reservation": {"branch": branch_name, "base_sha": base_sha}},
+                error=f"{error}; reservation rollback failed: {exc}",
+            )
+        if not released:
+            return JobResult(
+                ok=False,
+                error=f"{error}; direct scope reservation changed before it could be released",
+            )
+        return JobResult(ok=False, error=error)
+
+    def _finalize_created_worktree(
+        self,
+        *,
+        created: Path | None,
+        base_sha: str | None,
+        branch_name: str,
+        repo_root: Path,
+        repo: str,
+        sync_to_remote: bool,
+        pr_number: object,
+        timeout_s: int,
+    ) -> JobResult:
+        """Validate a created worktree and attach a direct reservation receipt."""
         if created is None:
+            if base_sha is not None:
+                return self._rollback_direct_scope_reservation(
+                    branch_name=branch_name,
+                    base_sha=base_sha,
+                    repo_root=repo_root,
+                    timeout_s=timeout_s,
+                    error="worktree manager returned no worktree",
+                )
+            # Non-direct callers retain the legacy no-op success contract.
             return JobResult(ok=True)
         worktree_path = Path(created)
         if repo_root not in worktree_path.parents and worktree_path != repo_root:
+            error = (
+                f"worktree {worktree_path} escaped resolved repo root {repo_root} "
+                f"for job.repo={repo!r}"
+            )
+            if base_sha is not None:
+                return self._rollback_direct_scope_reservation(
+                    branch_name=branch_name,
+                    base_sha=base_sha,
+                    repo_root=repo_root,
+                    timeout_s=timeout_s,
+                    error=error,
+                )
             return JobResult(
                 ok=False,
-                error=(
-                    f"worktree {worktree_path} escaped resolved repo root {repo_root} "
-                    f"for job.repo={job.repo!r}"
-                ),
+                error=error,
             )
-        branch_name = str(kwargs.get("branch_name") or "")
         if not sync_to_remote:
+            if base_sha is not None:
+                return JobResult(
+                    ok=True,
+                    value={
+                        "path": str(worktree_path),
+                        "direct_scope_reservation": {
+                            "branch": branch_name,
+                            "base_sha": base_sha,
+                        },
+                    },
+                )
             return JobResult(ok=True, value=str(worktree_path))
 
-        dirty = not git_utils.is_clean_working_tree(worktree_path, timeout=job.timeout_s)
+        if pr_number is not None and not isinstance(pr_number, (int, str)):
+            return JobResult(ok=False, error="worktree sync received an invalid PR number")
+
+        dirty = not git_utils.is_clean_working_tree(worktree_path, timeout=timeout_s)
         status = ""
         diff = ""
         if dirty:
@@ -1064,14 +1285,14 @@ class WorkerPool:
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
-                timeout=job.timeout_s,
+                timeout=timeout_s,
             )
             diff_result = git_utils.run(
                 ["git", "diff"],
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
-                timeout=job.timeout_s,
+                timeout=timeout_s,
             )
             status = status_result.stdout or ""
             diff = diff_result.stdout or ""
@@ -1079,8 +1300,8 @@ class WorkerPool:
             git_utils.sync_worktree_to_remote_branch(
                 worktree_path,
                 branch_name,
-                pr_number=int(pr_number) if pr_number is not None else None,
-                timeout=job.timeout_s,
+                pr_number=int(pr_number) if isinstance(pr_number, (int, str)) else None,
+                timeout=timeout_s,
             )
         return JobResult(
             ok=True,
@@ -1091,6 +1312,38 @@ class WorkerPool:
                 "diff": diff,
             },
         )
+
+    @staticmethod
+    def _prepare_direct_scope_worktree(
+        *,
+        kwargs: dict[str, object],
+        sync_to_remote: bool,
+        repo_root: Path,
+        timeout_s: int,
+    ) -> tuple[str | None, str] | JobResult:
+        """Validate and atomically reserve a direct-scope implementation branch."""
+        base_sha = kwargs.pop("base_sha", None)
+        branch_name = str(kwargs.get("branch_name") or "")
+        if base_sha is None:
+            return None, branch_name
+        if sync_to_remote or bool(kwargs.get("refresh_base", False)):
+            return JobResult(ok=False, error="direct scope base pin invalid")
+        if not _is_full_commit_sha(base_sha):
+            return JobResult(ok=False, error="direct scope base pin invalid")
+        checkout_head = git_utils.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo_root, timeout=timeout_s
+        ).stdout.strip()
+        if checkout_head != base_sha:
+            return JobResult(ok=False, error="direct scope checkout pin mismatch")
+        if not branch_name:
+            return JobResult(ok=False, error="direct scope branch name is missing")
+        git_utils.reserve_remote_branch_if_absent(
+            branch_name,
+            base_sha,
+            repo_root,
+            timeout=timeout_s,
+        )
+        return base_sha, branch_name
 
     @staticmethod
     def _git_verify_pr_review_checkout(job: GitJob) -> JobResult:
@@ -1155,16 +1408,37 @@ class WorkerPool:
         if job.kwargs.get("worktree_path"):
             worktree_path = Path(str(job.kwargs["worktree_path"]))
             repo_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
-            cmd = ["git", "worktree", "remove", str(worktree_path)]
-            if job.kwargs.get("force"):
-                cmd.append("--force")
-            git_utils.run(cmd, cwd=repo_root, timeout=job.timeout_s)
-            git_utils.run(
-                ["git", "worktree", "prune"],
-                cwd=repo_root,
-                check=False,
-                timeout=job.timeout_s,
-            )
+            # This is the same lock create_worktree takes. Keep it across
+            # removal, prune, and local cleanup so pipeline workers cannot
+            # attach the branch between those operations. The final
+            # ``git branch -d`` check also refuses an externally checked-out
+            # branch.
+            with file_lock(WorktreeManager.git_metadata_lock_path(repo_root)):
+                cmd = ["git", "worktree", "remove", str(worktree_path)]
+                if job.kwargs.get("force"):
+                    cmd.append("--force")
+                git_utils.run(cmd, cwd=repo_root, timeout=job.timeout_s)
+                git_utils.run(
+                    ["git", "worktree", "prune"],
+                    cwd=repo_root,
+                    check=False,
+                    timeout=job.timeout_s,
+                )
+                local_cleanup = job.kwargs.get("local_branch_cleanup")
+                if local_cleanup is not None:
+                    if not isinstance(local_cleanup, dict):
+                        return JobResult(ok=False, error="local branch cleanup receipt is invalid")
+                    branch_name = local_cleanup.get("branch")
+                    expected_sha = local_cleanup.get("base_sha")
+                    if not isinstance(branch_name, str) or not _is_full_commit_sha(expected_sha):
+                        return JobResult(ok=False, error="local branch cleanup receipt is invalid")
+                    deleted = git_utils.delete_local_branch_if_unchanged(
+                        branch_name,
+                        expected_sha,
+                        repo_root,
+                        timeout=job.timeout_s,
+                    )
+                    return JobResult(ok=True, value={"local_branch_deleted": deleted})
             return JobResult(ok=True)
         fallback_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
         manager = WorktreeManager(repo_root=fallback_root)
@@ -1200,11 +1474,16 @@ class WorkerPool:
             allowed_paths=job.kwargs.get("allowed_paths"),
             timeout=job.timeout_s,
         )
+        branch = str(job.kwargs.get("branch") or "")
         if not changed:
-            branch = str(job.kwargs.get("branch") or "")
-            if not branch or not git_utils.has_unpushed_commits(
-                branch, Path(worktree_path), timeout=job.timeout_s
-            ):
+            publish_state = self._commit_push_requires_publish(
+                job=job,
+                branch=branch,
+                worktree_path=Path(worktree_path),
+            )
+            if isinstance(publish_state, JobResult):
+                return publish_state
+            if not publish_state:
                 return JobResult(ok=True, value=False)
             status = git_utils.run(
                 ["git", "status", "--porcelain"],
@@ -1214,13 +1493,66 @@ class WorkerPool:
             )
             if status.stdout.strip():
                 return JobResult(ok=False, error="commit_push left uncommitted changes")
-        branch = str(job.kwargs.get("branch", "HEAD"))
+        branch = branch or "HEAD"
+        expected_remote_sha = job.kwargs.get("expected_remote_sha")
+        if expected_remote_sha is not None and not _is_full_commit_sha(expected_remote_sha):
+            return JobResult(ok=False, error="direct scope base pin invalid")
         if bool(job.kwargs.get("publish_detached_head", False)):
             git_utils.push_head_to_branch(
                 branch,
                 Path(worktree_path),
                 timeout=job.timeout_s,
             )
+        elif isinstance(expected_remote_sha, str):
+            git_utils.push_branch_if_remote_matches(
+                branch,
+                expected_remote_sha,
+                Path(worktree_path),
+                timeout=job.timeout_s,
+            )
         else:
             git_utils.push_branch(branch, Path(worktree_path), timeout=job.timeout_s)
         return JobResult(ok=True, value=True)
+
+    @staticmethod
+    def _commit_push_requires_publish(
+        *, job: GitJob, branch: str, worktree_path: Path
+    ) -> bool | JobResult:
+        """Return whether a clean worktree still needs coordinator-owned publication."""
+        expected_remote_sha = job.kwargs.get("expected_remote_sha")
+        if expected_remote_sha is None:
+            return bool(
+                branch
+                and git_utils.has_unpushed_commits(
+                    branch,
+                    worktree_path,
+                    timeout=job.timeout_s,
+                )
+            )
+        if not _is_full_commit_sha(expected_remote_sha):
+            return JobResult(ok=False, error="direct scope base pin invalid")
+        if not branch:
+            return JobResult(ok=False, error="direct scope branch name is missing")
+        ahead = git_utils.run(
+            ["git", "rev-list", "--count", f"{expected_remote_sha}..HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+            timeout=job.timeout_s,
+        )
+        if ahead.returncode != 0:
+            return JobResult(ok=False, error="cannot verify direct scope branch ancestry")
+        if ahead.stdout.strip() != "0":
+            return True
+        released = git_utils.delete_reserved_branch_if_unchanged(
+            branch,
+            expected_remote_sha,
+            worktree_path,
+            timeout=job.timeout_s,
+        )
+        if not released:
+            return JobResult(
+                ok=False,
+                error="direct scope reservation changed before it could be released",
+            )
+        return False

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -65,6 +65,11 @@ def _looks_like_sha(ref: str) -> bool:
     return len(ref) >= 7 and all(ch in "0123456789abcdefABCDEF" for ch in ref)
 
 
+def _is_full_commit_sha(ref: str) -> bool:
+    """Return whether ``ref`` is a full SHA-1 or SHA-256 commit id."""
+    return len(ref) in (40, 64) and all(ch in "0123456789abcdef" for ch in ref)
+
+
 class WorktreeDirtyError(Exception):
     """Raised when a worktree cannot be removed because it contains uncommitted changes."""
 
@@ -242,6 +247,8 @@ class WorktreeManager:
         branch_name: str | None = None,
         *,
         refresh_base: bool = False,
+        base_sha: str | None = None,
+        remote_branch_reserved: bool = False,
         isolated: bool = False,
         timeout: int | None = None,
     ) -> Path:
@@ -256,6 +263,12 @@ class WorktreeManager:
                 so each issue branches off the latest trunk; no-op when the base
                 is explicitly pinned. Default False preserves prior behavior for
                 all other callers (review, address-review, ci-driver).
+            base_sha: Exact synchronized base commit for a direct CLI scope.
+                It rejects all worktree/branch reuse and is incompatible with
+                ``refresh_base`` so a source cursor cannot silently move from
+                its bootstrap snapshot to a newer remote head.
+            remote_branch_reserved: Require the caller to have atomically
+                reserved the direct-scope branch on ``origin`` at ``base_sha``.
             isolated: When True, create an in-root detached checkout instead of
                 reusing another worktree that holds ``branch_name``. PR review
                 uses this so a preserved writer checkout is never
@@ -272,55 +285,43 @@ class WorktreeManager:
         with self.lock:
             isolated_key = f"review-pr-{issue_number}"
             worktree_key: int | str = isolated_key if isolated else issue_number
-            if worktree_key in self.worktrees:
-                logger.warning("Worktree for issue #%s already exists", issue_number)
-                return self.worktrees[worktree_key]
-
-            if refresh_base:
-                self.refresh_base_branch(timeout=timeout)
-
             if branch_name is None:
                 branch_name = f"{issue_number}-auto"
-
             worktree_path = self.base_dir / (isolated_key if isolated else f"issue-{issue_number}")
-
-            # Reuse, don't collide: git forbids the same branch in two worktrees.
-            # When ``branch_name`` is already checked out elsewhere (e.g. a PR
-            # resolved to its real head branch ``708-auto-impl`` which the
-            # issue-708 worktree already holds), ``git worktree add`` would fail
-            # with "already used by worktree at ..." (exit 128). Return that
-            # existing worktree and register it under this issue; the caller then
-            # syncs it to the PR head (fetch + reset --hard origin/<branch>).
-            existing = (
-                None if isolated else self._worktree_holding_branch(branch_name, timeout=timeout)
-            )
-            if existing is not None and existing != worktree_path:
-                logger.info(
-                    "Branch %s already checked out at %s — reusing that worktree for issue #%s",
-                    branch_name,
-                    existing,
-                    issue_number,
-                )
-                self.worktrees[worktree_key] = existing
-                return existing
-
-            if self._reuse_existing_dirty_worktree(
-                issue_number,
-                worktree_key,
-                worktree_path,
-                timeout=timeout,
+            if base_sha is not None and (
+                refresh_base
+                or isolated
+                or not remote_branch_reserved
+                or not _is_full_commit_sha(base_sha)
             ):
-                return worktree_path
-
-            # Remove existing clean worktree directory if present. Dirty
-            # registered worktrees are reused above; non-worktree paths with
-            # unknown contents fail closed there instead of being removed.
-            if worktree_path.exists():
-                logger.warning("Removing existing worktree directory: %s", worktree_path)
-                self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
+                raise RuntimeError("direct scope base pin invalid")
+            if base_sha is None and remote_branch_reserved:
+                raise RuntimeError("direct scope reservation requires a base pin")
+            if base_sha is None and (
+                existing := self._reuse_or_clear_normal_worktree(
+                    issue_number=issue_number,
+                    worktree_key=worktree_key,
+                    worktree_path=worktree_path,
+                    branch_name=branch_name,
+                    isolated=isolated,
+                    refresh_base=refresh_base,
+                    timeout=timeout,
+                )
+            ):
+                return existing
 
             try:
                 with file_lock(self._git_metadata_lock_path()):
+                    self._validate_direct_scope_worktree_request(
+                        base_sha=base_sha,
+                        remote_branch_reserved=remote_branch_reserved,
+                        refresh_base=refresh_base,
+                        isolated=isolated,
+                        worktree_key=worktree_key,
+                        worktree_path=worktree_path,
+                        branch_name=branch_name,
+                        timeout=timeout,
+                    )
                     try:
                         if isolated:
                             self._add_isolated_worktree_for_branch(
@@ -332,12 +333,14 @@ class WorktreeManager:
                             self._add_worktree_for_branch(
                                 worktree_path,
                                 branch_name,
+                                base_sha=base_sha,
                                 refresh_base=refresh_base,
                                 timeout=timeout,
                             )
                     except Exception:
                         self.worktrees.pop(worktree_key, None)
-                        self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
+                        if base_sha is None:
+                            self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
                         raise
                 self.worktrees[worktree_key] = worktree_path
                 logger.info("Created worktree for issue #%s at %s", issue_number, worktree_path)
@@ -345,6 +348,88 @@ class WorktreeManager:
 
             except Exception as e:
                 raise RuntimeError(f"Failed to create worktree: {e}") from e
+
+    def _reuse_or_clear_normal_worktree(
+        self,
+        *,
+        issue_number: int,
+        worktree_key: int | str,
+        worktree_path: Path,
+        branch_name: str,
+        isolated: bool,
+        refresh_base: bool,
+        timeout: int | None,
+    ) -> Path | None:
+        """Reuse normal worktrees or clear a known-clean path before creation."""
+        if worktree_key in self.worktrees:
+            logger.warning("Worktree for issue #%s already exists", issue_number)
+            return self.worktrees[worktree_key]
+        if refresh_base:
+            self.refresh_base_branch(timeout=timeout)
+        existing = None if isolated else self._worktree_holding_branch(branch_name, timeout=timeout)
+        if existing is not None and existing != worktree_path:
+            logger.info(
+                "Branch %s already checked out at %s — reusing that worktree for issue #%s",
+                branch_name,
+                existing,
+                issue_number,
+            )
+            self.worktrees[worktree_key] = existing
+            return existing
+        if self._reuse_existing_dirty_worktree(
+            issue_number,
+            worktree_key,
+            worktree_path,
+            timeout=timeout,
+        ):
+            return worktree_path
+        if worktree_path.exists():
+            logger.warning("Removing existing worktree directory: %s", worktree_path)
+            self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
+        return None
+
+    def _validate_direct_scope_worktree_request(
+        self,
+        *,
+        base_sha: str | None,
+        remote_branch_reserved: bool,
+        refresh_base: bool,
+        isolated: bool,
+        worktree_key: int | str,
+        worktree_path: Path,
+        branch_name: str,
+        timeout: int | None,
+    ) -> None:
+        """Reject direct-scope inputs that could reuse or move a pinned base."""
+        if base_sha is None:
+            return
+        if refresh_base or not remote_branch_reserved or not _is_full_commit_sha(base_sha):
+            raise RuntimeError("direct scope base pin invalid")
+        if isolated:
+            raise RuntimeError("direct scope base pin cannot create an isolated worktree")
+        if worktree_key in self.worktrees:
+            raise RuntimeError("direct scope refuses stale worktree reuse")
+        if (
+            worktree_path.exists()
+            or self._worktree_holding_branch(branch_name, timeout=timeout) is not None
+            or self._direct_scope_local_branch_exists(branch_name, timeout=timeout)
+        ):
+            raise RuntimeError("direct scope refuses stale branch or worktree reuse")
+
+    def _direct_scope_local_branch_exists(self, branch_name: str, *, timeout: int | None) -> bool:
+        """Return whether a local branch exists, propagating lookup failures."""
+        local = run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+            cwd=self.repo_root,
+            capture_output=True,
+            check=False,
+            **_timeout_kw(timeout),
+        )
+        if local.returncode == 0:
+            return True
+        if local.returncode != 1:
+            raise RuntimeError(f"cannot verify local branch {branch_name!r}")
+        return False
 
     def _add_isolated_worktree_for_branch(
         self,
@@ -430,6 +515,7 @@ class WorktreeManager:
         worktree_path: Path,
         branch_name: str,
         *,
+        base_sha: str | None = None,
         refresh_base: bool = False,
         timeout: int | None = None,
     ) -> None:
@@ -453,7 +539,13 @@ class WorktreeManager:
             timeout: Optional timeout in seconds for each git command.
 
         """
-        if self._local_branch_exists(branch_name, timeout=timeout):
+        if base_sha is not None:
+            run(
+                ["git", "worktree", "add", "-b", branch_name, str(worktree_path), base_sha],
+                cwd=self.repo_root,
+                **_timeout_kw(timeout),
+            )
+        elif self._local_branch_exists(branch_name, timeout=timeout):
             self._refresh_stale_local_branch_if_safe(branch_name, timeout=timeout)
             logger.info("Branch %s already exists, reusing it", branch_name)
             run(

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -130,6 +130,8 @@ class FakeWorkerPool:
         # rebase reports clean-rebase True, commit_push reports changed True.
         if job.op in ("rebase", "commit_push"):
             return JobResult(ok=True, value=True)
+        if job.op == "sync_checkout":
+            return JobResult(ok=True, value="a" * 40)
         if job.op == "verify_pr_review_checkout":
             return JobResult(ok=True, value={"ready": True, "diff": "checkout diff"})
         return JobResult(ok=True)

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -177,6 +177,103 @@ class TestCleanup:
 
         assert preserved == [("repo-a", 42, "/wt/issue-42")]
 
+    def test_failed_direct_scope_releases_unused_reservation_before_preserving_worktree(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[str, int, str]],
+        make_ctx: Any,
+    ) -> None:
+        """A terminal failure cannot strand a deterministic branch at its base SHA."""
+        ctx = make_ctx()
+        item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.payload["_direct_scope_reservation"] = {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        release = stage.step(item, ctx)
+
+        assert isinstance(release, JobRequest)
+        assert isinstance(release.job, GitJob)
+        assert release.job.op == "release_branch_reservation"
+        assert release.job.kwargs == {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+            "repo_root": str(ctx.paths.repo_root),
+        }
+        assert release.on_done_state == "CLEANUP"
+
+        stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue) and result.next_state == "DONE"
+        assert preserved == [("repo-a", 42, "/wt/issue-42")]
+
+    def test_passed_direct_scope_releases_before_removing_worktree(
+        self, stage: FinishedStage, make_ctx: Any
+    ) -> None:
+        """The release runs for every unpublished direct item, including a passing no-op."""
+        ctx = make_ctx()
+        item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.payload["_direct_scope_reservation"] = {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        first = stage.step(item, ctx)
+        assert isinstance(first, JobRequest)
+        assert isinstance(first.job, GitJob)
+        assert first.job.op == "release_branch_reservation"
+
+        stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+        second = stage.step(item, ctx)
+
+        assert isinstance(second, JobRequest)
+        assert isinstance(second.job, GitJob)
+        assert second.job.op == "remove_worktree"
+
+    def test_failed_reservation_release_retries_before_terminal_cleanup(
+        self, stage: FinishedStage, make_ctx: Any
+    ) -> None:
+        """An operational lease failure is retried instead of being misclassified as stale."""
+        ctx = make_ctx()
+        item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.payload["_direct_scope_reservation"] = {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        first = stage.step(item, ctx)
+        assert isinstance(first, JobRequest)
+        stage.on_job_done(item, JobResult(ok=False, error="network unavailable"), ctx)
+
+        second = stage.step(item, ctx)
+
+        assert isinstance(second, JobRequest)
+        assert isinstance(second.job, GitJob)
+        assert second.job.op == "release_branch_reservation"
+
+    def test_noop_local_branch_cleanup_is_coupled_to_worktree_removal(
+        self, stage: FinishedStage, make_ctx: Any
+    ) -> None:
+        """A direct no-op removes its local deterministic branch after detaching it."""
+        ctx = make_ctx()
+        item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.payload["_direct_scope_local_branch_cleanup"] = {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "remove_worktree"
+        assert result.job.kwargs["local_branch_cleanup"] == {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
     def test_pr_only_failure_preserves_pr_number(
         self,
         stage: FinishedStage,

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -274,6 +274,51 @@ class TestCleanup:
             "base_sha": "a" * 40,
         }
 
+    def test_failed_direct_noop_removes_clean_worktree_and_local_branch(
+        self, stage: FinishedStage, make_ctx: Any
+    ) -> None:
+        """A skipped no-op must not strand the deterministic local branch."""
+        ctx = make_ctx()
+        item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.payload["_direct_scope_local_branch_cleanup"] = {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "remove_worktree"
+        assert result.job.kwargs == {
+            "worktree_path": "/wt/issue-42",
+            "repo_root": str(ctx.paths.repo_root),
+            "force": False,
+            "local_branch_cleanup": {
+                "branch": "42-auto-impl",
+                "base_sha": "a" * 40,
+            },
+        }
+
+    def test_failed_direct_noop_preserves_worktree_when_safe_cleanup_fails(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[str, int, str]],
+        make_ctx: Any,
+    ) -> None:
+        """A late human edit blocks no-op cleanup without being discarded."""
+        item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.payload["_direct_scope_local_branch_cleanup"] = {
+            "branch": "42-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        result = stage.step(item, make_ctx())
+        assert isinstance(result, JobRequest)
+        stage.on_job_done(item, JobResult(ok=False, error="worktree contains changes"), make_ctx())
+
+        assert preserved == [("repo-a", 42, "/wt/issue-42")]
+
     def test_pr_only_failure_preserves_pr_number(
         self,
         stage: FinishedStage,

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -757,6 +757,28 @@ class TestWorktreeAndAdvise:
         }
         assert result.on_done_state == "DIRTY_DECISION_WAIT"
 
+    def test_direct_scope_worktree_uses_its_bootstrap_pin_without_refresh(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A direct fresh implementation is cut only from the synchronized SHA."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs == {
+            "issue_number": 1,
+            "branch_name": "1-auto-impl",
+            "refresh_base": False,
+            "repo_root": "/tmp/repo",
+            "base_sha": "a" * 40,
+        }
+
     def test_worktree_result_stores_path_and_dirty_state(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -774,6 +796,49 @@ class TestWorktreeAndAdvise:
         assert item.payload["worktree_dirty"] is True
         assert item.payload["worktree_status"] == "M x.py"
         assert item.payload["worktree_diff"] == "+x"
+
+    def test_direct_worktree_result_stores_remote_reservation_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Finished can release a failed direct run only from this exact receipt."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+        result = JobResult(
+            ok=True,
+            value={
+                "path": "/tmp/wt",
+                "direct_scope_reservation": {
+                    "branch": "1-auto-impl",
+                    "base_sha": "a" * 40,
+                },
+            },
+        )
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.worktree == "/tmp/wt"
+        assert item.payload["_direct_scope_reservation"] == {
+            "branch": "1-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+    def test_direct_worktree_rejects_missing_remote_reservation_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A protocol drift cannot let a direct agent run without its lease receipt."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        stage.on_job_done(item, JobResult(ok=True, value={"path": "/tmp/wt"}), ctx)
+
+        assert item.worktree == ""
+        assert item.payload["git_error"] is True
 
     def test_worktree_string_result_stores_path(self, make_ctx: Any, make_work_item: Any) -> None:
         """A plain string worktree result is the worktree path."""
@@ -800,6 +865,37 @@ class TestWorktreeAndAdvise:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.RETRY
         assert item.attempts["implement"] == 0  # transient: no budget burned
+
+    def test_worktree_rollback_failure_preserves_direct_reservation_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Finished can clean an early remote lease after the retry budget is exhausted."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={
+                    "direct_scope_reservation": {
+                        "branch": "1-auto-impl",
+                        "base_sha": "a" * 40,
+                    }
+                },
+                error="worktree creation failed; reservation rollback failed",
+            ),
+            ctx,
+        )
+
+        assert item.payload["_direct_scope_reservation"] == {
+            "branch": "1-auto-impl",
+            "base_sha": "a" * 40,
+        }
+        assert item.payload["git_error"] is True
 
     def test_clean_worktree_skips_dirty_decision(self, make_ctx: Any, make_work_item: Any) -> None:
         """A clean worktree continues straight to ADVISE_WAIT."""
@@ -1137,6 +1233,23 @@ class TestCommitPushAndPrCreate:
         }
         assert result.on_done_state == "PR_CREATE"
 
+    def test_direct_scope_commit_push_carries_its_remote_reservation_pin(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The publish job can reject a remote writer that changed the reservation."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+        item.branch = "1-auto-impl"
+        item.worktree = "/tmp/wt"
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs["expected_remote_sha"] == "a" * 40
+
     def test_commit_push_no_commit_sets_skip_payload(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -1148,6 +1261,43 @@ class TestCommitPushAndPrCreate:
         stage.on_job_done(item, JobResult(ok=True, value=False), ctx)
 
         assert item.payload["no_commits"] is True
+
+    def test_direct_no_commit_transfers_receipt_to_local_branch_cleanup(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Removing the remote no-op reservation must not strand its local ref."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+        item.payload["_direct_scope_reservation"] = {
+            "branch": "1-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        stage.on_job_done(item, JobResult(ok=True, value=False), ctx)
+
+        assert item.payload["no_commits"] is True
+        assert "_direct_scope_reservation" not in item.payload
+        assert item.payload["_direct_scope_local_branch_cleanup"] == {
+            "branch": "1-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+    def test_commit_push_success_consumes_direct_reservation_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A published branch must not be released by the terminal cleanup."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+        item.payload["_direct_scope_reservation"] = {
+            "branch": "1-auto-impl",
+            "base_sha": "a" * 40,
+        }
+
+        stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+
+        assert "_direct_scope_reservation" not in item.payload
 
     def test_pr_create_journals_pr_without_auto_merge_mutation(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -72,13 +72,21 @@ def _facts(
 
 
 class TestOnEnterAndCloneStates:
-    """Steps 1-2: ensure_state_labels [M], clone [W:G] with budget 2."""
+    """Checkout proof precedes label setup and discovery."""
 
-    def test_on_enter_ensures_state_labels(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+    def test_labels_are_deferred_until_checkout_is_verified(
+        self, repo_item: WorkItem, repo_ctx: Any
+    ) -> None:
         stage = RepoStage()
 
         assert stage.on_enter(repo_item, repo_ctx) is None
+        assert repo_ctx.github.mutation_log == []
 
+        repo_item.state = "LABELS"
+        result = stage.step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DISCOVER"
         assert ("ensure_state_labels", ()) in repo_ctx.github.mutation_log
 
     def test_enter_state_advances_to_clone_wait(self, repo_item: WorkItem, repo_ctx: Any) -> None:
@@ -102,7 +110,7 @@ class TestOnEnterAndCloneStates:
             "repo": "test-org/repo-a",
             "dest": str(tmp_path / "repo-a"),
         }
-        assert result.on_done_state == "DISCOVER"
+        assert result.on_done_state == "CLONE_WAIT"
 
     def test_existing_checkout_submits_sync_job_before_discovery(
         self, repo_item: WorkItem, repo_ctx: Any, tmp_path: Path
@@ -120,7 +128,30 @@ class TestOnEnterAndCloneStates:
             "repo": "test-org/repo-a",
             "dest": str(tmp_path / "repo-a"),
         }
-        assert result.on_done_state == "DISCOVER"
+        assert result.on_done_state == "CLONE_WAIT"
+
+    def test_successful_clone_requires_follow_up_sync_before_labels(
+        self, repo_item: WorkItem, repo_ctx: Any
+    ) -> None:
+        """A new clone cannot reach labels or discovery without a sync proof."""
+        repo_item.state = "CLONE_WAIT"
+        stage = RepoStage()
+
+        clone = stage.step(repo_item, repo_ctx)
+        assert isinstance(clone, JobRequest)
+        assert isinstance(clone.job, GitJob)
+        assert clone.job.op == "clone"
+
+        stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
+        sync = stage.step(repo_item, repo_ctx)
+        assert isinstance(sync, JobRequest)
+        assert isinstance(sync.job, GitJob)
+        assert sync.job.op == "sync_checkout"
+
+        stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
+        ready = stage.step(repo_item, repo_ctx)
+        assert isinstance(ready, Continue)
+        assert ready.next_state == "LABELS"
 
     def test_explicit_existing_repo_root_submits_sync_job(
         self, repo_item: WorkItem, tmp_path: Path, make_ctx: Callable[..., Any]
@@ -152,7 +183,7 @@ class TestOnEnterAndCloneStates:
         result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
-        assert result.next_state == "DISCOVER"
+        assert result.next_state == "LABELS"
 
     def test_existing_checkout_is_not_synchronized_in_dry_run(
         self,
@@ -170,7 +201,7 @@ class TestOnEnterAndCloneStates:
         result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
-        assert result.next_state == "DISCOVER"
+        assert result.next_state == "LABELS"
         assert "[dry-run] would synchronize test-org/repo-a" in caplog.text
 
     def test_clone_failure_retries_within_budget(self, repo_item: WorkItem, repo_ctx: Any) -> None:
@@ -201,11 +232,13 @@ class TestOnEnterAndCloneStates:
     def test_clone_success_records_nothing(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         stage = RepoStage()
         repo_item.state = "CLONE_WAIT"
+        repo_item.payload["checkout_op"] = "sync_checkout"
 
         stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
 
         assert repo_item.attempts["clone"] == 0
         assert "clone_failed" not in repo_item.payload
+        assert repo_item.payload["checkout_verified"] is True
 
 
 class TestDiscover:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -2042,7 +2042,10 @@ class TestPipelineScopeWiring:
         config = self._scoped_config(tmp_path, issues=[1, 2, 3], parallel_repos=2)
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
-        assert coordinator._seed_pass() == 2
+        assert coordinator._seed_pass() == 1
+        coordinator._drain_queues()
+        coordinator._drain_completions()
+        coordinator._drain_completions()
         assert [item.issue for item in coordinator.items] == [1, 3]
         assert gh.issue_json_calls == [1, 3]
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -90,6 +90,14 @@ def _item(issue: int = 1, stage: StageName = StageName.PLANNING) -> WorkItem:
     return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=stage, state="ENTER")
 
 
+def _complete_direct_scope_bootstrap(coordinator: Coordinator) -> None:
+    """Advance the clone-plus-sync gate before inspecting direct entries."""
+    coordinator._seed_pass()
+    coordinator._drain_queues()
+    coordinator._drain_completions()
+    coordinator._drain_completions()
+
+
 class TestWiring:
     """Constructor and run_pipeline production wiring."""
 
@@ -701,7 +709,7 @@ class TestSeedingEdges:
         )
         coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
 
-        coordinator._seed_pass()
+        _complete_direct_scope_bootstrap(coordinator)
 
         assert created == [("target-repo", tmp_path / "target-repo")]
         item = coordinator.queues[StageName.MERGE_WAIT].snapshot()[0]
@@ -745,7 +753,7 @@ class TestSeedingEdges:
         )
         coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
 
-        coordinator._seed_pass()
+        _complete_direct_scope_bootstrap(coordinator)
 
         assert created == [("target-repo", tmp_path / "target-repo")]
         item = coordinator.queues[StageName.MERGE_WAIT].snapshot()[0]
@@ -783,7 +791,7 @@ class TestSeedingEdges:
         )
         coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
 
-        coordinator._seed_pass()
+        _complete_direct_scope_bootstrap(coordinator)
 
         item = coordinator.queues[StageName.PR_REVIEW].snapshot()[0]
         assert item.repo == "target-repo"

--- a/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
+++ b/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
@@ -118,6 +118,41 @@ def test_explicit_scope_syncs_before_labels_and_classification(
     assert events[:3] == ["sync", "labels", "classify"]
 
 
+def test_direct_issue_carries_the_bootstrap_checkout_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An issue cursor preserves the exact default-branch SHA it was admitted under."""
+    checkout = tmp_path / "repo-a"
+    checkout.mkdir()
+    pin = "a" * 40
+    pool = FakeWorkerPool()
+    pool.script(JobResult(ok=True, value=pin))
+    github = FakeStageGitHub(labels=["state:needs-plan"])
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: list(issues),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[101],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.PLANNING})),
+        ),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage()
+
+    assert coordinator.run() == 0
+    issue_item = next(item for item in coordinator.items if item.issue == 101)
+    assert issue_item.payload["_direct_scope_base_sha"] == pin
+
+
 def test_explicit_pr_scope_syncs_before_labels_and_pr_classification(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
+++ b/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
@@ -1,0 +1,159 @@
+"""Regression coverage for explicit CLI scope checkout synchronization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
+from hephaestus.automation.pipeline.routing import (
+    Disposition,
+    PipelineScope,
+    StageName,
+    StageOutcome,
+)
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.work_item import WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class _ImmediatePassStage:
+    """Finish a seeded issue without an agent job."""
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> None:
+        del item, ctx
+
+    def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+        del item, ctx
+        return StageOutcome(Disposition.FINISH_PASS, "complete")
+
+    def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+        del item, result, ctx
+        raise AssertionError("the deterministic stage does not submit jobs")
+
+
+class _RecordingPool(FakeWorkerPool):
+    """Record the synchronization submission in the shared event trace."""
+
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self._events = events
+
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
+        if isinstance(job, GitJob) and job.op == "sync_checkout":
+            self._events.append("sync")
+        return super().submit(job, on_done_state, **kwargs)
+
+
+class _RecordingGitHub(FakeStageGitHub):
+    """Record the first label mutation relative to direct classification."""
+
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(labels=["state:needs-plan"])
+        self._events = events
+
+    def ensure_state_labels(self) -> None:
+        self._events.append("labels")
+        super().ensure_state_labels()
+
+
+def _facts(issue: int) -> IssueFacts:
+    return IssueFacts(
+        number=issue,
+        title=f"Issue {issue}",
+        body="",
+        is_epic=False,
+        labels={"state:needs-plan"},
+        pr_number=None,
+        pr_is_open=False,
+        pr_is_merged=False,
+    )
+
+
+def test_explicit_scope_syncs_before_labels_and_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scoped run gates direct source admission on a clean-main sync job."""
+    events: list[str] = []
+    checkout = tmp_path / "repo-a"
+    checkout.mkdir()
+    pool = _RecordingPool(events)
+    github = _RecordingGitHub(events)
+
+    def classify(issue: int, github_arg: Any) -> IssueFacts:
+        del github_arg
+        events.append("classify")
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: list(issues),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[101],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})),
+        ),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage()
+
+    assert coordinator.run() == 0
+    assert events[:3] == ["sync", "labels", "classify"]
+
+
+def test_explicit_scope_sync_failure_blocks_labels_sources_and_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed explicit-scope fetch never falls through to stale checkout work."""
+    checkout = tmp_path / "repo-a"
+    checkout.mkdir()
+    classifications: list[int] = []
+    pool = FakeWorkerPool()
+    pool.script(
+        JobResult(ok=False, error="fetch unavailable"),
+        JobResult(ok=False, error="fetch unavailable"),
+    )
+    github = FakeStageGitHub(labels=["state:needs-plan"])
+
+    def classify(issue: int, github_arg: Any) -> IssueFacts:
+        del github_arg
+        classifications.append(issue)
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: list(issues),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo-a"], issues=[101], projects_dir=tmp_path),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage()
+
+    assert coordinator.run() == 1
+    assert classifications == []
+    assert github.mutation_log == []
+    assert [handle.job.op for handle in pool.submitted if isinstance(handle.job, GitJob)] == [
+        "sync_checkout",
+        "sync_checkout",
+    ]
+    assert not any(isinstance(handle.job, AgentJob) for handle in pool.submitted)
+    assert len(coordinator.ledger) == 1
+    assert "clone exhausted" in coordinator.ledger[0].reason

--- a/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
+++ b/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
@@ -45,6 +45,8 @@ class _RecordingPool(FakeWorkerPool):
         self._events = events
 
     def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
+        if isinstance(job, GitJob) and job.op == "clone":
+            self._events.append("clone")
         if isinstance(job, GitJob) and job.op == "sync_checkout":
             self._events.append("sync")
         return super().submit(job, on_done_state, **kwargs)
@@ -116,6 +118,45 @@ def test_explicit_scope_syncs_before_labels_and_classification(
 
     assert coordinator.run() == 0
     assert events[:3] == ["sync", "labels", "classify"]
+
+
+def test_missing_direct_scope_checkout_clones_then_syncs_before_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing direct-scope checkout is synchronized before it is admitted."""
+    events: list[str] = []
+    pool = _RecordingPool(events)
+    github = _RecordingGitHub(events)
+
+    def classify(issue: int, github_arg: Any) -> IssueFacts:
+        del github_arg
+        events.append("classify")
+        return _facts(issue)
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    monkeypatch.setattr(seeding_mod, "seed_issue_from_github", classify)
+    monkeypatch.setattr(
+        "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+        lambda _repo, issues: list(issues),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[101],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})),
+        ),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.PLANNING] = _ImmediatePassStage()
+
+    assert coordinator.run() == 0
+    assert events[:4] == ["clone", "sync", "labels", "classify"]
+    issue_item = next(item for item in coordinator.items if item.issue == 101)
+    assert issue_item.payload["_direct_scope_base_sha"] == "a" * 40
 
 
 def test_direct_issue_carries_the_bootstrap_checkout_pin(

--- a/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
+++ b/tests/unit/automation/pipeline/test_explicit_scope_checkout_sync.py
@@ -53,13 +53,17 @@ class _RecordingPool(FakeWorkerPool):
 class _RecordingGitHub(FakeStageGitHub):
     """Record the first label mutation relative to direct classification."""
 
-    def __init__(self, events: list[str]) -> None:
-        super().__init__(labels=["state:needs-plan"])
+    def __init__(self, events: list[str], **kwargs: Any) -> None:
+        super().__init__(labels=["state:needs-plan"], **kwargs)
         self._events = events
 
     def ensure_state_labels(self) -> None:
         self._events.append("labels")
         super().ensure_state_labels()
+
+    def find_issue_for_pr(self, pr_number: int) -> int | None:
+        self._events.append("classify-pr")
+        return super().find_issue_for_pr(pr_number)
 
 
 def _facts(issue: int) -> IssueFacts:
@@ -114,17 +118,49 @@ def test_explicit_scope_syncs_before_labels_and_classification(
     assert events[:3] == ["sync", "labels", "classify"]
 
 
-def test_explicit_scope_sync_failure_blocks_labels_sources_and_agents(
+def test_explicit_pr_scope_syncs_before_labels_and_pr_classification(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A failed explicit-scope fetch never falls through to stale checkout work."""
+    """An explicit PR follows the same checkout proof before its first read."""
+    events: list[str] = []
+    (tmp_path / "repo-a").mkdir()
+    pool = _RecordingPool(events)
+    github = _RecordingGitHub(events, pr_issue=101, pr_impl_state=(True, False))
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda *_args: [])
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            prs=[77],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.MERGE_WAIT})),
+        ),
+        github=github,
+        pool=pool,
+        install_signals=False,
+    )
+    coordinator.stages[StageName.MERGE_WAIT] = _ImmediatePassStage()
+
+    assert coordinator.run() == 0
+    assert events[:3] == ["sync", "labels", "classify-pr"]
+
+
+@pytest.mark.parametrize(
+    "sync_error",
+    ["fetch unavailable", "checkout is dirty", "cannot fast-forward checkout"],
+)
+def test_explicit_scope_sync_failure_blocks_labels_sources_and_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sync_error: str
+) -> None:
+    """Fetch, dirty, or stale checkout failures cannot enter a scoped run."""
     checkout = tmp_path / "repo-a"
     checkout.mkdir()
     classifications: list[int] = []
     pool = FakeWorkerPool()
     pool.script(
-        JobResult(ok=False, error="fetch unavailable"),
-        JobResult(ok=False, error="fetch unavailable"),
+        JobResult(ok=False, error=sync_error),
+        JobResult(ok=False, error=sync_error),
     )
     github = FakeStageGitHub(labels=["state:needs-plan"])
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -968,6 +968,248 @@ class TestGitOps:
         assert result.ok is True
         assert result.value == str(tmp_path / "wt")
 
+    def test_direct_pinned_worktree_rejects_checkout_head_drift(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A direct-scope worktree never falls back when its checkout moved."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = tmp_path / "wt"
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance) as mock_manager,
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="b" * 40 + "\n"),
+            ),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "direct scope checkout pin mismatch"
+        mock_manager.assert_not_called()
+
+    def test_direct_pinned_worktree_reserves_remote_branch_before_agent_admission(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A direct scope creates a server-side branch lease before returning a worktree."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = tmp_path / "wt"
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout=pinned_sha + "\n"),
+            ),
+            patch(f"{_WP}.git_utils.reserve_remote_branch_if_absent") as reserve,
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        reserve.assert_called_once_with("7-auto", pinned_sha, tmp_path, timeout=60)
+        assert result.value == {
+            "path": str(tmp_path / "wt"),
+            "direct_scope_reservation": {
+                "branch": "7-auto",
+                "base_sha": pinned_sha,
+            },
+        }
+
+    def test_direct_pinned_worktree_releases_reservation_when_no_worktree_is_created(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A manager no-op cannot leave the server-side reservation behind."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = None
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout=pinned_sha + "\n"),
+            ),
+            patch(f"{_WP}.git_utils.reserve_remote_branch_if_absent"),
+            patch(
+                f"{_WP}.git_utils.delete_reserved_branch_if_unchanged", return_value=True
+            ) as release,
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree manager returned no worktree"
+        release.assert_called_once_with("7-auto", pinned_sha, tmp_path, timeout=60)
+
+    def test_direct_worktree_rollback_failure_preserves_reservation_receipt(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A retryable early rollback failure remains recoverable in Finished."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.side_effect = RuntimeError("disk failure")
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout=pinned_sha + "\n"),
+            ),
+            patch(f"{_WP}.git_utils.reserve_remote_branch_if_absent"),
+            patch(
+                f"{_WP}.git_utils.delete_reserved_branch_if_unchanged",
+                side_effect=RuntimeError("network unavailable"),
+            ),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {
+            "direct_scope_reservation": {"branch": "7-auto", "base_sha": pinned_sha}
+        }
+
+    def test_direct_worktree_rollback_timeout_preserves_reservation_receipt(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A transport timeout must reach Finished's bounded release protocol."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.side_effect = RuntimeError("disk failure")
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout=pinned_sha + "\n"),
+            ),
+            patch(f"{_WP}.git_utils.reserve_remote_branch_if_absent"),
+            patch(
+                f"{_WP}.git_utils.delete_reserved_branch_if_unchanged",
+                side_effect=subprocess.TimeoutExpired(["git", "push"], 60),
+            ),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {
+            "direct_scope_reservation": {"branch": "7-auto", "base_sha": pinned_sha}
+        }
+
+    def test_direct_pinned_worktree_fails_before_agent_admission_when_reservation_loses_race(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A concurrent remote branch owner fails the worktree job closed."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = tmp_path / "wt"
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout=pinned_sha + "\n"),
+            ),
+            patch(
+                f"{_WP}.git_utils.reserve_remote_branch_if_absent",
+                side_effect=RuntimeError("remote branch already exists"),
+            ),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "remote branch already exists" in (result.error or "")
+
     def test_create_worktree_syncs_adopted_clean_branch(
         self,
         pool: WorkerPool,
@@ -1328,6 +1570,38 @@ class TestGitOps:
         )
         assert result.ok is True
 
+    def test_remove_worktree_conditionally_releases_noop_local_branch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """The branch delete runs only after its worktree is removed and pruned."""
+        pin = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / "issue-7"),
+                "repo_root": str(tmp_path),
+                "force": True,
+                "local_branch_cleanup": {"branch": "7-auto", "base_sha": pin},
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.run"),
+            patch(
+                f"{_WP}.git_utils.delete_local_branch_if_unchanged", return_value=True
+            ) as release,
+        ):
+            pool.submit(job, StageName.FINISHED)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {"local_branch_deleted": True}
+        release.assert_called_once_with("7-auto", pin, tmp_path, timeout=60)
+
     @pytest.mark.parametrize("rebase_clean", [True, False])
     def test_rebase_dispatch_propagates_bool(
         self,
@@ -1378,6 +1652,35 @@ class TestGitOps:
         mock_push.assert_called_once_with(cwd=Path("/tmp/wt"), branch="7-auto", timeout=60)
         assert result.ok is True
 
+    def test_release_branch_reservation_dispatches_conditional_delete(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Terminal cleanup reports a stale reservation without force-deleting it."""
+        pin = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="release_branch_reservation",
+            timeout_s=60,
+            kwargs={
+                "branch": "7-auto",
+                "base_sha": pin,
+                "repo_root": str(tmp_path),
+            },
+        )
+        with patch(
+            "hephaestus.automation.git_utils.delete_reserved_branch_if_unchanged",
+            return_value=False,
+        ) as release:
+            pool.submit(job, StageName.FINISHED)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value is False
+        release.assert_called_once_with("7-auto", pin, tmp_path, timeout=60)
+
     def test_commit_push_extracts_explicit_keys(
         self,
         pool: WorkerPool,
@@ -1415,6 +1718,75 @@ class TestGitOps:
         mock_push.assert_called_once_with("5-auto", tmp_path, timeout=60)
         assert result.ok is True
         assert result.value is True  # value carries commit_if_changes' bool
+
+    def test_direct_scope_commit_push_requires_unchanged_remote_reservation(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Direct scopes publish only through the server-side reservation lease."""
+        pin = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "agent": "claude",
+                "expected_remote_sha": pin,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch("hephaestus.automation.git_utils.push_branch_if_remote_matches") as strict_push,
+            patch("hephaestus.automation.git_utils.push_branch") as normal_push,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        strict_push.assert_called_once_with("5-auto", pin, tmp_path, timeout=60)
+        normal_push.assert_not_called()
+
+    def test_direct_scope_no_commit_releases_unchanged_reservation(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """An unused reservation is conditionally deleted instead of blocking reruns."""
+        pin = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "agent": "claude",
+                "expected_remote_sha": pin,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=False),
+            patch(
+                "hephaestus.automation.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="0\n"),
+            ),
+            patch("hephaestus.automation.git_utils.delete_reserved_branch_if_unchanged") as release,
+            patch("hephaestus.automation.git_utils.push_branch") as normal_push,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value is False
+        release.assert_called_once_with("5-auto", pin, tmp_path, timeout=60)
+        normal_push.assert_not_called()
 
     def test_commit_push_value_false_does_not_push_when_nothing_committed(
         self,
@@ -1601,9 +1973,13 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
                 subprocess.CompletedProcess([], 0),
-                subprocess.CompletedProcess([], 0, stdout="new-head\nnew-head\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="a" * 40 + "\n" + "a" * 40 + "\n"),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -1689,6 +2065,27 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
+                [
+                    "git",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                ],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                cwd=checkout,
+                check=False,
+                log_errors=False,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
                 ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"],
                 cwd=checkout,
                 timeout=120,
@@ -1712,6 +2109,27 @@ class TestGitOps:
                 env=ANY,
             ),
             call(
+                [
+                    "git",
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=all",
+                ],
+                cwd=checkout,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
+                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                cwd=checkout,
+                check=False,
+                log_errors=False,
+                timeout=120,
+                env=ANY,
+            ),
+            call(
                 ["git", "rev-parse", "HEAD", "origin/main"],
                 cwd=checkout,
                 timeout=120,
@@ -1720,6 +2138,43 @@ class TestGitOps:
         ]
         assert (checkout / ".git" / ".hephaestus-git-metadata.lock").is_file()
         assert result.ok is True
+        assert result.value == "a" * 40
+
+    def test_sync_checkout_rechecks_clean_state_after_fetch_before_merge(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A checkout dirtied during sync is rejected before fast-forwarding it."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        job = GitJob(
+            repo="test/repo",
+            op="sync_checkout",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": str(checkout)},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=" M concurrent-change.py\n"),
+            ]
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "checkout is dirty" in (result.error or "")
+        argvs = [call.args[0] for call in mock_run.call_args_list]
+        assert ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"] not in argvs
+        assert not any(
+            argv[:3] == ["git", "-c", f"core.hooksPath={os.devnull}"] and "merge" in argv
+            for argv in argvs
+        )
 
     def test_sync_checkout_rejects_dirty_worktree_before_fetching(
         self,
@@ -1926,9 +2381,13 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
                 subprocess.CompletedProcess([], 0),
-                subprocess.CompletedProcess([], 0, stdout="new-head\nnew-head\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0, stdout="a" * 40 + "\n" + "a" * 40 + "\n"),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -2002,7 +2461,8 @@ class TestGitOps:
             timeout=120,
             env=ANY,
         )
-        for git_call in (mock_run.call_args_list[index] for index in (0, 1, 2, 4, 5, 6, 7)):
+        git_call_indices = (0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11)
+        for git_call in (mock_run.call_args_list[index] for index in git_call_indices):
             assert git_call.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
             assert "GIT_DIR" not in git_call.kwargs["env"]
             assert git_call.kwargs["env"]["GIT_NO_REPLACE_OBJECTS"] == "1"
@@ -2411,12 +2871,20 @@ class TestGitOps:
 
         assert result.ok is False
         assert result.error == "lock_timeout"
-        assert mock_run.call_args_list[-1] == call(
-            [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
-            cwd=checkout,
-            timeout=0,
-            env=ANY,
-        )
+        assert mock_run.call_args_list == [
+            call(
+                ["git", "config", "--null", "--list"],
+                cwd=checkout,
+                timeout=0,
+                env=ANY,
+            ),
+            call(
+                ["git", "rev-parse", "--git-path", "info/grafts"],
+                cwd=checkout,
+                timeout=0,
+                env=ANY,
+            ),
+        ]
 
     def test_sync_checkout_rejects_local_commits_ahead_of_remote(
         self,
@@ -2440,6 +2908,8 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="1\t0\n"),
             ]
             pool.submit(job, StageName.REPO)
@@ -2510,6 +2980,8 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
                 subprocess.CompletedProcess([], 1),
             ]
@@ -2541,8 +3013,12 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="0\t1\n"),
                 subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
                 subprocess.CompletedProcess([], 0, stdout="old-head\nnew-head\n"),
             ]
             pool.submit(job, StageName.REPO)

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -15,6 +15,8 @@ from hephaestus.automation.git_utils import (
     _remove_untracked_files_tracked_by_ref,
     clear_repo_caches,
     commit_if_changes,
+    delete_local_branch_if_unchanged,
+    delete_reserved_branch_if_unchanged,
     ensure_branch_commit_metadata,
     get_current_branch,
     get_repo_info,
@@ -22,9 +24,11 @@ from hephaestus.automation.git_utils import (
     is_clean_working_tree,
     issue_auto_impl_branch_name,
     push_branch,
+    push_branch_if_remote_matches,
     push_current_branch_with_lease_on_divergence,
     push_head_to_branch,
     rebase_worktree_onto,
+    reserve_remote_branch_if_absent,
     run,
     safe_git_fetch,
     sync_worktree_to_remote_branch,
@@ -370,6 +374,159 @@ class TestPushBranch:
             cwd=tmp_path,
             timeout=42,
         )
+
+
+class TestDirectScopeBranchReservation:
+    """Atomic server-side ownership checks for direct-scope implementation branches."""
+
+    def test_reserve_requires_remote_branch_to_be_absent(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        pin = "a" * 40
+
+        reserve_remote_branch_if_absent("2452-auto-impl", pin, tmp_path, timeout=42)
+
+        git_utils_mocks.run.assert_called_once_with(
+            [
+                "git",
+                "push",
+                "--force-with-lease=refs/heads/2452-auto-impl:",
+                "origin",
+                f"{pin}:refs/heads/2452-auto-impl",
+            ],
+            cwd=tmp_path,
+            timeout=42,
+        )
+
+    def test_strict_publish_requires_expected_remote_sha(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [
+            Mock(returncode=0),
+            Mock(returncode=0),
+        ]
+
+        push_branch_if_remote_matches("2452-auto-impl", pin, tmp_path, timeout=42)
+
+        assert git_utils_mocks.run.call_args_list[0].args[0] == [
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            pin,
+            "HEAD",
+        ]
+        assert git_utils_mocks.run.call_args_list[1].args[0] == [
+            "git",
+            "push",
+            f"--force-with-lease=refs/heads/2452-auto-impl:{pin}",
+            "origin",
+            "HEAD:refs/heads/2452-auto-impl",
+        ]
+
+    def test_strict_publish_rejects_non_fast_forward_local_branch(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        git_utils_mocks.run.return_value = Mock(returncode=1)
+
+        with pytest.raises(RuntimeError, match="not a fast-forward"):
+            push_branch_if_remote_matches("2452-auto-impl", "a" * 40, tmp_path)
+
+        assert git_utils_mocks.run.call_count == 1
+
+    def test_release_requires_the_original_reservation_sha(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        pin = "a" * 40
+
+        delete_reserved_branch_if_unchanged("2452-auto-impl", pin, tmp_path, timeout=42)
+
+        git_utils_mocks.run.assert_called_once_with(
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/2452-auto-impl:{pin}",
+                "origin",
+                ":refs/heads/2452-auto-impl",
+            ],
+            cwd=tmp_path,
+            timeout=42,
+        )
+
+    def test_release_reports_confirmed_remote_ownership_loss_without_force_deleting(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """Only a post-failure ref mismatch is a safe, non-retryable stale lease."""
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(1, ["git", "push"]),
+            Mock(stdout=("b" * 40) + "\trefs/heads/2452-auto-impl\n"),
+        ]
+
+        released = delete_reserved_branch_if_unchanged("2452-auto-impl", pin, tmp_path)
+
+        assert released is False
+        assert git_utils_mocks.run.call_args_list[1].args[0] == [
+            "git",
+            "ls-remote",
+            "--refs",
+            "origin",
+            "refs/heads/2452-auto-impl",
+        ]
+
+    def test_release_raises_when_remote_still_has_our_reservation(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A transport error cannot be silently treated as a released branch."""
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(1, ["git", "push"]),
+            Mock(stdout=pin + "\trefs/heads/2452-auto-impl\n"),
+        ]
+
+        with pytest.raises(RuntimeError, match="reservation remains unchanged"):
+            delete_reserved_branch_if_unchanged("2452-auto-impl", pin, tmp_path)
+
+    def test_local_release_uses_exact_old_value_compare_and_delete(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A direct no-op deletes only its still-expected local branch."""
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [Mock(returncode=0, stdout=pin), Mock()]
+
+        released = delete_local_branch_if_unchanged("2452-auto-impl", pin, tmp_path, timeout=42)
+
+        assert released is True
+        assert git_utils_mocks.run.call_args_list[0].args[0] == [
+            "git",
+            "show-ref",
+            "--verify",
+            "--hash",
+            "refs/heads/2452-auto-impl",
+        ]
+        git_utils_mocks.run.assert_called_with(
+            ["git", "branch", "-d", "2452-auto-impl"],
+            cwd=tmp_path,
+            timeout=42,
+        )
+
+    def test_local_release_refuses_a_branch_checked_out_elsewhere(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """The final Git command enforces Git's checked-out-branch protection."""
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [
+            Mock(returncode=0, stdout=pin),
+            subprocess.CalledProcessError(
+                1,
+                ["git", "branch", "-d", "2452-auto-impl"],
+                stderr="error: Cannot delete branch '2452-auto-impl' checked out at '/tmp/other'",
+            ),
+        ]
+
+        released = delete_local_branch_if_unchanged("2452-auto-impl", pin, tmp_path)
+
+        assert released is False
 
 
 class TestPushDetachedHead:

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -165,6 +165,101 @@ class TestWorktreeManager:
 
         assert lock_paths == [manager.repo_root / ".git" / ".hephaestus-git-metadata.lock"]
 
+    def test_direct_scope_worktree_uses_the_exact_verified_sha(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """Direct scopes create a fresh branch from their bootstrap SHA only."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        pin = "a" * 40
+
+        with (
+            patch.object(manager, "_worktree_holding_branch", return_value=None),
+            patch.object(manager, "_direct_scope_local_branch_exists", return_value=False),
+        ):
+            result = manager.create_worktree(
+                2460,
+                "2460-auto-impl",
+                base_sha=pin,
+                remote_branch_reserved=True,
+            )
+
+        assert result == manager.base_dir / "issue-2460"
+        assert worktree_mocks.run.call_args.args[0] == [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "2460-auto-impl",
+            str(result),
+            pin,
+        ]
+
+    def test_direct_scope_rejects_refresh_before_any_git_mutation(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A direct pin is never refreshed into a different base revision."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+
+        with pytest.raises(RuntimeError, match="direct scope base pin invalid"):
+            manager.create_worktree(2463, "2463-auto-impl", base_sha="a" * 40, refresh_base=True)
+
+        worktree_mocks.run.assert_not_called()
+
+    def test_direct_scope_propagates_local_branch_probe_failure(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A direct scope never treats an unavailable local probe as absent."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        worktree_mocks.run.side_effect = [
+            Mock(returncode=1, stdout=""),
+            subprocess.TimeoutExpired(["git", "ls-remote"], timeout=5),
+        ]
+        manager = WorktreeManager()
+
+        with (
+            patch.object(manager, "_worktree_holding_branch", return_value=None),
+            pytest.raises(RuntimeError, match="Failed to create worktree"),
+        ):
+            manager.create_worktree(
+                2461,
+                "2461-auto-impl",
+                base_sha="a" * 40,
+                remote_branch_reserved=True,
+            )
+
+        assert all("worktree add" not in call.args[0] for call in worktree_mocks.run.call_args_list)
+
+    def test_direct_scope_preserves_concurrently_created_worktree_on_add_failure(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A loser of the direct creation race never removes the winner's worktree."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        worktree_path = manager.base_dir / "issue-2462"
+
+        def concurrent_creator(path: Path, *_: Any, **__: Any) -> None:
+            path.mkdir(parents=True)
+            raise RuntimeError("branch was created by another process")
+
+        with (
+            patch.object(manager, "_worktree_holding_branch", return_value=None),
+            patch.object(manager, "_direct_scope_local_branch_exists", return_value=False),
+            patch.object(manager, "_add_worktree_for_branch", side_effect=concurrent_creator),
+            pytest.raises(RuntimeError, match="Failed to create worktree"),
+        ):
+            manager.create_worktree(
+                2462,
+                "2462-auto-impl",
+                base_sha="a" * 40,
+                remote_branch_reserved=True,
+            )
+
+        assert worktree_path.exists()
+        argvs = [call.args[0] for call in worktree_mocks.run.call_args_list]
+        assert ["git", "worktree", "remove", "--force", str(worktree_path)] not in argvs
+
     def test_create_worktree_default_branch_name(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test worktree creation with default branch name."""
         worktree_mocks.repo_root.return_value = tmp_path


### PR DESCRIPTION
Closes #2452

Supersedes #2458 without rewriting its behind branch.

This pins explicit --issues/--prs runs to the checkout SHA verified before classification; reserves deterministic remote branches atomically; uses conditional publication and cleanup; and preserves retry-safe receipts through terminal cleanup.

Validation:
- uv run pytest -q --no-cov: 6,829 passed, 24 skipped
- mypy (7 source files), Ruff, format, and diff checks passed
- independent lifecycle review completed with no remaining findings.