### PR TITLE
fix(automation): reconcile stale review threads

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -450,8 +450,9 @@ def _thread_comment_signature(thread: dict[str, Any]) -> tuple[tuple[str, str], 
 
 
 def _is_process_thread_receipt(raw: dict[str, Any]) -> bool:
-    """Return whether one post-time receipt proves exactly one created comment."""
+    """Return whether a post-time or host-normalized stale receipt is exact."""
     review_id = raw.get("review_id")
+    line = raw.get("line")
     comments = raw.get("comments")
     initial = comments[0] if isinstance(comments, list) and len(comments) == 1 else None
     return bool(
@@ -464,6 +465,10 @@ def _is_process_thread_receipt(raw: dict[str, Any]) -> bool:
         and isinstance(initial.get("id"), str)
         and initial["id"].strip()
         and initial.get("review_id") == review_id
+        and (
+            (isinstance(line, int) and not isinstance(line, bool) and line > 0)
+            or (line is None and raw.get("restart_stale_line") is True)
+        )
         and _thread_comment_signature(raw) is not None
     )
 

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -255,9 +255,7 @@ def _canonical_restart_process_receipt(thread: dict[str, Any]) -> dict[str, Any]
         and thread_id
         and isinstance(path, str)
         and path
-        and isinstance(line, int)
-        and not isinstance(line, bool)
-        and line > 0
+        and (line is None or (isinstance(line, int) and not isinstance(line, bool) and line > 0))
         and side == "RIGHT"
         and isinstance(author, str)
         and author
@@ -267,7 +265,7 @@ def _canonical_restart_process_receipt(thread: dict[str, Any]) -> dict[str, Any]
         and comment_id
     ):
         return None
-    return {
+    receipt = {
         "id": thread_id,
         "path": path,
         "line": line,
@@ -286,6 +284,12 @@ def _canonical_restart_process_receipt(thread: dict[str, Any]) -> dict[str, Any]
         "review_id": review_id,
         "created_head_sha": review_commit_sha,
     }
+    if line is None:
+        # GitHub clears the position when the reviewed diff moves.  This is
+        # restart-only provenance: newly posted threads must still have a
+        # current positive line at the post/readback boundary.
+        receipt["restart_stale_line"] = True
+    return receipt
 
 
 def _has_no_explicit_pull_request_bypasses(protection: dict[str, Any]) -> bool:
@@ -878,7 +882,7 @@ class PipelineGitHub:
 
     @staticmethod
     def _is_immutable_process_receipt(receipt: dict[str, Any]) -> bool:
-        """Return whether a receipt proves one initial process-created comment."""
+        """Return whether a receipt proves one immutable process-created comment."""
         thread_id = receipt.get("id")
         review_id = receipt.get("review_id")
         path = receipt.get("path")
@@ -896,9 +900,10 @@ class PipelineGitHub:
             and review_id.strip()
             and isinstance(path, str)
             and path.strip()
-            and isinstance(line, int)
-            and not isinstance(line, bool)
-            and line > 0
+            and (
+                (isinstance(line, int) and not isinstance(line, bool) and line > 0)
+                or (line is None and receipt.get("restart_stale_line") is True)
+            )
             and side == "RIGHT"
             and isinstance(author, str)
             and author.strip()

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1054,6 +1054,17 @@ class TestProcessOwnedReviewThreadLifecycle:
 
         assert not _is_process_thread_receipt(receipt)
 
+    def test_stale_line_receipt_requires_explicit_restart_provenance(self) -> None:
+        """Only host-normalized restart receipts may retain GitHub's null line."""
+        receipt = self._thread("process-1", 3, "fix this")
+        receipt["line"] = None
+
+        assert not _is_process_thread_receipt(receipt)
+
+        receipt["restart_stale_line"] = True
+
+        assert _is_process_thread_receipt(receipt)
+
     def test_validation_adopts_a_canonical_live_restart_receipt(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -229,6 +229,30 @@ class TestProcessReviewThreadReceipts:
                                             ],
                                         },
                                     },
+                                    {
+                                        "id": "stale-thread",
+                                        "isResolved": False,
+                                        "path": "stale.py",
+                                        "line": None,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "pageInfo": {"hasNextPage": False},
+                                            "nodes": [
+                                                {
+                                                    "id": "stale-comment",
+                                                    "body": automated_comment,
+                                                    "author": {"login": "mvillmow"},
+                                                    "pullRequestReview": {
+                                                        "id": review_id,
+                                                        "body": (
+                                                            "## Automated PR review\n\nSummary."
+                                                        ),
+                                                        "commit": {"oid": review_head},
+                                                    },
+                                                }
+                                            ],
+                                        },
+                                    },
                                 ],
                             }
                         }
@@ -260,6 +284,39 @@ class TestProcessReviewThreadReceipts:
         }
         assert "process_receipt" not in threads[1]
         assert "process_receipt" not in threads[2]
+        assert threads[3]["process_receipt"] == {
+            "id": "stale-thread",
+            "path": "stale.py",
+            "line": None,
+            "side": "RIGHT",
+            "body": automated_comment,
+            "author": "mvillmow",
+            "authors": ["mvillmow"],
+            "comments": [
+                {
+                    "id": "stale-comment",
+                    "author": "mvillmow",
+                    "body": automated_comment,
+                    "review_id": review_id,
+                }
+            ],
+            "review_id": review_id,
+            "created_head_sha": review_head,
+            "restart_stale_line": True,
+        }
+
+    def test_stale_line_receipt_requires_restart_provenance(
+        self, adapter: pg.PipelineGitHub
+    ) -> None:
+        """A null line is eligible only for the host-normalized restart shape."""
+        receipt = _process_thread_receipt("PRRT_stale", "PRR_stale", "finding")
+        receipt["line"] = None
+
+        assert not adapter._is_immutable_process_receipt(receipt)
+
+        receipt["restart_stale_line"] = True
+
+        assert adapter._is_immutable_process_receipt(receipt)
 
     def test_replies_before_resolving_a_revalidated_process_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- retain restart-only provenance when GitHub clears an old inline diff position
- require a valid live line for newly posted thread receipts
- continue binding reply-and-resolve actions to the exact thread, review, comment, and reviewed head

## Verification

- uv run --all-extras pytest tests/unit -q (6524 passed, 7 skipped)
- focused pipeline receipt and stage tests (285 passed)
- ruff check, ruff format --check, and mypy on the changed automation modules

Closes #2490