### PR TITLE
Worktree reuse binds multiple distinct issues to one branch/worktree (cross-issue overwrite)

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -93,7 +93,13 @@ from jinja2 import TemplateNotFound
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
-from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.jobs import (
+    WORKTREE_MATERIALIZED_KEY,
+    AgentJob,
+    GitJob,
+    JobHandle,
+    JobResult,
+)
 from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue, StageQueueLease
 from hephaestus.automation.pipeline.routing import (
     PIPELINE_ORDER,
@@ -2163,7 +2169,14 @@ class Coordinator:
         successful pipeline allocation.  It deliberately does not infer
         ownership from a conventional path such as ``issue-123``.
         """
-        if not isinstance(job, GitJob) or job.op != "create_worktree" or not result.ok:
+        materialized = (
+            isinstance(result.value, dict) and result.value.get(WORKTREE_MATERIALIZED_KEY) is True
+        )
+        if (
+            not isinstance(job, GitJob)
+            or job.op != "create_worktree"
+            or (not result.ok and not materialized)
+        ):
             return
         if item.stage is not StageName.IMPLEMENTATION or not item.branch or not item.worktree:
             return

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -118,6 +118,7 @@ from hephaestus.automation.pipeline.stages import (
     StageContext,
     StageGitHub,
 )
+from hephaestus.automation.pipeline.stages.base import BranchWorktreeOwnerStatus
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.stages.repo import (
     DIRECT_SCOPE_BASE_SHA_KEY,
@@ -690,9 +691,7 @@ class Coordinator:
                 now_fn=time.monotonic,
                 budget_fn=self._budget_for,
                 event_fn=self._record_stage_event,
-                branch_worktree_owner_is_pipeline_sibling=(
-                    self._is_pipeline_branch_worktree_sibling
-                ),
+                branch_worktree_owner_status=self._branch_worktree_owner_status,
             )
             if len(self._ctx_cache) >= self._ctx_cache_capacity:
                 self._ctx_cache.popitem(last=False)
@@ -2182,29 +2181,46 @@ class Coordinator:
             return
         self._pipeline_writer_worktrees[key] = item
 
-    def _is_pipeline_branch_worktree_sibling(
+    def _branch_worktree_owner_status(
         self, item: WorkItem, branch: str, owner_path: str
-    ) -> bool:
-        """Return whether *owner_path* is a verified live pipeline sibling.
+    ) -> BranchWorktreeOwnerStatus:
+        """Classify a branch holder as verified, pending, or unverified.
 
         A Git holder result by itself is not evidence of pipeline ownership.
         It becomes eligible for the documented first-writer-wins policy only
         when this run recorded the exact path after a successful writer
-        worktree job and that sibling is still live.  All absent, stale,
-        external, malformed, or cross-repository holders therefore route to a
-        terminal fail instead of silently dropping work.
+        worktree job and that sibling is still live. A matching in-flight
+        create-worktree job may have obtained the holder before its completion
+        is dequeued, so it is retried without consuming a work budget. All
+        absent, stale, external, malformed, or cross-repository holders route
+        to a terminal fail instead of silently dropping work.
         """
         if not branch or branch != item.branch or not owner_path:
-            return False
+            return "unverified"
         owner = self._pipeline_writer_worktrees.get((item.repo, branch))
-        return bool(
+        if (
             owner is not None
             and owner is not item
             and owner.result is None
             and owner.stage is not StageName.FINISHED
             and owner.branch == branch
             and owner.worktree == owner_path
-        )
+        ):
+            return "verified"
+        for handle, candidate in self.in_flight.items():
+            job = handle.job
+            if (
+                candidate is not item
+                and candidate.repo == item.repo
+                and candidate.branch == branch
+                and candidate.stage is StageName.IMPLEMENTATION
+                and isinstance(job, GitJob)
+                and job.op == "create_worktree"
+                and job.kwargs.get("branch_name") == branch
+                and not bool(job.kwargs.get("isolated", False))
+            ):
+                return "pending"
+        return "unverified"
 
     def _route_fail_back(self, item: WorkItem, outcome: StageOutcome, route: Route) -> None:
         """Apply the FAIL_BACK row: reason-keyed regression, globally capped.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -93,7 +93,7 @@ from jinja2 import TemplateNotFound
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
-from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobHandle, JobResult
 from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue, StageQueueLease
 from hephaestus.automation.pipeline.routing import (
     PIPELINE_ORDER,
@@ -537,6 +537,11 @@ class Coordinator:
         }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
+        # A holder path reported by Git becomes a safe supersession signal
+        # only after a successful create-worktree completion registered it
+        # here.  Paths discovered from Git alone can belong to a human or a
+        # different automation process and must fail closed.
+        self._pipeline_writer_worktrees: dict[tuple[str, str], WorkItem] = {}
         # Known implementation plans retain their repository-scoped file
         # claims for the lifetime of the submitted job.  Never reconstruct
         # this from mutable issue comments during later drain rounds (#2451).
@@ -685,6 +690,9 @@ class Coordinator:
                 now_fn=time.monotonic,
                 budget_fn=self._budget_for,
                 event_fn=self._record_stage_event,
+                branch_worktree_owner_is_pipeline_sibling=(
+                    self._is_pipeline_branch_worktree_sibling
+                ),
             )
             if len(self._ctx_cache) >= self._ctx_cache_capacity:
                 self._ctx_cache.popitem(last=False)
@@ -1358,6 +1366,7 @@ class Coordinator:
             )
             self._finish(item, passed=False, reason="poisoned: on_job_done raised")
             return
+        self._register_pipeline_writer_worktree(item, handle.job, result)
         item.state = (
             handle.on_done_state.value
             if isinstance(handle.on_done_state, StageName)
@@ -2142,6 +2151,61 @@ class Coordinator:
         else:
             self._timer_park(item, float(delay))
 
+    def _register_pipeline_writer_worktree(
+        self,
+        item: WorkItem,
+        job: object,
+        result: JobResult,
+    ) -> None:
+        """Register a successful implementation writer worktree.
+
+        The registry is coordinator-owned evidence: a future collision may
+        supersede only when its holder path exactly matches this live,
+        successful pipeline allocation.  It deliberately does not infer
+        ownership from a conventional path such as ``issue-123``.
+        """
+        if not isinstance(job, GitJob) or job.op != "create_worktree" or not result.ok:
+            return
+        if item.stage is not StageName.IMPLEMENTATION or not item.branch or not item.worktree:
+            return
+        expected_branch = job.kwargs.get("branch_name")
+        if expected_branch != item.branch or bool(job.kwargs.get("isolated", False)):
+            return
+        key = (item.repo, item.branch)
+        existing = self._pipeline_writer_worktrees.get(key)
+        if existing is not None and existing is not item and existing.result is None:
+            logger.error(
+                "coordinator: refusing to replace live writer registration for %s at %s",
+                item.repo,
+                item.branch,
+            )
+            return
+        self._pipeline_writer_worktrees[key] = item
+
+    def _is_pipeline_branch_worktree_sibling(
+        self, item: WorkItem, branch: str, owner_path: str
+    ) -> bool:
+        """Return whether *owner_path* is a verified live pipeline sibling.
+
+        A Git holder result by itself is not evidence of pipeline ownership.
+        It becomes eligible for the documented first-writer-wins policy only
+        when this run recorded the exact path after a successful writer
+        worktree job and that sibling is still live.  All absent, stale,
+        external, malformed, or cross-repository holders therefore route to a
+        terminal fail instead of silently dropping work.
+        """
+        if not branch or branch != item.branch or not owner_path:
+            return False
+        owner = self._pipeline_writer_worktrees.get((item.repo, branch))
+        return bool(
+            owner is not None
+            and owner is not item
+            and owner.result is None
+            and owner.stage is not StageName.FINISHED
+            and owner.branch == branch
+            and owner.worktree == owner_path
+        )
+
     def _route_fail_back(self, item: WorkItem, outcome: StageOutcome, route: Route) -> None:
         """Apply the FAIL_BACK row: reason-keyed regression, globally capped.
 
