### PR TITLE
fix(automation): use repository test root in pre-PR gate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1346,9 +1346,9 @@ out-of-band.
 
 `--run-pre-pr-tests` is an opt-in queue-runner flag enabling the
 [`implementation`](hephaestus/automation/pipeline/stages/implementation.py)
-pre-PR unit-test gate — argv comes from
-`PipelineConfig.pre_pr_test_argv` so non-standard unit-test layouts
-work without code change.
+pre-PR test gate. Its vetted default is `uv run pytest tests -q --tb=short`;
+programmatic callers can supply `PipelineConfig.pre_pr_test_argv` for a
+different vetted test command.
 
 Three Codex-only flags control per-role reasoning effort:
 `--planner-reasoning-effort {default|low|medium|high|xhigh}` and the

--- a/hephaestus/automation/_pr_create_phase.py
+++ b/hephaestus/automation/_pr_create_phase.py
@@ -78,11 +78,11 @@ class PRCreatePhase(StageMixin):
         return pr_number
 
     def _run_tests_in_worktree(self, worktree_path: Path, issue_number: int) -> bool:
-        """Run the unit test suite inside the worktree as a pre-PR gate (A2-004)."""
+        """Run the worktree test suite as a pre-PR gate (A2-004)."""
         timeout_s = pre_pr_test_timeout()
         try:
             result = subprocess.run(
-                ["uv", "run", "pytest", "tests/unit", "-q", "--tb=short"],
+                ["uv", "run", "pytest", "tests", "-q", "--tb=short"],
                 cwd=worktree_path,
                 capture_output=True,
                 text=True,

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -343,9 +343,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--run-pre-pr-tests",
         action="store_true",
-        help=(
-            "Run the implementation-stage pre-PR unit-test gate before committing and creating PRs."
-        ),
+        help=("Run the implementation-stage pre-PR test gate before committing and creating PRs."),
     )
     p.add_argument(
         "--model",

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -285,7 +285,7 @@ class PipelineConfig:
     budget_overrides: dict[str, int] = field(default_factory=dict)
     # Configurable argv for the optional pre-PR test gate. The
     # implementation stage reads this vector instead of hardcoding the test
-    # command so repositories with non-standard unit-test layouts can opt in.
+    # command so repositories with non-standard test layouts can opt in.
     pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV
     run_pre_pr_tests: bool = False
     serialize_file_overlap: bool = True

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -283,7 +283,7 @@ class PipelineConfig:
     # Per-budget overrides applied on top of the ROUTES defaults by the
     # coordinator's budget accessor.
     budget_overrides: dict[str, int] = field(default_factory=dict)
-    # Configurable argv for the optional pre-PR unit-test gate. The
+    # Configurable argv for the optional pre-PR test gate. The
     # implementation stage reads this vector instead of hardcoding the test
     # command so repositories with non-standard unit-test layouts can opt in.
     pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -73,7 +73,7 @@ class BuildTestJob:
 
     repo: str
     cwd: Path
-    argv: tuple[str, ...]  # e.g. ("uv", "run", "pytest", "tests/unit", "-q")
+    argv: tuple[str, ...]  # e.g. ("uv", "run", "pytest", "tests", "-q")
     timeout_s: int
     descr: str = ""
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -167,7 +167,7 @@ def _issue_number(item: WorkItem) -> int:
 #: remote must still terminate. Reset on any successful git job.
 GIT_ERROR_RETRY_CAP = 2
 
-#: Timeout for the optional pre-PR unit-test run (mirrors the legacy
+#: Timeout for the optional pre-PR test run (mirrors the legacy
 #: ``_pr_create_phase`` bound; the budget that matters — ``test_fix`` —
 #: lives in ROUTES).
 PRE_PR_TEST_TIMEOUT_S = 1800

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -174,7 +174,7 @@ PRE_PR_TEST_TIMEOUT_S = 1800
 
 #: Vetted pre-PR test command (BuildTestJob argv must never carry
 #: issue-derived strings).
-PRE_PR_TEST_ARGV: tuple[str, ...] = ("uv", "run", "pytest", "tests/unit", "-q", "--tb=short")
+PRE_PR_TEST_ARGV: tuple[str, ...] = ("uv", "run", "pytest", "tests", "-q", "--tb=short")
 
 
 def build_implementation_prompt(
@@ -1015,7 +1015,7 @@ class ImplementationStage(Stage):
                 summary=item.payload.get("implement_summary", "")
                 or f"Automated implementation for issue #{item.issue}.",
                 changes="See the PR diff for the full change set.",
-                testing=item.payload.get("test_output") or "uv run pytest tests/unit -q",
+                testing=item.payload.get("test_output") or "uv run pytest tests -q --tb=short",
             )
             pr_number = ctx.github.create_pr(item.issue, item.branch, title, body)
             item.pr = pr_number

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1111,7 +1111,9 @@ class TestTestsAndFix:
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, BuildTestJob)
-        assert result.job.argv == PRE_PR_TEST_ARGV
+        expected_argv = ("uv", "run", "pytest", "tests", "-q", "--tb=short")
+        assert expected_argv == PRE_PR_TEST_ARGV
+        assert result.job.argv == expected_argv
         assert result.on_done_state == "COMMIT_PUSH_WAIT"
         assert "tests_failed" not in item.payload  # stale result cleared at submit
 
