### PR TITLE
fix(automation): route verified bot review threads

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -455,6 +455,7 @@ def _is_process_thread_receipt(raw: dict[str, Any]) -> bool:
     line = raw.get("line")
     comments = raw.get("comments")
     initial = comments[0] if isinstance(comments, list) and len(comments) == 1 else None
+    external_bot = raw.get("external_bot") is True
     return bool(
         _durable_thread_id(raw)
         and isinstance(review_id, str)
@@ -470,6 +471,14 @@ def _is_process_thread_receipt(raw: dict[str, Any]) -> bool:
             or (line is None and raw.get("restart_stale_line") is True)
         )
         and _thread_comment_signature(raw) is not None
+        and (
+            not external_bot
+            or (
+                raw.get("author_type") == "Bot"
+                and isinstance(initial, dict)
+                and initial.get("author_type") == "Bot"
+            )
+        )
     )
 
 
@@ -1283,12 +1292,14 @@ class PrReviewStage(Stage):
     def _reconcile_process_threads_before_post(
         item: WorkItem, ctx: StageContext, threads: list[dict[str, Any]]
     ) -> list[dict[str, Any]] | StepResult:
-        """Suppress duplicate findings and hand live process threads to a human.
+        """Suppress duplicate findings and preserve process-thread boundaries.
 
         Guarded receipt reconciliation runs immediately before this helper.
-        Any process thread still live here was unaddressed, changed, or not
-        provably process-owned, so it remains a GitHub-human gate. A fresh run
-        can proceed after a human resolves it or a new exact receipt is made.
+        A live loop-created thread remains a GitHub-human gate.  A verified
+        external Bot receipt may proceed only when the validator explicitly
+        reports it unaddressed; POST then routes its fenced finding through
+        the normal address path.  Any changed, replied, malformed, user, or
+        validator-ambiguous thread remains a hard handoff.
         """
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
@@ -1312,12 +1323,29 @@ class PrReviewStage(Stage):
         if live_process is None:
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
-        if live_process:
+        bot_ids = {
+            thread_id
+            for thread_id, receipt in records.items()
+            if receipt.get("external_bot") is True and thread_id in live_process
+        }
+        if set(live_process) - bot_ids:
             return PrReviewStage._handle_automation_threads_requiring_human_resolution(
                 item,
-                len(live_process),
+                len(set(live_process) - bot_ids),
                 ctx,
             )
+        if bot_ids:
+            parsed = _parse_validation_result(item.payload.get("validation_result"))
+            if parsed is None:
+                return PrReviewStage._handle_automation_threads_requiring_human_resolution(
+                    item, len(bot_ids), ctx
+                )
+            unaddressed = _thread_ids(parsed.get("unaddressed"))
+            wont_fix = _thread_ids(parsed.get("wont_fix"))
+            if bot_ids & wont_fix or not bot_ids.issubset(unaddressed):
+                return PrReviewStage._handle_automation_threads_requiring_human_resolution(
+                    item, len(bot_ids), ctx
+                )
         return _without_duplicate_live_process_findings(threads, live_process)
 
     @staticmethod

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -120,7 +120,11 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
+    automation = sum(
+        1
+        for thread in threads
+        if _is_automation_owned_thread(thread, current_login) or _has_external_bot_receipt(thread)
+    )
     return automation, len(threads) - automation
 
 
@@ -290,6 +294,80 @@ def _canonical_restart_process_receipt(thread: dict[str, Any]) -> dict[str, Any]
         # current positive line at the post/readback boundary.
         receipt["restart_stale_line"] = True
     return receipt
+
+
+def _canonical_external_bot_receipt(thread: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a restart receipt for one immutable GitHub Bot review thread.
+
+    A verified GitHub ``Bot`` actor is distinct from a user handoff, but its
+    finding remains untrusted and must still pass the same validator, changed
+    head, exact reply/readback, and resolution/readback boundaries as a
+    process-created thread.  Threads with replies or incomplete review
+    provenance deliberately remain outside this path.
+    """
+    comments = thread.get("comments")
+    if not isinstance(comments, list) or len(comments) != 1:
+        return None
+    comment = comments[0]
+    if not isinstance(comment, dict) or comment.get("author_type") != "Bot":
+        return None
+    thread_id = thread.get("id")
+    path = thread.get("path")
+    line = thread.get("line")
+    side = thread.get("side")
+    body = comment.get("body")
+    author = comment.get("author")
+    review_id = comment.get("review_id")
+    comment_id = comment.get("id")
+    review_commit_sha = thread.get("review_commit_sha")
+    if not (
+        isinstance(thread_id, str)
+        and thread_id
+        and isinstance(path, str)
+        and path
+        and isinstance(line, int)
+        and not isinstance(line, bool)
+        and line > 0
+        and side == "RIGHT"
+        and isinstance(body, str)
+        and isinstance(author, str)
+        and author
+        and isinstance(review_id, str)
+        and review_id
+        and isinstance(comment_id, str)
+        and comment_id
+        and isinstance(review_commit_sha, str)
+        and re.fullmatch(r"[0-9a-f]{40}", review_commit_sha) is not None
+    ):
+        return None
+    return {
+        "id": thread_id,
+        "path": path,
+        "line": line,
+        "side": side,
+        "body": body,
+        "author": author,
+        "author_type": "Bot",
+        "authors": [author],
+        "comments": [
+            {
+                "id": comment_id,
+                "author": author,
+                "author_type": "Bot",
+                "body": body,
+                "review_id": review_id,
+            }
+        ],
+        "review_id": review_id,
+        "created_head_sha": review_commit_sha,
+        "external_bot": True,
+    }
+
+
+def _has_external_bot_receipt(thread: dict[str, Any]) -> bool:
+    """Return whether a host-normalized thread is eligible for bot remediation."""
+    receipt = thread.get("process_receipt")
+    return isinstance(receipt, dict) and receipt.get("external_bot") is True
 
 
 def _has_no_explicit_pull_request_bypasses(protection: dict[str, Any]) -> bool:
