### PR TITLE
fix(automation): reconcile review threads after restart

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -275,6 +275,10 @@ class StageGitHub(Protocol):
         """Return fresh unresolved review-thread facts, including ownership."""
         ...
 
+    def list_restart_process_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+        """Return host-proven canonical receipts eligible for restart adoption."""
+        ...
+
     def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
         """Durably ensure the PR exists and return its number (idempotent).
 

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -484,6 +484,37 @@ def _process_thread_records(item: WorkItem) -> dict[str, dict[str, Any]] | None:
     return records
 
 
+def _adopt_live_process_receipts(
+    records: dict[str, dict[str, Any]], live_threads: list[dict[str, Any]]
+) -> dict[str, dict[str, Any]] | None:
+    """Merge host-normalized restart receipts into the single receipt set.
+
+    ``PipelineGitHub`` attaches ``process_receipt`` only after proving the
+    marker, sole-comment shape, automated-review parent, and review commit.
+    The stage still verifies the complete receipt against the same live thread
+    before letting the validator describe it as addressed.
+    """
+    adopted = dict(records)
+    for live in live_threads:
+        if not isinstance(live, dict):
+            return None
+        raw_receipt = live.get("process_receipt")
+        if raw_receipt is None:
+            continue
+        if not isinstance(raw_receipt, dict) or not _is_process_thread_receipt(raw_receipt):
+            return None
+        thread_id = _durable_thread_id(raw_receipt)
+        if thread_id is None or thread_id != _durable_thread_id(live):
+            return None
+        if _thread_comment_signature(raw_receipt) != _thread_comment_signature(live):
+            return None
+        existing = adopted.get(thread_id)
+        if existing is not None and existing != raw_receipt:
+            return None
+        adopted[thread_id] = raw_receipt
+    return adopted
+
+
 def _handled_process_receipts(
     item: WorkItem,
 ) -> tuple[list[dict[str, Any]], dict[str, str]] | None:
@@ -970,20 +1001,35 @@ class PrReviewStage(Stage):
                 live_threads = ctx.github.list_unresolved_review_threads(item.pr)
             except Exception as error:
                 logger.warning(
-                    "pr_review:%s: could not fetch complete process-thread facts for "
-                    "validation (%s)",
+                    "pr_review:%s: could not fetch complete process-thread facts "
+                    "for validation (%s)",
                     item.issue,
                     type(error).__name__,
                 )
                 item.payload["review_audit_failure"] = True
                 return Continue(next_state=EVAL)
-            live_process = _live_process_threads(records, live_threads)
-            if live_process is None:
+        else:
+            try:
+                live_threads = ctx.github.list_restart_process_review_threads(item.pr)
+            except Exception as error:
+                logger.warning(
+                    "pr_review:%s: could not fetch complete process-thread facts "
+                    "for restart validation (%s)",
+                    item.issue,
+                    type(error).__name__,
+                )
                 item.payload["review_audit_failure"] = True
                 return Continue(next_state=EVAL)
-            validation_threads = list(live_process.values())
-        else:
-            validation_threads = []
+        records = _adopt_live_process_receipts(records, live_threads)
+        if records is None:
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        item.payload["process_review_threads"] = list(records.values())
+        live_process = _live_process_threads(records, live_threads)
+        if live_process is None:
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        validation_threads = list(live_process.values())
         item.payload["validation_process_threads"] = [dict(thread) for thread in validation_threads]
         item.payload["prior_comments_json"] = json.dumps(
             validation_threads, ensure_ascii=False, sort_keys=True

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -207,6 +207,87 @@ def _thread_severity_is_blocking(thread: dict[str, Any]) -> bool:
     return severity is None or severity in BLOCKING_SEVERITIES
 
 
+_AUTOMATED_REVIEW_PREFIX = "## Automated PR review"
+
+
+def _canonical_restart_process_receipt(thread: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the one canonical receipt proven by an immutable automated review.
+
+    A worker restart loses its in-memory post receipt, but GitHub still holds
+    enough immutable provenance to reconstruct the same receipt: one initial
+    inline comment, its parent automated review, and that review's commit.
+    This is deliberately stricter than account ownership, because operators
+    and automation can share a GitHub login.
+    """
+    comments = thread.get("comments")
+    if not isinstance(comments, list) or len(comments) != 1:
+        return None
+    comment = comments[0]
+    if not isinstance(comment, dict):
+        return None
+    body = comment.get("body")
+    if not isinstance(body, str):
+        return None
+    marker = body.splitlines()[0].strip() if body.splitlines() else ""
+    if not marker.startswith(SEVERITY_MARKER_PREFIX) or not marker.endswith("-->"):
+        return None
+    severity = marker[len(SEVERITY_MARKER_PREFIX) : -3].strip().lower()
+    if severity not in VALID_SEVERITIES:
+        return None
+    review_body = thread.get("review_body")
+    review_commit_sha = thread.get("review_commit_sha")
+    if (
+        not isinstance(review_body, str)
+        or not review_body.startswith(_AUTOMATED_REVIEW_PREFIX)
+        or not isinstance(review_commit_sha, str)
+        or re.fullmatch(r"[0-9a-f]{40}", review_commit_sha) is None
+    ):
+        return None
+    thread_id = thread.get("id")
+    path = thread.get("path")
+    line = thread.get("line")
+    side = thread.get("side")
+    author = comment.get("author")
+    review_id = comment.get("review_id")
+    comment_id = comment.get("id")
+    if not (
+        isinstance(thread_id, str)
+        and thread_id
+        and isinstance(path, str)
+        and path
+        and isinstance(line, int)
+        and not isinstance(line, bool)
+        and line > 0
+        and side == "RIGHT"
+        and isinstance(author, str)
+        and author
+        and isinstance(review_id, str)
+        and review_id
+        and isinstance(comment_id, str)
+        and comment_id
+    ):
+        return None
+    return {
+        "id": thread_id,
+        "path": path,
+        "line": line,
+        "side": side,
+        "body": body,
+        "author": author,
+        "authors": [author],
+        "comments": [
+            {
+                "id": comment_id,
+                "author": author,
+                "body": body,
+                "review_id": review_id,
+            }
+        ],
+        "review_id": review_id,
+        "created_head_sha": review_commit_sha,
+    }
+
+
 def _has_no_explicit_pull_request_bypasses(protection: dict[str, Any]) -> bool:
     """Return whether the classic protection response grants no PR bypasses.
 
@@ -534,7 +615,7 @@ class PipelineGitHub:
             "        pageInfo{ hasNextPage endCursor }"
             "        nodes{ id isResolved path line side:diffSide "
             "comments(first:20){ pageInfo{ hasNextPage } "
-            "nodes{ id body author{ login } pullRequestReview{ id } } } }"
+            "nodes{ id body author{ login } pullRequestReview{ id body commit{ oid } } } } }"
             "      }"
             "    }"
             "  }"
@@ -565,6 +646,8 @@ class PipelineGitHub:
                 first_comment = comment_nodes[0] if comment_nodes else {}
                 comments: list[dict[str, str]] = []
                 authors: list[str] = []
+                review_body = ""
+                review_commit_sha = ""
                 for comment in comment_nodes:
                     author_node = comment.get("author")
                     author = author_node.get("login") if isinstance(author_node, dict) else ""
@@ -573,6 +656,12 @@ class PipelineGitHub:
                         authors.append(author)
                     review = comment.get("pullRequestReview") or {}
                     review_id = review.get("id") if isinstance(review, dict) else ""
+                    if isinstance(review, dict) and not review_body:
+                        review_body = str(review.get("body") or "")
+                        commit = review.get("commit") or {}
+                        review_commit_sha = (
+                            str(commit.get("oid") or "") if isinstance(commit, dict) else ""
+                        )
                     comments.append(
                         {
                             "id": str(comment.get("id") or ""),
@@ -581,19 +670,23 @@ class PipelineGitHub:
                             "review_id": review_id or "",
                         }
                     )
-                threads.append(
-                    {
-                        "id": node["id"],
-                        "path": node.get("path", ""),
-                        "line": node.get("line"),
-                        "side": node.get("side") or "RIGHT",
-                        "body": first_comment.get("body", ""),
-                        "author": authors[0] if authors else "",
-                        "authors": authors,
-                        "comments": comments,
-                        "review_id": comments[0].get("review_id", "") if comments else "",
-                    }
-                )
+                thread = {
+                    "id": node["id"],
+                    "path": node.get("path", ""),
+                    "line": node.get("line"),
+                    "side": node.get("side") or "RIGHT",
+                    "body": first_comment.get("body", ""),
+                    "author": authors[0] if authors else "",
+                    "authors": authors,
+                    "comments": comments,
+                    "review_id": comments[0].get("review_id", "") if comments else "",
+                    "review_body": review_body,
+                    "review_commit_sha": review_commit_sha,
+                }
+                restart_receipt = _canonical_restart_process_receipt(thread)
+                if restart_receipt is not None:
+                    thread["process_receipt"] = restart_receipt
+                threads.append(thread)
             page_info = review_threads.get("pageInfo", {})
             if not page_info.get("hasNextPage"):
                 break
@@ -895,9 +988,9 @@ class PipelineGitHub:
     ) -> ProcessThreadResolutionResult:
         """Reply then resolve exact active-work-item process receipts.
 