@@ -2171,6 +2235,9 @@ class Coordinator:
 
     def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
         """Set the item's result and hand it to the finished sink."""
+        writer_key = (item.repo, item.branch)
+        if self._pipeline_writer_worktrees.get(writer_key) is item:
+            self._pipeline_writer_worktrees.pop(writer_key, None)
         if item.stage is StageName.REPO and item.payload.get(DIRECT_SCOPE_BOOTSTRAP_KEY, False):
             self._direct_scope_bootstrap_pending = False
         if item.stage is StageName.FINISHED:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -2217,7 +2217,8 @@ class Coordinator:
             and owner.result is None
             and owner.stage is not StageName.FINISHED
             and owner.branch == branch
-            and owner.worktree == owner_path
+            and owner.worktree
+            and Path(owner.worktree).resolve() == Path(owner_path).resolve()
         ):
             return "verified"
         for handle, candidate in self.in_flight.items():

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -30,6 +30,12 @@ GIT_OPS: frozenset[str] = frozenset(
     }
 )
 
+#: Structured failed ``create_worktree`` results set this only after a
+#: checkout was created but a later adopted-branch preparation step failed.
+#: The coordinator retains that physical checkout as first-writer evidence
+#: while its transient retry is pending.
+WORKTREE_MATERIALIZED_KEY = "worktree_materialized"
+
 
 @dataclass(frozen=True)
 class AgentJob:

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -507,6 +507,12 @@ class StageContext:
     now_fn: Callable[[], float] | None = None  # injectable clock (tests pass a fake)
     budget_fn: Callable[[str], int] | None = None  # injected overrides; falls back to ROUTES
     event_fn: Callable[[StageEvent], None] | None = None
+    # A worktree-holder result is only a diagnostic fact from Git.  The
+    # coordinator proves that it belongs to a live pipeline sibling before
+    # implementation can treat a collision as redundant work.  Leaving this
+    # unset intentionally fails closed in isolated stage tests and alternate
+    # hosts.
+    branch_worktree_owner_is_pipeline_sibling: Callable[[WorkItem, str, str], bool] | None = None
 
     def now(self) -> float:
         """Return the injected stage clock value (monotonic in the coordinator)."""

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -54,7 +54,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from hephaestus.agents.runtime import DEFAULT_AGENT
 from hephaestus.automation.review_journal import IssueComment
@@ -480,6 +480,7 @@ class JobRequest:
 
 
 StepResult: TypeAlias = "Continue | JobRequest | StageOutcome"
+BranchWorktreeOwnerStatus: TypeAlias = Literal["verified", "pending", "unverified"]
 
 
 @dataclass(frozen=True)
@@ -512,7 +513,9 @@ class StageContext:
     # implementation can treat a collision as redundant work.  Leaving this
     # unset intentionally fails closed in isolated stage tests and alternate
     # hosts.
-    branch_worktree_owner_is_pipeline_sibling: Callable[[WorkItem, str, str], bool] | None = None
+    branch_worktree_owner_status: (
+        Callable[[WorkItem, str, str], BranchWorktreeOwnerStatus] | None
+    ) = None
 
     def now(self) -> float:
         """Return the injected stage clock value (monotonic in the coordinator)."""

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -341,18 +341,26 @@ class ImplementationStage(Stage):
     def _dirty_decision_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """DIRTY_DECISION_WAIT routes either to retry or to the dirty-decision job."""
         issue = _issue_number(item)
-        if ownership := item.payload.pop("branch_worktree_owner", None):
+        if (ownership := item.payload.get("branch_worktree_owner")) is not None:
             branch = ownership.get("branch") if isinstance(ownership, dict) else None
             owner_path = ownership.get("owner_path") if isinstance(ownership, dict) else None