@@ -619,7 +697,8 @@ class PipelineGitHub:
             "        pageInfo{ hasNextPage endCursor }"
             "        nodes{ id isResolved path line side:diffSide "
             "comments(first:20){ pageInfo{ hasNextPage } "
-            "nodes{ id body author{ login } pullRequestReview{ id body commit{ oid } } } } }"
+            "nodes{ id body author{ login __typename } "
+            "pullRequestReview{ id body commit{ oid } } } } }"
             "      }"
             "    }"
             "  }"
@@ -656,6 +735,10 @@ class PipelineGitHub:
                     author_node = comment.get("author")
                     author = author_node.get("login") if isinstance(author_node, dict) else ""
                     author = author or ""
+                    author_type = (
+                        author_node.get("__typename") if isinstance(author_node, dict) else ""
+                    )
+                    author_type = author_type or ""
                     if author:
                         authors.append(author)
                     review = comment.get("pullRequestReview") or {}
@@ -671,6 +754,7 @@ class PipelineGitHub:
                             "id": str(comment.get("id") or ""),
                             "body": comment.get("body") or "",
                             "author": author,
+                            "author_type": author_type,
                             "review_id": review_id or "",
                         }
                     )
@@ -681,13 +765,16 @@ class PipelineGitHub:
                     "side": node.get("side") or "RIGHT",
                     "body": first_comment.get("body", ""),
                     "author": authors[0] if authors else "",
+                    "author_type": comments[0].get("author_type", "") if comments else "",
                     "authors": authors,
                     "comments": comments,
                     "review_id": comments[0].get("review_id", "") if comments else "",
                     "review_body": review_body,
                     "review_commit_sha": review_commit_sha,
                 }
-                restart_receipt = _canonical_restart_process_receipt(thread)
+                restart_receipt = _canonical_restart_process_receipt(
+                    thread
+                ) or _canonical_external_bot_receipt(thread)
                 if restart_receipt is not None:
                     thread["process_receipt"] = restart_receipt
                 threads.append(thread)
