### PR TITLE
fix(automation): converge direct PR handoffs

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -212,6 +212,14 @@ _DIRECT_ISSUE_ENTRY_STAGES: frozenset[StageName] = frozenset(
     }
 )
 
+# A direct PR that reached one of these explicit safety handoffs cannot make
+# further progress until a person changes the review state on GitHub.  Retain
+# the identity only for this coordinator invocation so the current run
+# converges, while a later invocation still re-evaluates fresh GitHub facts.
+_DIRECT_PR_HANDOFF_REASONS: frozenset[str] = frozenset(
+    {"human_blocked", "automation_threads_require_human_resolution"}
+)
+
 StageStepResult: TypeAlias = Continue | JobRequest | StageOutcome
 
 
@@ -542,6 +550,7 @@ class Coordinator:
         self._pending_handoffs: dict[int, _PendingHandoff] = {}
         self._direct_issue_source: _DirectIssueSource | None = None
         self._direct_pr_source: _DirectPrSource | None = None
+        self._direct_pr_handoff_keys: set[tuple[str, int]] = set()
         self._direct_scope_bootstrap_pending = False
         self._repo_entry_source: _RepoEntrySource | None = None
         self._repo_issue_sources: deque[_ActiveRepoIssueSource] = deque()
@@ -1001,6 +1010,12 @@ class Coordinator:
         """
         if item.result is None or item.payload.get("_summary_recorded", False):
             return
+        if (
+            item.kind is ItemKind.PR
+            and item.pr is not None
+            and item.result.reason in _DIRECT_PR_HANDOFF_REASONS
+        ):
+            self._direct_pr_handoff_keys.add((item.repo, item.pr))
         item.payload["_summary_recorded"] = True
         self._terminal_summary.record(item)
         self._seen_item_ids.discard(id(item))
@@ -2427,7 +2442,9 @@ class Coordinator:
         if self.config.prs:
             self._direct_pr_source = _DirectPrSource(
                 repo=repo,
-                prs=iter(self.config.prs),
+                prs=(
+                    pr for pr in self.config.prs if (repo, pr) not in self._direct_pr_handoff_keys
+                ),
                 base_sha=base_sha,
             )
 
@@ -2824,6 +2841,19 @@ class Coordinator:
             )
         )
 
+    def _only_direct_pr_handoffs_remain(self) -> bool:
+        """Return whether every explicitly scoped PR needs an external human action.
+
+        This is deliberately limited to ``--prs`` without ``--issues`` and
+        only lasts for the current coordinator.  A later invocation must
+        query GitHub again because a reviewer may have resolved a thread or
+        changed the PR head in the meantime.
+        """
+        if self.config.issues or not self.config.prs or not self.config.repos:
+            return False
+        repo = self.config.repos[0]
+        return all((repo, pr) in self._direct_pr_handoff_keys for pr in self.config.prs)
+
     def _reseed_if_converged(self) -> bool:
         """Re-seed after full drain; False = stop (loops or zero-work exit).
 