@@ -1319,6 +1321,7 @@ class TestCommitPushAndPrCreate:
         assert [name for name, _ in github.mutation_log] == ["gh_pr_create"]
         # The PR body is a get_pr_description body carrying the closing line.
         assert "Closes #9" in github.prs[1001]["body"]
+        assert "uv run pytest tests -q --tb=short" in github.prs[1001]["body"]
         assert github.prs[1001]["title"] == "Add the widget"
 
     def test_pr_create_does_not_call_the_removed_auto_merge_mutator(

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -657,8 +657,7 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
         _store_true(
             "--run-pre-pr-tests",
             "run_pre_pr_tests",
-            "Run the implementation-stage pre-PR unit-test gate before committing and "
-            "creating PRs.",
+            "Run the implementation-stage pre-PR test gate before committing and creating PRs.",
         ),
         _action_spec(
             ("--model",),

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -863,6 +863,19 @@ def test_ci_driver_help_describes_loop_owned_review() -> None:
     assert "enable auto-merge" not in description
 
 
+def test_loop_runner_pre_pr_tests_help_describes_the_test_gate() -> None:
+    """The optional gate is not restricted to repositories' unit-test roots."""
+    parser = loop_runner._build_parser()
+    action = next(
+        action for action in parser._actions if "--run-pre-pr-tests" in action.option_strings
+    )
+
+    assert (
+        action.help
+        == "Run the implementation-stage pre-PR test gate before committing and creating PRs."
+    )
+
+
 def test_build_automation_parser_does_not_add_throttle_by_default() -> None:
     """The shared helper does not expose GitHub throttle flags unless opted in."""
     flags = {

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -303,6 +303,14 @@ def test_pr_create_run_tests_uses_env_configured_timeout(
 
         assert phase._run_tests_in_worktree(tmp_path, 7) is True
 
+    assert mock_run.call_args.args[0] == [
+        "uv",
+        "run",
+        "pytest",
+        "tests",
+        "-q",
+        "--tb=short",
+    ]
     assert mock_run.call_args.kwargs["timeout"] == 777
 
 


### PR DESCRIPTION
Summary: use the UV-only repository test root so the org-level loop no longer assumes the Hephaestus-specific tests/unit layout.

Changes:
- default vetted command uses uv run pytest tests -q --tb=short
- preserves the explicit programmatic configuration seam for a vetted repository-specific command
- aligns the compatibility phase, generated PR testing text, help text, documentation, and regression tests
- applies the repository formatter to the updated parser help text

Validation:
- all-files pre-commit passed
- locked full suite: 6,885 passed, 6 skipped; 85.07 percent coverage
- ruff and mypy passed

Closes #2482