### PR TITLE
[nit] Clarify root-level metadata navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,41 +91,64 @@ Hephaestus ships two layers from one distribution:
 `tests/unit/validation/test_automation_boundary.py`. See
 [`docs/adr/0001-automation-library-boundary.md`](docs/adr/0001-automation-library-boundary.md).
 
-## Directory Structure
+## Repository navigation
 
-```
-Hephaestus/
-├── pyproject.toml          # uv configuration
-├── pyproject.toml     # Python package configuration
-├── hephaestus/        # Main package
-│   ├── __init__.py
-│   ├── agents/        # Agent frontmatter + loader + runtime
-│   ├── automation/    # Queue-based automation pipeline and scoped wrappers
-│   ├── benchmarks/    # Benchmark comparison utilities
-│   ├── ci/            # CI helpers (precommit, workflows, docker timing)
-│   ├── cli/           # CLI helpers (argument parsing, output formatting)
-│   ├── config/        # Configuration utilities (YAML, JSON, env vars)
-│   ├── datasets/      # Dataset downloading utilities
-│   ├── discovery/     # Discovery of agents, skills, and code blocks
-│   ├── forensics/     # Coredump capture + gdb post-mortem runner
-│   ├── github/        # GitHub automation (PR merging, fleet sync, tidy, stats)
-│   ├── io/            # I/O utilities (read, write, safe_write, load/save data)
-│   ├── logging/       # Logging utilities (ContextLogger, setup_logging)
-│   ├── markdown/      # Markdown linting and link fixing
-│   ├── nats/          # NATS JetStream subscriber (event-driven workflows)
-│   ├── observability/ # Prometheus metrics, local health endpoint, and alert transitions
-│   ├── prompts/       # Packaged Jinja templates and CLI-only override catalog
-│   ├── resilience/    # Circuit breaker + retry + subprocess resilience primitives
-│   ├── scripts_lib/   # Standalone consistency-check scripts (CLI table, version)
-│   ├── system/        # System information collection
-│   ├── utils/         # General utility functions (slugify, retry, subprocess, git helpers)
-│   ├── validation/    # README, schema, and structural validation
-│   └── version/       # Version management (hatch-vcs + consistency checks)
-├── tests/             # Unit tests
-├── docs/              # Documentation
-├── scripts/           # Utility scripts
-└── README.md          # This file
-```
+This index covers every tracked top-level path except `README.md` itself. The
+navigation guard in `tests/unit/validation/test_readme_subpackage_tree.py`
+requires new tracked root entries to be added here. Checkout-only state and
+ignored generated output such as `.git/`, `.venv/`, `.pytest_cache/`, and
+`build/` are intentionally outside this index.
+
+### Source and supporting material
+
+| Path | Purpose |
+| --- | --- |
+| [hephaestus/](hephaestus/) | Python package, including the utility library and optional automation product layer. |
+| [tests/](tests/) | Unit and integration test suites. |
+| [docs/](docs/) | User documentation, architecture decisions, roadmap, and release guidance. |
+| [scripts/](scripts/) | Maintenance, validation, demonstration, and operational scripts. |
+| [.github/](.github/) | GitHub templates, ownership rules, dependency automation, and workflows. |
+| [.claude/](.claude/) | Repository-scoped Claude settings, security guidance, and development workflow. |
+| [.vscode/](.vscode/) | Shared VS Code extensions, settings, and debug configuration. |
+
+### Project and policy documents
+
+| Path | Purpose |
+| --- | --- |
+| [AGENTS.md](AGENTS.md) | Authoritative repository and agent-development contract. |
+| [CLAUDE.md](CLAUDE.md) | Claude Code entry point to the authoritative agent contract. |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community conduct expectations. |
+| [COMPATIBILITY.md](COMPATIBILITY.md) | Supported versions and compatibility policy. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor setup, development, and pull-request workflow. |
+| [LICENSE](LICENSE) | BSD 3-Clause license terms. |
+| [NOTICE](NOTICE) | Attribution and third-party notice information. |
+| [PRIVACY.md](PRIVACY.md) | Privacy, retention, and deletion policy. |
+| [SECURITY.md](SECURITY.md) | Vulnerability reporting and security-support policy. |
+
+### Build and dependency metadata
+
+| Path | Purpose |
+| --- | --- |
+| [pyproject.toml](pyproject.toml) | Package metadata, dependencies, entry points, build settings, and Python tool configuration. |
+| [uv.lock](uv.lock) | Reproducible resolved dependency set. |
+| [justfile](justfile) | Canonical contributor command shortcuts. |
+| [coverage.toml](coverage.toml) | Coverage collection, reporting, and omit policy. |
+
+### Repository tool configuration
+
+| Path | Purpose |
+| --- | --- |
+| [.codexignore](.codexignore) | Paths excluded from Codex context discovery. |
+| [.editorconfig](.editorconfig) | Cross-editor formatting defaults. |
+| [.fleet.yml](.fleet.yml) | Fleet synchronization organization and repository inventory. |
+| [.gitattributes](.gitattributes) | Git text and line-ending normalization. |
+| [.gitignore](.gitignore) | Ignored generated, local, and sensitive paths. |
+| [.heph-project-denylist](.heph-project-denylist) | Centrally enforced project privacy and PII denylist. |
+| [.markdownlint.yaml](.markdownlint.yaml) | Markdown lint policy. |
+| [.mcp.json](.mcp.json) | Repository MCP server declarations. |
+| [.pip-audit-ignore.txt](.pip-audit-ignore.txt) | Documented dependency-audit suppressions. |
+| [.pre-commit-config.yaml](.pre-commit-config.yaml) | Pre-commit quality and policy hooks. |
+| [.yamllint.yaml](.yamllint.yaml) | YAML lint policy. |
 
 ## Getting Started with uv
 