-            is_pipeline_sibling = (
+            owner_status = "unverified"
+            if (
                 isinstance(branch, str)
                 and branch == item.branch
                 and isinstance(owner_path, str)
                 and bool(owner_path)
-                and ctx.branch_worktree_owner_is_pipeline_sibling is not None
-                and ctx.branch_worktree_owner_is_pipeline_sibling(item, branch, owner_path)
-            )
-            if not is_pipeline_sibling:
+                and ctx.branch_worktree_owner_status is not None
+            ):
+                owner_status = ctx.branch_worktree_owner_status(item, branch, owner_path)
+            if owner_status == "pending":
+                # A same-branch pipeline allocation already observed the
+                # holder but its success/failure completion has not reached
+                # the coordinator. Keep the collision receipt intact and
+                # retry after that completion; no Git/agent budget is spent.
+                return StageOutcome(Disposition.RETRY, "branch_worktree_owner_pending")
+            item.payload.pop("branch_worktree_owner", None)
+            if owner_status != "verified":
                 logger.warning(
                     "implementation:%d: branch-worktree holder for %r at %r is not a "
                     "verified pipeline sibling; refusing to supersede",

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -95,6 +95,7 @@ from hephaestus.automation.state_labels import (
 from hephaestus.automation.worktree_manager import BRANCH_WORKTREE_OWNED
 from hephaestus.prompts import PromptCatalog
 
+from ..jobs import WORKTREE_MATERIALIZED_KEY
 from .base import (
     GIT_JOB_TIMEOUT_S,
     AgentJob,
@@ -167,6 +168,10 @@ def _issue_number(item: WorkItem) -> int:
 #: failures never burn the implement budget, but a persistently broken
 #: remote must still terminate. Reset on any successful git job.
 GIT_ERROR_RETRY_CAP = 2
+
+#: A pending shared-branch holder waits for the in-flight creator's completion
+#: instead of re-entering the implementation drain in a tight loop.
+BRANCH_WORKTREE_OWNER_PENDING_DELAY_S = 0.1
 
 #: Timeout for the optional pre-PR test run (mirrors the legacy
 #: ``_pr_create_phase`` bound; the budget that matters — ``test_fix`` —
@@ -357,7 +362,9 @@ class ImplementationStage(Stage):
                 # A same-branch pipeline allocation already observed the
                 # holder but its success/failure completion has not reached
                 # the coordinator. Keep the collision receipt intact and
-                # retry after that completion; no Git/agent budget is spent.
+                # timer-park until that completion; no Git/agent budget is
+                # spent and the queue cannot busy-spin while it is pending.
+                item.payload["retry_delay_s"] = BRANCH_WORKTREE_OWNER_PENDING_DELAY_S
                 return StageOutcome(Disposition.RETRY, "branch_worktree_owner_pending")
             item.payload.pop("branch_worktree_owner", None)
             if owner_status != "verified":
@@ -689,6 +696,17 @@ class ImplementationStage(Stage):
                 }
                 item.worktree = ""
                 return
+            materialized_path = (
+                result.value.get("path")
+                if isinstance(result.value, dict)
+                and result.value.get(WORKTREE_MATERIALIZED_KEY) is True
+                else None
+            )
+            if isinstance(materialized_path, str) and materialized_path:
+                item.worktree = materialized_path
+                item.payload[WORKTREE_MATERIALIZED_KEY] = True
+            else:
+                item.worktree = ""
             direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
             reservation = (
                 result.value.get("direct_scope_reservation")
@@ -709,13 +727,13 @@ class ImplementationStage(Stage):
                     "branch": item.branch,
                     "base_sha": direct_base_sha,
                 }
-            item.worktree = ""
             item.payload.pop("worktree_dirty", None)
             item.payload.pop("worktree_status", None)
             item.payload.pop("worktree_diff", None)
             item.payload["git_error"] = True
             return
         # A successful worktree job ends the consecutive-git-failure streak.
+        item.payload.pop(WORKTREE_MATERIALIZED_KEY, None)
         item.payload.pop("git_error_retries", None)
         value = result.value
         if isinstance(value, dict):

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -92,6 +92,7 @@ from hephaestus.automation.state_labels import (
     is_plan_go,
     is_skipped,
 )
+from hephaestus.automation.worktree_manager import BRANCH_WORKTREE_OWNED
 from hephaestus.prompts import PromptCatalog
 
 from .base import (
@@ -340,6 +341,14 @@ class ImplementationStage(Stage):
     def _dirty_decision_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """DIRTY_DECISION_WAIT routes either to retry or to the dirty-decision job."""
         issue = _issue_number(item)
+        if ownership := item.payload.pop("branch_worktree_owner", None):
+            branch = str(ownership.get("branch") or item.branch)
+            owner_path = str(ownership.get("owner_path") or "")
+            return StageOutcome(
+                Disposition.FINISH_PASS,
+                f"branch {branch!r} already owned at {owner_path}; "
+                "redundant implementation superseded",
+            )
         if item.payload.pop("git_error", None):
             # Worktree creation failed: transient infrastructure, not an
             # implement outcome. If the retry budget remains, retry the
@@ -647,6 +656,14 @@ class ImplementationStage(Stage):
         """
         if not result.ok:
             logger.warning("implementation:%s: worktree job failed: %s", item.issue, result.error)
+            if result.error == BRANCH_WORKTREE_OWNED:
+                ownership = result.value if isinstance(result.value, dict) else {}
+                item.payload["branch_worktree_owner"] = {
+                    "branch": str(ownership.get("branch") or item.branch),
+                    "owner_path": str(ownership.get("owner_path") or ""),
+                }
+                item.worktree = ""
+                return
             direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
             reservation = (
                 result.value.get("direct_scope_reservation")

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -342,8 +342,25 @@ class ImplementationStage(Stage):
         """DIRTY_DECISION_WAIT routes either to retry or to the dirty-decision job."""
         issue = _issue_number(item)
         if ownership := item.payload.pop("branch_worktree_owner", None):
-            branch = str(ownership.get("branch") or item.branch)
-            owner_path = str(ownership.get("owner_path") or "")
+            branch = ownership.get("branch") if isinstance(ownership, dict) else None
+            owner_path = ownership.get("owner_path") if isinstance(ownership, dict) else None
+            is_pipeline_sibling = (
+                isinstance(branch, str)
+                and branch == item.branch
+                and isinstance(owner_path, str)
+                and bool(owner_path)
+                and ctx.branch_worktree_owner_is_pipeline_sibling is not None
+                and ctx.branch_worktree_owner_is_pipeline_sibling(item, branch, owner_path)
+            )
+            if not is_pipeline_sibling:
+                logger.warning(
+                    "implementation:%d: branch-worktree holder for %r at %r is not a "
+                    "verified pipeline sibling; refusing to supersede",
+                    issue,
+                    branch,
+                    owner_path,
+                )
+                return StageOutcome(Disposition.FINISH_FAIL, "branch_worktree_owner_unverified")
             return StageOutcome(
                 Disposition.FINISH_PASS,
                 f"branch {branch!r} already owned at {owner_path}; "
@@ -659,8 +676,8 @@ class ImplementationStage(Stage):
             if result.error == BRANCH_WORKTREE_OWNED:
                 ownership = result.value if isinstance(result.value, dict) else {}
                 item.payload["branch_worktree_owner"] = {
-                    "branch": str(ownership.get("branch") or item.branch),
-                    "owner_path": str(ownership.get("owner_path") or ""),
+                    "branch": ownership.get("branch"),
+                    "owner_path": ownership.get("owner_path"),
                 }
                 item.worktree = ""
                 return

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -28,6 +28,7 @@ from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
 from hephaestus.automation.learn import compact_agent_session
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
+    WORKTREE_MATERIALIZED_KEY,
     AgentJob,
     BuildTestJob,
     CompactJob,
@@ -1288,32 +1289,39 @@ class WorkerPool:
         if pr_number is not None and not isinstance(pr_number, (int, str)):
             return JobResult(ok=False, error="worktree sync received an invalid PR number")
 
-        dirty = not git_utils.is_clean_working_tree(worktree_path, timeout=timeout_s)
-        status = ""
-        diff = ""
-        if dirty:
-            status_result = git_utils.run(
-                ["git", "status", "--short"],
-                cwd=worktree_path,
-                capture_output=True,
-                check=False,
-                timeout=timeout_s,
-            )
-            diff_result = git_utils.run(
-                ["git", "diff"],
-                cwd=worktree_path,
-                capture_output=True,
-                check=False,
-                timeout=timeout_s,
-            )
-            status = status_result.stdout or ""
-            diff = diff_result.stdout or ""
-        elif branch_name:
-            git_utils.sync_worktree_to_remote_branch(
-                worktree_path,
-                branch_name,
-                pr_number=int(pr_number) if isinstance(pr_number, (int, str)) else None,
-                timeout=timeout_s,
+        try:
+            dirty = not git_utils.is_clean_working_tree(worktree_path, timeout=timeout_s)
+            status = ""
+            diff = ""
+            if dirty:
+                status_result = git_utils.run(
+                    ["git", "status", "--short"],
+                    cwd=worktree_path,
+                    capture_output=True,
+                    check=False,
+                    timeout=timeout_s,
+                )
+                diff_result = git_utils.run(
+                    ["git", "diff"],
+                    cwd=worktree_path,
+                    capture_output=True,
+                    check=False,
+                    timeout=timeout_s,
+                )
+                status = status_result.stdout or ""
+                diff = diff_result.stdout or ""
+            elif branch_name:
+                git_utils.sync_worktree_to_remote_branch(
+                    worktree_path,
+                    branch_name,
+                    pr_number=int(pr_number) if isinstance(pr_number, (int, str)) else None,
+                    timeout=timeout_s,
+                )
+        except Exception as exc:
+            return JobResult(
+                ok=False,
+                error=f"worktree post-create preparation failed: {exc}",
+                value={"path": str(worktree_path), WORKTREE_MATERIALIZED_KEY: True},
             )
         return JobResult(
             ok=True,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -42,7 +42,11 @@ from hephaestus.automation.pipeline.tool_scopes import (
     ToolScope,
     tool_scope_for,
 )
-from hephaestus.automation.worktree_manager import WorktreeManager
+from hephaestus.automation.worktree_manager import (
+    BRANCH_WORKTREE_OWNED,
+    BranchWorktreeOwnedError,
+    WorktreeManager,
+)
 from hephaestus.resilience import (
     CircuitBreakerOpenError,
     resilient_call,
@@ -766,6 +770,12 @@ class WorkerPool:
                 ok=False,
                 interrupted=True,
                 error="interrupted_waiting_for_git_lock",
+            )
+        except BranchWorktreeOwnedError as exc:
+            return JobResult(
+                ok=False,
+                error=BRANCH_WORKTREE_OWNED,
+                value={"branch": exc.branch, "owner_path": str(exc.owner_path)},
             )
         except subprocess.TimeoutExpired as exc:
             return JobResult(

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -384,7 +384,7 @@ class WorktreeManager:
             return self.worktrees[worktree_key]
         existing = None if isolated else self._worktree_holding_branch(branch_name, timeout=timeout)
         if existing is not None:
-            if existing == worktree_path:
+            if existing.resolve() == worktree_path.resolve():
                 self.worktrees[worktree_key] = existing
                 return existing
             raise BranchWorktreeOwnedError(branch_name, existing)

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -80,6 +80,19 @@ class WorktreeDirtyError(Exception):
         super().__init__(f"Worktree for issue #{issue_number} at {path} has uncommitted changes")
 
 
+BRANCH_WORKTREE_OWNED = "branch_worktree_owned"
+
+
+class BranchWorktreeOwnedError(RuntimeError):
+    """A different issue already owns the requested writer branch."""
+
+    def __init__(self, branch: str, owner_path: Path) -> None:
+        """Initialize the error with the branch and owning worktree."""
+        self.branch = branch
+        self.owner_path = owner_path
+        super().__init__(f"{branch!r} is already checked out at {owner_path}")
+
+
 class WorktreeManager:
     """Thread-safe manager for git worktrees.
 
@@ -297,21 +310,24 @@ class WorktreeManager:
                 raise RuntimeError("direct scope base pin invalid")
             if base_sha is None and remote_branch_reserved:
                 raise RuntimeError("direct scope reservation requires a base pin")
-            if base_sha is None and (
-                existing := self._reuse_or_clear_normal_worktree(
-                    issue_number=issue_number,
-                    worktree_key=worktree_key,
-                    worktree_path=worktree_path,
-                    branch_name=branch_name,
-                    isolated=isolated,
-                    refresh_base=refresh_base,
-                    timeout=timeout,
-                )
-            ):
-                return existing
-
+            if base_sha is None and refresh_base:
+                # Refresh acquires the same metadata lock; complete it before
+                # entering the lock that serializes holder detection and add.
+                self.refresh_base_branch(timeout=timeout)
             try:
                 with file_lock(self._git_metadata_lock_path()):
+                    if base_sha is None and (
+                        existing := self._reuse_or_clear_normal_worktree(
+                            issue_number=issue_number,
+                            worktree_key=worktree_key,
+                            worktree_path=worktree_path,
+                            branch_name=branch_name,
+                            isolated=isolated,
+                            refresh_base=refresh_base,
+                            timeout=timeout,
+                        )
+                    ):
+                        return existing
                     self._validate_direct_scope_worktree_request(
                         base_sha=base_sha,
                         remote_branch_reserved=remote_branch_reserved,
@@ -346,6 +362,8 @@ class WorktreeManager:
                 logger.info("Created worktree for issue #%s at %s", issue_number, worktree_path)
                 return worktree_path
 
+            except BranchWorktreeOwnedError:
+                raise
             except Exception as e:
                 raise RuntimeError(f"Failed to create worktree: {e}") from e
 
@@ -364,18 +382,12 @@ class WorktreeManager:
         if worktree_key in self.worktrees:
             logger.warning("Worktree for issue #%s already exists", issue_number)
             return self.worktrees[worktree_key]
-        if refresh_base:
-            self.refresh_base_branch(timeout=timeout)
         existing = None if isolated else self._worktree_holding_branch(branch_name, timeout=timeout)
-        if existing is not None and existing != worktree_path:
-            logger.info(
-                "Branch %s already checked out at %s — reusing that worktree for issue #%s",
-                branch_name,
-                existing,
-                issue_number,
-            )
-            self.worktrees[worktree_key] = existing
-            return existing
+        if existing is not None:
+            if existing == worktree_path:
+                self.worktrees[worktree_key] = existing
+                return existing
+            raise BranchWorktreeOwnedError(branch_name, existing)
         if self._reuse_existing_dirty_worktree(
             issue_number,
             worktree_key,
@@ -883,10 +895,9 @@ class WorktreeManager:
 
             worktree_path = self.worktrees[issue_number]
 
-            # Idempotent removal: when several issues share one branch they alias
-            # the same path (see create_worktree's branch-reuse), so cleanup_all
-            # may reach this with the directory already gone after the first key
-            # removed it. Treat an absent directory as already-removed rather than
+            # Idempotent removal: a legacy/stale registration may point at a
+            # directory already removed while recovering an interrupted run.
+            # Treat an absent directory as already-removed rather than
             # raising [Errno 2] — drop the key and prune stale git metadata (#1532).
             if not worktree_path.exists():
                 logger.info(
@@ -956,11 +967,10 @@ class WorktreeManager:
         with self.lock:
             issue_numbers = list(self.worktrees.keys())
 
-        # Several issues can alias the same path when they share a branch (see
-        # create_worktree's branch-reuse). Remove each distinct directory once;
-        # for aliased keys whose path was already removed, just drop the stale
-        # registration instead of re-running `git worktree remove` on a gone dir
-        # (which logged "[Errno 2]" failures before #1532).
+        # Remove each distinct directory once. A legacy/stale registration may
+        # point at a path already removed by an interrupted run; drop that
+        # registration instead of re-running `git worktree remove` on a gone
+        # directory (which logged "[Errno 2]" failures before #1532).
         removed_paths: set[Path] = set()
         for issue_num in issue_numbers:
             with self.lock:
@@ -969,7 +979,7 @@ class WorktreeManager:
                 with self.lock:
                     self.worktrees.pop(issue_num, None)
                 logger.debug(
-                    "Issue #%s aliases already-removed worktree %s; dropping registration",
+                    "Issue #%s references already-removed worktree %s; dropping registration",
                     issue_num,
                     path,
                 )

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -578,6 +578,8 @@ def make_ctx() -> Callable[..., StageContext]:
         now_fn: Callable[[], float] | None = None,
         budget_fn: Callable[[str], int] | None = None,
         event_fn: Callable[[StageEvent], None] | None = None,
+        branch_worktree_owner_is_pipeline_sibling: Callable[[WorkItem, str, str], bool]
+        | None = None,
     ) -> StageContext:
         ticks = [0]
 
@@ -594,6 +596,7 @@ def make_ctx() -> Callable[..., StageContext]:
             now_fn=now_fn if now_fn is not None else default_now_fn,
             budget_fn=budget_fn if budget_fn is not None else _budget_fn,
             event_fn=event_fn,
+            branch_worktree_owner_is_pipeline_sibling=branch_worktree_owner_is_pipeline_sibling,
         )
 
     return _make_ctx

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -578,8 +578,7 @@ def make_ctx() -> Callable[..., StageContext]:
         now_fn: Callable[[], float] | None = None,
         budget_fn: Callable[[str], int] | None = None,
         event_fn: Callable[[StageEvent], None] | None = None,
-        branch_worktree_owner_is_pipeline_sibling: Callable[[WorkItem, str, str], bool]
-        | None = None,
+        branch_worktree_owner_status: Callable[[WorkItem, str, str], str] | None = None,
     ) -> StageContext:
         ticks = [0]
 
@@ -596,7 +595,7 @@ def make_ctx() -> Callable[..., StageContext]:
             now_fn=now_fn if now_fn is not None else default_now_fn,
             budget_fn=budget_fn if budget_fn is not None else _budget_fn,
             event_fn=event_fn,
-            branch_worktree_owner_is_pipeline_sibling=branch_worktree_owner_is_pipeline_sibling,
+            branch_worktree_owner_status=branch_worktree_owner_status,
         )
 
     return _make_ctx

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -23,6 +23,7 @@ from hephaestus.automation.pipeline.stages import (
     StageContext,
     StageGitHub,
 )
+from hephaestus.automation.pipeline.stages.base import BranchWorktreeOwnerStatus
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from hephaestus.automation.protocol import (
@@ -578,7 +579,9 @@ def make_ctx() -> Callable[..., StageContext]:
         now_fn: Callable[[], float] | None = None,
         budget_fn: Callable[[str], int] | None = None,
         event_fn: Callable[[StageEvent], None] | None = None,
-        branch_worktree_owner_status: Callable[[WorkItem, str, str], str] | None = None,
+        branch_worktree_owner_status: (
+            Callable[[WorkItem, str, str], BranchWorktreeOwnerStatus] | None
+        ) = None,
     ) -> StageContext:
         ticks = [0]
 

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -30,6 +30,7 @@ from hephaestus.automation.state_labels import (
     STATE_PLAN_NO_GO,
     STATE_SKIP,
 )
+from hephaestus.automation.worktree_manager import BRANCH_WORKTREE_OWNED
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -623,6 +624,36 @@ class TestAgentErrorPingPongBound:
 
 class TestGitErrorRetryCap:
     """M5: transient git RETRYs are bounded by GIT_ERROR_RETRY_CAP."""
+
+    def test_branch_worktree_owner_supersedes_without_retry(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A second issue finishes without retrying or starting implementation."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=2269, state="WORKTREE_WAIT")
+        item.branch = "shared-head"
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error=BRANCH_WORKTREE_OWNED,
+                value={
+                    "branch": "shared-head",
+                    "owner_path": "/repo/build/.worktrees/issue-2268",
+                },
+            ),
+            make_ctx(),
+        )
+        item.state = "DIRTY_DECISION_WAIT"
+        outcome = stage.step(item, make_ctx())
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition is Disposition.FINISH_PASS
+        assert "superseded" in outcome.note
+        assert item.worktree == ""
+        assert item.attempts["implement"] == 0
+        assert "git_error_retries" not in item.payload
 
     def test_worktree_failures_retry_to_the_cap_then_fail(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -646,7 +646,10 @@ class TestGitErrorRetryCap:
             make_ctx(),
         )
         item.state = "DIRTY_DECISION_WAIT"
-        outcome = stage.step(item, make_ctx())
+        outcome = stage.step(
+            item,
+            make_ctx(branch_worktree_owner_is_pipeline_sibling=lambda _item, _branch, _path: True),
+        )
 
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition is Disposition.FINISH_PASS
@@ -654,6 +657,39 @@ class TestGitErrorRetryCap:
         assert item.worktree == ""
         assert item.attempts["implement"] == 0
         assert "git_error_retries" not in item.payload
+
+    def test_external_branch_worktree_holder_fails_closed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Git holder data without coordinator ownership proof cannot supersede work."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=2269, state="WORKTREE_WAIT")
+        item.branch = "shared-head"
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error=BRANCH_WORKTREE_OWNED,
+                value={
+                    "branch": "shared-head",
+                    "owner_path": "/external/manual-worktree",
+                },
+            ),
+            make_ctx(),
+        )
+        item.state = "DIRTY_DECISION_WAIT"
+
+        outcome = stage.step(
+            item,
+            make_ctx(branch_worktree_owner_is_pipeline_sibling=lambda _item, _branch, _path: False),
+        )
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition is Disposition.FINISH_FAIL
+        assert outcome.note == "branch_worktree_owner_unverified"
+        assert item.worktree == ""
+        assert item.attempts["implement"] == 0
 
     def test_worktree_failures_retry_to_the_cap_then_fail(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -648,7 +648,7 @@ class TestGitErrorRetryCap:
         item.state = "DIRTY_DECISION_WAIT"
         outcome = stage.step(
             item,
-            make_ctx(branch_worktree_owner_is_pipeline_sibling=lambda _item, _branch, _path: True),
+            make_ctx(branch_worktree_owner_status=lambda _item, _branch, _path: "verified"),
         )
 
         assert isinstance(outcome, StageOutcome)
@@ -682,7 +682,7 @@ class TestGitErrorRetryCap:
 
         outcome = stage.step(
             item,
-            make_ctx(branch_worktree_owner_is_pipeline_sibling=lambda _item, _branch, _path: False),
+            make_ctx(branch_worktree_owner_status=lambda _item, _branch, _path: "unverified"),
         )
 
         assert isinstance(outcome, StageOutcome)
@@ -690,6 +690,42 @@ class TestGitErrorRetryCap:
         assert outcome.note == "branch_worktree_owner_unverified"
         assert item.worktree == ""
         assert item.attempts["implement"] == 0
+
+    def test_pending_branch_worktree_owner_retries_without_losing_the_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A collision waits for the candidate owner completion without spending budget."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=2269, state="WORKTREE_WAIT")
+        item.branch = "shared-head"
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error=BRANCH_WORKTREE_OWNED,
+                value={
+                    "branch": "shared-head",
+                    "owner_path": "/repo/build/.worktrees/issue-2268",
+                },
+            ),
+            make_ctx(),
+        )
+        item.state = "DIRTY_DECISION_WAIT"
+
+        outcome = stage.step(
+            item,
+            make_ctx(branch_worktree_owner_status=lambda _item, _branch, _path: "pending"),
+        )
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition is Disposition.RETRY
+        assert outcome.note == "branch_worktree_owner_pending"
+        assert item.payload["branch_worktree_owner"] == {
+            "branch": "shared-head",
+            "owner_path": "/repo/build/.worktrees/issue-2268",
+        }
+        assert item.attempts["implement"] == 0
+        assert "git_error_retries" not in item.payload
 
     def test_worktree_failures_retry_to_the_cap_then_fail(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -17,6 +17,7 @@ from hephaestus.automation.pipeline.stages import (
     implementation as implementation_module,
 )
 from hephaestus.automation.pipeline.stages.implementation import (
+    BRANCH_WORKTREE_OWNER_PENDING_DELAY_S,
     GIT_ERROR_RETRY_CAP,
     PRE_PR_TEST_ARGV,
     ImplementationStage,
@@ -720,6 +721,7 @@ class TestGitErrorRetryCap:
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition is Disposition.RETRY
         assert outcome.note == "branch_worktree_owner_pending"
+        assert item.payload["retry_delay_s"] == BRANCH_WORKTREE_OWNER_PENDING_DELAY_S
         assert item.payload["branch_worktree_owner"] == {
             "branch": "shared-head",
             "owner_path": "/repo/build/.worktrees/issue-2268",

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1048,6 +1048,37 @@ class TestFailBackRouting:
 class TestImplementationAdmission:
     """Topological order + file-overlap reuse for the implementation queue."""
 
+    def test_relative_writer_path_matches_an_absolute_git_holder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relative configured worktree still verifies Git's absolute holder path."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        monkeypatch.chdir(tmp_path)
+        shared_branch = "shared-head"
+        owner_path = tmp_path / "repo-a" / "build" / ".worktrees" / "issue-2268"
+        owner_path.mkdir(parents=True)
+        owner = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2268,
+            stage=StageName.IMPLEMENTATION,
+            branch=shared_branch,
+            worktree="repo-a/build/.worktrees/issue-2268",
+        )
+        sibling = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2269,
+            stage=StageName.IMPLEMENTATION,
+            branch=shared_branch,
+        )
+        coordinator._pipeline_writer_worktrees[("repo-a", shared_branch)] = owner
+
+        assert (
+            coordinator._branch_worktree_owner_status(sibling, shared_branch, str(owner_path))
+            == "verified"
+        )
+
     @pytest.mark.parametrize(
         ("owner_pr", "sibling_pr"),
         [(3001, 3002), (3001, 3001)],

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -25,7 +25,13 @@ from hephaestus.automation.pipeline.coordinator import (
     Coordinator,
     PipelineConfig,
 )
-from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.jobs import (
+    WORKTREE_MATERIALIZED_KEY,
+    AgentJob,
+    GitJob,
+    JobHandle,
+    JobResult,
+)
 from hephaestus.automation.pipeline.routing import (
     Disposition,
     PipelineScope,
@@ -1124,7 +1130,11 @@ class TestImplementationAdmission:
             "branch": shared_branch,
             "owner_path": str(owner_path),
         }
-        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [sibling]
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
+        assert len(coordinator.timers) == 1
+        coordinator._drain_implementation()
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
+        assert len(coordinator.timers) == 1
         assert sibling.attempts["implement"] == 0
         assert "git_error_retries" not in sibling.payload
 
@@ -1138,6 +1148,9 @@ class TestImplementationAdmission:
                 value={"path": str(owner_path), "dirty": False, "status": "", "diff": ""},
             ),
         )