@@ -893,6 +980,7 @@ class PipelineGitHub:
         comments = receipt.get("comments")
         created_head_sha = receipt.get("created_head_sha")
         initial = comments[0] if isinstance(comments, list) and len(comments) == 1 else None
+        external_bot = receipt.get("external_bot") is True
         return bool(
             isinstance(thread_id, str)
             and thread_id.strip()
@@ -918,6 +1006,10 @@ class PipelineGitHub:
             and initial.get("author") == author
             and initial.get("body") == body
             and initial.get("review_id") == review_id
+            and (
+                not external_bot
+                or (receipt.get("author_type") == "Bot" and initial.get("author_type") == "Bot")
+            )
         )
 
     @staticmethod
@@ -1313,7 +1405,7 @@ class PipelineGitHub:
         current_login = github_api.gh_current_login()
         blocking = minor = human = 0
         for t in threads:
-            if _is_automation_owned_thread(t, current_login):
+            if _is_automation_owned_thread(t, current_login) or _has_external_bot_receipt(t):
                 if _thread_severity_is_blocking(t):
                     blocking += 1
                 else:
@@ -1327,11 +1419,13 @@ class PipelineGitHub:
         threads = self._unresolved_threads(pr_number)
         current_login = github_api.gh_current_login()
         for thread in threads:
-            thread["automation_owned"] = _is_automation_owned_thread(thread, current_login)
+            thread["automation_owned"] = _is_automation_owned_thread(
+                thread, current_login
+            ) or _has_external_bot_receipt(thread)
         return threads
 
     def list_restart_process_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