--- a/tests/unit/validation/test_readme_subpackage_tree.py
+++ b/tests/unit/validation/test_readme_subpackage_tree.py
@@ -6,6 +6,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PACKAGE_DIR = REPO_ROOT / "hephaestus"
 README = REPO_ROOT / "README.md"
@@ -15,7 +17,7 @@ NAVIGATION_HEADING = "## Repository navigation"
 NAVIGATION_EXCLUSIONS = {
     "README.md": "The navigation index lives in README.md, so a self-link adds no value.",
 }
-LINK_TARGET_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+TABLE_TARGET_RE = re.compile(r"^\|\s*\[[^\]]+\]\(([^)]+)\)\s*\|", re.MULTILINE)
 TREE_MARKER_RE = re.compile(r"^\s*(?:├──|└──|(?:\|--|`--|\+--)\s+\S)")
 
 
@@ -52,14 +54,54 @@ def _navigation_section() -> str:
     return section
 
 
-def _local_navigation_targets() -> list[str]:
-    """Return normalized local link targets from the navigation section."""
-    targets: list[str] = []
-    for raw_target in LINK_TARGET_RE.findall(_navigation_section()):
-        target = raw_target.strip().strip("<>").split("#", 1)[0].rstrip("/")
-        if target and not target.startswith("/") and "://" not in target:
-            targets.append(target.removeprefix("./"))
-    return targets
+def _navigation_table_targets(section: str | None = None) -> list[str]:
+    """Return normalized targets from the navigation table's Path column only."""
+    if section is None:
+        section = _navigation_section()
+    return [
+        raw_target.strip().strip("<>").split("#", 1)[0].rstrip("/").removeprefix("./")
+        for raw_target in TABLE_TARGET_RE.findall(section)
+    ]
+
+
+def _assert_exact_root_navigation_inventory(targets: list[str]) -> None:
+    """Require navigation rows to be the exact tracked root-path inventory."""
+    non_root_targets = sorted(
+        target
+        for target in targets
+        if not target or target in {".", ".."} or len(Path(target).parts) != 1
+    )
+    assert not non_root_targets, (
+        "README repository navigation must use direct top-level targets, not nested "
+        f"or invalid paths: {non_root_targets}"
+    )
+
+    expected = _tracked_top_level_entries() - set(NAVIGATION_EXCLUSIONS)
+    actual = set(targets)
+    missing = sorted(expected - actual)
+    stale = sorted(actual - expected)
+    assert actual == expected, (
+        "README repository navigation must be the exact tracked root-path inventory; "
+        f"missing={missing}, stale={stale}"
+    )
+
+
+def _assert_targets_resolve_within_repository(
+    targets: list[str], repository_root: Path = REPO_ROOT
+) -> None:
+    """Require every navigation target to resolve to an existing in-repository path."""
+    root = repository_root.resolve()
+    escaped: list[str] = []
+    missing: list[str] = []
+    for target in targets:
+        resolved = (root / target).resolve()
+        if not resolved.is_relative_to(root):
+            escaped.append(target)
+        elif not resolved.exists():
+            missing.append(target)
+
+    assert not escaped, f"README repository navigation escapes the repository: {escaped}"
+    assert not missing, f"README repository navigation has broken links: {missing}"
 
 
 def test_navigation_exclusion_policy_is_explicit() -> None:
