### PR TITLE
fix(automation): remediate prior review threads

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -341,7 +341,7 @@ class StageGitHub(Protocol):
         receipts: list[dict[str, Any]],
         dispositions: dict[str, str],
     ) -> ProcessThreadResolutionResult:
-        """Reply then resolve exact, freshly revalidated process-owned receipts."""
+        """Reply then resolve exact, freshly revalidated thread receipts."""
         ...
 
     def mark_pr_implementation_go(self, pr_number: int) -> None:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1295,11 +1295,10 @@ class PrReviewStage(Stage):
         """Suppress duplicate findings and preserve process-thread boundaries.
 
         Guarded receipt reconciliation runs immediately before this helper.
-        A live loop-created thread remains a GitHub-human gate.  A verified
-        external Bot receipt may proceed only when the validator explicitly
-        reports it unaddressed; POST then routes its fenced finding through
-        the normal address path.  Any changed, replied, malformed, user, or
-        validator-ambiguous thread remains a hard handoff.
+        A verified process receipt may proceed only when the validator
+        explicitly reports it unaddressed; POST then routes its fenced finding
+        through the normal address path. Any changed, replied, malformed,
+        user, or validator-ambiguous thread remains a hard handoff.
         """
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
@@ -1323,28 +1322,18 @@ class PrReviewStage(Stage):
         if live_process is None:
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
-        bot_ids = {
-            thread_id
-            for thread_id, receipt in records.items()
-            if receipt.get("external_bot") is True and thread_id in live_process
-        }
-        if set(live_process) - bot_ids:
-            return PrReviewStage._handle_automation_threads_requiring_human_resolution(
-                item,
-                len(set(live_process) - bot_ids),
-                ctx,
-            )
-        if bot_ids:
+        process_ids = set(live_process)
+        if process_ids:
             parsed = _parse_validation_result(item.payload.get("validation_result"))
             if parsed is None:
                 return PrReviewStage._handle_automation_threads_requiring_human_resolution(
-                    item, len(bot_ids), ctx
+                    item, len(process_ids), ctx
                 )
             unaddressed = _thread_ids(parsed.get("unaddressed"))
             wont_fix = _thread_ids(parsed.get("wont_fix"))
-            if bot_ids & wont_fix or not bot_ids.issubset(unaddressed):
+            if process_ids & wont_fix or not process_ids.issubset(unaddressed):
                 return PrReviewStage._handle_automation_threads_requiring_human_resolution(
-                    item, len(bot_ids), ctx
+                    item, len(process_ids), ctx
                 )
         return _without_duplicate_live_process_findings(threads, live_process)
 
@@ -2192,12 +2181,12 @@ class PrReviewStage(Stage):
         automation_unresolved: int,
         ctx: StageContext,
     ) -> StepResult:
-        """Record a fail-closed handoff for open threads outside the receipt scope.
+        """Record a fail-closed handoff for open threads that cannot be proven safe.
 
