### PR TITLE
fix(automation): lease rebased direct PR pushes

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -443,21 +443,26 @@ def delete_local_branch_if_unchanged(
 
 
 def push_head_to_branch(
-    branch_name: str, worktree_path: Path, *, timeout: int | None = None
+    branch_name: str,
+    expected_remote_sha: str,
+    worktree_path: Path,
+    *,
+    timeout: int | None = None,
 ) -> None:
     """Publish detached ``HEAD`` to ``origin/<branch_name>`` safely.
 
     Direct PR review uses a detached, isolated worktree so it can never reset
-    or remove a writer checkout.  Addressing commits therefore live on its
-    detached ``HEAD`` rather than on the local branch ref.  An ordinary
-    fast-forward push of that exact HEAD fails closed if the PR branch changed;
-    it neither records a proof nor force-updates another writer's work.
+    or remove a writer checkout. Addressing commits therefore live on its
+    detached ``HEAD`` rather than on the local branch ref. The explicit lease
+    permits an address agent to rebase onto current main while refusing to
+    overwrite a PR head that changed after its reviewed-head proof.
     """
     try:
         run(
             [
                 "git",
                 "push",
+                f"--force-with-lease=refs/heads/{branch_name}:{expected_remote_sha}",
                 "origin",
                 f"HEAD:refs/heads/{branch_name}",
             ],

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1106,9 +1106,11 @@ class PrReviewStage(Stage):
         }
         if item.payload.get("direct_pr_worktree"):
             # Direct review addresses findings from a detached checkout; the
-            # coordinator must publish that exact HEAD to the PR branch with
-            # a normal fast-forward push.
+            # coordinator may publish that exact HEAD only while the remote
+            # still equals the checkout-proven reviewed head. This permits a
+            # deliberate rebase without overwriting a concurrent writer.
             kwargs["publish_detached_head"] = True
+            kwargs["expected_remote_sha"] = item.payload.get("reviewed_pr_head_sha")
         git_job = GitJob(
             repo=item.repo,
             op="commit_push",

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1500,8 +1500,14 @@ class WorkerPool:
         if expected_remote_sha is not None and not _is_full_commit_sha(expected_remote_sha):
             return JobResult(ok=False, error="direct scope base pin invalid")
         if bool(job.kwargs.get("publish_detached_head", False)):
+            if not isinstance(expected_remote_sha, str):
+                return JobResult(
+                    ok=False,
+                    error="detached PR push requires the reviewed remote head",
+                )
             git_utils.push_head_to_branch(
                 branch,
+                expected_remote_sha,
                 Path(worktree_path),
                 timeout=job.timeout_s,
             )

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -959,6 +959,29 @@ class TestPrReviewStageStep:
         }
         assert result.on_done_state == "EVAL"
 
+    def test_push_wait_binds_detached_push_to_reviewed_head(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A rebased detached address commit may update only the reviewed PR head."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.branch = "1-auto-impl"
+        item.worktree = "/tmp/review-pr"
+        item.payload.update(
+            {
+                "direct_pr_worktree": "/tmp/review-pr",
+                "reviewed_pr_head_sha": "a" * 40,
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs["publish_detached_head"] is True
+        assert result.job.kwargs["expected_remote_sha"] == "a" * 40
+
     def test_address_refuses_fork_head_without_base_origin_write(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1888,6 +1888,7 @@ class TestGitOps:
                 "worktree_path": tmp_path,
                 "branch": "5-auto",
                 "publish_detached_head": True,
+                "expected_remote_sha": "a" * 40,
             },
         )
         with (
@@ -1898,7 +1899,7 @@ class TestGitOps:
             pool.submit(job, StageName.PR_REVIEW)
             _, result = completion_q.get(timeout=10)
 
-        mock_push.assert_called_once_with("5-auto", tmp_path, timeout=60)
+        mock_push.assert_called_once_with("5-auto", "a" * 40, tmp_path, timeout=60)
         normal_push.assert_not_called()
         assert result.ok is True
         assert result.value is True

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -532,13 +532,21 @@ class TestDirectScopeBranchReservation:
 class TestPushDetachedHead:
     """Tests for publishing direct PR-review commits from a detached checkout."""
 
-    def test_pushes_head_to_branch_without_force_or_proof(
+    def test_pushes_head_to_branch_with_the_reviewed_head_lease(
         self, git_utils_mocks: Any, tmp_path: Path
     ) -> None:
-        push_head_to_branch("123-auto-impl", tmp_path, timeout=42)
+        reviewed_head = "a" * 40
+
+        push_head_to_branch("123-auto-impl", reviewed_head, tmp_path, timeout=42)
 
         git_utils_mocks.run.assert_called_once_with(
-            ["git", "push", "origin", "HEAD:refs/heads/123-auto-impl"],
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/123-auto-impl:{reviewed_head}",
+                "origin",
+                "HEAD:refs/heads/123-auto-impl",
+            ],
             cwd=tmp_path,
             timeout=42,
         )

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -551,6 +551,19 @@ class TestPushDetachedHead:
             timeout=42,
         )
 
+    def test_rejects_a_detached_push_when_the_remote_head_advanced(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A lease rejection remains a hard failure for the coordinator."""
+        git_utils_mocks.run.side_effect = subprocess.CalledProcessError(
+            1,
+            ["git", "push"],
+            stderr="! [rejected] HEAD -> 123-auto-impl (stale info)",
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to publish detached HEAD"):
+            push_head_to_branch("123-auto-impl", "a" * 40, tmp_path)
+
 
 class TestGetCurrentBranch:
     """Tests for get_current_branch function."""


### PR DESCRIPTION
## Summary

- bind detached direct-PR address pushes to the exact reviewed remote SHA
- permit intentional address-agent rebases while refusing concurrent-head overwrites
- cover the stage, worker, and Git command contract with unit tests

## Verification

- uv run --all-extras --locked pytest -q (6908 passed, 6 skipped; 85.09% coverage)
- uv run ruff check and ruff format --check on changed files
- uv run mypy on changed production modules

Closes #2498