@@ -68,23 +110,52 @@ def test_navigation_exclusion_policy_is_explicit() -> None:
     assert all(reason.strip() for reason in NAVIGATION_EXCLUSIONS.values())
 
 
-def test_navigation_covers_every_tracked_top_level_entry() -> None:
-    """Every tracked root file or directory is linked regardless of extension."""
+def test_navigation_table_is_exact_tracked_root_inventory() -> None:
+    """Each tracked root entry has one direct navigation-table target."""
     tracked = _tracked_top_level_entries()
     exclusions = set(NAVIGATION_EXCLUSIONS)
     assert exclusions <= tracked
 
-    linked = {target.split("/", 1)[0] for target in _local_navigation_targets()}
-    missing = sorted(tracked - exclusions - linked)
-    assert not missing, f"README repository navigation omits tracked root entries: {missing}"
+    _assert_exact_root_navigation_inventory(_navigation_table_targets())
 
 
-def test_navigation_links_resolve() -> None:
-    """Every local target in the repository-navigation section exists."""
-    missing = sorted(
-        target for target in _local_navigation_targets() if not (REPO_ROOT / target).exists()
+def test_navigation_table_targets_resolve_inside_repository() -> None:
+    """Every local navigation-table target resolves inside the repository."""
+    _assert_targets_resolve_within_repository(_navigation_table_targets())
+
+
+def test_navigation_inventory_rejects_stale_or_nested_table_targets() -> None:
+    """A nested or stale table target cannot masquerade as a root entry."""
+    expected = _tracked_top_level_entries() - set(NAVIGATION_EXCLUSIONS)
+
+    nested_targets = _navigation_table_targets(
+        "\n".join(
+            f"| [entry]({target}) | test target |"
+            for target in [*sorted(expected - {"hephaestus"}), "hephaestus/automation"]
+        )
     )
-    assert not missing, f"README repository navigation has broken links: {missing}"
+    with pytest.raises(AssertionError, match="direct top-level targets"):
+        _assert_exact_root_navigation_inventory(nested_targets)
+
+    stale_targets = _navigation_table_targets(
+        "\n".join(
+            f"| [entry]({target}) | test target |"
+            for target in [*sorted(expected - {"AGENTS.md"}), "obsolete-root.md"]
+        )
+    )
+    with pytest.raises(AssertionError, match="exact tracked root-path inventory"):
+        _assert_exact_root_navigation_inventory(stale_targets)
+
+
+def test_navigation_target_validation_rejects_repository_escape(tmp_path: Path) -> None:
+    """A relative target that resolves above the checkout is rejected."""
+    repository_root = tmp_path / "repository"
+    repository_root.mkdir()
+    escaped_target = "../../../outside"
+    (tmp_path / "outside").touch()
+
+    with pytest.raises(AssertionError, match="escapes the repository"):
+        _assert_targets_resolve_within_repository([escaped_target], repository_root)
 
 
 def test_navigation_replaces_hand_maintained_directory_tree() -> None:

--- a/tests/unit/validation/test_readme_subpackage_tree.py
+++ b/tests/unit/validation/test_readme_subpackage_tree.py
@@ -1,15 +1,22 @@
-"""Guard: README and AGENTS.md directory trees must list every hephaestus/ subpackage.
+"""Guards for README root navigation and the AGENTS.md package inventory."""
 
-Prevents doc-vs-reality drift (issues #1188, #1449): scripts_lib/ was on disk
-but absent from the agent-contract tree while the doc still claimed 20 subpackages.
-"""
+from __future__ import annotations
 
+import re
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PACKAGE_DIR = REPO_ROOT / "hephaestus"
 README = REPO_ROOT / "README.md"
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
+
+NAVIGATION_HEADING = "## Repository navigation"
+NAVIGATION_EXCLUSIONS = {
+    "README.md": "The navigation index lives in README.md, so a self-link adds no value.",
+}
+LINK_TARGET_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+TREE_MARKER_RE = re.compile(r"^\s*(?:├──|└──|(?:\|--|`--|\+--)\s+\S)")
 
 
 def _real_subpackages() -> set[str]:
@@ -21,19 +28,78 @@ def _real_subpackages() -> set[str]:
     }
 
 