+        _deadline, sequence, parked_item = coordinator.timers[0]
+        coordinator.timers[0] = (0.0, sequence, parked_item)
+        coordinator._wake_timers()
         claimed = coordinator._claim_item(StageName.IMPLEMENTATION)
         assert claimed is sibling
         coordinator._run_item(sibling)
@@ -1281,6 +1294,9 @@ class TestImplementationAdmission:
         coordinator._handle_completion(owner_handle, JobResult(ok=False, error="disk full"))
 
         assert coordinator._pipeline_writer_worktrees == {}
+        _deadline, sequence, parked_item = coordinator.timers[0]
+        coordinator.timers[0] = (0.0, sequence, parked_item)
+        coordinator._wake_timers()
         claimed = coordinator._claim_item(StageName.IMPLEMENTATION, index=1)
         assert claimed is sibling
         coordinator._run_item(sibling)
@@ -1289,6 +1305,95 @@ class TestImplementationAdmission:
         assert sibling.result.reason == "branch_worktree_owner_unverified"
         assert sibling.worktree == ""
         assert coordinator.queues[StageName.FINISHED].snapshot() == [sibling]
+
+    def test_materialized_owner_sync_failure_remains_the_verified_writer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A post-create sync retry cannot make a sibling fail as unverified."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            max_workers=2,
+            serialize_file_overlap=False,
+        )
+        shared_branch = "shared-head"
+        owner_path = tmp_path / "repo-a" / "build" / ".worktrees" / "issue-2268"
+        owner_path.mkdir(parents=True)
+        owner = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2268,
+            pr=3001,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch=shared_branch,
+            payload={"existing_pr": True},
+        )
+        sibling = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2269,
+            pr=3002,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch=shared_branch,
+            payload={"existing_pr": True},
+        )
+        coordinator._push_item(owner, StageName.IMPLEMENTATION, enter=False)
+        coordinator._push_item(sibling, StageName.IMPLEMENTATION, enter=False)
+        assert coordinator._claim_item(StageName.IMPLEMENTATION) is owner
+        assert coordinator._claim_item(StageName.IMPLEMENTATION) is sibling
+        owner_handle = JobHandle(
+            job=GitJob(
+                repo="repo-a",
+                op="create_worktree",
+                timeout_s=60,
+                kwargs={"issue_number": 2268, "branch_name": shared_branch},
+            ),
+            on_done_state="DIRTY_DECISION_WAIT",
+        )
+        sibling_handle = JobHandle(
+            job=GitJob(
+                repo="repo-a",
+                op="create_worktree",
+                timeout_s=60,
+                kwargs={"issue_number": 2269, "branch_name": shared_branch},
+            ),
+            on_done_state="DIRTY_DECISION_WAIT",
+        )
+        coordinator.in_flight[owner_handle] = owner
+        coordinator.in_flight[sibling_handle] = sibling
+        coordinator.inflight_per_repo["repo-a"] = 2
+
+        coordinator._handle_completion(
+            sibling_handle,
+            JobResult(
+                ok=False,
+                error="branch_worktree_owned",
+                value={"branch": shared_branch, "owner_path": str(owner_path)},
+            ),
+        )
+        coordinator._handle_completion(
+            owner_handle,
+            JobResult(
+                ok=False,
+                error="worktree post-create preparation failed: sync timeout",
+                value={"path": str(owner_path), WORKTREE_MATERIALIZED_KEY: True},
+            ),
+        )
+
+        assert owner.worktree == str(owner_path)
+        assert coordinator._pipeline_writer_worktrees[("repo-a", shared_branch)] is owner
+        _deadline, sequence, parked_item = coordinator.timers[0]
+        coordinator.timers[0] = (0.0, sequence, parked_item)
+        coordinator._wake_timers()
+        claimed = coordinator._claim_item(StageName.IMPLEMENTATION, index=1)
+        assert claimed is sibling
+        coordinator._run_item(sibling)
+
+        assert sibling.result is not None and sibling.result.passed
+        assert "superseded" in sibling.result.reason
+        assert not any(isinstance(handle.job, AgentJob) for handle in coordinator.in_flight)
 
     def test_full_downstream_retains_implementation_lease_until_handoff(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1042,6 +1042,136 @@ class TestFailBackRouting:
 class TestImplementationAdmission:
     """Topological order + file-overlap reuse for the implementation queue."""
 
+    def test_distinct_prs_sharing_head_allow_one_writer_and_supersede_verified_sibling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A live writer receipt, not a matching branch name, permits supersession."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            max_workers=2,
+            serialize_file_overlap=False,
+        )
+        shared_branch = "shared-head"
+        owner_path = tmp_path / "repo-a" / "build" / ".worktrees" / "issue-2268"
+        owner_path.mkdir(parents=True)
+        owner = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2268,
+            pr=3001,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch=shared_branch,
+            payload={"existing_pr": True},
+        )
+        sibling = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2269,
+            pr=3002,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch=shared_branch,
+            payload={"existing_pr": True},
+        )
+        coordinator._push_item(owner, StageName.IMPLEMENTATION, enter=False)
+        coordinator._push_item(sibling, StageName.IMPLEMENTATION, enter=False)
+        owner.worktree = str(owner_path)
+        coordinator._register_pipeline_writer_worktree(
+            owner,
+            GitJob(
+                repo="repo-a",
+                op="create_worktree",
+                timeout_s=60,
+                kwargs={"issue_number": 2268, "branch_name": shared_branch},
+            ),
+            JobResult(ok=True, value={"path": str(owner_path)}),
+        )
+        claimed = coordinator._claim_item(StageName.IMPLEMENTATION, index=1)
+        assert claimed is sibling
+        stage = coordinator.stages[StageName.IMPLEMENTATION]
+        stage.on_job_done(
+            sibling,
+            JobResult(
+                ok=False,
+                error="branch_worktree_owned",
+                value={"branch": shared_branch, "owner_path": str(owner_path)},
+            ),
+            coordinator._ctx_for(sibling),
+        )
+        sibling.state = "DIRTY_DECISION_WAIT"
+        outcome = stage.step(sibling, coordinator._ctx_for(sibling))
+        assert isinstance(outcome, StageOutcome)
+        coordinator._route(sibling, outcome)
+
+        assert owner.pr == 3001
+        assert sibling.pr == 3002
+        assert owner.branch == sibling.branch == shared_branch
+        assert owner.worktree == str(owner_path)
+        assert coordinator._pipeline_writer_worktrees[("repo-a", shared_branch)] is owner
+        assert sibling.result is not None and sibling.result.passed
+        assert "superseded" in sibling.result.reason
+        assert sibling.worktree == ""
+        assert coordinator.queues[StageName.FINISHED].snapshot() == [sibling]
+
+        # If the sole writer later fails, only its checkout is preserved and
+        # shown in rerun guidance; the superseded sibling never aliases it.
+        owner.result = ItemResult(
+            passed=False,
+            reason="writer failed",
+            final_stage=StageName.PR_REVIEW,
+        )
+        coordinator.preserved.append(("repo-a", 2268, str(owner_path)))
+        assert coordinator._active_preserved_worktrees() == [("repo-a", 2268, str(owner_path))]
+
+    def test_external_branch_holder_fails_closed_without_a_writer_registration(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A manually held branch cannot be mistaken for a redundant pipeline sibling."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            max_workers=1,
+            serialize_file_overlap=False,
+        )
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2269,
+            pr=3002,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch="shared-head",
+            payload={"existing_pr": True},
+        )
+        coordinator._push_item(item, StageName.IMPLEMENTATION, enter=False)
+        claimed = coordinator._claim_item(StageName.IMPLEMENTATION)
+        assert claimed is item
+        stage = coordinator.stages[StageName.IMPLEMENTATION]
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error="branch_worktree_owned",
+                value={
+                    "branch": "shared-head",
+                    "owner_path": str(tmp_path / "manual-worktree"),
+                },
+            ),
+            coordinator._ctx_for(item),
+        )
+        item.state = "DIRTY_DECISION_WAIT"
+        outcome = stage.step(item, coordinator._ctx_for(item))
+        assert isinstance(outcome, StageOutcome)
+        coordinator._route(item, outcome)
+
+        assert item.result is not None and not item.result.passed
+        assert item.result.reason == "branch_worktree_owner_unverified"
+        assert item.worktree == ""
+        assert coordinator._pipeline_writer_worktrees == {}
+        assert coordinator.queues[StageName.FINISHED].snapshot() == [item]
+
     def test_full_downstream_retains_implementation_lease_until_handoff(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1042,10 +1042,19 @@ class TestFailBackRouting:
 class TestImplementationAdmission:
     """Topological order + file-overlap reuse for the implementation queue."""
 
-    def test_distinct_prs_sharing_head_allow_one_writer_and_supersede_verified_sibling(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize(
+        ("owner_pr", "sibling_pr"),
+        [(3001, 3002), (3001, 3001)],
+        ids=("distinct-prs", "consolidated-pr"),
+    )
+    def test_reversed_worktree_completions_wait_for_one_shared_head_writer(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        owner_pr: int,
+        sibling_pr: int,
     ) -> None:
-        """A live writer receipt, not a matching branch name, permits supersession."""
+        """A collision waits for its owner completion, for either shared-head topology."""
         coordinator, _pool, _ = make_coordinator(
             tmp_path,
             monkeypatch,
@@ -1059,7 +1068,7 @@ class TestImplementationAdmission:
             repo="repo-a",
             kind=ItemKind.ISSUE,
             issue=2268,
-            pr=3001,
+            pr=owner_pr,
             stage=StageName.IMPLEMENTATION,
             state="WORKTREE_WAIT",
             branch=shared_branch,
@@ -1069,7 +1078,7 @@ class TestImplementationAdmission:
             repo="repo-a",
             kind=ItemKind.ISSUE,
             issue=2269,
-            pr=3002,
+            pr=sibling_pr,
             stage=StageName.IMPLEMENTATION,
             state="WORKTREE_WAIT",
             branch=shared_branch,
@@ -1077,36 +1086,64 @@ class TestImplementationAdmission:
         )
         coordinator._push_item(owner, StageName.IMPLEMENTATION, enter=False)
         coordinator._push_item(sibling, StageName.IMPLEMENTATION, enter=False)
-        owner.worktree = str(owner_path)
-        coordinator._register_pipeline_writer_worktree(
-            owner,
-            GitJob(
-                repo="repo-a",
-                op="create_worktree",
-                timeout_s=60,
-                kwargs={"issue_number": 2268, "branch_name": shared_branch},
-            ),
-            JobResult(ok=True, value={"path": str(owner_path)}),
+        owner_lease = coordinator._claim_item(StageName.IMPLEMENTATION)
+        sibling_lease = coordinator._claim_item(StageName.IMPLEMENTATION)
+        assert owner_lease is owner
+        assert sibling_lease is sibling
+        owner_job = GitJob(
+            repo="repo-a",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={"issue_number": 2268, "branch_name": shared_branch},
         )
-        claimed = coordinator._claim_item(StageName.IMPLEMENTATION, index=1)
-        assert claimed is sibling
-        stage = coordinator.stages[StageName.IMPLEMENTATION]
-        stage.on_job_done(
-            sibling,
+        sibling_job = GitJob(
+            repo="repo-a",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={"issue_number": 2269, "branch_name": shared_branch},
+        )
+        owner_handle = JobHandle(job=owner_job, on_done_state="DIRTY_DECISION_WAIT")
+        sibling_handle = JobHandle(job=sibling_job, on_done_state="DIRTY_DECISION_WAIT")
+        coordinator.in_flight[owner_handle] = owner
+        coordinator.in_flight[sibling_handle] = sibling
+        coordinator.inflight_per_repo["repo-a"] = 2
+
+        # The collision reaches the coordinator first even though the owner
+        # allocated the branch first. It must defer rather than fail closed or
+        # incorrectly start another implementation session.
+        coordinator._handle_completion(
+            sibling_handle,
             JobResult(
                 ok=False,
                 error="branch_worktree_owned",
                 value={"branch": shared_branch, "owner_path": str(owner_path)},
             ),
-            coordinator._ctx_for(sibling),
         )
-        sibling.state = "DIRTY_DECISION_WAIT"
-        outcome = stage.step(sibling, coordinator._ctx_for(sibling))
-        assert isinstance(outcome, StageOutcome)
-        coordinator._route(sibling, outcome)
+        assert sibling.result is None
+        assert sibling.payload["branch_worktree_owner"] == {
+            "branch": shared_branch,
+            "owner_path": str(owner_path),
+        }
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [sibling]
+        assert sibling.attempts["implement"] == 0
+        assert "git_error_retries" not in sibling.payload
 
-        assert owner.pr == 3001
-        assert sibling.pr == 3002
+        # The owner completion then establishes the only durable writer
+        # receipt. Re-running the sibling consumes its retained receipt and
+        # terminally supersedes it without an implementation agent job.
+        coordinator._handle_completion(
+            owner_handle,
+            JobResult(
+                ok=True,
+                value={"path": str(owner_path), "dirty": False, "status": "", "diff": ""},
+            ),
+        )
+        claimed = coordinator._claim_item(StageName.IMPLEMENTATION)
+        assert claimed is sibling
+        coordinator._run_item(sibling)
+
+        assert owner.pr == owner_pr
+        assert sibling.pr == sibling_pr
         assert owner.branch == sibling.branch == shared_branch
         assert owner.worktree == str(owner_path)
         assert coordinator._pipeline_writer_worktrees[("repo-a", shared_branch)] is owner
@@ -1114,6 +1151,7 @@ class TestImplementationAdmission:
         assert "superseded" in sibling.result.reason
         assert sibling.worktree == ""
         assert coordinator.queues[StageName.FINISHED].snapshot() == [sibling]
+        assert not any(isinstance(handle.job, AgentJob) for handle in coordinator.in_flight)
 
         # If the sole writer later fails, only its checkout is preserved and
         # shown in rerun guidance; the superseded sibling never aliases it.
@@ -1171,6 +1209,86 @@ class TestImplementationAdmission:
         assert item.worktree == ""
         assert coordinator._pipeline_writer_worktrees == {}
         assert coordinator.queues[StageName.FINISHED].snapshot() == [item]
+
+    def test_pending_branch_owner_that_fails_to_register_leaves_sibling_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deferred collision fails closed if the candidate owner allocation fails."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            max_workers=2,
+            serialize_file_overlap=False,
+        )
+        shared_branch = "shared-head"
+        owner = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2268,
+            pr=3001,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch=shared_branch,
+            payload={"existing_pr": True},
+        )
+        sibling = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=2269,
+            pr=3002,
+            stage=StageName.IMPLEMENTATION,
+            state="WORKTREE_WAIT",
+            branch=shared_branch,
+            payload={"existing_pr": True},
+        )
+        coordinator._push_item(owner, StageName.IMPLEMENTATION, enter=False)
+        coordinator._push_item(sibling, StageName.IMPLEMENTATION, enter=False)
+        assert coordinator._claim_item(StageName.IMPLEMENTATION) is owner
+        assert coordinator._claim_item(StageName.IMPLEMENTATION) is sibling
+        owner_handle = JobHandle(
+            job=GitJob(
+                repo="repo-a",
+                op="create_worktree",
+                timeout_s=60,
+                kwargs={"issue_number": 2268, "branch_name": shared_branch},
+            ),
+            on_done_state="DIRTY_DECISION_WAIT",
+        )
+        sibling_handle = JobHandle(
+            job=GitJob(
+                repo="repo-a",
+                op="create_worktree",
+                timeout_s=60,
+                kwargs={"issue_number": 2269, "branch_name": shared_branch},
+            ),
+            on_done_state="DIRTY_DECISION_WAIT",
+        )
+        coordinator.in_flight[owner_handle] = owner
+        coordinator.in_flight[sibling_handle] = sibling
+        coordinator.inflight_per_repo["repo-a"] = 2
+
+        coordinator._handle_completion(
+            sibling_handle,
+            JobResult(
+                ok=False,
+                error="branch_worktree_owned",
+                value={
+                    "branch": shared_branch,
+                    "owner_path": str(tmp_path / "manual-worktree"),
+                },
+            ),
+        )
+        coordinator._handle_completion(owner_handle, JobResult(ok=False, error="disk full"))
+
+        assert coordinator._pipeline_writer_worktrees == {}
+        claimed = coordinator._claim_item(StageName.IMPLEMENTATION, index=1)
+        assert claimed is sibling
+        coordinator._run_item(sibling)
+
+        assert sibling.result is not None and not sibling.result.passed
+        assert sibling.result.reason == "branch_worktree_owner_unverified"
+        assert sibling.worktree == ""
+        assert coordinator.queues[StageName.FINISHED].snapshot() == [sibling]
 
     def test_full_downstream_retains_implementation_lease_until_handoff(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -993,9 +993,7 @@ class TestGitOps:
         )
         owner_path = tmp_path / "build" / ".worktrees" / "issue-2268"
         instance = MagicMock()
-        instance.create_worktree.side_effect = BranchWorktreeOwnedError(
-            "shared-head", owner_path
-        )
+        instance.create_worktree.side_effect = BranchWorktreeOwnedError("shared-head", owner_path)
         with patch(f"{_WP}.WorktreeManager", return_value=instance):
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -42,6 +42,10 @@ from hephaestus.automation.session_naming import (
     AGENT_IMPLEMENTER,
     AGENT_PR_REVIEWER,
 )
+from hephaestus.automation.worktree_manager import (
+    BRANCH_WORKTREE_OWNED,
+    BranchWorktreeOwnedError,
+)
 from hephaestus.prompts import PromptCatalog
 from hephaestus.resilience import CircuitBreakerOpenError, get_circuit_breaker
 from hephaestus.utils.file_lock import LockUnavailableError, file_lock
@@ -969,6 +973,39 @@ class TestGitOps:
         )
         assert result.ok is True
         assert result.value == str(tmp_path / "wt")