-        """Return only host-proven automation threads eligible for restart adoption."""
+        """Return only host-proven process or verified-bot restart receipts."""
         return [
             thread
             for thread in self._unresolved_threads(pr_number)

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1065,6 +1065,69 @@ class TestProcessOwnedReviewThreadLifecycle:
 
         assert _is_process_thread_receipt(receipt)
 
+    def test_external_bot_receipt_requires_verified_bot_actor(self) -> None:
+        """A login-shaped user thread must not enter the external-bot path."""
+        receipt = self._thread("bot-1", 3, "fix this")
+        receipt.update(
+            {
+                "external_bot": True,
+                "author_type": "Bot",
+            }
+        )
+        receipt["comments"][0]["author_type"] = "Bot"
+
+        assert _is_process_thread_receipt(receipt)
+
+        receipt["author_type"] = "User"
+
+        assert not _is_process_thread_receipt(receipt)
+
+    def test_unaddressed_external_bot_receipt_routes_to_remediation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An exact bot finding is fenced into the address path, not a human handoff."""
+        bot = self._thread("bot-1", 3, "fix this")
+        bot.update(
+            {
+                "external_bot": True,
+                "author_type": "Bot",
+                "automation_owned": True,
+            }
+        )
+        bot["comments"][0]["author_type"] = "Bot"
+
+        class BotGitHub(FakeStageGitHub):
+            def list_unresolved_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+                del pr_number
+                return [dict(bot)]
+
+        item = make_work_item(issue=1, pr=1001, state="POST")
+        item.worktree = "/tmp/wt"
+        item.payload.update(
+            {
+                "existing_pr": True,
+                "reviewed_pr_head_sha": "a" * 40,
+                "process_review_threads": [dict(bot)],
+                "validation_process_threads": [dict(bot)],
+                "validation_result": {"unaddressed": [{"thread_id": "bot-1"}], "wont_fix": []},
+                "review_audit": ReviewAudit("A", "clean", (), "", valid=True),
+                "review_threads": [],
+            }
+        )
+
+        stage = PrReviewStage()
+        assert stage.step(item, make_ctx(github=BotGitHub())) == Continue(
+            next_state="DIFFICULTY_WAIT"
+        )
+        assert item.payload["remediation_threads"] == [
+            {
+                "thread_id": "bot-1",
+                "path": "a.py",
+                "line": 3,
+                "body": "<!-- hephaestus-severity: major -->\nfix this",
+            }
+        ]
+
     def test_validation_adopts_a_canonical_live_restart_receipt(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -253,6 +253,31 @@ class TestProcessReviewThreadReceipts:
                                             ],
                                         },
                                     },
+                                    {
+                                        "id": "bot-thread",
+                                        "isResolved": False,
+                                        "path": "bot.py",
+                                        "line": 13,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "pageInfo": {"hasNextPage": False},
+                                            "nodes": [
+                                                {
+                                                    "id": "bot-comment",
+                                                    "body": "Please handle this finding.",
+                                                    "author": {
+                                                        "login": "github-code-quality",
+                                                        "__typename": "Bot",
+                                                    },
+                                                    "pullRequestReview": {
+                                                        "id": "PRR_bot",
+                                                        "body": "Automated quality review.",
+                                                        "commit": {"oid": review_head},
+                                                    },
+                                                }
+                                            ],
+                                        },
+                                    },
                                 ],
                             }
                         }
@@ -304,6 +329,28 @@ class TestProcessReviewThreadReceipts:
             "created_head_sha": review_head,
             "restart_stale_line": True,
         }
+        assert threads[4]["process_receipt"] == {
+            "id": "bot-thread",
+            "path": "bot.py",
+            "line": 13,
+            "side": "RIGHT",
+            "body": "Please handle this finding.",
+            "author": "github-code-quality",
+            "author_type": "Bot",
+            "authors": ["github-code-quality"],
+            "comments": [
+                {
+                    "id": "bot-comment",
+                    "author": "github-code-quality",
+                    "author_type": "Bot",
+                    "body": "Please handle this finding.",
+                    "review_id": "PRR_bot",
+                }
+            ],
+            "review_id": "PRR_bot",
+            "created_head_sha": review_head,
+            "external_bot": True,
+        }
 
     def test_stale_line_receipt_requires_restart_provenance(
         self, adapter: pg.PipelineGitHub
@@ -318,12 +365,36 @@ class TestProcessReviewThreadReceipts:
 
         assert adapter._is_immutable_process_receipt(receipt)
 
-    def test_replies_before_resolving_a_revalidated_process_receipt(
+    def test_verified_bot_receipt_is_automation_owned_without_login_matching(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A handled receipt gets the loop reply before its thread is resolved."""
+        """A host-proven Bot receipt does not rely on a login allowlist."""
+        thread = {
+            "id": "bot-thread",
+            "process_receipt": {"external_bot": True},
+            "author": "github-code-quality",
+            "authors": ["github-code-quality"],
+        }
+        monkeypatch.setattr(adapter, "_unresolved_threads", lambda _pr: [dict(thread)])
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "mvillmow")
+
+        threads = adapter.list_unresolved_review_threads(7)
+
+        assert threads[0]["automation_owned"] is True
+
+    @pytest.mark.parametrize("external_bot", [False, True], ids=["process", "verified-bot"])
+    def test_replies_before_resolving_a_revalidated_process_receipt(
+        self,
+        adapter: pg.PipelineGitHub,
+        monkeypatch: pytest.MonkeyPatch,
+        external_bot: bool,
+    ) -> None:
+        """A handled process or verified-bot receipt replies before resolution."""
         adapter.repo = "repo"
         receipt = _process_thread_receipt("PRRT_process_1", "PRR_process_1", "finding")
+        if external_bot:
+            receipt.update({"external_bot": True, "author_type": "Bot"})
+            receipt["comments"][0]["author_type"] = "Bot"
         reply_body: dict[str, str] = {}
         live_reads = 0
 


### PR DESCRIPTION
## Summary

- retain GitHub actor kind and normalize only strict Bot review receipts
- send explicitly unaddressed Bot findings through the fenced remediation path
- preserve User, malformed, replied, changed, ambiguous, and wont-fix threads as human handoffs

## Verification

- full unit suite: 6,528 passed, 7 skipped
- pre-push full suite completed successfully
- focused pipeline and stage tests: 289 passed
- ruff, formatting, and mypy passed

Closes #2492