@@ -2832,6 +2862,9 @@ class Coordinator:
         actionable (non-repo, non-finished) work, the run converged — exit
         even if ``--loops`` remain.
         """
+        if self._only_direct_pr_handoffs_remain():
+            logger.info("direct PR handoff convergence: all scoped PRs require human action")
+            return False
         if self._loops_run >= self.config.loops:
             logger.info("loop budget exhausted (%d/%d)", self._loops_run, self.config.loops)
             return False

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -378,6 +378,61 @@ class TestQuiescence:
         assert coordinator._reseed_if_converged() is False
         assert coordinator._loops_run == 1
 
+    def test_fresh_coordinator_rechecks_direct_pr_after_handoff(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A later invocation has no in-memory handoff state from the prior run."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            prs=[701],
+            max_workers=2,
+            projects_dir=tmp_path,
+        )
+        prior = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        prior_item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.PR,
+            issue=700,
+            pr=701,
+            stage=StageName.PR_REVIEW,
+        )
+        prior_item.result = ItemResult(
+            passed=False,
+            reason="human_blocked",
+            final_stage=StageName.PR_REVIEW,
+        )
+        prior._record_terminal_result(prior_item)
+
+        current = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        entry = SeedEntry(
+            kind="pr",
+            identifier=701,
+            stage=StageName.PR_REVIEW,
+            reason="awaiting review",
+            pr_number=701,
+            issue_number=700,
+        )
+        monkeypatch.setattr(
+            current,
+            "_seed_direct_pr_scope",
+            lambda _repo, _prs: [entry],
+        )
+
+        current._begin_direct_pr_source("repo-a", "")
+
+        assert current._drain_direct_pr_source() == 1
+
     def test_poisoned_item_routes_finished_fail_and_loop_survives(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -34,7 +34,7 @@ from hephaestus.automation.pipeline.routing import (
 )
 from hephaestus.automation.pipeline.seeding import SeedEntry
 from hephaestus.automation.pipeline.stages.base import JobRequest
-from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
 from hephaestus.resilience import (
     all_circuit_breaker_snapshots,
     get_circuit_breaker,
@@ -287,6 +287,96 @@ class TestQuiescence:
 
         assert coordinator._reseed_if_converged() is False
         assert coordinator._loops_run == 2
+
+    @pytest.mark.parametrize(
+        "handoff_reason",
+        ["human_blocked", "automation_threads_require_human_resolution"],
+    )
+    def test_direct_pr_human_handoff_is_not_reseeded_in_same_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, handoff_reason: str
+    ) -> None:
+        """An unchanged human handoff converges instead of re-reviewing the PR."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                prs=[701],
+                max_workers=2,
+                projects_dir=tmp_path,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        entry = SeedEntry(
+            kind="pr",
+            identifier=701,
+            stage=StageName.PR_REVIEW,
+            reason="awaiting review",
+            pr_number=701,
+            issue_number=700,
+        )
+        monkeypatch.setattr(
+            coordinator,
+            "_seed_direct_pr_scope",
+            lambda _repo, _prs: [entry],
+        )
+
+        coordinator._begin_direct_pr_source("repo-a", "")
+        assert coordinator._drain_direct_pr_source() == 1
+        first_item = coordinator.items[0]
+        first_item.result = ItemResult(
+            passed=False,
+            reason=handoff_reason,
+            final_stage=StageName.PR_REVIEW,
+        )
+        coordinator._record_terminal_result(first_item)
+
+        coordinator._pass_work_count = 0
+        coordinator._begin_direct_pr_source("repo-a", "")
+
+        assert coordinator._drain_direct_pr_source() == 0
+        assert coordinator._pass_work_count == 0
+
+    def test_only_direct_pr_handoffs_stop_before_a_new_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All explicit PRs awaiting a person end the run without a reseed."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                prs=[701],
+                loops=2,
+                projects_dir=tmp_path,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.PR,
+            issue=700,
+            pr=701,
+            stage=StageName.PR_REVIEW,
+        )
+        item.result = ItemResult(
+            passed=False,
+            reason="human_blocked",
+            final_stage=StageName.PR_REVIEW,
+        )
+        coordinator._record_terminal_result(item)
+        coordinator._loops_run = 1
+        coordinator._pass_work_count = 1
+        monkeypatch.setattr(
+            coordinator,
+            "_seed_pass",
+            lambda: pytest.fail("a terminal direct PR handoff must not reseed"),
+        )
+
+        assert coordinator._reseed_if_converged() is False
+        assert coordinator._loops_run == 1
 
     def test_poisoned_item_routes_finished_fail_and_loop_survives(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Summary:
- Stop re-seeding explicitly scoped PRs that have reached a terminal human-action handoff.
- End a direct-PR-only run before an empty follow-up pass.
- Keep GitHub discovery fresh for the next invocation.

Verification:
- Pipeline suite: 1,169 passed.
- Pre-commit: all hooks passed.
- Locked pre-push suite: 6,906 passed, 6 skipped, 85.08% coverage.

Closes #2494