-        The guarded adapter may reply and resolve only immutable receipts it
-        revalidates immediately before each mutation. Any remaining thread is
-        unaddressed, human-owned, changed, or otherwise unprovable and must
-        remain a human gate.
+        The guarded adapter may reply and resolve a canonical receipt from any
+        loop invocation after revalidating it immediately before each mutation.
+        A remaining changed, human-owned, malformed, or otherwise unprovable
+        thread must remain a human gate.
         """
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
@@ -2208,7 +2197,7 @@ class PrReviewStage(Stage):
             "**Automation stand-down: unresolved automation review thread(s) require "
             "human resolution.**\n\n"
             f"{automation_unresolved} automation-created review thread(s) remain open on this "
-            "PR outside the immutable process-receipt scope. The guarded loop could not prove "
+            "PR without a verifiable immutable receipt. The guarded loop could not prove "
             "that a reply and resolution would leave human activity untouched. "
             "The PR is marked `state:implementation-no-go`; automation does not arm auto-merge. "
             "A human must "

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1083,11 +1083,12 @@ class PipelineGitHub:
         receipts: list[dict[str, Any]],
         dispositions: dict[str, str],
     ) -> ProcessThreadResolutionResult:
-        """Reply then resolve exact active-work-item process receipts.
+        """Reply then resolve exact, freshly revalidated review-thread receipts.
 
-        The stage supplies only canonical receipts held by the current active
-        work item. A restart may re-adopt a host-normalized receipt, but this
-        accessor intentionally owns no second persistence journal.
+        The stage may supply a receipt posted in this work item or a canonical
+        receipt reconstructed from a prior loop invocation. This accessor owns
+        no second persistence journal; it proves the submitted receipt still
+        exactly matches GitHub immediately before each mutation.
         """
         candidate_ids = tuple(sorted(dispositions))
         if self._skip(

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1140,16 +1140,42 @@ class TestProcessOwnedReviewThreadLifecycle:
                 del pr_number
                 return [dict(live)]
 
+            def list_unresolved_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+                del pr_number
+                return [dict(live)]
+
         item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
         item.payload["reviewed_pr_head_sha"] = "a" * 40
-        result = PrReviewStage().step(item, make_ctx(github=RestartGitHub()))
+        stage = PrReviewStage()
+        result = stage.step(item, make_ctx(github=RestartGitHub()))
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
         assert item.payload["process_review_threads"] == [receipt]
         assert json.loads(result.job.prompt_kwargs["prior_comments_json"]) == [live]
-        item.payload["validation_result"] = {"unaddressed": [], "wont_fix": []}
-        assert _handled_process_receipts(item) == ([receipt], {"process-1": "addressed"})
+        item.state = "POST"
+        item.payload.update(
+            {
+                "validation_result": {
+                    "unaddressed": [{"thread_id": "process-1"}],
+                    "wont_fix": [],
+                },
+                "review_audit": ReviewAudit("A", "clean", (), "", valid=True),
+                "review_threads": [],
+            }
+        )
+
+        assert stage.step(item, make_ctx(github=RestartGitHub())) == Continue(
+            next_state="DIFFICULTY_WAIT"
+        )
+        assert item.payload["remediation_threads"] == [
+            {
+                "thread_id": "process-1",
+                "path": "a.py",
+                "line": 3,
+                "body": "<!-- hephaestus-severity: major -->\nfix this",
+            }
+        ]
 
     def test_wont_fix_process_thread_is_not_a_resolution_candidate(
         self, make_work_item: Any
@@ -1636,10 +1662,10 @@ class TestProcessOwnedReviewThreadLifecycle:
             assert result == Continue(next_state="REVIEW_WAIT")
             assert github.mutation_log == []
 
-    def test_live_process_thread_requires_human_resolution_without_thread_write(
+    def test_unaddressed_process_thread_routes_to_remediation(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """No receipt revalidation can authorize an automatic thread mutation."""
+        """A verified prior finding is sent to the address leg, not handed off."""
 
         class GuardRaceGitHub(FakeStageGitHub):
             def __init__(self, live: dict[str, Any]) -> None:
@@ -1658,7 +1684,10 @@ class TestProcessOwnedReviewThreadLifecycle:
                 "reviewed_pr_head_sha": "a" * 40,
                 "process_review_threads": [process],
                 "validation_process_threads": [process],
-                "validation_result": {"unaddressed": [], "wont_fix": []},
+                "validation_result": {
+                    "unaddressed": [{"thread_id": "process-1"}],
+                    "wont_fix": [],
+                },
                 "review_audit": ReviewAudit("A", "clean", (), "", valid=True),
                 "review_threads": [],
             }
@@ -1666,11 +1695,16 @@ class TestProcessOwnedReviewThreadLifecycle:
 
         result = PrReviewStage().step(item, make_ctx(github=github))
 
-        assert result == StageOutcome(
-            Disposition.FINISH_FAIL,
-            "automation_threads_require_human_resolution",
-        )
-        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+        assert result == Continue(next_state="DIFFICULTY_WAIT")
+        assert item.payload["remediation_threads"] == [
+            {
+                "thread_id": "process-1",
+                "path": "a.py",
+                "line": 3,
+                "body": "<!-- hephaestus-severity: major -->\nfix this",
+            }
+        ]
+        assert ("mark_pr_implementation_no_go", (1001,)) not in github.mutation_log
 
     def test_truncated_live_thread_facts_skip_validation_and_all_writes(
         self, make_ctx: Any, make_work_item: Any


### PR DESCRIPTION
## Summary

- Route any canonical, validator-confirmed unaddressed automation review receipt into the existing difficulty/address workflow, including receipts reconstructed by a later loop invocation.
- Preserve the existing fail-closed handling for changed, replied-to, malformed, ambiguous, or wont-fix threads.
- Correct the public adapter/stage contract so it no longer claims resolution is limited to the current work item.

Closes #2496

## Test plan

- uv run pytest tests/unit -v — 6,515 passed, 24 skipped, 84.91% coverage
- Pre-push uv run --all-extras --locked pytest -q — 6,907 passed, 6 skipped, 85.08% coverage
- uv run pytest --no-cov tests/unit/automation/test_pipeline_github.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py -v — 289 passed
- uv run ruff format --check and uv run ruff check on changed files
- uv run mypy on changed files