### PR TITLE
fix(automation): reap direct Codex sessions on shutdown

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -7,10 +7,11 @@ import contextlib
 import json
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -21,6 +22,7 @@ from hephaestus.constants import (
 from hephaestus.utils.helpers import strip_null_bytes
 
 AgentName = Literal["claude", "codex", "pi"]
+ProcessTracker = Callable[[int], contextlib.AbstractContextManager[None]]
 SubprocessCommandPart = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 SubprocessCommand = SubprocessCommandPart | Sequence[SubprocessCommandPart]
 AGENT_CHOICES: tuple[AgentName, ...] = ("claude", "codex", "pi")
@@ -644,10 +646,17 @@ def run_codex_session(
     model: str = "",
     sandbox: str = "workspace-write",
     approval: str = "never",
+    process_tracker: ProcessTracker | None = None,
 ) -> AgentRunResult:
     """Run a new persisted Codex exec session and capture its UUID."""
     cmd = _codex_base_cmd(cwd=cwd, model=model, sandbox=sandbox, approval=approval)
-    return _run_codex_command(cmd, prompt=prompt, cwd=cwd, timeout=timeout)
+    return _run_codex_command(
+        cmd,
+        prompt=prompt,
+        cwd=cwd,
+        timeout=timeout,
+        process_tracker=process_tracker,
+    )
 
 
 def resume_codex_session(
@@ -659,6 +668,7 @@ def resume_codex_session(
     model: str = "",
     sandbox: str = "workspace-write",
     approval: str = "never",
+    process_tracker: ProcessTracker | None = None,
 ) -> AgentRunResult:
     """Resume a persisted Codex exec session and capture its latest output."""
     cmd = _codex_base_cmd(
@@ -667,7 +677,13 @@ def resume_codex_session(
         approval=approval,
         resume_id=session_id,
     )
-    return _run_codex_command(cmd, prompt=prompt, cwd=cwd, timeout=timeout)
+    return _run_codex_command(
+        cmd,
+        prompt=prompt,
+        cwd=cwd,
+        timeout=timeout,
+        process_tracker=process_tracker,
+    )
 
 
 def _run_codex_command(
@@ -676,6 +692,7 @@ def _run_codex_command(
     prompt: str,
     cwd: Path,
     timeout: int,
+    process_tracker: ProcessTracker | None = None,
 ) -> AgentRunResult:
     """Execute Codex with JSON events and return final text plus session id."""
     with tempfile.NamedTemporaryFile(prefix="codex-last-", suffix=".txt") as output_file:
@@ -692,6 +709,7 @@ def _run_codex_command(
                 timeout=timeout,
                 env=env,
                 output_path=Path(output_file.name),
+                process_tracker=process_tracker,
             )
         except subprocess.TimeoutExpired as e:
             last_message = Path(output_file.name).read_text(encoding="utf-8").strip()
@@ -923,6 +941,7 @@ def run_agent_session(
     model: str = "",
     sandbox: str = "workspace-write",
     approval: str = "never",
+    process_tracker: ProcessTracker | None = None,
 ) -> AgentRunResult:
     """Run a direct-runner agent session and return output plus session id."""
     if is_codex(agent):
@@ -933,6 +952,7 @@ def run_agent_session(
             model=model,
             sandbox=sandbox,
             approval=approval,
+            process_tracker=process_tracker,
         )
     if is_pi(agent):
         return run_pi_session(
@@ -956,6 +976,7 @@ def resume_agent_session(
     model: str = "",
     sandbox: str = "workspace-write",
     approval: str = "never",
+    process_tracker: ProcessTracker | None = None,
 ) -> AgentRunResult:
     """Resume a direct-runner agent session."""
     if is_codex(agent):
@@ -967,6 +988,7 @@ def resume_agent_session(
             model=model,
             sandbox=sandbox,
             approval=approval,
+            process_tracker=process_tracker,
         )
     if is_pi(agent):
         return resume_pi_session(
@@ -989,6 +1011,7 @@ def _communicate_codex_process(
     timeout: int,
     env: dict[str, str],
     output_path: Path,
+    process_tracker: ProcessTracker | None = None,
 ) -> tuple[str, str]:
     """Run Codex and recover when a completed final message leaves the wrapper alive."""
     proc = subprocess.Popen(
@@ -999,60 +1022,80 @@ def _communicate_codex_process(
         cwd=cwd,
         text=True,
         env=env,
+        start_new_session=True,
     )
-    started_at = time.monotonic()
-    final_seen_at: float | None = None
-    # Strip NUL bytes: proc.communicate(input=...) marshals text stdin and would
-    # raise ``ValueError: embedded null byte`` on a stray NUL, before Codex runs
-    # (#1661) — the same crash the Claude path guards against.
-    input_text: str | None = strip_null_bytes(prompt)
-    grace_seconds = _codex_final_message_grace_seconds()
+    tracker = process_tracker(proc.pid) if process_tracker is not None else contextlib.nullcontext()
+    with tracker:
+        started_at = time.monotonic()
+        final_seen_at: float | None = None
+        # Strip NUL bytes: proc.communicate(input=...) marshals text stdin and would
+        # raise ``ValueError: embedded null byte`` on a stray NUL, before Codex runs
+        # (#1661) — the same crash the Claude path guards against.
+        input_text: str | None = strip_null_bytes(prompt)
+        grace_seconds = _codex_final_message_grace_seconds()
 
-    while True:
-        elapsed = time.monotonic() - started_at
-        remaining = timeout - elapsed
-        if remaining <= 0:
-            stdout_text, stderr_text = _terminate_codex_process(proc)
-            last_message = _read_text_file(output_path).strip()
-            if last_message:
-                return stdout_text, stderr_text or f"Codex wrapper timed out after {timeout}s"
-            raise subprocess.TimeoutExpired(cmd, timeout, output=stdout_text, stderr=stderr_text)
-
-        try:
-            stdout_text, stderr_text = proc.communicate(
-                input=input_text,
-                timeout=min(1.0, remaining),
-            )
-            if proc.returncode:
-                raise subprocess.CalledProcessError(
-                    proc.returncode,
-                    cmd,
-                    output=stdout_text,
-                    stderr=stderr_text,
+        while True:
+            elapsed = time.monotonic() - started_at
+            remaining = timeout - elapsed
+            if remaining <= 0:
+                stdout_text, stderr_text = _terminate_codex_process(proc)
+                last_message = _read_text_file(output_path).strip()
+                if last_message:
+                    return stdout_text, stderr_text or f"Codex wrapper timed out after {timeout}s"
+                raise subprocess.TimeoutExpired(
+                    cmd, timeout, output=stdout_text, stderr=stderr_text
                 )
-            return stdout_text or "", stderr_text or ""
-        except subprocess.TimeoutExpired:
-            input_text = None
-            if _read_text_file(output_path).strip():
-                final_seen_at = final_seen_at or time.monotonic()
-                if time.monotonic() - final_seen_at >= grace_seconds:
-                    stdout_text, stderr_text = _terminate_codex_process(proc)
-                    return (
-                        stdout_text,
-                        stderr_text or "Codex wrapper terminated after final message",
+
+            try:
+                stdout_text, stderr_text = proc.communicate(
+                    input=input_text,
+                    timeout=min(1.0, remaining),
+                )
+                if proc.returncode:
+                    raise subprocess.CalledProcessError(
+                        proc.returncode,
+                        cmd,
+                        output=stdout_text,
+                        stderr=stderr_text,
                     )
+                return stdout_text or "", stderr_text or ""
+            except subprocess.TimeoutExpired:
+                input_text = None
+                if _read_text_file(output_path).strip():
+                    final_seen_at = final_seen_at or time.monotonic()
+                    if time.monotonic() - final_seen_at >= grace_seconds:
+                        stdout_text, stderr_text = _terminate_codex_process(proc)
+                        return (
+                            stdout_text,
+                            stderr_text or "Codex wrapper terminated after final message",
+                        )
 
 
 def _terminate_codex_process(proc: subprocess.Popen[str]) -> tuple[str, str]:
-    """Terminate a Codex process and collect any remaining stdout/stderr."""
+    """Terminate a Codex process group and collect any remaining stdout/stderr."""
     if proc.poll() is None:
-        proc.terminate()
+        _signal_codex_process_group(proc, signal.SIGTERM)
     try:
         stdout_text, stderr_text = proc.communicate(timeout=CODEX_TERMINATION_GRACE_SECONDS)
     except subprocess.TimeoutExpired:
-        proc.kill()
+        _signal_codex_process_group(proc, signal.SIGKILL)
         stdout_text, stderr_text = proc.communicate()
     return stdout_text or "", stderr_text or ""
+
+
+def _signal_codex_process_group(proc: subprocess.Popen[str], sig: signal.Signals) -> None:
+    """Signal Codex's dedicated process group, falling back to its wrapper."""
+    pid = getattr(proc, "pid", None)
+    if isinstance(pid, int) and hasattr(os, "killpg") and hasattr(os, "getpgid"):
+        try:
+            os.killpg(os.getpgid(pid), sig)
+            return
+        except (ProcessLookupError, OSError):
+            pass
+    if sig == signal.SIGKILL:
+        proc.kill()
+    else:
+        proc.terminate()
 
 
 def _read_text_file(path: Path) -> str:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -631,6 +631,7 @@ class WorkerPool:
                         model=job.model,
                         sandbox=job.sandbox,
                         approval="never",
+                        process_tracker=subprocess_registry.track_process_group,
                     )
                 else:
                     agent_result = run_agent_session(
@@ -641,6 +642,7 @@ class WorkerPool:
                         model=job.model,
                         sandbox=job.sandbox,
                         approval="never",
+                        process_tracker=subprocess_registry.track_process_group,
                     )
                 # A resumed command may not repeat the session-start event;
                 # retain the known id in that case.

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -186,6 +187,42 @@ def test_run_codex_session_returns_session_id_and_last_message(tmp_path: Path) -
 
     assert result.session_id == "019e1e57-7652-7892-b1ca-c31c93d4b160"
     assert result.stdout == "final answer"
+
+
+def test_run_codex_session_tracks_a_dedicated_process_group(tmp_path: Path) -> None:
+    """An automation caller can reap the complete Codex process group on shutdown."""
+    popen_kwargs: dict[str, Any] = {}
+    tracker_events: list[tuple[str, int]] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        popen_kwargs.update(kwargs)
+        proc = _FakeCodexPopen(cmd, proc_stdout="", final_message="done", **kwargs)
+        proc.pid = 2468  # type: ignore[attr-defined]
+        return proc
+
+    @contextmanager
+    def track_process_group(pid: int) -> Any:
+        tracker_events.append(("enter", pid))
+        try:
+            yield
+        finally:
+            tracker_events.append(("exit", pid))
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        agent_runtime.run_codex_session(
+            "prompt",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+            process_tracker=track_process_group,
+        )
+
+    assert popen_kwargs["start_new_session"] is True
+    assert tracker_events == [("enter", 2468), ("exit", 2468)]
 
 
 def test_run_claude_text_strips_null_byte_from_stdin(tmp_path: Path) -> None:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -19,7 +19,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
-from hephaestus.automation import git_utils
+from hephaestus.automation import git_utils, subprocess_registry
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
@@ -303,6 +303,7 @@ class TestWorkerPoolSubmitComplete:
             model=job.model,
             sandbox="workspace-write",
             approval="never",
+            process_tracker=subprocess_registry.track_process_group,
         )
         assert result.ok is True
         assert result.value == "codex output"
@@ -334,6 +335,7 @@ class TestWorkerPoolSubmitComplete:
             model=job.model,
             sandbox="workspace-write",
             approval="never",
+            process_tracker=subprocess_registry.track_process_group,
         )
         run.assert_not_called()
         assert result.ok is True
@@ -3557,6 +3559,35 @@ class TestOnFutureDone:
 )
 class TestShutdownReapsSubprocess:
     """WorkerPool.shutdown() SIGTERMs in-flight agent process groups (#2059)."""
+
+    def test_shutdown_terminates_running_codex_subprocess_fast(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """A direct Codex session is registered and reaped with the worker pool."""
+        sleeper = [sys.executable, "-c", "import time; time.sleep(60)"]
+        job = _agent_job(
+            agent="codex", model="reap-test", timeout_s=60, session_agent="implementer"
+        )
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="codex"),
+            patch("hephaestus.agents.runtime._codex_base_cmd", return_value=sleeper),
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            deadline = time.monotonic() + 10
+            while subprocess_registry.live_count() == 0 and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert subprocess_registry.live_count() == 1, "Codex subprocess never registered"
+
+            t0 = time.monotonic()
+            pool.shutdown()
+            _handle, result = completion_q.get(timeout=10)
+            elapsed = time.monotonic() - t0
+
+        assert elapsed < 15, f"shutdown did not reap Codex fast ({elapsed:.1f}s)"
+        assert result.ok is False
+        assert result.interrupted is True
 
     def test_shutdown_terminates_running_agent_subprocess_fast(
         self,


### PR DESCRIPTION
## Summary

- run direct Codex sessions in their own process groups
- pass the automation process registry through a provider-neutral runtime callback
- terminate a complete Codex process group on timeout or worker shutdown

## Verification

- `uv run --all-extras pytest tests/unit/agents/test_runtime.py tests/unit/automation/pipeline/test_worker_pool.py --no-cov -q` (200 passed)
- focused real-process shutdown regression: a 60-second Codex stand-in was reaped promptly
- `uv run ruff check …`
- `uv run ruff format --check …`
- `uv run mypy hephaestus/agents/runtime.py hephaestus/automation/pipeline/worker_pool.py`

Closes #2487