-        The stage supplies only receipts created in the current active work
-        item.  Restarted work has no receipt and is therefore a human gate;
-        this accessor intentionally owns no second persistence journal.
+        The stage supplies only canonical receipts held by the current active
+        work item. A restart may re-adopt a host-normalized receipt, but this
+        accessor intentionally owns no second persistence journal.
         """
         candidate_ids = tuple(sorted(dispositions))
         if self._skip(
@@ -1231,6 +1324,14 @@ class PipelineGitHub:
         for thread in threads:
             thread["automation_owned"] = _is_automation_owned_thread(thread, current_login)
         return threads
+
+    def list_restart_process_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+        """Return only host-proven automation threads eligible for restart adoption."""
+        return [
+            thread
+            for thread in self._unresolved_threads(pr_number)
+            if isinstance(thread.get("process_receipt"), dict)
+        ]
 
     def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
         """Read shared PR state for seed, implementation, and merge_wait.

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -301,6 +301,11 @@ class FakeStageGitHub(FakeGitHub):
                 )
         return threads
 
+    def list_restart_process_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+        """Return no restart receipts unless a test explicitly supplies one."""
+        del pr_number
+        return []
+
     # -- mutator surface used by the stages ----------------------------------
     # Coordinator-neutral names (the pipeline architecture guard forbids
     # github_api mutator names inside pipeline modules); each delegates to

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1071,6 +1071,7 @@ class TestProcessOwnedReviewThreadLifecycle:
         result = PrReviewStage().step(item, make_ctx(github=RestartGitHub()))
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
         assert item.payload["process_review_threads"] == [receipt]
         assert json.loads(result.job.prompt_kwargs["prior_comments_json"]) == [live]
         item.payload["validation_result"] = {"unaddressed": [], "wont_fix": []}

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1054,6 +1054,28 @@ class TestProcessOwnedReviewThreadLifecycle:
 
         assert not _is_process_thread_receipt(receipt)
 