-def test_readme_tree_lists_every_subpackage() -> None:
-    """Every real subpackage must appear in the README directory tree block."""
-    readme = README.read_text(encoding="utf-8")
-    missing = sorted(
-        name
-        for name in _real_subpackages()
-        if f"├── {name}/" not in readme and f"└── {name}/" not in readme
+def _tracked_top_level_entries() -> set[str]:
+    """Return every top-level path represented by a tracked repository file."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
     )
-    assert not missing, f"README directory tree omits subpackage(s): {missing}"
+    return {
+        raw_path.decode("utf-8").split("/", 1)[0]
+        for raw_path in result.stdout.split(b"\0")
+        if raw_path
+    }
+
+
+def _navigation_section() -> str:
+    """Return the README repository-navigation section."""
+    readme = README.read_text(encoding="utf-8")
+    _, separator, remainder = readme.partition(f"{NAVIGATION_HEADING}\n")
+    assert separator, f"README is missing {NAVIGATION_HEADING!r}"
+    section, _, _ = remainder.partition("\n## ")
+    return section
+
+
+def _local_navigation_targets() -> list[str]:
+    """Return normalized local link targets from the navigation section."""
+    targets: list[str] = []
+    for raw_target in LINK_TARGET_RE.findall(_navigation_section()):
+        target = raw_target.strip().strip("<>").split("#", 1)[0].rstrip("/")
+        if target and not target.startswith("/") and "://" not in target:
+            targets.append(target.removeprefix("./"))
+    return targets
+
+
+def test_navigation_exclusion_policy_is_explicit() -> None:
+    """README itself is the only tracked root entry excluded from navigation."""
+    assert set(NAVIGATION_EXCLUSIONS) == {"README.md"}
+    assert all(reason.strip() for reason in NAVIGATION_EXCLUSIONS.values())
+
+
+def test_navigation_covers_every_tracked_top_level_entry() -> None:
+    """Every tracked root file or directory is linked regardless of extension."""
+    tracked = _tracked_top_level_entries()
+    exclusions = set(NAVIGATION_EXCLUSIONS)
+    assert exclusions <= tracked
+
+    linked = {target.split("/", 1)[0] for target in _local_navigation_targets()}
+    missing = sorted(tracked - exclusions - linked)
+    assert not missing, f"README repository navigation omits tracked root entries: {missing}"
+
+
+def test_navigation_links_resolve() -> None:
+    """Every local target in the repository-navigation section exists."""
+    missing = sorted(
+        target for target in _local_navigation_targets() if not (REPO_ROOT / target).exists()
+    )
+    assert not missing, f"README repository navigation has broken links: {missing}"
+
+
+def test_navigation_replaces_hand_maintained_directory_tree() -> None:
+    """README must not duplicate repository structure as a directory tree."""
+    readme = README.read_text(encoding="utf-8")
+    offenders = [
+        f"{line_number}: {line}"
+        for line_number, line in enumerate(readme.splitlines(), start=1)
+        if TREE_MARKER_RE.search(line)
+    ]
+    assert not offenders, f"README contains hand-maintained tree entries: {offenders}"
 
 
 def test_agents_md_tree_lists_every_subpackage() -> None:
-    """Every real subpackage must appear in the AGENTS.md directory tree block."""
+    """Every real subpackage must appear in the authoritative AGENTS.md tree."""
     agents_md = AGENTS_MD.read_text(encoding="utf-8")
     missing = sorted(
         name


### PR DESCRIPTION
## Summary
Implemented #2183.

- Replaced the stale README tree with exhaustive categorized root navigation.
- Added dynamic coverage, link-resolution, exclusion, and stale-tree regression guards.
- Preserved the AGENTS.md package inventory check.

Validation:

- Targeted tests: 5 passed
- Validation suite: 765 passed, 16 skipped
- Markdown lint, Ruff, and diff checks passed
- Full `tests/` run reached 1,195 passing tests before being interrupted due to runtime.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2183

Generated by Hephaestus automation
