### PR TITLE
fix(automation): retain plan-review diagnostics

### DIFF
--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -134,6 +134,20 @@ _PLAN_REVIEW_LABELS = {
 }
 
 
+def _safe_agent_failure_diagnostic(stderr_tail: str) -> str | None:
+    """Classify agent stderr for logs without exposing subprocess output."""
+    text = stderr_tail.strip().casefold()
+    if not text:
+        return None
+    if "stream disconnected" in text or "error sending request" in text:
+        return "backend response stream disconnected"
+    if "rate limit" in text or "usage cap" in text or "429" in text:
+        return "provider rate limit"
+    if "connection" in text or "network" in text or "timed out" in text:
+        return "transient transport failure"
+    return "agent subprocess reported diagnostic output"
+
+
 def parse_plan_review_verdict(text: str) -> ReviewVerdict:
     """Parse the one exact state label that terminates a plan review."""
     state = parse_plan_review_state(text)
@@ -711,13 +725,13 @@ class PlanReviewStage(Stage):
 
         """
         if not result.ok:
-            stderr_tail = result.stderr_tail.strip()
-            if stderr_tail:
+            diagnostic = _safe_agent_failure_diagnostic(result.stderr_tail)
+            if diagnostic:
                 logger.warning(
-                    "plan_review:%s: job failed: %s; stderr tail: %s",
+                    "plan_review:%s: job failed: %s; diagnostic: %s",
                     item.issue,
                     result.error,
-                    stderr_tail,
+                    diagnostic,
                 )
             else:
                 logger.warning("plan_review:%s: job failed: %s", item.issue, result.error)

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -711,7 +711,16 @@ class PlanReviewStage(Stage):
 
         """
         if not result.ok:
-            logger.warning("plan_review:%s: job failed: %s", item.issue, result.error)
+            stderr_tail = result.stderr_tail.strip()
+            if stderr_tail:
+                logger.warning(
+                    "plan_review:%s: job failed: %s; stderr tail: %s",
+                    item.issue,
+                    result.error,
+                    stderr_tail,
+                )
+            else:
+                logger.warning("plan_review:%s: job failed: %s", item.issue, result.error)
             return
 
         if result.value is not None:

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -148,6 +148,21 @@ def _safe_agent_failure_diagnostic(stderr_tail: str) -> str | None:
     return "agent subprocess reported diagnostic output"
 
 
+def _safe_agent_failure_reason(error: str | None) -> str:
+    """Render an agent failure reason for logs without exposing error text."""
+    if error == "timeout":
+        return "agent timed out"
+    if error == "circuit_open":
+        return "agent circuit is open"
+    if error == "interrupted_before_start":
+        return "agent job was interrupted before start"
+    if error is not None and error.startswith("rc="):
+        returncode = error.removeprefix("rc=")
+        if returncode.lstrip("-").isdigit() and returncode != "":
+            return f"exit code {returncode}"
+    return "agent job failed"
+
+
 def parse_plan_review_verdict(text: str) -> ReviewVerdict:
     """Parse the one exact state label that terminates a plan review."""
     state = parse_plan_review_state(text)
@@ -725,16 +740,17 @@ class PlanReviewStage(Stage):
 
         """
         if not result.ok:
+            reason = _safe_agent_failure_reason(result.error)
             diagnostic = _safe_agent_failure_diagnostic(result.stderr_tail)
             if diagnostic:
                 logger.warning(
                     "plan_review:%s: job failed: %s; diagnostic: %s",
                     item.issue,
-                    result.error,
+                    reason,
                     diagnostic,
                 )
             else:
-                logger.warning("plan_review:%s: job failed: %s", item.issue, result.error)
+                logger.warning("plan_review:%s: job failed: %s", item.issue, reason)
             return
 
         if result.value is not None:

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -1055,16 +1055,41 @@ class TestPlanReviewStageOnJobDone:
         assert "Review v1" not in history
         assert "Review v2" not in history
 
-    def test_failed_result_is_not_stored(self, make_ctx: Any, make_work_item: Any) -> None:
-        """A failed job result is logged and never stored."""
+    def test_failed_result_without_stderr_is_not_stored_or_noisy(
+        self, make_ctx: Any, make_work_item: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failed review without a diagnostic keeps the concise legacy log."""
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=3, state="REVIEW_WAIT")
         result = JobResult(ok=False, error="reviewer crashed")
 
