### PR TITLE
fix(automation): materialize reused worktree refs

### DIFF
--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -565,7 +565,16 @@ class WorktreeManager:
                 branch_name,
                 branch_name,
             )
-            run(["git", "fetch", "origin", branch_name], cwd=self.repo_root, **_timeout_kw(timeout))
+            run(
+                [
+                    "git",
+                    "fetch",
+                    "origin",
+                    f"+refs/heads/{branch_name}:refs/remotes/origin/{branch_name}",
+                ],
+                cwd=self.repo_root,
+                **_timeout_kw(timeout),
+            )
             run(
                 [
                     "git",

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -386,8 +386,16 @@ class TestWorktreeManager:
             manager.create_worktree(768, "768-auto-impl")
 
         argvs = [c[0][0] for c in worktree_mocks.run.call_args_list]
-        # A fetch of the remote branch must occur.
-        assert any(a[:2] == ["git", "fetch"] and "768-auto-impl" in a for a in argvs)
+        # A single-branch clone does not materialize a remote-tracking ref for
+        # ``git fetch origin <branch>``; fetch the ref explicitly because the
+        # next command must resolve ``origin/<branch>`` locally.
+        fetch_argv = next(a for a in argvs if a[:2] == ["git", "fetch"])
+        assert fetch_argv == [
+            "git",
+            "fetch",
+            "origin",
+            "+refs/heads/768-auto-impl:refs/remotes/origin/768-auto-impl",
+        ]
         # The worktree-add must use origin/<branch>, NOT the base branch.
         add_argv = next(a for a in argvs if a[:3] == ["git", "worktree", "add"])
         assert add_argv == [


### PR DESCRIPTION
## Summary

Materialize the local origin tracking ref before creating a worktree from a remotely existing issue branch. This lets a fresh single-branch loop clone safely reuse an existing automation branch.

## Verification

- Reproduced the original failure in a fresh single-branch main clone before the fix.
- Focused WorktreeManager suite: 63 passed.
- Live reproduction after the fix: the created worktree HEAD matched refs/remotes/origin/2146-auto-impl.
- Pre-push full suite: 6,885 passed, 6 skipped.

Closes #2480