+
+    def test_create_worktree_reports_existing_branch_owner(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Branch ownership is a stable structured result for the stage."""
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 2269,
+                "branch_name": "shared-head",
+                "repo_root": str(tmp_path),
+            },
+        )
+        owner_path = tmp_path / "build" / ".worktrees" / "issue-2268"
+        instance = MagicMock()
+        instance.create_worktree.side_effect = BranchWorktreeOwnedError(
+            "shared-head", owner_path
+        )
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == BRANCH_WORKTREE_OWNED
+        assert result.value == {
+            "branch": "shared-head",
+            "owner_path": str(owner_path),
+        }
 
     def test_direct_pinned_worktree_rejects_checkout_head_drift(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -23,6 +23,7 @@ from hephaestus.automation import git_utils, subprocess_registry
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
+    WORKTREE_MATERIALIZED_KEY,
     AgentJob,
     BuildTestJob,
     CompactJob,
@@ -1292,6 +1293,46 @@ class TestGitOps:
             "status": "",
             "diff": "",
         }
+
+    def test_create_worktree_sync_failure_retains_materialized_checkout(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A post-create adopted sync error preserves first-writer evidence."""
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-existing",
+                "refresh_base": False,
+                "repo_root": str(tmp_path),
+                "sync_to_remote": True,
+                "pr_number": 70,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = tmp_path / "wt"
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
+            patch(
+                f"{_WP}.git_utils.sync_worktree_to_remote_branch",
+                side_effect=RuntimeError("sync timeout"),
+            ),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {
+            "path": str(tmp_path / "wt"),
+            WORKTREE_MATERIALIZED_KEY: True,
+        }
+        assert "post-create preparation failed" in (result.error or "")
 
     def test_create_isolated_worktree_syncs_only_detached_checkout(
         self,

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -965,6 +965,27 @@ class TestCreateWorktreeBranchCollision:
             assert manager.create_worktree(708, "708-auto-impl") == existing
         assert manager.worktrees[708] == existing
 
+    def test_same_issue_reuses_absolute_holder_with_a_relative_base_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Git's absolute worktree path matches a relative manager configuration."""
+        repo_root = tmp_path / "repo"
+        (repo_root / ".git").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        manager = WorktreeManager(repo_root=Path("repo"), base_dir=Path("repo/build/.worktrees"))
+        existing = (repo_root / "build" / ".worktrees" / "issue-708").resolve()
+
+        with patch.object(
+            manager,
+            "list_worktrees",
+            return_value=[
+                {"path": str(existing), "branch": "refs/heads/708-auto-impl", "commit": "abc"},
+            ],
+        ):
+            assert manager.create_worktree(708, "708-auto-impl") == existing
+
+        assert manager.worktrees[708] == existing
+
     def test_isolated_checkout_does_not_reuse_branch_holder(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from hephaestus.automation.worktree_manager import WorktreeDirtyError, WorktreeManager
+from hephaestus.automation.worktree_manager import (
+    BranchWorktreeOwnedError,
+    WorktreeDirtyError,
+    WorktreeManager,
+)
 from hephaestus.utils.file_lock import file_lock
 
 
@@ -920,16 +924,9 @@ class TestBaseBranchDetectionRaisesOnFailure:
 
 
 class TestCreateWorktreeBranchCollision:
-    """create_worktree reuses an existing worktree when the branch is checked out there.
+    """create_worktree protects writer worktrees from cross-issue collisions."""
 
-    Regression for the exit-128 collision: the implement loop resolves a PR's
-    real head branch (e.g. 708-auto-impl) for a DIFFERENT issue (#725), but that
-    branch is already checked out in the issue-708 worktree. git forbids the same
-    branch in two worktrees, so `git worktree add` failed. Reuse the existing
-    worktree instead of forcing or adding a second one.
-    """
-
-    def test_reuses_worktree_already_holding_branch(
+    def test_different_issue_cannot_reuse_branch_worktree(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:
         worktree_mocks.repo_root.return_value = tmp_path
@@ -946,19 +943,29 @@ class TestCreateWorktreeBranchCollision:
                 {"path": str(existing), "branch": "refs/heads/708-auto-impl", "commit": "abc"},
             ],
         ):
-            # Now ask for a worktree for issue #725 on that same branch.
-            result = manager.create_worktree(725, "708-auto-impl")
+            with pytest.raises(BranchWorktreeOwnedError) as raised:
+                manager.create_worktree(725, "708-auto-impl")
 
-        # Reuses the existing path, registers it under #725, and does NOT add a
-        # second worktree for the same branch.
-        assert result == existing
-        assert manager.worktrees[725] == existing
-        add_calls = [
-            c
-            for c in worktree_mocks.run.call_args_list
-            if c[0] and c[0][0][:3] == ["git", "worktree", "add"]
-        ]
-        assert add_calls == [], "must NOT run `git worktree add` when reusing"
+        assert raised.value.branch == "708-auto-impl"
+        assert raised.value.owner_path == existing
+        assert 725 not in manager.worktrees
+
+    def test_same_issue_reuses_branch_worktree(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        existing = manager.base_dir / "issue-708"
+
+        with patch.object(
+            manager,
+            "list_worktrees",
+            return_value=[
+                {"path": str(existing), "branch": "refs/heads/708-auto-impl", "commit": "abc"},
+            ],
+        ):
+            assert manager.create_worktree(708, "708-auto-impl") == existing
+        assert manager.worktrees[708] == existing
 
     def test_isolated_checkout_does_not_reuse_branch_holder(
         self, worktree_mocks: Any, tmp_path: Any

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -950,9 +950,7 @@ class TestCreateWorktreeBranchCollision:
         assert raised.value.owner_path == existing
         assert 725 not in manager.worktrees
 
-    def test_same_issue_reuses_branch_worktree(
-        self, worktree_mocks: Any, tmp_path: Any
-    ) -> None:
+    def test_same_issue_reuses_branch_worktree(self, worktree_mocks: Any, tmp_path: Any) -> None:
         worktree_mocks.repo_root.return_value = tmp_path
         manager = WorktreeManager()
         existing = manager.base_dir / "issue-708"


### PR DESCRIPTION
## Summary

Implements exclusive, fail-closed ownership for automation worktrees sharing a PR branch.

- Detects branch ownership while the Git metadata lock is held.
- Defers only while a matching pipeline writer is in flight; external holders fail closed.
- Parks pending ownership retries on a timer rather than spinning the implementation queue.
- Retains ownership evidence if post-create checkout synchronization fails, preventing a later writer from claiming the branch.
- Canonicalizes both Git holder paths and coordinator registrations, so relative worktree configurations still recognize their verified absolute holder.
- Covers shared-head ordering, external holders, timer wake-up, post-create failure, and relative-path regressions.

## Validation

- `uv run --all-extras --locked pytest -q` — 6922 passed, 6 skipped.
- `uv run pre-commit run --all-files` passed before the final review fixes; final changed-file hooks passed.
- `uv run ruff check` passed.
- `uv run mypy` passed.
- Coverage: 85.11% (required: 83%).

Closes #2285