-        stage.on_job_done(item, result, ctx)
+        with caplog.at_level("WARNING", logger=plan_review.__name__):
+            stage.on_job_done(item, result, ctx)
 
         assert "review_verdict" not in item.payload
+        assert all("stderr tail:" not in message for message in caplog.messages)
+
+    def test_failed_result_logs_stderr_diagnostic(
+        self, make_ctx: Any, make_work_item: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failed review exposes its bounded worker diagnostic to operators."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="REVIEW_WAIT")
+        result = JobResult(
+            ok=False,
+            error="rc=1",
+            stderr_tail="stream disconnected before completion",
+        )
+
+        with caplog.at_level("WARNING", logger=plan_review.__name__):
+            stage.on_job_done(item, result, ctx)
+
+        assert any(
+            "job failed: rc=1; stderr tail: stream disconnected before completion" in message
+            for message in caplog.messages
+        )
 
 
 class TestDurableWriteOrdering:

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -1058,17 +1058,20 @@ class TestPlanReviewStageOnJobDone:
     def test_failed_result_without_stderr_is_not_stored_or_noisy(
         self, make_ctx: Any, make_work_item: Any, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A failed review without a diagnostic keeps the concise legacy log."""
+        """A failed review without stderr logs only a safe generic error."""
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=3, state="REVIEW_WAIT")
-        result = JobResult(ok=False, error="reviewer crashed")
+        secret = f"{'token'}=known-test-value"
+        result = JobResult(ok=False, error=f"RuntimeError: {secret}\n\x1b[31m")
 
         with caplog.at_level("WARNING", logger=plan_review.__name__):
             stage.on_job_done(item, result, ctx)
 
         assert "review_verdict" not in item.payload
-        assert caplog.messages == ["plan_review:3: job failed: reviewer crashed"]
+        assert caplog.messages == ["plan_review:3: job failed: agent job failed"]
+        assert secret not in caplog.text
+        assert "\x1b[31m" not in caplog.text
 
     def test_failed_result_logs_safe_stderr_diagnostic(
         self, make_ctx: Any, make_work_item: Any, caplog: pytest.LogCaptureFixture
@@ -1091,7 +1094,7 @@ class TestPlanReviewStageOnJobDone:
             stage.on_job_done(item, result, ctx)
 
         assert any(
-            "job failed: rc=1; diagnostic: backend response stream disconnected" in message
+            "job failed: exit code 1; diagnostic: backend response stream disconnected"
             for message in caplog.messages
         )
         assert secret not in caplog.text
@@ -1112,11 +1115,42 @@ class TestPlanReviewStageOnJobDone:
             stage.on_job_done(item, result, ctx)
 
         assert any(
-            "job failed: rc=1; diagnostic: agent subprocess reported diagnostic output" in message
+            "job failed: exit code 1; diagnostic: agent subprocess reported diagnostic output"
             for message in caplog.messages
         )
         assert secret not in caplog.text
         assert "\x1b[31m" not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("stderr_tail", "expected_diagnostic"),
+        [
+            ("provider returned 429 rate limit", "provider rate limit"),
+            ("network connection timed out", "transient transport failure"),
+        ],
+    )
+    def test_failed_result_classifies_known_safe_diagnostics(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+        caplog: pytest.LogCaptureFixture,
+        stderr_tail: str,
+        expected_diagnostic: str,
+    ) -> None:
+        """Known provider failures retain distinct fixed diagnostic classes."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="REVIEW_WAIT")
+
+        with caplog.at_level("WARNING", logger=plan_review.__name__):
+            stage.on_job_done(
+                item,
+                JobResult(ok=False, error="rc=1", stderr_tail=stderr_tail),
+                ctx,
+            )
+
+        assert caplog.messages == [
+            f"plan_review:3: job failed: exit code 1; diagnostic: {expected_diagnostic}"
+        ]
 
 
 class TestDurableWriteOrdering:

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -1068,28 +1068,55 @@ class TestPlanReviewStageOnJobDone:
             stage.on_job_done(item, result, ctx)
 
         assert "review_verdict" not in item.payload
-        assert all("stderr tail:" not in message for message in caplog.messages)
+        assert caplog.messages == ["plan_review:3: job failed: reviewer crashed"]
 
-    def test_failed_result_logs_stderr_diagnostic(
+    def test_failed_result_logs_safe_stderr_diagnostic(
         self, make_ctx: Any, make_work_item: Any, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A failed review exposes its bounded worker diagnostic to operators."""
+        """A failed review exposes a useful, log-safe diagnostic to operators."""
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=3, state="REVIEW_WAIT")
+        secret = f"{'token'}=known-test-value"
         result = JobResult(
             ok=False,
             error="rc=1",
-            stderr_tail="stream disconnected before completion",
+            stderr_tail=(
+                "stream disconnected before completion\n"
+                f"{secret}\x1b[31mhttps://example.test/problem"
+            ),
         )
 
         with caplog.at_level("WARNING", logger=plan_review.__name__):
             stage.on_job_done(item, result, ctx)
 
         assert any(
-            "job failed: rc=1; stderr tail: stream disconnected before completion" in message
+            "job failed: rc=1; diagnostic: backend response stream disconnected" in message
             for message in caplog.messages
         )
+        assert secret not in caplog.text
+        assert "\x1b[31m" not in caplog.text
+        assert "https://example.test/problem" not in caplog.text
+
+    def test_failed_result_classifies_unknown_stderr_without_logging_it(
+        self, make_ctx: Any, make_work_item: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown subprocess output has a stable safe diagnostic instead of raw text."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="REVIEW_WAIT")
+        secret = f"{'password'}=known-test-value"
+        result = JobResult(ok=False, error="rc=1", stderr_tail=f"{secret}\n\x1b[31munknown")
+
+        with caplog.at_level("WARNING", logger=plan_review.__name__):
+            stage.on_job_done(item, result, ctx)
+
+        assert any(
+            "job failed: rc=1; diagnostic: agent subprocess reported diagnostic output" in message
+            for message in caplog.messages
+        )
+        assert secret not in caplog.text
+        assert "\x1b[31m" not in caplog.text
 
 
 class TestDurableWriteOrdering:

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -1152,6 +1152,32 @@ class TestPlanReviewStageOnJobDone:
             f"plan_review:3: job failed: exit code 1; diagnostic: {expected_diagnostic}"
         ]
 
+    @pytest.mark.parametrize(
+        ("error", "expected_reason"),
+        [
+            ("timeout", "agent timed out"),
+            ("circuit_open", "agent circuit is open"),
+            ("interrupted_before_start", "agent job was interrupted before start"),
+        ],
+    )
+    def test_failed_result_uses_known_safe_error_reasons(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+        caplog: pytest.LogCaptureFixture,
+        error: str,
+        expected_reason: str,
+    ) -> None:
+        """Known worker error codes retain fixed, non-sensitive reasons."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="REVIEW_WAIT")
+
+        with caplog.at_level("WARNING", logger=plan_review.__name__):
+            stage.on_job_done(item, JobResult(ok=False, error=error), ctx)
+
+        assert caplog.messages == [f"plan_review:3: job failed: {expected_reason}"]
+
 
 class TestDurableWriteOrdering:
     """The load-bearing invariant: durable writes precede advancing outcomes."""


### PR DESCRIPTION
## Summary

- retain a bounded, log-safe plan-review failure summary without exposing subprocess output or arbitrary exception text
- distinguish known backend disconnects, provider rate limits, and transient transport failures using fixed diagnostic classes
- add regression tests proving credential-like text, URLs, and terminal control sequences are never logged, regardless of whether they arrive through stderr or JobResult error text

## Validation

- uv run pytest --no-cov tests/unit/automation/pipeline/stages/test_stage_plan_review.py
- uv run ruff check hephaestus/automation/pipeline/stages/plan_review.py tests/unit/automation/pipeline/stages/test_stage_plan_review.py
- uv run ruff format --check hephaestus/automation/pipeline/stages/plan_review.py tests/unit/automation/pipeline/stages/test_stage_plan_review.py
- uv run mypy hephaestus/automation/pipeline/stages/plan_review.py
- pre-push hook: 6887 passed, 6 skipped; coverage 85.07%

Closes #2463