+    def test_validation_adopts_a_canonical_live_restart_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A host-normalized prior automation thread re-enters the one receipt flow."""
+        receipt = self._thread("process-1", 3, "fix this")
+        live = {**receipt, "process_receipt": dict(receipt)}
+
+        class RestartGitHub(FakeStageGitHub):
+            def list_restart_process_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+                del pr_number
+                return [dict(live)]
+
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
+        result = PrReviewStage().step(item, make_ctx(github=RestartGitHub()))
+
+        assert isinstance(result, JobRequest)
+        assert item.payload["process_review_threads"] == [receipt]
+        assert json.loads(result.job.prompt_kwargs["prior_comments_json"]) == [live]
+        item.payload["validation_result"] = {"unaddressed": [], "wont_fix": []}
+        assert _handled_process_receipts(item) == ([receipt], {"process-1": "addressed"})
+
     def test_wont_fix_process_thread_is_not_a_resolution_candidate(
         self, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -126,6 +126,141 @@ def _process_thread_receipt(thread_id: str, review_id: str, body: str) -> dict[s
 class TestProcessReviewThreadReceipts:
     """Durable receipts limit automated thread actions to this loop's threads."""
 
+    def test_live_automated_thread_exposes_a_canonical_restart_receipt(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only an immutable, marked automated review may be re-adopted after restart."""
+        review_id = "PRR_automation"
+        review_head = "b" * 40
+        automated_comment = "<!-- hephaestus-severity: major -->\nfix this"
+
+        monkeypatch.setattr(
+            adapter,
+            "_graphql",
+            lambda *_args, **_kwargs: {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "automated-thread",
+                                        "isResolved": False,
+                                        "path": "a.py",
+                                        "line": 7,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "pageInfo": {"hasNextPage": False},
+                                            "nodes": [
+                                                {
+                                                    "id": "automated-comment",
+                                                    "body": automated_comment,
+                                                    "author": {"login": "mvillmow"},
+                                                    "pullRequestReview": {
+                                                        "id": review_id,
+                                                        "body": (
+                                                            "## Automated PR review\n\nSummary."
+                                                        ),
+                                                        "commit": {"oid": review_head},
+                                                    },
+                                                }
+                                            ],
+                                        },
+                                    },
+                                    {
+                                        "id": "human-thread",
+                                        "isResolved": False,
+                                        "path": "a.py",
+                                        "line": 9,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "pageInfo": {"hasNextPage": False},
+                                            "nodes": [
+                                                {
+                                                    "id": "human-comment",
+                                                    "body": (
+                                                        "<!-- hephaestus-severity: major -->\n"
+                                                        "Keep the original text."
+                                                    ),
+                                                    "author": {"login": "mvillmow"},
+                                                    "pullRequestReview": {
+                                                        "id": "PRR_human",
+                                                        "body": "",
+                                                        "commit": {"oid": review_head},
+                                                    },
+                                                }
+                                            ],
+                                        },
+                                    },
+                                    {
+                                        "id": "replied-thread",
+                                        "isResolved": False,
+                                        "path": "a.py",
+                                        "line": 11,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "pageInfo": {"hasNextPage": False},
+                                            "nodes": [
+                                                {
+                                                    "id": "replied-comment",
+                                                    "body": automated_comment,
+                                                    "author": {"login": "mvillmow"},
+                                                    "pullRequestReview": {
+                                                        "id": review_id,
+                                                        "body": (
+                                                            "## Automated PR review\n\nSummary."
+                                                        ),
+                                                        "commit": {"oid": review_head},
+                                                    },
+                                                },
+                                                {
+                                                    "id": "human-reply",
+                                                    "body": "Please leave this open.",
+                                                    "author": {"login": "reviewer"},
+                                                    "pullRequestReview": {
+                                                        "id": review_id,
+                                                        "body": (
+                                                            "## Automated PR review\n\nSummary."
+                                                        ),
+                                                        "commit": {"oid": review_head},
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+        threads = adapter._repo_unresolved_threads(7)
+
+        assert threads[0]["process_receipt"] == {
+            "id": "automated-thread",
+            "path": "a.py",
+            "line": 7,
+            "side": "RIGHT",
+            "body": automated_comment,
+            "author": "mvillmow",
+            "authors": ["mvillmow"],
+            "comments": [
+                {
+                    "id": "automated-comment",
+                    "author": "mvillmow",
+                    "body": automated_comment,
+                    "review_id": review_id,
+                }
+            ],
+            "review_id": review_id,
+            "created_head_sha": review_head,
+        }
+        assert "process_receipt" not in threads[1]
+        assert "process_receipt" not in threads[2]
+
     def test_replies_before_resolving_a_revalidated_process_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- normalize host-proven automated review threads into canonical receipts after a worker restart
- validate, reply, and resolve only when the PR head has changed since the review
- preserve human and replied threads as hard boundaries

## Verification

- Full unit suite passed: 6,521 passed, 6 skipped; 85.02% coverage
- Ruff, formatter, mypy, and git diff --check passed

Closes #2486