### PR TITLE
fix(automation): materialize worktree tracking refs

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -725,9 +725,10 @@ def sync_worktree_to_remote_branch(
 
     This runs in two steps in ``cwd``:
 
-    1. ``git fetch <remote> <branch>`` — updates the remote-tracking ref so the
-       reset has a current target. If that branch ref is unavailable and
-       ``pr_number`` is supplied, fetch GitHub's ``refs/pull/N/head`` instead.
+    1. ``git fetch <remote> +refs/heads/<branch>:refs/remotes/<remote>/<branch>``
+       — materializes the remote-tracking ref so the reset has a current
+       target. If that branch ref is unavailable and ``pr_number`` is supplied,
+       fetch GitHub's ``refs/pull/N/head`` instead.
     2. ``git reset --hard <remote>/<branch>`` (or ``FETCH_HEAD`` for the pull
        ref fallback) moves HEAD to the PR's actual head.
 
@@ -749,8 +750,13 @@ def sync_worktree_to_remote_branch(
 
     """
     logger.info("Syncing worktree at %s to %s/%s before agent run", cwd, remote, branch)
+    tracking_ref = f"refs/remotes/{remote}/{branch}"
     try:
-        run(["git", "fetch", remote, branch], cwd=cwd, **_timeout_kw(timeout))
+        run(
+            ["git", "fetch", remote, f"+refs/heads/{branch}:{tracking_ref}"],
+            cwd=cwd,
+            **_timeout_kw(timeout),
+        )
     except subprocess.CalledProcessError as error:
         if pr_number is None or not _is_missing_remote_ref_error(error):
             raise

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -842,8 +842,8 @@ class TestPushCurrentBranchWithLeaseOnDivergence:
 class TestSyncWorktreeToRemoteBranch:
     """Tests for sync_worktree_to_remote_branch (#832 — reset before agent)."""
 
-    def test_fetches_then_resets_to_remote_head(self, git_utils_mocks: Any) -> None:
-        """Runs ``git fetch origin <branch>`` then ``git reset --hard origin/<branch>``."""
+    def test_materializes_tracking_ref_before_reset(self, git_utils_mocks: Any) -> None:
+        """Fetches into the reset target when no tracking ref exists yet."""
         git_utils_mocks.run.return_value = Mock(returncode=0)
         worktree = Path("/tmp/worktree-xyz")
 
@@ -851,7 +851,12 @@ class TestSyncWorktreeToRemoteBranch:
 
         assert git_utils_mocks.run.call_count == 2
         fetch_args, fetch_kwargs = git_utils_mocks.run.call_args_list[0]
-        assert fetch_args[0] == ["git", "fetch", "origin", "5450-auto-impl"]
+        assert fetch_args[0] == [
+            "git",
+            "fetch",
+            "origin",
+            "+refs/heads/5450-auto-impl:refs/remotes/origin/5450-auto-impl",
+        ]
         assert fetch_kwargs["cwd"] == worktree
         reset_args, reset_kwargs = git_utils_mocks.run.call_args_list[1]
         assert reset_args[0] == ["git", "reset", "--hard", "origin/5450-auto-impl"]


### PR DESCRIPTION
## Summary
- materialize the remote-tracking ref before resetting an automation worktree
- preserve the pull-request ref recovery path when the branch is unavailable
- cover the missing-tracking-ref regression

## Validation
- `uv run pytest tests/unit/automation/test_git_utils.py -q --no-cov`
- `uv run ruff check hephaestus/automation/git_utils.py tests/unit/automation/test_git_utils.py`
- `uv run ruff format --check hephaestus/automation/git_utils.py tests/unit/automation/test_git_utils.py`

Closes #2470