### PR TITLE
fix(automation): retain failed detached review pushes

### DIFF
--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -445,6 +445,8 @@ def record_direct_review_recovery(
         raise ValueError("direct review recovery branch is invalid")
     if not _is_full_sha(expected_remote_sha) or not _is_full_sha(source_sha):
         raise ValueError("direct review recovery commit receipt is invalid")
+    if not _DIR_FD_SUPPORTED:
+        raise ValueError("direct review recovery requires no-follow directory descriptors")
     normalized_root = Path(repo_root).resolve()
     normalized_worktree = _validated_worktree_path(normalized_root, issue, worktree)
     if not normalized_worktree.is_dir():
@@ -488,6 +490,8 @@ def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -
     arbitrary occupied checkout is safe to surface as a recovery artifact.
     """
     if isinstance(pr, bool) or not isinstance(pr, int) or pr <= 0:
+        return []
+    if not _DIR_FD_SUPPORTED:
         return []
     normalized_root = Path(repo_root).resolve()
     try:

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
+import os
+import secrets
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -12,8 +18,10 @@ from hephaestus.io.utils import write_secure
 from hephaestus.utils.file_lock import file_lock
 
 _RECEIPT_DIR = "direct-review-recovery"
-_RECEIPT_VERSION = 2
+_RECEIPT_VERSION = 3
 _REMOTE_CHANGED_REASON = "remote_changed"
+_WORKTREE_MARKER = "hephaestus-direct-review-recovery"
+_DIR_FD_SUPPORTED = os.name == "posix" and hasattr(os, "O_DIRECTORY")
 
 
 def _is_full_sha(value: object) -> bool:
@@ -83,10 +91,231 @@ def _receipt_lock_path(receipt_dir: Path, pr: int) -> Path:
     return receipt_dir / f"direct-review-{pr}.lock"
 
 
+def _directory_open_flags() -> int:
+    """Return flags for a directory descriptor that refuses final symlinks."""
+    flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return flags
+
+
+def _open_directory_component(parent_fd: int, name: str, *, create: bool) -> int | None:
+    """Open one trusted directory component relative to ``parent_fd``."""
+    flags = _directory_open_flags()
+    try:
+        child_fd = os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create:
+            return None
+        # Another loop process may have created it between open and mkdir.
+        with suppress(FileExistsError):
+            os.mkdir(name, 0o700, dir_fd=parent_fd)
+        try:
+            child_fd = os.open(name, flags, dir_fd=parent_fd)
+        except OSError as error:
+            if error.errno in (errno.ELOOP, errno.ENOTDIR):
+                raise ValueError("direct review recovery receipt directory is unsafe") from error
+            raise
+    except OSError as error:
+        if error.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise ValueError("direct review recovery receipt directory is unsafe") from error
+        raise
+    try:
+        if not stat.S_ISDIR(os.fstat(child_fd).st_mode):
+            raise ValueError("direct review recovery receipt directory is not a directory")
+    except BaseException:
+        os.close(child_fd)
+        raise
+    return child_fd
+
+
+@contextmanager
+def _open_receipt_directory(
+    repo_root: Path, *, create: bool = False
+) -> Iterator[tuple[Path, int | None]]:
+    """Yield a receipt path and a no-follow descriptor when the platform supports it.
+
+    The descriptor-relative operations that follow cannot be redirected by a
+    concurrent replacement of the automation state directory. On platforms
+    without directory-descriptor support, retain the existing portable path
+    validation and locking behavior.
+    """
+    normalized_root = Path(repo_root).resolve()
+    receipt_path = normalized_root / DEFAULT_STATE_DIR / _RECEIPT_DIR
+    if not _DIR_FD_SUPPORTED:
+        yield _receipt_dir(normalized_root, create=create), None
+        return
+
+    root_fd = os.open(normalized_root, _directory_open_flags())
+    current_fd = root_fd
+    try:
+        for component in (*Path(DEFAULT_STATE_DIR).parts, _RECEIPT_DIR):
+            child_fd = _open_directory_component(current_fd, component, create=create)
+            if child_fd is None:
+                yield receipt_path, None
+                return
+            os.close(current_fd)
+            current_fd = child_fd
+        yield receipt_path, current_fd
+    finally:
+        os.close(current_fd)
+
+
+@contextmanager
+def _receipt_lock(receipt_dir: Path, receipt_fd: int | None, pr: int) -> Iterator[None]:
+    """Serialize receipt access without following a replaced receipt parent."""
+    if receipt_fd is None:
+        with file_lock(_receipt_lock_path(receipt_dir, pr)):
+            yield
+        return
+
+    name = _receipt_lock_path(receipt_dir, pr).name
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(name, flags, 0o600, dir_fd=receipt_fd)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("direct review recovery receipt lock is not a regular file")
+        os.fchmod(fd, 0o600)
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover - guarded by _DIR_FD_SUPPORTED on CI
+            yield
+            return
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _write_receipt(
+    receipt_dir: Path, receipt_fd: int | None, target: Path, content: str
+) -> None:
+    """Atomically write a receipt without resolving its parent again."""
+    if receipt_fd is None:
+        write_secure(target, content)
+        return
+
+    target_name = target.name
+    temporary_name = f".{target_name}.{secrets.token_hex(16)}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(temporary_name, flags, 0o600, dir_fd=receipt_fd)
+    try:
+        os.fchmod(fd, 0o600)
+        data = content.encode("utf-8")
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(
+            temporary_name,
+            target_name,
+            src_dir_fd=receipt_fd,
+            dst_dir_fd=receipt_fd,
+        )
+        os.fsync(receipt_fd)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        with suppress(FileNotFoundError):
+            os.unlink(temporary_name, dir_fd=receipt_fd)
+        raise
+
+
+def _read_receipt(receipt_dir: Path, receipt_fd: int | None, name: str) -> Any:
+    """Read one regular receipt from a trusted descriptor or portable path."""
+    if receipt_fd is None:
+        return json.loads((receipt_dir / name).read_text(encoding="utf-8"))
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(name, flags, dir_fd=receipt_fd)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("direct review recovery receipt is not a regular file")
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return json.load(handle)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _receipt_names(receipt_dir: Path, receipt_fd: int | None, pr: int) -> list[str]:
+    """Return receipt basenames for a PR without traversing a mutable parent."""
+    prefix = f"direct-review-{pr}-"
+    if receipt_fd is None:
+        return [path.name for path in receipt_dir.glob(f"{prefix}*.json")]
+    return sorted(
+        name
+        for name in os.listdir(receipt_fd)
+        if name.startswith(prefix) and name.endswith(".json")
+    )
+
+
+def _receipt_directory_is_current(repo_root: Path, receipt_fd: int | None) -> bool:
+    """Return whether the receipt descriptor still names the live state directory."""
+    if receipt_fd is None:
+        return True
+    try:
+        with _open_receipt_directory(repo_root) as (_, current_fd):
+            return current_fd is not None and os.path.samestat(
+                os.fstat(receipt_fd), os.fstat(current_fd)
+            )
+    except (OSError, ValueError):
+        return False
+
+
 def _worktree_identity(worktree: Path) -> tuple[int, int]:
     """Return the filesystem identity that binds a receipt to one checkout."""
     stat = worktree.stat()
     return stat.st_dev, stat.st_ino
+
+
+def _worktree_marker_path(worktree: Path) -> Path:
+    """Return the private Git-metadata marker for one direct-review checkout."""
+    dot_git = worktree / ".git"
+    if dot_git.is_dir():
+        git_dir = dot_git
+    else:
+        try:
+            line = dot_git.read_text(encoding="utf-8").strip()
+        except OSError as error:
+            raise ValueError("direct review recovery Git metadata is unavailable") from error
+        prefix = "gitdir: "
+        if not line.startswith(prefix):
+            raise ValueError("direct review recovery Git metadata is invalid")
+        raw_git_dir = Path(line.removeprefix(prefix))
+        git_dir = raw_git_dir if raw_git_dir.is_absolute() else (worktree / raw_git_dir)
+    git_dir = git_dir.resolve()
+    if not git_dir.is_dir():
+        raise ValueError("direct review recovery Git metadata is unavailable")
+    return git_dir / _WORKTREE_MARKER
+
+
+def _write_worktree_marker(worktree: Path) -> str:
+    """Create an unguessable marker that cannot survive checkout replacement."""
+    marker = secrets.token_urlsafe(32)
+    write_secure(_worktree_marker_path(worktree), marker + "\n")
+    return marker
+
+
+def _read_worktree_marker(worktree: Path) -> str:
+    """Read the checkout-local marker or raise when it is absent or unsafe."""
+    marker_path = _worktree_marker_path(worktree)
+    if marker_path.is_symlink():
+        raise ValueError("direct review recovery worktree marker is symlinked")
+    marker = marker_path.read_text(encoding="utf-8").strip()
+    if not marker:
+        raise ValueError("direct review recovery worktree marker is invalid")
+    return marker
 
 
 def record_direct_review_recovery(
@@ -116,7 +345,7 @@ def record_direct_review_recovery(
     if not normalized_worktree.is_dir():
         raise ValueError("direct review recovery worktree is missing")
     worktree_device, worktree_inode = _worktree_identity(normalized_worktree)
-    receipt_dir = _receipt_dir(normalized_root, create=True)
+    worktree_marker = _write_worktree_marker(normalized_worktree)
     receipt = {
         "branch": branch,
         "expected_remote_sha": expected_remote_sha,
@@ -129,11 +358,22 @@ def record_direct_review_recovery(
         "worktree": str(normalized_worktree),
         "worktree_device": worktree_device,
         "worktree_inode": worktree_inode,
+        "worktree_marker": worktree_marker,
     }
-    target = _receipt_path(receipt_dir, pr, normalized_worktree)
-    with file_lock(_receipt_lock_path(receipt_dir, pr)):
-        write_secure(target, json.dumps(receipt, sort_keys=True) + "\n")
-    return target
+    with _open_receipt_directory(normalized_root, create=True) as (receipt_dir, receipt_fd):
+        if receipt_fd is None and _DIR_FD_SUPPORTED:  # pragma: no cover - create=True guarantees it
+            raise ValueError("direct review recovery receipt directory is unavailable")
+        target = _receipt_path(receipt_dir, pr, normalized_worktree)
+        with _receipt_lock(receipt_dir, receipt_fd, pr):
+            _write_receipt(
+                receipt_dir,
+                receipt_fd,
+                target,
+                json.dumps(receipt, sort_keys=True) + "\n",
+            )
+            if not _receipt_directory_is_current(normalized_root, receipt_fd):
+                raise ValueError("direct review recovery receipt directory changed during write")
+        return target
 
 
 def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -> list[Path]:
@@ -146,44 +386,52 @@ def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -
         return []
     normalized_root = Path(repo_root).resolve()
     try:
-        receipt_dir = _receipt_dir(normalized_root)
+        receipt_directory = _open_receipt_directory(normalized_root)
     except ValueError:
-        return []
-    if not receipt_dir.is_dir():
         return []
     paths: list[Path] = []
     seen: set[Path] = set()
-    with file_lock(_receipt_lock_path(receipt_dir, pr)):
-        for receipt_path in receipt_dir.glob(f"direct-review-{pr}-*.json"):
-            try:
-                payload: Any = json.loads(receipt_path.read_text(encoding="utf-8"))
-                if not isinstance(payload, dict):
-                    continue
-                worktree = _validated_worktree_path(
-                    normalized_root, issue, Path(str(payload.get("worktree", "")))
-                )
-                worktree_device, worktree_inode = _worktree_identity(worktree)
-                if (
-                    payload.get("schema_version") != _RECEIPT_VERSION
-                    or payload.get("reason") != _REMOTE_CHANGED_REASON
-                    or payload.get("repo_root") != str(normalized_root)
-                    or payload.get("issue") != issue
-                    or payload.get("pr") != pr
-                    or not isinstance(payload.get("branch"), str)
-                    or not _is_full_sha(payload.get("expected_remote_sha"))
-                    or not _is_full_sha(payload.get("source_sha"))
-                    or not worktree.is_dir()
-                    or isinstance(payload.get("worktree_device"), bool)
-                    or not isinstance(payload.get("worktree_device"), int)
-                    or payload.get("worktree_device") != worktree_device
-                    or isinstance(payload.get("worktree_inode"), bool)
-                    or not isinstance(payload.get("worktree_inode"), int)
-                    or payload.get("worktree_inode") != worktree_inode
-                    or worktree in seen
-                ):
-                    continue
-            except (OSError, TypeError, ValueError, json.JSONDecodeError):
-                continue
-            seen.add(worktree)
-            paths.append(worktree)
+    try:
+        with receipt_directory as (receipt_dir, receipt_fd):
+            if receipt_fd is None and (_DIR_FD_SUPPORTED or not receipt_dir.is_dir()):
+                return []
+            with _receipt_lock(receipt_dir, receipt_fd, pr):
+                for receipt_name in _receipt_names(receipt_dir, receipt_fd, pr):
+                    try:
+                        payload: Any = _read_receipt(receipt_dir, receipt_fd, receipt_name)
+                        if not isinstance(payload, dict):
+                            continue
+                        worktree = _validated_worktree_path(
+                            normalized_root, issue, Path(str(payload.get("worktree", "")))
+                        )
+                        worktree_device, worktree_inode = _worktree_identity(worktree)
+                        worktree_marker = _read_worktree_marker(worktree)
+                        recorded_marker = payload.get("worktree_marker")
+                        if (
+                            payload.get("schema_version") != _RECEIPT_VERSION
+                            or payload.get("reason") != _REMOTE_CHANGED_REASON
+                            or payload.get("repo_root") != str(normalized_root)
+                            or payload.get("issue") != issue
+                            or payload.get("pr") != pr
+                            or not isinstance(payload.get("branch"), str)
+                            or not _is_full_sha(payload.get("expected_remote_sha"))
+                            or not _is_full_sha(payload.get("source_sha"))
+                            or not worktree.is_dir()
+                            or isinstance(payload.get("worktree_device"), bool)
+                            or not isinstance(payload.get("worktree_device"), int)
+                            or payload.get("worktree_device") != worktree_device
+                            or isinstance(payload.get("worktree_inode"), bool)
+                            or not isinstance(payload.get("worktree_inode"), int)
+                            or payload.get("worktree_inode") != worktree_inode
+                            or not isinstance(recorded_marker, str)
+                            or not secrets.compare_digest(recorded_marker, worktree_marker)
+                            or worktree in seen
+                        ):
+                            continue
+                    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                        continue
+                    seen.add(worktree)
+                    paths.append(worktree)
+    except (OSError, ValueError):
+        return []
     return sorted(paths)

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -245,7 +245,10 @@ def _write_receipt(receipt_dir: Path, receipt_fd: int | None, target: Path, cont
 def _read_receipt(receipt_dir: Path, receipt_fd: int | None, name: str) -> Any:
     """Read one regular receipt from a trusted descriptor or portable path."""
     if receipt_fd is None:
-        return json.loads((receipt_dir / name).read_text(encoding="utf-8"))
+        target = receipt_dir / name
+        if target.is_symlink() or not target.is_file():
+            raise ValueError("direct review recovery receipt is not a regular file")
+        return json.loads(target.read_text(encoding="utf-8"))
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -264,7 +267,10 @@ def _read_receipt(receipt_dir: Path, receipt_fd: int | None, name: str) -> Any:
 def _read_secure_text(directory: Path, directory_fd: int | None, name: str) -> str:
     """Read a regular no-follow text file from a trusted directory."""
     if directory_fd is None:
-        return (directory / name).read_text(encoding="utf-8")
+        target = directory / name
+        if target.is_symlink() or not target.is_file():
+            raise ValueError("direct review recovery marker is not a regular file")
+        return target.read_text(encoding="utf-8")
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -299,7 +305,7 @@ def _open_marker_directory(repo_root: Path, marker_path: Path) -> Iterator[tuple
     if not _DIR_FD_SUPPORTED:
         yield marker_dir, None
         return
-    root = repo_root.resolve()
+    root = _common_git_dir(repo_root)
     try:
         components = marker_dir.relative_to(root).parts
     except ValueError as error:
@@ -337,6 +343,28 @@ def _worktree_identity(worktree: Path) -> tuple[int, int]:
     return stat.st_dev, stat.st_ino
 
 
+def _common_git_dir(repo_root: Path) -> Path:
+    """Return the common Git metadata directory for a checkout or linked worktree."""
+    root = repo_root.resolve()
+    dot_git = root / ".git"
+    if dot_git.is_dir() and not dot_git.is_symlink():
+        return dot_git.resolve()
+    try:
+        line = dot_git.read_text(encoding="utf-8").strip()
+    except OSError:
+        # Lightweight fixtures without a repository-level Git directory keep
+        # metadata confined to the fixture root.
+        return root
+    prefix = "gitdir: "
+    if not line.startswith(prefix):
+        raise ValueError("direct review recovery repository Git metadata is invalid")
+    raw_git_dir = Path(line.removeprefix(prefix))
+    git_dir = (raw_git_dir if raw_git_dir.is_absolute() else root / raw_git_dir).resolve()
+    if git_dir.parent.name != "worktrees" or not git_dir.parent.parent.is_dir():
+        raise ValueError("direct review recovery repository Git metadata is unavailable")
+    return git_dir.parent.parent
+
+
 def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
     """Return the private Git-metadata marker for one direct-review checkout."""
     dot_git = worktree / ".git"
@@ -358,17 +386,20 @@ def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
     if not git_dir.is_dir():
         raise ValueError("direct review recovery Git metadata is unavailable")
     normalized_root = repo_root.resolve()
-    try:
-        git_dir.relative_to(normalized_root)
-    except ValueError as error:
-        raise ValueError("direct review recovery Git metadata is outside the repository") from error
+    common_git_dir = _common_git_dir(normalized_root)
     if not dot_git.is_dir():
-        common_git_dir = normalized_root / ".git" / "worktrees"
         try:
-            git_dir.relative_to(common_git_dir.resolve())
+            git_dir.relative_to(common_git_dir / "worktrees")
         except ValueError as error:
             raise ValueError(
                 "direct review recovery Git metadata is not a linked worktree"
+            ) from error
+    else:
+        try:
+            git_dir.relative_to(normalized_root)
+        except ValueError as error:
+            raise ValueError(
+                "direct review recovery Git metadata is outside the repository"
             ) from error
     return git_dir / _WORKTREE_MARKER
 

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -22,6 +22,16 @@ _RECEIPT_VERSION = 3
 _REMOTE_CHANGED_REASON = "remote_changed"
 _WORKTREE_MARKER = "hephaestus-direct-review-recovery"
 _DIR_FD_SUPPORTED = os.name == "posix" and hasattr(os, "O_DIRECTORY")
+_INSPECTION_ONLY_FAILURES = frozenset(
+    {
+        "remote_changed",
+        "remote_changed_unrecorded",
+        "remote_unchanged",
+        "remote_unconfirmed",
+        "retry_checkout_changed",
+        "retry_checkout_unconfirmed",
+    }
+)
 
 
 def _is_full_sha(value: object) -> bool:
@@ -31,6 +41,11 @@ def _is_full_sha(value: object) -> bool:
         and len(value) in (40, 64)
         and all(char in "0123456789abcdef" for char in value)
     )
+
+
+def is_inspection_only_detached_push_failure(value: object) -> bool:
+    """Return whether a failed detached publication needs manual inspection."""
+    return isinstance(value, str) and value in _INSPECTION_ONLY_FAILURES
 
 
 def _validated_worktree_path(repo_root: Path, issue: int, path: Path) -> Path:
@@ -192,9 +207,7 @@ def _receipt_lock(receipt_dir: Path, receipt_fd: int | None, pr: int) -> Iterato
         os.close(fd)
 
 
-def _write_receipt(
-    receipt_dir: Path, receipt_fd: int | None, target: Path, content: str
-) -> None:
+def _write_receipt(receipt_dir: Path, receipt_fd: int | None, target: Path, content: str) -> None:
     """Atomically write a receipt without resolving its parent again."""
     if receipt_fd is None:
         write_secure(target, content)
@@ -248,6 +261,25 @@ def _read_receipt(receipt_dir: Path, receipt_fd: int | None, name: str) -> Any:
             os.close(fd)
 
 
+def _read_secure_text(directory: Path, directory_fd: int | None, name: str) -> str:
+    """Read a regular no-follow text file from a trusted directory."""
+    if directory_fd is None:
+        return (directory / name).read_text(encoding="utf-8")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(name, flags, dir_fd=directory_fd)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("direct review recovery marker is not a regular file")
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return handle.read()
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
 def _receipt_names(receipt_dir: Path, receipt_fd: int | None, pr: int) -> list[str]:
     """Return receipt basenames for a PR without traversing a mutable parent."""
     prefix = f"direct-review-{pr}-"
@@ -258,6 +290,32 @@ def _receipt_names(receipt_dir: Path, receipt_fd: int | None, pr: int) -> list[s
         for name in os.listdir(receipt_fd)
         if name.startswith(prefix) and name.endswith(".json")
     )
+
+
+@contextmanager
+def _open_marker_directory(repo_root: Path, marker_path: Path) -> Iterator[tuple[Path, int | None]]:
+    """Yield the marker parent through a no-follow descriptor when available."""
+    marker_dir = marker_path.parent
+    if not _DIR_FD_SUPPORTED:
+        yield marker_dir, None
+        return
+    root = repo_root.resolve()
+    try:
+        components = marker_dir.relative_to(root).parts
+    except ValueError as error:
+        raise ValueError("direct review recovery marker is outside the repository") from error
+    root_fd = os.open(root, _directory_open_flags())
+    current_fd = root_fd
+    try:
+        for component in components:
+            child_fd = _open_directory_component(current_fd, component, create=False)
+            if child_fd is None:
+                raise ValueError("direct review recovery Git metadata is unavailable")
+            os.close(current_fd)
+            current_fd = child_fd
+        yield marker_dir, current_fd
+    finally:
+        os.close(current_fd)
 
 
 def _receipt_directory_is_current(repo_root: Path, receipt_fd: int | None) -> bool:
@@ -279,9 +337,11 @@ def _worktree_identity(worktree: Path) -> tuple[int, int]:
     return stat.st_dev, stat.st_ino
 
 
-def _worktree_marker_path(worktree: Path) -> Path:
+def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
     """Return the private Git-metadata marker for one direct-review checkout."""
     dot_git = worktree / ".git"
+    if dot_git.is_symlink():
+        raise ValueError("direct review recovery Git metadata is symlinked")
     if dot_git.is_dir():
         git_dir = dot_git
     else:
@@ -297,22 +357,36 @@ def _worktree_marker_path(worktree: Path) -> Path:
     git_dir = git_dir.resolve()
     if not git_dir.is_dir():
         raise ValueError("direct review recovery Git metadata is unavailable")
+    normalized_root = repo_root.resolve()
+    try:
+        git_dir.relative_to(normalized_root)
+    except ValueError as error:
+        raise ValueError("direct review recovery Git metadata is outside the repository") from error
+    if not dot_git.is_dir():
+        common_git_dir = normalized_root / ".git" / "worktrees"
+        try:
+            git_dir.relative_to(common_git_dir.resolve())
+        except ValueError as error:
+            raise ValueError(
+                "direct review recovery Git metadata is not a linked worktree"
+            ) from error
     return git_dir / _WORKTREE_MARKER
 
 
-def _write_worktree_marker(worktree: Path) -> str:
+def _write_worktree_marker(repo_root: Path, worktree: Path) -> str:
     """Create an unguessable marker that cannot survive checkout replacement."""
     marker = secrets.token_urlsafe(32)
-    write_secure(_worktree_marker_path(worktree), marker + "\n")
+    marker_path = _worktree_marker_path(repo_root, worktree)
+    with _open_marker_directory(repo_root, marker_path) as (marker_dir, marker_fd):
+        _write_receipt(marker_dir, marker_fd, marker_path, marker + "\n")
     return marker
 
 
-def _read_worktree_marker(worktree: Path) -> str:
+def _read_worktree_marker(repo_root: Path, worktree: Path) -> str:
     """Read the checkout-local marker or raise when it is absent or unsafe."""
-    marker_path = _worktree_marker_path(worktree)
-    if marker_path.is_symlink():
-        raise ValueError("direct review recovery worktree marker is symlinked")
-    marker = marker_path.read_text(encoding="utf-8").strip()
+    marker_path = _worktree_marker_path(repo_root, worktree)
+    with _open_marker_directory(repo_root, marker_path) as (marker_dir, marker_fd):
+        marker = _read_secure_text(marker_dir, marker_fd, marker_path.name).strip()
     if not marker:
         raise ValueError("direct review recovery worktree marker is invalid")
     return marker
@@ -345,7 +419,7 @@ def record_direct_review_recovery(
     if not normalized_worktree.is_dir():
         raise ValueError("direct review recovery worktree is missing")
     worktree_device, worktree_inode = _worktree_identity(normalized_worktree)
-    worktree_marker = _write_worktree_marker(normalized_worktree)
+    worktree_marker = _write_worktree_marker(normalized_root, normalized_worktree)
     receipt = {
         "branch": branch,
         "expected_remote_sha": expected_remote_sha,
@@ -405,7 +479,7 @@ def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -
                             normalized_root, issue, Path(str(payload.get("worktree", "")))
                         )
                         worktree_device, worktree_inode = _worktree_identity(worktree)
-                        worktree_marker = _read_worktree_marker(worktree)
+                        worktree_marker = _read_worktree_marker(normalized_root, worktree)
                         recorded_marker = payload.get("worktree_marker")
                         if (
                             payload.get("schema_version") != _RECEIPT_VERSION

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -1,0 +1,145 @@
+"""Durable receipts for detached-review checkouts preserved after remote drift."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation.models import DEFAULT_STATE_DIR
+from hephaestus.io.utils import write_secure
+from hephaestus.utils.file_lock import file_lock
+
+_RECEIPT_DIR = "direct-review-recovery"
+_RECEIPT_VERSION = 1
+_REMOTE_CHANGED_REASON = "remote_changed"
+
+
+def _is_full_sha(value: object) -> bool:
+    """Return whether *value* is a full SHA-1 or SHA-256 commit identifier."""
+    return (
+        isinstance(value, str)
+        and len(value) in (40, 64)
+        and all(char in "0123456789abcdef" for char in value)
+    )
+
+
+def _validated_worktree_path(repo_root: Path, issue: int, path: Path) -> Path:
+    """Return a normalized isolated-review path or raise for an unsafe receipt."""
+    if isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0:
+        raise ValueError("direct review recovery issue is invalid")
+    root = (repo_root / "build" / ".worktrees").resolve()
+    normalized = path.resolve()
+    prefix = f"review-pr-{issue}"
+    suffix = normalized.name.removeprefix(prefix)
+    if (
+        normalized.parent != root
+        or not normalized.name.startswith(prefix)
+        or (suffix and (not suffix.startswith("-") or not suffix[1:].isdigit()))
+    ):
+        raise ValueError("direct review recovery worktree is invalid")
+    return normalized
+
+
+def _receipt_dir(repo_root: Path) -> Path:
+    """Return the repository-scoped direct-review receipt directory."""
+    return repo_root / DEFAULT_STATE_DIR / _RECEIPT_DIR
+
+
+def _receipt_path(receipt_dir: Path, pr: int, worktree: Path) -> Path:
+    """Return a stable path for one PR/worktree recovery receipt."""
+    digest = hashlib.sha256(str(worktree).encode("utf-8")).hexdigest()
+    return receipt_dir / f"direct-review-{pr}-{digest}.json"
+
+
+def _receipt_lock_path(receipt_dir: Path, pr: int) -> Path:
+    """Return the per-PR lock serializing receipt writes and reads."""
+    return receipt_dir / f"direct-review-{pr}.lock"
+
+
+def record_direct_review_recovery(
+    *,
+    repo_root: Path,
+    issue: int,
+    pr: int,
+    worktree: Path,
+    branch: str,
+    expected_remote_sha: str,
+    source_sha: str,
+) -> Path:
+    """Persist an immutable receipt for a verified detached-push remote drift.
+
+    A receipt is written only after the remote has authoritatively changed, so
+    later runs can distinguish an abandoned recovery checkout from a merely
+    occupied (and potentially active) checkout.
+    """
+    if isinstance(pr, bool) or not isinstance(pr, int) or pr <= 0:
+        raise ValueError("direct review recovery PR is invalid")
+    if not isinstance(branch, str) or not branch:
+        raise ValueError("direct review recovery branch is invalid")
+    if not _is_full_sha(expected_remote_sha) or not _is_full_sha(source_sha):
+        raise ValueError("direct review recovery commit receipt is invalid")
+    normalized_root = repo_root.resolve()
+    normalized_worktree = _validated_worktree_path(normalized_root, issue, worktree)
+    if not normalized_worktree.is_dir():
+        raise ValueError("direct review recovery worktree is missing")
+    receipt_dir = _receipt_dir(normalized_root)
+    receipt = {
+        "branch": branch,
+        "expected_remote_sha": expected_remote_sha,
+        "issue": issue,
+        "pr": pr,
+        "reason": _REMOTE_CHANGED_REASON,
+        "repo_root": str(normalized_root),
+        "schema_version": _RECEIPT_VERSION,
+        "source_sha": source_sha,
+        "worktree": str(normalized_worktree),
+    }
+    target = _receipt_path(receipt_dir, pr, normalized_worktree)
+    with file_lock(_receipt_lock_path(receipt_dir, pr)):
+        write_secure(target, json.dumps(receipt, sort_keys=True) + "\n")
+    return target
+
+
+def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -> list[Path]:
+    """Return only valid, receipt-backed detached-review recovery paths.
+
+    Invalid or tampered receipts are ignored. They are not evidence that an
+    arbitrary occupied checkout is safe to surface as a recovery artifact.
+    """
+    if isinstance(pr, bool) or not isinstance(pr, int) or pr <= 0:
+        return []
+    normalized_root = repo_root.resolve()
+    receipt_dir = _receipt_dir(normalized_root)
+    if not receipt_dir.is_dir():
+        return []
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    with file_lock(_receipt_lock_path(receipt_dir, pr)):
+        for receipt_path in receipt_dir.glob(f"direct-review-{pr}-*.json"):
+            try:
+                payload: Any = json.loads(receipt_path.read_text(encoding="utf-8"))
+                if not isinstance(payload, dict):
+                    continue
+                worktree = _validated_worktree_path(
+                    normalized_root, issue, Path(str(payload.get("worktree", "")))
+                )
+                if (
+                    payload.get("schema_version") != _RECEIPT_VERSION
+                    or payload.get("reason") != _REMOTE_CHANGED_REASON
+                    or payload.get("repo_root") != str(normalized_root)
+                    or payload.get("issue") != issue
+                    or payload.get("pr") != pr
+                    or not isinstance(payload.get("branch"), str)
+                    or not _is_full_sha(payload.get("expected_remote_sha"))
+                    or not _is_full_sha(payload.get("source_sha"))
+                    or not worktree.is_dir()
+                    or worktree in seen
+                ):
+                    continue
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                continue
+            seen.add(worktree)
+            paths.append(worktree)
+    return sorted(paths)

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -347,14 +347,18 @@ def _common_git_dir(repo_root: Path) -> Path:
     """Return the common Git metadata directory for a checkout or linked worktree."""
     root = repo_root.resolve()
     dot_git = root / ".git"
-    if dot_git.is_dir() and not dot_git.is_symlink():
+    if dot_git.is_symlink():
+        raise ValueError("direct review recovery repository Git metadata is symlinked")
+    if dot_git.is_dir():
         return dot_git.resolve()
     try:
         line = dot_git.read_text(encoding="utf-8").strip()
-    except OSError:
+    except FileNotFoundError:
         # Lightweight fixtures without a repository-level Git directory keep
         # metadata confined to the fixture root.
         return root
+    except OSError as error:
+        raise ValueError("direct review recovery repository Git metadata is unavailable") from error
     prefix = "gitdir: "
     if not line.startswith(prefix):
         raise ValueError("direct review recovery repository Git metadata is invalid")

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -21,7 +21,7 @@ _RECEIPT_DIR = "direct-review-recovery"
 _RECEIPT_VERSION = 3
 _REMOTE_CHANGED_REASON = "remote_changed"
 _WORKTREE_MARKER = "hephaestus-direct-review-recovery"
-_DIR_FD_SUPPORTED = os.name == "posix" and hasattr(os, "O_DIRECTORY")
+_DIR_FD_SUPPORTED = os.name == "posix" and hasattr(os, "O_DIRECTORY") and hasattr(os, "O_NOFOLLOW")
 _INSPECTION_ONLY_FAILURES = frozenset(
     {
         "remote_changed",
@@ -343,30 +343,84 @@ def _worktree_identity(worktree: Path) -> tuple[int, int]:
     return stat.st_dev, stat.st_ino
 
 
+def _open_root_gitfile(root_fd: int) -> int | None:
+    """Open ``.git`` from a trusted root descriptor without following symlinks."""
+    try:
+        return os.open(".git", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=root_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        if error.errno == errno.ELOOP:
+            raise ValueError(
+                "direct review recovery repository Git metadata is symlinked"
+            ) from error
+        raise ValueError("direct review recovery repository Git metadata is unavailable") from error
+
+
+def _read_root_git_metadata(root: Path) -> tuple[bool, str | None]:
+    """Return whether ``.git`` is a directory and a no-follow gitfile payload."""
+    root_fd = os.open(root, _directory_open_flags())
+    try:
+        git_fd = _open_root_gitfile(root_fd)
+        if git_fd is None:
+            return False, None
+        try:
+            mode = os.fstat(git_fd).st_mode
+            if stat.S_ISDIR(mode):
+                return True, None
+            if not stat.S_ISREG(mode):
+                raise ValueError("direct review recovery repository Git metadata is unavailable")
+            with os.fdopen(git_fd, "r", encoding="utf-8") as handle:
+                git_fd = -1
+                return False, handle.read().strip()
+        finally:
+            if git_fd >= 0:
+                os.close(git_fd)
+    finally:
+        os.close(root_fd)
+
+
+def _verified_common_git_dir(git_dir: Path) -> Path:
+    """Return the common directory proven by a linked worktree's ``commondir``."""
+    if git_dir.parent.name != "worktrees" or not git_dir.parent.parent.is_dir():
+        raise ValueError("direct review recovery repository Git metadata is unavailable")
+    common_git_dir = git_dir.parent.parent
+    try:
+        git_dir_fd = os.open(git_dir, _directory_open_flags())
+    except OSError as error:
+        raise ValueError("direct review recovery repository Git metadata is unavailable") from error
+    try:
+        common_dir_text = _read_secure_text(git_dir, git_dir_fd, "commondir").strip()
+    except (OSError, ValueError) as error:
+        raise ValueError("direct review recovery repository Git metadata is unavailable") from error
+    finally:
+        os.close(git_dir_fd)
+    raw_common_dir = Path(common_dir_text)
+    resolved_common_dir = (
+        raw_common_dir if raw_common_dir.is_absolute() else git_dir / raw_common_dir
+    ).resolve()
+    if resolved_common_dir != common_git_dir:
+        raise ValueError("direct review recovery repository Git metadata is unavailable")
+    return common_git_dir
+
+
 def _common_git_dir(repo_root: Path) -> Path:
     """Return the common Git metadata directory for a checkout or linked worktree."""
     root = repo_root.resolve()
     dot_git = root / ".git"
-    if dot_git.is_symlink():
-        raise ValueError("direct review recovery repository Git metadata is symlinked")
-    if dot_git.is_dir():
-        return dot_git.resolve()
-    try:
-        line = dot_git.read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
+    if not _DIR_FD_SUPPORTED:
+        raise ValueError("direct review recovery requires no-follow directory descriptors")
+    is_directory, line = _read_root_git_metadata(root)
+    if line is None:
         # Lightweight fixtures without a repository-level Git directory keep
         # metadata confined to the fixture root.
-        return root
-    except OSError as error:
-        raise ValueError("direct review recovery repository Git metadata is unavailable") from error
+        return dot_git.resolve() if is_directory else root
     prefix = "gitdir: "
     if not line.startswith(prefix):
         raise ValueError("direct review recovery repository Git metadata is invalid")
     raw_git_dir = Path(line.removeprefix(prefix))
     git_dir = (raw_git_dir if raw_git_dir.is_absolute() else root / raw_git_dir).resolve()
-    if git_dir.parent.name != "worktrees" or not git_dir.parent.parent.is_dir():
-        raise ValueError("direct review recovery repository Git metadata is unavailable")
-    return git_dir.parent.parent
+    return _verified_common_git_dir(git_dir)
 
 
 def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -299,10 +299,22 @@ def _receipt_names(receipt_dir: Path, receipt_fd: int | None, pr: int) -> list[s
 
 
 @contextmanager
-def _open_marker_directory(repo_root: Path, marker_path: Path) -> Iterator[tuple[Path, int | None]]:
-    """Yield the marker parent through a no-follow descriptor when available."""
+def _open_marker_directory(
+    repo_root: Path,
+    marker_path: Path,
+    expected_marker_dir_stat: os.stat_result,
+) -> Iterator[tuple[Path, int | None]]:
+    """Yield the previously verified marker parent through a no-follow descriptor.
+
+    Git's metadata paths can be renamed between the validation of a worktree
+    gitdir and the marker operation.  Requiring the reopened descriptor to
+    identify the same directory keeps a replacement directory from receiving
+    recovery metadata.
+    """
     marker_dir = marker_path.parent
     if not _DIR_FD_SUPPORTED:
+        if not os.path.samestat(marker_dir.stat(), expected_marker_dir_stat):
+            raise ValueError("direct review recovery marker directory changed")
         yield marker_dir, None
         return
     root = _common_git_dir(repo_root)
@@ -322,6 +334,8 @@ def _open_marker_directory(repo_root: Path, marker_path: Path) -> Iterator[tuple
                 raise ValueError("direct review recovery Git metadata is unavailable")
             os.close(current_fd)
             current_fd = child_fd
+        if not os.path.samestat(os.fstat(current_fd), expected_marker_dir_stat):
+            raise ValueError("direct review recovery marker directory changed")
         yield marker_dir, current_fd
     finally:
         os.close(current_fd)
@@ -383,7 +397,7 @@ def _read_root_git_metadata(root: Path) -> tuple[bool, str | None]:
         os.close(root_fd)
 
 
-def _read_worktree_git_metadata(worktree: Path) -> tuple[bool, str]:
+def _read_worktree_git_metadata(worktree: Path) -> tuple[bool, str, os.stat_result]:
     """Return direct-review Git metadata after a descriptor-relative no-follow read."""
     worktree_fd = os.open(worktree, _directory_open_flags())
     try:
@@ -394,14 +408,15 @@ def _read_worktree_git_metadata(worktree: Path) -> tuple[bool, str]:
                 raise ValueError("direct review recovery Git metadata is symlinked") from error
             raise ValueError("direct review recovery Git metadata is unavailable") from error
         try:
-            mode = os.fstat(git_fd).st_mode
+            git_stat = os.fstat(git_fd)
+            mode = git_stat.st_mode
             if stat.S_ISDIR(mode):
-                return True, ""
+                return True, "", git_stat
             if not stat.S_ISREG(mode):
                 raise ValueError("direct review recovery Git metadata is unavailable")
             with os.fdopen(git_fd, "r", encoding="utf-8") as handle:
                 git_fd = -1
-                return False, handle.read().strip()
+                return False, handle.read().strip(), git_stat
         finally:
             if git_fd >= 0:
                 os.close(git_fd)
@@ -409,23 +424,34 @@ def _read_worktree_git_metadata(worktree: Path) -> tuple[bool, str]:
         os.close(worktree_fd)
 
 
-def _verify_linked_worktree_backlink(worktree: Path, git_dir: Path) -> None:
-    """Require a linked-worktree admin directory to point back to this checkout."""
+def _verify_linked_worktree_metadata(
+    worktree: Path, git_dir: Path, common_git_dir: Path
+) -> os.stat_result:
+    """Bind one linked-worktree admin directory to its common dir and checkout."""
     try:
         git_dir_fd = os.open(git_dir, _directory_open_flags())
     except OSError as error:
         raise ValueError("direct review recovery Git metadata is unavailable") from error
     try:
+        git_dir_stat = os.fstat(git_dir_fd)
+        common_dir_text = _read_secure_text(git_dir, git_dir_fd, "commondir").strip()
         backlink = _read_secure_text(git_dir, git_dir_fd, "gitdir").strip()
     except (OSError, ValueError) as error:
         raise ValueError("direct review recovery Git metadata is unavailable") from error
     finally:
         os.close(git_dir_fd)
+    raw_common_dir = Path(common_dir_text)
+    resolved_common_dir = (
+        raw_common_dir if raw_common_dir.is_absolute() else git_dir / raw_common_dir
+    ).resolve()
+    if resolved_common_dir != common_git_dir:
+        raise ValueError("direct review recovery repository Git metadata is unavailable")
     raw_backlink = Path(backlink)
     backlink_path = raw_backlink if raw_backlink.is_absolute() else git_dir / raw_backlink
     expected_path = worktree / ".git"
     if os.path.normpath(str(backlink_path)) != os.path.normpath(str(expected_path)):
         raise ValueError("direct review recovery Git metadata is not bound to its worktree")
+    return git_dir_stat
 
 
 def _verified_common_git_dir(git_dir: Path) -> Path:
@@ -471,10 +497,10 @@ def _common_git_dir(repo_root: Path) -> Path:
     return _verified_common_git_dir(git_dir)
 
 
-def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
-    """Return the private Git-metadata marker for one direct-review checkout."""
+def _worktree_marker_target(repo_root: Path, worktree: Path) -> tuple[Path, os.stat_result]:
+    """Return a marker path and the identity of its verified parent directory."""
     dot_git = worktree / ".git"
-    is_directory, line = _read_worktree_git_metadata(worktree)
+    is_directory, line, git_dir_stat = _read_worktree_git_metadata(worktree)
     if is_directory:
         git_dir = dot_git
     else:
@@ -495,9 +521,7 @@ def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
             raise ValueError(
                 "direct review recovery Git metadata is not a linked worktree"
             ) from error
-        if _verified_common_git_dir(git_dir) != common_git_dir:
-            raise ValueError("direct review recovery Git metadata is unavailable")
-        _verify_linked_worktree_backlink(worktree, git_dir)
+        git_dir_stat = _verify_linked_worktree_metadata(worktree, git_dir, common_git_dir)
     else:
         try:
             git_dir.relative_to(normalized_root)
@@ -505,22 +529,22 @@ def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
             raise ValueError(
                 "direct review recovery Git metadata is outside the repository"
             ) from error
-    return git_dir / _WORKTREE_MARKER
+    return git_dir / _WORKTREE_MARKER, git_dir_stat
 
 
 def _write_worktree_marker(repo_root: Path, worktree: Path) -> str:
     """Create an unguessable marker that cannot survive checkout replacement."""
     marker = secrets.token_urlsafe(32)
-    marker_path = _worktree_marker_path(repo_root, worktree)
-    with _open_marker_directory(repo_root, marker_path) as (marker_dir, marker_fd):
+    marker_path, marker_dir_stat = _worktree_marker_target(repo_root, worktree)
+    with _open_marker_directory(repo_root, marker_path, marker_dir_stat) as (marker_dir, marker_fd):
         _write_receipt(marker_dir, marker_fd, marker_path, marker + "\n")
     return marker
 
 
 def _read_worktree_marker(repo_root: Path, worktree: Path) -> str:
     """Read the checkout-local marker or raise when it is absent or unsafe."""
-    marker_path = _worktree_marker_path(repo_root, worktree)
-    with _open_marker_directory(repo_root, marker_path) as (marker_dir, marker_fd):
+    marker_path, marker_dir_stat = _worktree_marker_target(repo_root, worktree)
+    with _open_marker_directory(repo_root, marker_path, marker_dir_stat) as (marker_dir, marker_fd):
         marker = _read_secure_text(marker_dir, marker_fd, marker_path.name).strip()
     if not marker:
         raise ValueError("direct review recovery worktree marker is invalid")

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -12,7 +12,7 @@ from hephaestus.io.utils import write_secure
 from hephaestus.utils.file_lock import file_lock
 
 _RECEIPT_DIR = "direct-review-recovery"
-_RECEIPT_VERSION = 1
+_RECEIPT_VERSION = 2
 _REMOTE_CHANGED_REASON = "remote_changed"
 
 
@@ -42,9 +42,34 @@ def _validated_worktree_path(repo_root: Path, issue: int, path: Path) -> Path:
     return normalized
 
 
-def _receipt_dir(repo_root: Path) -> Path:
-    """Return the repository-scoped direct-review receipt directory."""
-    return repo_root / DEFAULT_STATE_DIR / _RECEIPT_DIR
+def _receipt_dir(repo_root: Path, *, create: bool = False) -> Path:
+    """Return a confined direct-review receipt directory.
+
+    Receipt metadata participates in recovery decisions, so it must not escape
+    the repository when a pre-existing state-directory component is a symlink.
+    The caller that writes a receipt requests directory creation explicitly;
+    read-only discovery leaves an absent state directory absent.
+    """
+    root = repo_root.resolve()
+    receipt_dir = root / DEFAULT_STATE_DIR / _RECEIPT_DIR
+    resolved_receipt_dir = receipt_dir.resolve()
+    if root not in resolved_receipt_dir.parents:
+        raise ValueError("direct review recovery receipt directory is outside the repository")
+    component = root
+    for part in (*Path(DEFAULT_STATE_DIR).parts, _RECEIPT_DIR):
+        component /= part
+        if component.is_symlink():
+            raise ValueError("direct review recovery receipt directory is symlinked")
+        if component.exists() and not component.is_dir():
+            raise ValueError("direct review recovery receipt directory is not a directory")
+    if create:
+        receipt_dir.mkdir(parents=True, exist_ok=True)
+        # Re-check after mkdir: a concurrent replacement must not redirect the
+        # lock or atomic receipt write outside this repository.
+        resolved_receipt_dir = receipt_dir.resolve()
+        if root not in resolved_receipt_dir.parents or receipt_dir.is_symlink():
+            raise ValueError("direct review recovery receipt directory is unsafe")
+    return receipt_dir
 
 
 def _receipt_path(receipt_dir: Path, pr: int, worktree: Path) -> Path:
@@ -56,6 +81,12 @@ def _receipt_path(receipt_dir: Path, pr: int, worktree: Path) -> Path:
 def _receipt_lock_path(receipt_dir: Path, pr: int) -> Path:
     """Return the per-PR lock serializing receipt writes and reads."""
     return receipt_dir / f"direct-review-{pr}.lock"
+
+
+def _worktree_identity(worktree: Path) -> tuple[int, int]:
+    """Return the filesystem identity that binds a receipt to one checkout."""
+    stat = worktree.stat()
+    return stat.st_dev, stat.st_ino
 
 
 def record_direct_review_recovery(
@@ -80,11 +111,12 @@ def record_direct_review_recovery(
         raise ValueError("direct review recovery branch is invalid")
     if not _is_full_sha(expected_remote_sha) or not _is_full_sha(source_sha):
         raise ValueError("direct review recovery commit receipt is invalid")
-    normalized_root = repo_root.resolve()
+    normalized_root = Path(repo_root).resolve()
     normalized_worktree = _validated_worktree_path(normalized_root, issue, worktree)
     if not normalized_worktree.is_dir():
         raise ValueError("direct review recovery worktree is missing")
-    receipt_dir = _receipt_dir(normalized_root)
+    worktree_device, worktree_inode = _worktree_identity(normalized_worktree)
+    receipt_dir = _receipt_dir(normalized_root, create=True)
     receipt = {
         "branch": branch,
         "expected_remote_sha": expected_remote_sha,
@@ -95,6 +127,8 @@ def record_direct_review_recovery(
         "schema_version": _RECEIPT_VERSION,
         "source_sha": source_sha,
         "worktree": str(normalized_worktree),
+        "worktree_device": worktree_device,
+        "worktree_inode": worktree_inode,
     }
     target = _receipt_path(receipt_dir, pr, normalized_worktree)
     with file_lock(_receipt_lock_path(receipt_dir, pr)):
@@ -110,8 +144,11 @@ def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -
     """
     if isinstance(pr, bool) or not isinstance(pr, int) or pr <= 0:
         return []
-    normalized_root = repo_root.resolve()
-    receipt_dir = _receipt_dir(normalized_root)
+    normalized_root = Path(repo_root).resolve()
+    try:
+        receipt_dir = _receipt_dir(normalized_root)
+    except ValueError:
+        return []
     if not receipt_dir.is_dir():
         return []
     paths: list[Path] = []
@@ -125,6 +162,7 @@ def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -
                 worktree = _validated_worktree_path(
                     normalized_root, issue, Path(str(payload.get("worktree", "")))
                 )
+                worktree_device, worktree_inode = _worktree_identity(worktree)
                 if (
                     payload.get("schema_version") != _RECEIPT_VERSION
                     or payload.get("reason") != _REMOTE_CHANGED_REASON
@@ -135,6 +173,12 @@ def list_direct_review_recovery_paths(*, repo_root: Path, issue: int, pr: int) -
                     or not _is_full_sha(payload.get("expected_remote_sha"))
                     or not _is_full_sha(payload.get("source_sha"))
                     or not worktree.is_dir()
+                    or isinstance(payload.get("worktree_device"), bool)
+                    or not isinstance(payload.get("worktree_device"), int)
+                    or payload.get("worktree_device") != worktree_device
+                    or isinstance(payload.get("worktree_inode"), bool)
+                    or not isinstance(payload.get("worktree_inode"), int)
+                    or payload.get("worktree_inode") != worktree_inode
                     or worktree in seen
                 ):
                     continue

--- a/hephaestus/automation/direct_review_recovery.py
+++ b/hephaestus/automation/direct_review_recovery.py
@@ -310,7 +310,10 @@ def _open_marker_directory(repo_root: Path, marker_path: Path) -> Iterator[tuple
         components = marker_dir.relative_to(root).parts
     except ValueError as error:
         raise ValueError("direct review recovery marker is outside the repository") from error
-    root_fd = os.open(root, _directory_open_flags())
+    try:
+        root_fd = os.open(root, _directory_open_flags())
+    except OSError as error:
+        raise ValueError("direct review recovery Git metadata is unavailable") from error
     current_fd = root_fd
     try:
         for component in components:
@@ -380,6 +383,51 @@ def _read_root_git_metadata(root: Path) -> tuple[bool, str | None]:
         os.close(root_fd)
 
 
+def _read_worktree_git_metadata(worktree: Path) -> tuple[bool, str]:
+    """Return direct-review Git metadata after a descriptor-relative no-follow read."""
+    worktree_fd = os.open(worktree, _directory_open_flags())
+    try:
+        try:
+            git_fd = os.open(".git", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=worktree_fd)
+        except OSError as error:
+            if error.errno == errno.ELOOP:
+                raise ValueError("direct review recovery Git metadata is symlinked") from error
+            raise ValueError("direct review recovery Git metadata is unavailable") from error
+        try:
+            mode = os.fstat(git_fd).st_mode
+            if stat.S_ISDIR(mode):
+                return True, ""
+            if not stat.S_ISREG(mode):
+                raise ValueError("direct review recovery Git metadata is unavailable")
+            with os.fdopen(git_fd, "r", encoding="utf-8") as handle:
+                git_fd = -1
+                return False, handle.read().strip()
+        finally:
+            if git_fd >= 0:
+                os.close(git_fd)
+    finally:
+        os.close(worktree_fd)
+
+
+def _verify_linked_worktree_backlink(worktree: Path, git_dir: Path) -> None:
+    """Require a linked-worktree admin directory to point back to this checkout."""
+    try:
+        git_dir_fd = os.open(git_dir, _directory_open_flags())
+    except OSError as error:
+        raise ValueError("direct review recovery Git metadata is unavailable") from error
+    try:
+        backlink = _read_secure_text(git_dir, git_dir_fd, "gitdir").strip()
+    except (OSError, ValueError) as error:
+        raise ValueError("direct review recovery Git metadata is unavailable") from error
+    finally:
+        os.close(git_dir_fd)
+    raw_backlink = Path(backlink)
+    backlink_path = raw_backlink if raw_backlink.is_absolute() else git_dir / raw_backlink
+    expected_path = worktree / ".git"
+    if os.path.normpath(str(backlink_path)) != os.path.normpath(str(expected_path)):
+        raise ValueError("direct review recovery Git metadata is not bound to its worktree")
+
+
 def _verified_common_git_dir(git_dir: Path) -> Path:
     """Return the common directory proven by a linked worktree's ``commondir``."""
     if git_dir.parent.name != "worktrees" or not git_dir.parent.parent.is_dir():
@@ -414,7 +462,7 @@ def _common_git_dir(repo_root: Path) -> Path:
     if line is None:
         # Lightweight fixtures without a repository-level Git directory keep
         # metadata confined to the fixture root.
-        return dot_git.resolve() if is_directory else root
+        return dot_git if is_directory else root
     prefix = "gitdir: "
     if not line.startswith(prefix):
         raise ValueError("direct review recovery repository Git metadata is invalid")
@@ -426,15 +474,10 @@ def _common_git_dir(repo_root: Path) -> Path:
 def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
     """Return the private Git-metadata marker for one direct-review checkout."""
     dot_git = worktree / ".git"
-    if dot_git.is_symlink():
-        raise ValueError("direct review recovery Git metadata is symlinked")
-    if dot_git.is_dir():
+    is_directory, line = _read_worktree_git_metadata(worktree)
+    if is_directory:
         git_dir = dot_git
     else:
-        try:
-            line = dot_git.read_text(encoding="utf-8").strip()
-        except OSError as error:
-            raise ValueError("direct review recovery Git metadata is unavailable") from error
         prefix = "gitdir: "
         if not line.startswith(prefix):
             raise ValueError("direct review recovery Git metadata is invalid")
@@ -445,13 +488,16 @@ def _worktree_marker_path(repo_root: Path, worktree: Path) -> Path:
         raise ValueError("direct review recovery Git metadata is unavailable")
     normalized_root = repo_root.resolve()
     common_git_dir = _common_git_dir(normalized_root)
-    if not dot_git.is_dir():
+    if not is_directory:
         try:
             git_dir.relative_to(common_git_dir / "worktrees")
         except ValueError as error:
             raise ValueError(
                 "direct review recovery Git metadata is not a linked worktree"
             ) from error
+        if _verified_common_git_dir(git_dir) != common_git_dir:
+            raise ValueError("direct review recovery Git metadata is unavailable")
+        _verify_linked_worktree_backlink(worktree, git_dir)
     else:
         try:
             git_dir.relative_to(normalized_root)

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -504,6 +504,13 @@ def push_head_to_branch(
             raise DetachedHeadPushRemoteProbeError(
                 "Detached review push failed and the remote head could not be verified"
             ) from probe_exc
+        if source_sha is not None and observed and observed[0] == source_sha:
+            # A transport error can arrive after receive-pack accepted this
+            # exact immutable source commit. The intended remote state is
+            # already present, so treating it as drift would needlessly start
+            # a second review and preserve a checkout that was published.
+            logger.info("Detached review commit was published before the push result was lost")
+            return
         if not observed or observed[0] != expected_remote_sha:
             raise DetachedHeadPushRemoteHeadChangedError(
                 "Detached review push observed a different remote head"

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -463,6 +463,7 @@ def push_head_to_branch(
     expected_remote_sha: str,
     worktree_path: Path,
     *,
+    source_sha: str | None = None,
     timeout: int | None = None,
 ) -> None:
     """Publish detached ``HEAD`` to ``origin/<branch_name>`` safely.
@@ -473,6 +474,7 @@ def push_head_to_branch(
     permits an address agent to rebase onto current main while refusing to
     overwrite a PR head that changed after its reviewed-head proof.
     """
+    source_ref = source_sha or "HEAD"
     try:
         run(
             [
@@ -480,13 +482,13 @@ def push_head_to_branch(
                 "push",
                 f"--force-with-lease=refs/heads/{branch_name}:{expected_remote_sha}",
                 "origin",
-                f"HEAD:refs/heads/{branch_name}",
+                f"{source_ref}:refs/heads/{branch_name}",
             ],
             cwd=worktree_path,
             **_timeout_kw(timeout),
         )
         logger.info("Published detached HEAD to origin/%s", branch_name)
-    except subprocess.CalledProcessError as exc:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         # The rejected push can be a local pre-push-hook failure, transport
         # failure, or a server-side lease rejection.  Never infer which from
         # git's stderr: hook output is untrusted diagnostic content and may

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -33,6 +33,22 @@ logger = logging.getLogger(__name__)
 COMMIT_POLICY_REWRITE_EXEC = "git commit --amend --no-edit -S -s --allow-empty"
 
 
+class DetachedHeadPushError(RuntimeError):
+    """Base error for a failed lease-protected detached-head publication."""
+
+
+class DetachedHeadPushRemoteHeadChangedError(DetachedHeadPushError):
+    """The remote branch changed after the reviewed-head proof was obtained."""
+
+
+class DetachedHeadPushRemoteHeadUnchangedError(DetachedHeadPushError):
+    """The detached push failed while the remote branch still matched its proof."""
+
+
+class DetachedHeadPushRemoteProbeError(DetachedHeadPushError):
+    """The remote branch could not be checked after a detached push failure."""
+
+
 def _timeout_kw(timeout: int | None) -> dict[str, Any]:
     """Return a ``run`` kwargs fragment only when a timeout was provided."""
     return {} if timeout is None else {"timeout": timeout}
@@ -470,8 +486,29 @@ def push_head_to_branch(
             **_timeout_kw(timeout),
         )
         logger.info("Published detached HEAD to origin/%s", branch_name)
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to publish detached HEAD to branch {branch_name}: {e}") from e
+    except subprocess.CalledProcessError as exc:
+        # The rejected push can be a local pre-push-hook failure, transport
+        # failure, or a server-side lease rejection.  Never infer which from
+        # git's stderr: hook output is untrusted diagnostic content and may
+        # contain repository data.  A fresh authoritative ref read classifies
+        # only the safe ownership distinction needed by the pipeline.
+        try:
+            observed = run(
+                ["git", "ls-remote", "--refs", "origin", f"refs/heads/{branch_name}"],
+                cwd=worktree_path,
+                **_timeout_kw(timeout),
+            ).stdout.split()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as probe_exc:
+            raise DetachedHeadPushRemoteProbeError(
+                "Detached review push failed and the remote head could not be verified"
+            ) from probe_exc
+        if not observed or observed[0] != expected_remote_sha:
+            raise DetachedHeadPushRemoteHeadChangedError(
+                "Detached review push observed a different remote head"
+            ) from exc
+        raise DetachedHeadPushRemoteHeadUnchangedError(
+            "Detached review push failed while the remote head remained unchanged"
+        ) from exc
 
 
 def has_unpushed_commits(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -923,6 +923,7 @@ class Coordinator:
             )
             summary_items = self._effective_items()
             preserved = self._active_preserved_worktrees()
+            recovery_preserved = self._active_recovery_worktrees()
             try:
                 self._record_event(
                     "run_end",
@@ -939,6 +940,7 @@ class Coordinator:
                     stats,
                     preserved,
                     json_out=self.config.json_out,
+                    recovery_preserved=recovery_preserved,
                     terminal_summary=(
                         self._terminal_summary if self._terminal_summary.total else None
                     ),
@@ -953,7 +955,7 @@ class Coordinator:
         return latest_logical_items(self.items)
 
     def _active_preserved_worktrees(self) -> list[PreservedWorktree]:
-        """Return extant failed-item and direct-review recovery worktrees."""
+        """Return extant failed-item worktrees for the latest logical items."""
         failed_items = {
             (item.repo, item.issue or item.pr or 0)
             for item in self._effective_items()
@@ -967,6 +969,12 @@ class Coordinator:
                 continue
             seen.add(entry)
             active.append(entry)
+        return active
+
+    def _active_recovery_worktrees(self) -> list[PreservedWorktree]:
+        """Return extant receipt-backed detached-review recovery worktrees."""
+        active: list[PreservedWorktree] = []
+        seen: set[PreservedWorktree] = set()
         for repo, issue_or_pr, path in self.recovery_preserved:
             entry = (repo, issue_or_pr, path)
             if entry in seen or not Path(path).exists():

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1444,8 +1444,14 @@ class Coordinator:
         reaches ``FinishedStage``, so collect the same durable evidence here
         for the interrupt summary rather than losing the operator guidance.
         """
-        if item.worktree and is_inspection_only_detached_push_failure(
-            item.payload.get("detached_push_failure")
+        direct_publication_interrupted = (
+            item.worktree
+            and item.payload.get("direct_pr_worktree") == item.worktree
+            and item.state in {"ADDRESS_WAIT", "PUSH_WAIT"}
+        )
+        if direct_publication_interrupted or (
+            item.worktree
+            and is_inspection_only_detached_push_failure(item.payload.get("detached_push_failure"))
         ):
             entry = (item.repo, item.issue or item.pr or 0, item.worktree)
             if entry not in self.recovery_preserved:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -90,6 +90,7 @@ from typing import Any, TypeAlias
 
 from jinja2 import TemplateNotFound
 
+from hephaestus.automation.direct_review_recovery import list_direct_review_recovery_paths
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
@@ -1416,6 +1417,7 @@ class Coordinator:
         seeding reconstruction resumes exactly here with no shutdown
         bookkeeping.
         """
+        self._record_resumable_recovery_worktrees(item)
         self._release_source_lease(item)
         item.result = ItemResult(
             passed=False,
@@ -1430,6 +1432,34 @@ class Coordinator:
             self._item_key(item),
             item.stage.value,
         )
+
+    def _record_resumable_recovery_worktrees(self, item: WorkItem) -> None:
+        """Retain receipt-backed recovery paths when shutdown skips FinishedStage.
+
+        A worker writes a remote-drift receipt before returning the result that
+        triggers a fresh review.  A shutdown can park that item before it ever
+        reaches ``FinishedStage``, so collect the same durable evidence here
+        for the interrupt summary rather than losing the operator guidance.
+        """
+        if item.issue is None or item.pr is None:
+            return
+        try:
+            worktrees = list_direct_review_recovery_paths(
+                repo_root=_effective_repo_root(self.config, item.repo),
+                issue=item.issue,
+                pr=item.pr,
+            )
+        except (OSError, RuntimeError) as error:
+            logger.warning(
+                "interrupt:%s: could not read detached-review recovery receipts: %s",
+                item.issue or item.repo,
+                error,
+            )
+            return
+        for worktree in worktrees:
+            entry = (item.repo, item.issue, str(worktree))
+            if entry not in self.recovery_preserved:
+                self.recovery_preserved.append(entry)
 
     @staticmethod
     def _job_result_event_fields(result: JobResult) -> dict[str, Any]:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -575,6 +575,10 @@ class Coordinator:
         self._live_work_permit_ids: set[int] = set()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
+        # Recovery checkouts are intentionally distinct from failed-item
+        # debugging worktrees: a later fresh review may pass, but the prior
+        # checkout still needs explicit operator cleanup guidance.
+        self.recovery_preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
         self._terminal_summary = TerminalSummary()
         self.event_log: deque[tuple[Any, ...]] = deque(maxlen=config.event_log_capacity)
@@ -670,7 +674,11 @@ class Coordinator:
             StageName.IMPLEMENTATION: ImplementationStage(),
             StageName.PR_REVIEW: PrReviewStage(),
             StageName.MERGE_WAIT: MergeWaitStage(),
-            StageName.FINISHED: FinishedStage(self.ledger, self.preserved),
+            StageName.FINISHED: FinishedStage(
+                self.ledger,
+                self.preserved,
+                self.recovery_preserved,
+            ),
         }
 
     def _ctx_for_repo(self, repo: str) -> StageContext:
@@ -945,7 +953,7 @@ class Coordinator:
         return latest_logical_items(self.items)
 
     def _active_preserved_worktrees(self) -> list[PreservedWorktree]:
-        """Return preserved worktrees for latest failed items that still exist."""
+        """Return extant failed-item and direct-review recovery worktrees."""
         failed_items = {
             (item.repo, item.issue or item.pr or 0)
             for item in self._effective_items()
@@ -956,6 +964,12 @@ class Coordinator:
         for repo, issue_or_pr, path in self.preserved:
             entry = (repo, issue_or_pr, path)
             if entry in seen or (repo, issue_or_pr) not in failed_items or not Path(path).exists():
+                continue
+            seen.add(entry)
+            active.append(entry)
+        for repo, issue_or_pr, path in self.recovery_preserved:
+            entry = (repo, issue_or_pr, path)
+            if entry in seen or not Path(path).exists():
                 continue
             seen.add(entry)
             active.append(entry)
@@ -1059,6 +1073,8 @@ class Coordinator:
             del self.ledger[:-retained]
         if len(self.preserved) > retained:
             del self.preserved[:-retained]
+        if len(self.recovery_preserved) > retained:
+            del self.recovery_preserved[:-retained]
 
     # -- stage-queue leases -------------------------------------------------
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -90,7 +90,10 @@ from typing import Any, TypeAlias
 
 from jinja2 import TemplateNotFound
 
-from hephaestus.automation.direct_review_recovery import list_direct_review_recovery_paths
+from hephaestus.automation.direct_review_recovery import (
+    is_inspection_only_detached_push_failure,
+    list_direct_review_recovery_paths,
+)
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
@@ -1441,6 +1444,12 @@ class Coordinator:
         reaches ``FinishedStage``, so collect the same durable evidence here
         for the interrupt summary rather than losing the operator guidance.
         """
+        if item.worktree and is_inspection_only_detached_push_failure(
+            item.payload.get("detached_push_failure")
+        ):
+            entry = (item.repo, item.issue or item.pr or 0, item.worktree)
+            if entry not in self.recovery_preserved:
+                self.recovery_preserved.append(entry)
         if item.issue is None or item.pr is None:
             return
         try:

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -59,6 +59,9 @@ class FinishedStage(Stage):
             (``(repo, item_number, worktree_path)`` tuples) the summary prints.
             Failed issue items use the issue number; PR-only items use the PR
             number; unknown items fall back to 0.
+        recovery_preserved: The coordinator's direct-review recovery list.
+            These checkouts remain reported even if a later fresh review
+            succeeds, unlike ordinary failed-item debugging worktrees.
 
     """
 
@@ -68,10 +71,12 @@ class FinishedStage(Stage):
         self,
         ledger: list[ItemResult],
         preserved: list[PreservedWorktree],
+        recovery_preserved: list[PreservedWorktree],
     ) -> None:
         """Bind the coordinator-owned ledger and preserved-worktree list."""
         self._ledger = ledger
         self._preserved = preserved
+        self._recovery_preserved = recovery_preserved
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
         """Proceed unconditionally (the sink never routes away).
@@ -224,8 +229,8 @@ class FinishedStage(Stage):
             if not isinstance(worktree, str) or not worktree:
                 continue
             entry = (item.repo, item.issue or item.pr or 0, worktree)
-            if entry not in self._preserved:
-                self._preserved.append(entry)
+            if entry not in self._recovery_preserved:
+                self._recovery_preserved.append(entry)
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Log cleanup failures (never fatal — the result is already recorded).

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -122,6 +122,7 @@ class FinishedStage(Stage):
 
     def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Clean or preserve the writer worktree."""
+        self._record_recovery_worktrees(item)
         reservation = item.payload.get(DIRECT_SCOPE_RESERVATION_KEY)
         if not item.payload.get("_direct_scope_reservation_release_attempted", False):
             if isinstance(reservation, dict):
@@ -213,6 +214,18 @@ class FinishedStage(Stage):
             descr=f"remove worktree {item.worktree}",
         )
         return JobRequest(job=job, on_done_state="DONE")
+
+    def _record_recovery_worktrees(self, item: WorkItem) -> None:
+        """Retain failed direct-review checkouts even when a re-review succeeds."""
+        recovery_worktrees = item.payload.get("preserved_direct_worktrees", [])
+        if not isinstance(recovery_worktrees, list):
+            return
+        for worktree in recovery_worktrees:
+            if not isinstance(worktree, str) or not worktree:
+                continue
+            entry = (item.repo, item.issue or item.pr or 0, worktree)
+            if entry not in self._preserved:
+                self._preserved.append(entry)
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Log cleanup failures (never fatal — the result is already recorded).

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -23,7 +23,10 @@ from __future__ import annotations
 
 import logging
 
-from hephaestus.automation.direct_review_recovery import list_direct_review_recovery_paths
+from hephaestus.automation.direct_review_recovery import (
+    is_inspection_only_detached_push_failure,
+    list_direct_review_recovery_paths,
+)
 from hephaestus.automation.pipeline.work_item import ItemResult, PreservedWorktree
 
 from .base import (
@@ -49,16 +52,6 @@ from .repo import (
 logger = logging.getLogger(__name__)
 
 _RESERVATION_RELEASE_RETRY_CAP = 2
-_DETACHED_PUSH_INSPECTION_FAILURES = frozenset(
-    {
-        "remote_changed",
-        "remote_changed_unrecorded",
-        "remote_unchanged",
-        "remote_unconfirmed",
-        "retry_checkout_changed",
-        "retry_checkout_unconfirmed",
-    }
-)
 
 
 class FinishedStage(Stage):
@@ -195,7 +188,7 @@ class FinishedStage(Stage):
             and is_full_commit_sha(local_cleanup.get("base_sha"))
         )
         inspection_only = (
-            item.payload.get("detached_push_failure") in _DETACHED_PUSH_INSPECTION_FAILURES
+            is_inspection_only_detached_push_failure(item.payload.get("detached_push_failure"))
             or item.worktree in recovery_worktrees
         )
         if not passed and inspection_only:

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -49,6 +49,16 @@ from .repo import (
 logger = logging.getLogger(__name__)
 
 _RESERVATION_RELEASE_RETRY_CAP = 2
+_DETACHED_PUSH_INSPECTION_FAILURES = frozenset(
+    {
+        "remote_changed",
+        "remote_changed_unrecorded",
+        "remote_unchanged",
+        "remote_unconfirmed",
+        "retry_checkout_changed",
+        "retry_checkout_unconfirmed",
+    }
+)
 
 
 class FinishedStage(Stage):
@@ -128,7 +138,7 @@ class FinishedStage(Stage):
 
     def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Clean or preserve the writer worktree."""
-        self._record_recovery_worktrees(item, ctx)
+        recovery_worktrees = self._record_recovery_worktrees(item, ctx)
         reservation = item.payload.get(DIRECT_SCOPE_RESERVATION_KEY)
         if not item.payload.get("_direct_scope_reservation_release_attempted", False):
             if isinstance(reservation, dict):
@@ -184,6 +194,21 @@ class FinishedStage(Stage):
             and bool(local_cleanup["branch"])
             and is_full_commit_sha(local_cleanup.get("base_sha"))
         )
+        inspection_only = (
+            item.payload.get("detached_push_failure") in _DETACHED_PUSH_INSPECTION_FAILURES
+            or item.worktree in recovery_worktrees
+        )
+        if not passed and inspection_only:
+            entry = (item.repo, item.issue or item.pr or 0, item.worktree)
+            if entry not in self._recovery_preserved:
+                self._recovery_preserved.append(entry)
+            logger.info(
+                "finished:%s: retaining detached-review checkout for inspection: %s",
+                item.issue or item.repo,
+                item.worktree,
+            )
+            return Continue(next_state="DONE")
+
         if not passed and not is_direct_noop:
             entry = (item.repo, item.issue or item.pr or 0, item.worktree)
             if entry not in self._preserved:
@@ -221,10 +246,10 @@ class FinishedStage(Stage):
         )
         return JobRequest(job=job, on_done_state="DONE")
 
-    def _record_recovery_worktrees(self, item: WorkItem, ctx: StageContext) -> None:
-        """Retain only receipt-backed direct-review recovery checkouts."""
+    def _record_recovery_worktrees(self, item: WorkItem, ctx: StageContext) -> set[str]:
+        """Record receipt-backed recoveries and return their concrete paths."""
         if item.issue is None or item.pr is None:
-            return
+            return set()
         try:
             recovery_worktrees = list_direct_review_recovery_paths(
                 repo_root=ctx.paths.repo_root,
@@ -237,11 +262,13 @@ class FinishedStage(Stage):
                 item.issue or item.repo,
                 error,
             )
-            return
+            return set()
+        paths = {str(worktree) for worktree in recovery_worktrees}
         for worktree in recovery_worktrees:
             entry = (item.repo, item.issue, str(worktree))
             if entry not in self._recovery_preserved:
                 self._recovery_preserved.append(entry)
+        return paths
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Log cleanup failures (never fatal — the result is already recorded).

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 
+from hephaestus.automation.direct_review_recovery import list_direct_review_recovery_paths
 from hephaestus.automation.pipeline.work_item import ItemResult, PreservedWorktree
 
 from .base import (
@@ -127,7 +128,7 @@ class FinishedStage(Stage):
 
     def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Clean or preserve the writer worktree."""
-        self._record_recovery_worktrees(item)
+        self._record_recovery_worktrees(item, ctx)
         reservation = item.payload.get(DIRECT_SCOPE_RESERVATION_KEY)
         if not item.payload.get("_direct_scope_reservation_release_attempted", False):
             if isinstance(reservation, dict):
@@ -220,15 +221,25 @@ class FinishedStage(Stage):
         )
         return JobRequest(job=job, on_done_state="DONE")
 
-    def _record_recovery_worktrees(self, item: WorkItem) -> None:
-        """Retain failed direct-review checkouts even when a re-review succeeds."""
-        recovery_worktrees = item.payload.get("preserved_direct_worktrees", [])
-        if not isinstance(recovery_worktrees, list):
+    def _record_recovery_worktrees(self, item: WorkItem, ctx: StageContext) -> None:
+        """Retain only receipt-backed direct-review recovery checkouts."""
+        if item.issue is None or item.pr is None:
+            return
+        try:
+            recovery_worktrees = list_direct_review_recovery_paths(
+                repo_root=ctx.paths.repo_root,
+                issue=item.issue,
+                pr=item.pr,
+            )
+        except (OSError, RuntimeError) as error:
+            logger.warning(
+                "finished:%s: could not read detached-review recovery receipts: %s",
+                item.issue or item.repo,
+                error,
+            )
             return
         for worktree in recovery_worktrees:
-            if not isinstance(worktree, str) or not worktree:
-                continue
-            entry = (item.repo, item.issue or item.pr or 0, worktree)
+            entry = (item.repo, item.issue, str(worktree))
             if entry not in self._recovery_preserved:
                 self._recovery_preserved.append(entry)
 

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -161,6 +161,7 @@ from .base import (
     stage_model,
     write_skip_label,
 )
+from .repo import is_full_commit_sha
 
 logger = logging.getLogger(__name__)
 
@@ -252,6 +253,8 @@ _ROUND_PAYLOAD_KEYS = (
     "difficulty_tiers",
     "address_error",
     "address_output",
+    "direct_push_retries",
+    "detached_push_retry_head_sha",
     "push_no_commit",
     "no_commit_retry_done",
     "unaddressed_findings",
@@ -858,27 +861,33 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_no_head_branch")
         item.branch = branch
         item.payload["existing_pr"] = True
+        generation = item.payload.get("direct_pr_worktree_generation", 0)
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_worktree_generation_invalid")
         logger.info(
             "pr_review:%d: adopting direct PR #%d (branch %r) for review",
             _issue_number(item),
             item.pr,
             branch,
         )
+        kwargs: dict[str, object] = {
+            "issue_number": _issue_number(item),
+            "branch_name": branch,
+            "refresh_base": False,
+            # This mutable review checkout cannot reuse the writer's branch
+            # checkout.
+            "isolated": True,
+            "sync_to_remote": True,
+            "pr_number": item.pr,
+            "repo_root": str(ctx.paths.repo_root),
+        }
+        if generation:
+            kwargs["isolated_generation"] = generation
         job = GitJob(
             repo=item.repo,
             op="create_worktree",
             timeout_s=GIT_JOB_TIMEOUT_S,
-            kwargs={
-                "issue_number": _issue_number(item),
-                "branch_name": branch,
-                "refresh_base": False,
-                # This mutable review checkout cannot reuse the writer's
-                # branch checkout.
-                "isolated": True,
-                "sync_to_remote": True,
-                "pr_number": item.pr,
-                "repo_root": str(ctx.paths.repo_root),
-            },
+            kwargs=kwargs,
             descr="direct_pr_review_worktree",
         )
         # Coordinator completion callbacks run before on_done_state is
@@ -1116,6 +1125,13 @@ class PrReviewStage(Stage):
             # deliberate rebase without overwriting a concurrent writer.
             kwargs["publish_detached_head"] = True
             kwargs["expected_remote_sha"] = item.payload.get("reviewed_pr_head_sha")
+            retry_head_sha = item.payload.get("detached_push_retry_head_sha")
+            if retry_head_sha is not None:
+                if not is_full_commit_sha(retry_head_sha):
+                    return StageOutcome(
+                        Disposition.FINISH_FAIL, "detached_push_retry_receipt_invalid"
+                    )
+                kwargs["detached_push_retry_head_sha"] = retry_head_sha
         git_job = GitJob(
             repo=item.repo,
             op="commit_push",
@@ -1293,13 +1309,19 @@ class PrReviewStage(Stage):
             # the flag lets VALIDATE_WAIT skip the dead round.
             item.payload["review_failed"] = True
         elif item.state == PUSH_WAIT:
-            failure = (
-                result.value.get("detached_push_failure")
-                if isinstance(result.value, dict)
-                else None
-            )
-            if failure in {"remote_changed", "remote_unchanged", "remote_unconfirmed"}:
+            receipt = result.value if isinstance(result.value, dict) else {}
+            failure = receipt.get("detached_push_failure")
+            if failure in {
+                "remote_changed",
+                "remote_unchanged",
+                "remote_unconfirmed",
+                "retry_checkout_changed",
+                "retry_checkout_unconfirmed",
+            }:
                 item.payload["detached_push_failure"] = failure
+                source_sha = receipt.get("detached_push_head_sha")
+                if is_full_commit_sha(source_sha):
+                    item.payload["detached_push_head_sha"] = source_sha
                 return
             item.payload["address_error"] = True
         elif item.state == ADDRESS_WAIT:
@@ -1586,6 +1608,29 @@ class PrReviewStage(Stage):
         )
         return JobRequest(job, on_done_state=PUSH_WAIT)
 
+    @staticmethod
+    def _restart_direct_pr_review(item: WorkItem) -> StageOutcome | None:
+        """Preserve a drifted checkout and route the PR through a fresh review."""
+        if not item.worktree:
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_recovery_worktree_missing")
+        generation = item.payload.get("direct_pr_worktree_generation", 0)
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_worktree_generation_invalid")
+        preserved = item.payload.setdefault("preserved_direct_worktrees", [])
+        if not isinstance(preserved, list):
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_recovery_receipt_invalid")
+        if item.worktree not in preserved:
+            preserved.append(item.worktree)
+        item.worktree = ""
+        item.payload["existing_pr"] = True
+        item.payload.pop("direct_pr_worktree", None)
+        item.payload.pop("direct_pr_worktree_dirty", None)
+        item.payload["direct_pr_worktree_generation"] = generation + 1
+        item.session_ids.pop(AGENT_PR_REVIEWER, None)
+        item.session_ids.pop(AGENT_ADDRESS_REVIEW, None)
+        _clear_round_review_state(item)
+        return None
+
     def _eval(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901 - state-machine gate
         """EVAL [M]: apply the structural-audit gate and review budget.
 
@@ -1602,11 +1647,20 @@ class PrReviewStage(Stage):
 
         detached_push_failure = payload.pop("detached_push_failure", None)
         if detached_push_failure == "remote_unchanged":
+            source_sha = payload.pop("detached_push_head_sha", None)
+            if not is_full_commit_sha(source_sha):
+                logger.warning(
+                    "pr_review:%d: detached push retry receipt lacks an exact local head",
+                    item.issue,
+                )
+                return StageOutcome(Disposition.FINISH_FAIL, "detached_push_retry_receipt_invalid")
             retries = int(payload.get("direct_push_retries", 0))
             if retries < DIRECT_PUSH_RETRY_CAP:
                 payload["direct_push_retries"] = retries + 1
+                payload["detached_push_retry_head_sha"] = source_sha
                 logger.warning(
-                    "pr_review:%d: detached push failed with an unchanged remote; retrying commit",
+                    "pr_review:%d: detached push failed with unchanged remote; "
+                    "retrying exact commit",
                     item.issue,
                 )
                 return Continue(next_state=PUSH_WAIT)
@@ -1617,20 +1671,27 @@ class PrReviewStage(Stage):
             )
             return StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
         if detached_push_failure == "remote_changed":
-            payload["detached_push_failure"] = detached_push_failure
+            recovery = self._restart_direct_pr_review(item)
+            if recovery is not None:
+                return recovery
             logger.warning(
-                "pr_review:%d: detached push saw a changed remote head; preserving checkout",
+                "pr_review:%d: detached push saw changed remote head; "
+                "restarting from a fresh checkout",
                 item.issue,
             )
-            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_head_changed")
-        if detached_push_failure == "remote_unconfirmed":
+            return Continue(next_state=ENTER)
+        if detached_push_failure in {
+            "remote_unconfirmed",
+            "retry_checkout_changed",
+            "retry_checkout_unconfirmed",
+        }:
             payload["detached_push_failure"] = detached_push_failure
             logger.warning(
-                "pr_review:%d: detached push remote head could not be verified; "
-                "preserving checkout",
+                "pr_review:%d: detached push recovery state %s; preserving checkout",
                 item.issue,
+                detached_push_failure,
             )
-            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_remote_unconfirmed")
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
 
         address_error = self._handle_address_error(item)
         if address_error is not None:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -202,6 +202,12 @@ COMPACT_WRITER_WAIT = "COMPACT_WRITER_WAIT"
 # commit once; never ask the address agent to recreate it or discard it.
 DIRECT_PUSH_RETRY_CAP = 1
 
+# A changed remote requires a new review checkout because the previous one is
+# a recovery artifact. One fresh pass handles a concurrent update without
+# allowing a continuously advancing branch to accumulate unbounded agent runs
+# and preserved worktrees in one coordinator invocation.
+DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP = 1
+
 _STEP_HANDLER_NAMES: dict[str, str] = {
     ENTER: "_enter",
     ADOPT_WORKTREE_WAIT: "_adopt_worktree_wait",
@@ -1671,6 +1677,21 @@ class PrReviewStage(Stage):
             )
             return StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
         if detached_push_failure == "remote_changed":
+            restarts = payload.get("direct_push_remote_changed_restarts", 0)
+            if isinstance(restarts, bool) or not isinstance(restarts, int) or restarts < 0:
+                return StageOutcome(
+                    Disposition.FINISH_FAIL,
+                    "detached_push_recovery_receipt_invalid",
+                )
+            if restarts >= DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP:
+                payload["detached_push_failure"] = detached_push_failure
+                logger.warning(
+                    "pr_review:%d: detached push remote-change recovery cap reached; "
+                    "preserving checkout",
+                    item.issue,
+                )
+                return StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
+            payload["direct_push_remote_changed_restarts"] = restarts + 1
             recovery = self._restart_direct_pr_review(item)
             if recovery is not None:
                 return recovery

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1332,6 +1332,13 @@ class PrReviewStage(Stage):
                 if is_full_commit_sha(source_sha):
                     item.payload["detached_push_head_sha"] = source_sha
                 return
+            if item.payload.get("direct_pr_worktree") and item.worktree:
+                # A direct-review checkout may hold an address commit even
+                # when publication setup itself failed before it could return
+                # a classified receipt. Preserve rather than failing back to
+                # an agent re-adoption path that could orphan that commit.
+                item.payload["detached_push_failure"] = "remote_unconfirmed"
+                return
             item.payload["address_error"] = True
         elif item.state == ADDRESS_WAIT:
             item.payload["address_error"] = True

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -196,6 +196,11 @@ EVAL = "EVAL"
 COMPACT_REVIEWER_WAIT = "COMPACT_REVIEWER_WAIT"
 COMPACT_WRITER_WAIT = "COMPACT_WRITER_WAIT"
 
+# A failed push with an unchanged live remote may be a transient local
+# pre-push-hook or transport failure. Retry the already-created detached
+# commit once; never ask the address agent to recreate it or discard it.
+DIRECT_PUSH_RETRY_CAP = 1
+
 _STEP_HANDLER_NAMES: dict[str, str] = {
     ENTER: "_enter",
     ADOPT_WORKTREE_WAIT: "_adopt_worktree_wait",
@@ -1287,7 +1292,17 @@ class PrReviewStage(Stage):
             # EVAL treats the missing audit as reviewer infrastructure failure;
             # the flag lets VALIDATE_WAIT skip the dead round.
             item.payload["review_failed"] = True
-        elif item.state in (ADDRESS_WAIT, PUSH_WAIT):
+        elif item.state == PUSH_WAIT:
+            failure = (
+                result.value.get("detached_push_failure")
+                if isinstance(result.value, dict)
+                else None
+            )
+            if failure in {"remote_changed", "remote_unchanged", "remote_unconfirmed"}:
+                item.payload["detached_push_failure"] = failure
+                return
+            item.payload["address_error"] = True
+        elif item.state == ADDRESS_WAIT:
             item.payload["address_error"] = True
 
     @staticmethod
@@ -1584,6 +1599,38 @@ class PrReviewStage(Stage):
         if item.issue is None:  # guarded by step(); kept for type narrowing
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         payload = item.payload
+
+        detached_push_failure = payload.pop("detached_push_failure", None)
+        if detached_push_failure == "remote_unchanged":
+            retries = int(payload.get("direct_push_retries", 0))
+            if retries < DIRECT_PUSH_RETRY_CAP:
+                payload["direct_push_retries"] = retries + 1
+                logger.warning(
+                    "pr_review:%d: detached push failed with an unchanged remote; retrying commit",
+                    item.issue,
+                )
+                return Continue(next_state=PUSH_WAIT)
+            payload["detached_push_failure"] = detached_push_failure
+            logger.warning(
+                "pr_review:%d: detached push retry cap reached; preserving checkout",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
+        if detached_push_failure == "remote_changed":
+            payload["detached_push_failure"] = detached_push_failure
+            logger.warning(
+                "pr_review:%d: detached push saw a changed remote head; preserving checkout",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_head_changed")
+        if detached_push_failure == "remote_unconfirmed":
+            payload["detached_push_failure"] = detached_push_failure
+            logger.warning(
+                "pr_review:%d: detached push remote head could not be verified; "
+                "preserving checkout",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_remote_unconfirmed")
 
         address_error = self._handle_address_error(item)
         if address_error is not None:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1297,6 +1297,24 @@ class PrReviewStage(Stage):
         if isinstance(value, dict):
             item.worktree = str(value.get("path", ""))
             item.payload["direct_pr_worktree_dirty"] = bool(value.get("dirty"))
+            recovery_worktrees = value.get("preserved_direct_worktrees", [])
+            if not isinstance(recovery_worktrees, list) or any(
+                not isinstance(path, str) or not path for path in recovery_worktrees
+            ):
+                item.payload["direct_pr_worktree_error"] = (
+                    "worktree job returned invalid recovery paths"
+                )
+                return
+            if recovery_worktrees:
+                preserved = item.payload.setdefault("preserved_direct_worktrees", [])
+                if not isinstance(preserved, list):
+                    item.payload["direct_pr_worktree_error"] = (
+                        "direct review recovery receipt is invalid"
+                    )
+                    return
+                for path in recovery_worktrees:
+                    if path not in preserved:
+                        preserved.append(path)
             if item.worktree and not item.payload["direct_pr_worktree_dirty"]:
                 item.payload["direct_pr_worktree"] = item.worktree
         elif isinstance(value, str):

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1120,6 +1120,8 @@ class PrReviewStage(Stage):
         logger.info("pr_review:%d: requesting push job", issue)
         kwargs: dict[str, object] = {
             "issue_number": issue,
+            "pr_number": item.pr,
+            "repo_root": str(ctx.paths.repo_root),
             "worktree_path": item.worktree,
             "branch": item.branch,
             "agent": agent_provider(ctx),
@@ -1297,24 +1299,6 @@ class PrReviewStage(Stage):
         if isinstance(value, dict):
             item.worktree = str(value.get("path", ""))
             item.payload["direct_pr_worktree_dirty"] = bool(value.get("dirty"))
-            recovery_worktrees = value.get("preserved_direct_worktrees", [])
-            if not isinstance(recovery_worktrees, list) or any(
-                not isinstance(path, str) or not path for path in recovery_worktrees
-            ):
-                item.payload["direct_pr_worktree_error"] = (
-                    "worktree job returned invalid recovery paths"
-                )
-                return
-            if recovery_worktrees:
-                preserved = item.payload.setdefault("preserved_direct_worktrees", [])
-                if not isinstance(preserved, list):
-                    item.payload["direct_pr_worktree_error"] = (
-                        "direct review recovery receipt is invalid"
-                    )
-                    return
-                for path in recovery_worktrees:
-                    if path not in preserved:
-                        preserved.append(path)
             if item.worktree and not item.payload["direct_pr_worktree_dirty"]:
                 item.payload["direct_pr_worktree"] = item.worktree
         elif isinstance(value, str):
@@ -1337,6 +1321,7 @@ class PrReviewStage(Stage):
             failure = receipt.get("detached_push_failure")
             if failure in {
                 "remote_changed",
+                "remote_changed_unrecorded",
                 "remote_unchanged",
                 "remote_unconfirmed",
                 "retry_checkout_changed",
@@ -1640,11 +1625,6 @@ class PrReviewStage(Stage):
         generation = item.payload.get("direct_pr_worktree_generation", 0)
         if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
             return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_worktree_generation_invalid")
-        preserved = item.payload.setdefault("preserved_direct_worktrees", [])
-        if not isinstance(preserved, list):
-            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_recovery_receipt_invalid")
-        if item.worktree not in preserved:
-            preserved.append(item.worktree)
         item.worktree = ""
         item.payload["existing_pr"] = True
         item.payload.pop("direct_pr_worktree", None)
@@ -1719,6 +1699,14 @@ class PrReviewStage(Stage):
                 item.issue,
             )
             return Continue(next_state=ENTER)
+        if detached_push_failure == "remote_changed_unrecorded":
+            payload["detached_push_failure"] = detached_push_failure
+            logger.warning(
+                "pr_review:%d: detached push remote-change receipt could not be recorded; "
+                "preserving checkout",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
         if detached_push_failure in {
             "remote_unconfirmed",
             "retry_checkout_changed",

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -73,6 +73,26 @@ def format_preserved_worktrees(preserved: Sequence[PreservedWorktree], script: s
     return lines
 
 
+def format_direct_review_recovery_worktrees(
+    recovery: Sequence[PreservedWorktree],
+) -> list[str]:
+    """Format inspection-only guidance for receipt-backed detached recoveries.
+
+    Unlike ordinary failed-item worktrees, a recovery checkout may contain an
+    unpublished detached commit. Never offer a destructive command for it:
+    operators must first establish that no loop is still using the checkout.
+    """
+    if not recovery:
+        return []
+    lines = ["\nDetached-review recovery worktrees (inspection required):"]
+    lines.extend(f"  #{number}: {path}" for _, number, path in recovery)
+    lines.append(
+        "Do not remove or reuse these paths until you have confirmed that no "
+        "automation loop is active."
+    )
+    return lines
+
+
 def _logical_item_key(item: WorkItem) -> tuple[object, ...]:
     """Return the stable logical identity for a potentially re-seeded item."""
     if item.kind is ItemKind.REPO:
@@ -181,6 +201,7 @@ def print_summary(
     preserved: list[PreservedWorktree],
     *,
     json_out: bool,
+    recovery_preserved: Sequence[PreservedWorktree] = (),
     terminal_summary: TerminalSummary | None = None,
 ) -> None:
     """Log the end-of-run summary; emit the JSON envelope when requested.
@@ -191,6 +212,8 @@ def print_summary(
         preserved: ``(repo, issue_number, worktree_path)`` tuples retained for
             recovery or failed-item debugging.
         json_out: Emit the machine-readable ``emit_json_status`` envelope.
+        recovery_preserved: Receipt-backed detached-review checkouts requiring
+            inspection-only recovery guidance.
         terminal_summary: Optional constant-space aggregate for all terminal
             outcomes.  When supplied, it controls aggregate counts while
             ``items`` remains the bounded detailed reporting window.
@@ -240,6 +263,8 @@ def print_summary(
 
     for line in format_preserved_worktrees(preserved, sys.argv[0]):
         logger.info("%s", line)
+    for line in format_direct_review_recovery_worktrees(recovery_preserved):
+        logger.info("%s", line)
 
     if json_out:
         resumable = [
@@ -257,4 +282,5 @@ def print_summary(
             wall_s=round(stats.wall_s, 1),
             resumable=resumable,
             preserved_worktrees=[[number, path] for _, number, path in preserved],
+            recovery_worktrees=[[number, path] for _, number, path in recovery_preserved],
         )

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -48,7 +48,8 @@ def format_preserved_worktrees(preserved: Sequence[PreservedWorktree], script: s
     with the pipeline conversion (#1821).
 
     Args:
-        preserved: ``(repo, issue_number, worktree_path)`` tuples for failed items.
+        preserved: ``(repo, issue_number, worktree_path)`` tuples retained for
+            recovery or failed-item debugging.
         script: The script name (``sys.argv[0]``) for the rerun hint.
 
     Returns:
@@ -63,7 +64,7 @@ def format_preserved_worktrees(preserved: Sequence[PreservedWorktree], script: s
     # rest, and ``--resume`` is not an option on this CLI at all (#2281). The loop
     # resumes a preserved worktree by re-seeding the same ``--issues``.
     issues_arg = ",".join(str(n) for n in issue_nums)
-    lines: list[str] = ["\nPreserved worktrees (contain uncommitted changes):"]
+    lines: list[str] = ["\nPreserved worktrees (retained for recovery or debugging):"]
     lines.extend(f"  #{number}: {path}" for _, number, path in preserved)
     lines.append("\nRerun these issues after inspecting/cleaning the worktrees:")
     lines.append(f"  {script} --issues {issues_arg}")
@@ -187,7 +188,8 @@ def print_summary(
     Args:
         items: Recent detailed work items (results attached).
         stats: Aggregate run statistics (exit code, loops, agent time, wall).
-        preserved: ``(repo, issue_number, worktree_path)`` tuples for failed items.
+        preserved: ``(repo, issue_number, worktree_path)`` tuples retained for
+            recovery or failed-item debugging.
         json_out: Emit the machine-readable ``emit_json_status`` envelope.
         terminal_summary: Optional constant-space aggregate for all terminal
             outcomes.  When supplied, it controls aggregate counts while

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1523,12 +1523,14 @@ class WorkerPool:
                     ok=False,
                     error="detached PR push requires the reviewed remote head",
                 )
-            git_utils.push_head_to_branch(
+            detached_push_result = self._publish_detached_head(
                 branch,
                 expected_remote_sha,
                 Path(worktree_path),
                 timeout=job.timeout_s,
             )
+            if detached_push_result is not None:
+                return detached_push_result
         elif isinstance(expected_remote_sha, str):
             git_utils.push_branch_if_remote_matches(
                 branch,
@@ -1539,6 +1541,42 @@ class WorkerPool:
         else:
             git_utils.push_branch(branch, Path(worktree_path), timeout=job.timeout_s)
         return JobResult(ok=True, value=True)
+
+    @staticmethod
+    def _publish_detached_head(
+        branch: str,
+        expected_remote_sha: str,
+        worktree_path: Path,
+        *,
+        timeout: int,
+    ) -> JobResult | None:
+        """Publish a detached review commit, classifying only verified failures."""
+        try:
+            git_utils.push_head_to_branch(
+                branch,
+                expected_remote_sha,
+                worktree_path,
+                timeout=timeout,
+            )
+        except git_utils.DetachedHeadPushRemoteHeadChangedError as exc:
+            return JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_changed"},
+                error=str(exc),
+            )
+        except git_utils.DetachedHeadPushRemoteHeadUnchangedError as exc:
+            return JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_unchanged"},
+                error=str(exc),
+            )
+        except git_utils.DetachedHeadPushRemoteProbeError as exc:
+            return JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_unconfirmed"},
+                error=str(exc),
+            )
+        return None
 
     @staticmethod
     def _commit_push_requires_publish(

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1481,6 +1481,9 @@ class WorkerPool:
                 ok=False,
                 error="commit_push requires non-empty 'worktree_path' and 'issue_number' kwargs",
             )
+        retry_result = self._detached_push_retry_result(job, Path(worktree_path))
+        if retry_result is not None:
+            return retry_result
         # ``commit_if_changes`` returns False for a clean worktree.  An agent
         # is instructed to leave its edits uncommitted, but a defensive
         # recovery still recognizes a clean branch that is ahead of its
@@ -1513,6 +1516,12 @@ class WorkerPool:
             )
             if status.stdout.strip():
                 return JobResult(ok=False, error="commit_push left uncommitted changes")
+        return self._publish_commit_push(job, branch, Path(worktree_path))
+
+    def _publish_commit_push(
+        self, job: GitJob, branch: str, worktree_path: Path
+    ) -> JobResult:
+        """Publish a newly created commit through the configured branch mode."""
         branch = branch or "HEAD"
         expected_remote_sha = job.kwargs.get("expected_remote_sha")
         if expected_remote_sha is not None and not _is_full_commit_sha(expected_remote_sha):
@@ -1523,24 +1532,112 @@ class WorkerPool:
                     ok=False,
                     error="detached PR push requires the reviewed remote head",
                 )
+            source_sha = self._read_detached_push_head(worktree_path, timeout=job.timeout_s)
+            if isinstance(source_sha, JobResult):
+                return source_sha
             detached_push_result = self._publish_detached_head(
                 branch,
                 expected_remote_sha,
-                Path(worktree_path),
+                worktree_path,
+                source_sha=source_sha,
                 timeout=job.timeout_s,
             )
-            if detached_push_result is not None:
-                return detached_push_result
-        elif isinstance(expected_remote_sha, str):
+            return detached_push_result or JobResult(ok=True, value=True)
+        if isinstance(expected_remote_sha, str):
             git_utils.push_branch_if_remote_matches(
                 branch,
                 expected_remote_sha,
-                Path(worktree_path),
+                worktree_path,
                 timeout=job.timeout_s,
             )
         else:
-            git_utils.push_branch(branch, Path(worktree_path), timeout=job.timeout_s)
+            git_utils.push_branch(branch, worktree_path, timeout=job.timeout_s)
         return JobResult(ok=True, value=True)
+
+    def _detached_push_retry_result(
+        self, job: GitJob, worktree_path: Path
+    ) -> JobResult | None:
+        """Return the push-only retry result when a detached retry receipt exists."""
+        retry_head_sha = job.kwargs.get("detached_push_retry_head_sha")
+        if retry_head_sha is None:
+            return None
+        return self._retry_detached_head_push(
+            branch=str(job.kwargs.get("branch") or ""),
+            expected_remote_sha=job.kwargs.get("expected_remote_sha"),
+            source_sha=retry_head_sha,
+            worktree_path=worktree_path,
+            timeout=job.timeout_s,
+            publish_detached_head=bool(job.kwargs.get("publish_detached_head", False)),
+        )
+
+    @staticmethod
+    def _read_detached_push_head(worktree_path: Path, *, timeout: int) -> str | JobResult:
+        """Read the immutable commit a detached review push is allowed to publish."""
+        try:
+            head = git_utils.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                timeout=timeout,
+            ).stdout.strip()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return JobResult(ok=False, error="cannot bind detached review push head")
+        if not _is_full_commit_sha(head):
+            return JobResult(ok=False, error="cannot bind detached review push head")
+        return head
+
+    @classmethod
+    def _retry_detached_head_push(
+        cls,
+        *,
+        branch: str,
+        expected_remote_sha: object,
+        source_sha: object,
+        worktree_path: Path,
+        timeout: int,
+        publish_detached_head: bool,
+    ) -> JobResult:
+        """Retry only the exact detached commit captured before the first push."""
+        if (
+            not publish_detached_head
+            or not branch
+            or not _is_full_commit_sha(expected_remote_sha)
+            or not _is_full_commit_sha(source_sha)
+        ):
+            return JobResult(ok=False, error="detached review retry receipt is invalid")
+        try:
+            status = git_utils.run(
+                ["git", "status", "--porcelain"],
+                cwd=worktree_path,
+                capture_output=True,
+                timeout=timeout,
+            )
+            current_head = git_utils.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                timeout=timeout,
+            ).stdout.strip()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return JobResult(
+                ok=False,
+                value={"detached_push_failure": "retry_checkout_unconfirmed"},
+                error="detached review retry checkout could not be verified",
+            )
+        if status.stdout.strip() or current_head != source_sha:
+            return JobResult(
+                ok=False,
+                value={"detached_push_failure": "retry_checkout_changed"},
+                error="detached review retry checkout changed after the failed push",
+            )
+        result = cls._publish_detached_head(
+            branch,
+            expected_remote_sha,
+            worktree_path,
+            source_sha=source_sha,
+            timeout=timeout,
+        )
+        return result or JobResult(ok=True, value=True)
 
     @staticmethod
     def _publish_detached_head(
@@ -1548,6 +1645,7 @@ class WorkerPool:
         expected_remote_sha: str,
         worktree_path: Path,
         *,
+        source_sha: str,
         timeout: int,
     ) -> JobResult | None:
         """Publish a detached review commit, classifying only verified failures."""
@@ -1556,24 +1654,34 @@ class WorkerPool:
                 branch,
                 expected_remote_sha,
                 worktree_path,
+                source_sha=source_sha,
                 timeout=timeout,
             )
         except git_utils.DetachedHeadPushRemoteHeadChangedError as exc:
             return JobResult(
                 ok=False,
-                value={"detached_push_failure": "remote_changed"},
+                value={
+                    "detached_push_failure": "remote_changed",
+                    "detached_push_head_sha": source_sha,
+                },
                 error=str(exc),
             )
         except git_utils.DetachedHeadPushRemoteHeadUnchangedError as exc:
             return JobResult(
                 ok=False,
-                value={"detached_push_failure": "remote_unchanged"},
+                value={
+                    "detached_push_failure": "remote_unchanged",
+                    "detached_push_head_sha": source_sha,
+                },
                 error=str(exc),
             )
         except git_utils.DetachedHeadPushRemoteProbeError as exc:
             return JobResult(
                 ok=False,
-                value={"detached_push_failure": "remote_unconfirmed"},
+                value={
+                    "detached_push_failure": "remote_unconfirmed",
+                    "detached_push_head_sha": source_sha,
+                },
                 error=str(exc),
             )
         return None

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1176,6 +1176,7 @@ class WorkerPool:
                     error=f"worktree creation failed: {exc}",
                 )
             raise
+        recovery_worktrees = list(manager.last_isolated_recovery_paths)
         return self._finalize_created_worktree(
             created=created,
             base_sha=base_sha,
@@ -1184,6 +1185,7 @@ class WorkerPool:
             repo=job.repo,
             sync_to_remote=sync_to_remote,
             pr_number=pr_number,
+            recovery_worktrees=recovery_worktrees,
             timeout_s=job.timeout_s,
         )
 
@@ -1240,6 +1242,7 @@ class WorkerPool:
         repo: str,
         sync_to_remote: bool,
         pr_number: object,
+        recovery_worktrees: list[Path],
         timeout_s: int,
     ) -> JobResult:
         """Validate a created worktree and attach a direct reservation receipt."""
@@ -1323,15 +1326,15 @@ class WorkerPool:
                 error=f"worktree post-create preparation failed: {exc}",
                 value={"path": str(worktree_path), WORKTREE_MATERIALIZED_KEY: True},
             )
-        return JobResult(
-            ok=True,
-            value={
-                "path": str(worktree_path),
-                "dirty": dirty,
-                "status": status,
-                "diff": diff,
-            },
-        )
+        value: dict[str, object] = {
+            "path": str(worktree_path),
+            "dirty": dirty,
+            "status": status,
+            "diff": diff,
+        }
+        if recovery_worktrees:
+            value["preserved_direct_worktrees"] = [str(path) for path in recovery_worktrees]
+        return JobResult(ok=True, value=value)
 
     @staticmethod
     def _prepare_direct_scope_worktree(

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1518,9 +1518,7 @@ class WorkerPool:
                 return JobResult(ok=False, error="commit_push left uncommitted changes")
         return self._publish_commit_push(job, branch, Path(worktree_path))
 
-    def _publish_commit_push(
-        self, job: GitJob, branch: str, worktree_path: Path
-    ) -> JobResult:
+    def _publish_commit_push(self, job: GitJob, branch: str, worktree_path: Path) -> JobResult:
         """Publish a newly created commit through the configured branch mode."""
         branch = branch or "HEAD"
         expected_remote_sha = job.kwargs.get("expected_remote_sha")
@@ -1554,9 +1552,7 @@ class WorkerPool:
             git_utils.push_branch(branch, worktree_path, timeout=job.timeout_s)
         return JobResult(ok=True, value=True)
 
-    def _detached_push_retry_result(
-        self, job: GitJob, worktree_path: Path
-    ) -> JobResult | None:
+    def _detached_push_retry_result(self, job: GitJob, worktree_path: Path) -> JobResult | None:
         """Return the push-only retry result when a detached retry receipt exists."""
         retry_head_sha = job.kwargs.get("detached_push_retry_head_sha")
         if retry_head_sha is None:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -25,6 +25,7 @@ from typing import TypeGuard
 
 from hephaestus.agents.runtime import resolve_agent, resume_agent_session, run_agent_session
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
+from hephaestus.automation.direct_review_recovery import record_direct_review_recovery
 from hephaestus.automation.learn import compact_agent_session
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
@@ -1176,7 +1177,6 @@ class WorkerPool:
                     error=f"worktree creation failed: {exc}",
                 )
             raise
-        recovery_worktrees = list(manager.last_isolated_recovery_paths)
         return self._finalize_created_worktree(
             created=created,
             base_sha=base_sha,
@@ -1185,7 +1185,6 @@ class WorkerPool:
             repo=job.repo,
             sync_to_remote=sync_to_remote,
             pr_number=pr_number,
-            recovery_worktrees=recovery_worktrees,
             timeout_s=job.timeout_s,
         )
 
@@ -1242,7 +1241,6 @@ class WorkerPool:
         repo: str,
         sync_to_remote: bool,
         pr_number: object,
-        recovery_worktrees: list[Path],
         timeout_s: int,
     ) -> JobResult:
         """Validate a created worktree and attach a direct reservation receipt."""
@@ -1332,8 +1330,6 @@ class WorkerPool:
             "status": status,
             "diff": diff,
         }
-        if recovery_worktrees:
-            value["preserved_direct_worktrees"] = [str(path) for path in recovery_worktrees]
         return JobResult(ok=True, value=value)
 
     @staticmethod
@@ -1537,6 +1533,7 @@ class WorkerPool:
             if isinstance(source_sha, JobResult):
                 return source_sha
             detached_push_result = self._publish_detached_head(
+                job,
                 branch,
                 expected_remote_sha,
                 worktree_path,
@@ -1561,6 +1558,7 @@ class WorkerPool:
         if retry_head_sha is None:
             return None
         return self._retry_detached_head_push(
+            job=job,
             branch=str(job.kwargs.get("branch") or ""),
             expected_remote_sha=job.kwargs.get("expected_remote_sha"),
             source_sha=retry_head_sha,
@@ -1585,10 +1583,10 @@ class WorkerPool:
             return JobResult(ok=False, error="cannot bind detached review push head")
         return head
 
-    @classmethod
     def _retry_detached_head_push(
-        cls,
+        self,
         *,
+        job: GitJob,
         branch: str,
         expected_remote_sha: object,
         source_sha: object,
@@ -1629,7 +1627,8 @@ class WorkerPool:
                 value={"detached_push_failure": "retry_checkout_changed"},
                 error="detached review retry checkout changed after the failed push",
             )
-        result = cls._publish_detached_head(
+        result = self._publish_detached_head(
+            job,
             branch,
             expected_remote_sha,
             worktree_path,
@@ -1638,8 +1637,9 @@ class WorkerPool:
         )
         return result or JobResult(ok=True, value=True)
 
-    @staticmethod
     def _publish_detached_head(
+        self,
+        job: GitJob,
         branch: str,
         expected_remote_sha: str,
         worktree_path: Path,
@@ -1657,6 +1657,22 @@ class WorkerPool:
                 timeout=timeout,
             )
         except git_utils.DetachedHeadPushRemoteHeadChangedError as exc:
+            recovery_error = self._record_detached_push_recovery(
+                job=job,
+                branch=branch,
+                worktree_path=worktree_path,
+                expected_remote_sha=expected_remote_sha,
+                source_sha=source_sha,
+            )
+            if recovery_error is not None:
+                return JobResult(
+                    ok=False,
+                    value={
+                        "detached_push_failure": "remote_changed_unrecorded",
+                        "detached_push_head_sha": source_sha,
+                    },
+                    error=f"{exc}; recovery receipt could not be recorded: {recovery_error}",
+                )
             return JobResult(
                 ok=False,
                 value={
@@ -1683,6 +1699,42 @@ class WorkerPool:
                 },
                 error=str(exc),
             )
+        return None
+
+    @staticmethod
+    def _record_detached_push_recovery(
+        *,
+        job: GitJob,
+        branch: str,
+        worktree_path: Path,
+        expected_remote_sha: str,
+        source_sha: str,
+    ) -> str | None:
+        """Record a drifted detached checkout before allowing a fresh review."""
+        issue = job.kwargs.get("issue_number")
+        pr = job.kwargs.get("pr_number")
+        repo_root = job.kwargs.get("repo_root")
+        if (
+            isinstance(issue, bool)
+            or not isinstance(issue, int)
+            or isinstance(pr, bool)
+            or not isinstance(pr, int)
+            or not isinstance(repo_root, str)
+            or not repo_root
+        ):
+            return "detached review recovery receipt context is invalid"
+        try:
+            record_direct_review_recovery(
+                repo_root=Path(repo_root),
+                issue=issue,
+                pr=pr,
+                worktree=worktree_path,
+                branch=branch,
+                expected_remote_sha=expected_remote_sha,
+                source_sha=source_sha,
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            return str(error)
         return None
 
     @staticmethod

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -396,6 +396,12 @@ class WorktreeManager:
         ):
             return worktree_path
         if worktree_path.exists():
+            if isolated:
+                # A detached review checkout can contain a committed but
+                # unpublished address fix, which ``git status`` reports as
+                # clean.  Removing it here would erase the only recovery
+                # artifact after a failed lease-protected push.
+                raise RuntimeError("refuses to replace existing isolated review worktree")
             logger.warning("Removing existing worktree directory: %s", worktree_path)
             self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
         return None

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -263,6 +263,7 @@ class WorktreeManager:
         base_sha: str | None = None,
         remote_branch_reserved: bool = False,
         isolated: bool = False,
+        isolated_generation: int = 0,
         timeout: int | None = None,
     ) -> Path:
         """Create a new worktree for an issue.
@@ -286,6 +287,10 @@ class WorktreeManager:
                 reusing another worktree that holds ``branch_name``. PR review
                 uses this so a preserved writer checkout is never
                 reset or exposed to an agent.
+            isolated_generation: Recovery generation for an isolated checkout.
+                A nonzero value creates a distinct path so a changed PR head
+                is reviewed from a fresh checkout without replacing the
+                preserved failed checkout.
             timeout: Optional timeout in seconds for each git command.
 
         Returns:
@@ -295,8 +300,18 @@ class WorktreeManager:
             RuntimeError: If worktree creation fails
 
         """
+        if (
+            isinstance(isolated_generation, bool)
+            or not isinstance(isolated_generation, int)
+            or isolated_generation < 0
+        ):
+            raise RuntimeError("isolated worktree generation is invalid")
+        if isolated_generation and not isolated:
+            raise RuntimeError("isolated worktree generation requires isolation")
         with self.lock:
             isolated_key = f"review-pr-{issue_number}"
+            if isolated_generation:
+                isolated_key = f"{isolated_key}-{isolated_generation}"
             worktree_key: int | str = isolated_key if isolated else issue_number
             if branch_name is None:
                 branch_name = f"{issue_number}-auto"

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -139,6 +139,9 @@ class WorktreeManager:
         self._base_branch_resolved: str | None = None
         self.worktrees: dict[int | str, Path] = {}
         self.preserved: list[tuple[int | str, Path]] = []
+        # The WorkerPool reads this receipt after an isolated creation so a
+        # cold-start review can surface older recovery checkouts in Finished.
+        self.last_isolated_recovery_paths: list[Path] = []
         self.lock = threading.Lock()
 
         logger.debug("Initialized WorktreeManager at %s", self.base_dir)
@@ -425,16 +428,18 @@ class WorktreeManager:
         # generation hint. This supports cold-start re-review safely.
         if refresh_base:
             self.refresh_base_branch(timeout=timeout)
+        self.last_isolated_recovery_paths = []
         try:
             with file_lock(self._git_metadata_lock_path()):
-                worktree_key, worktree_path = self._next_isolated_worktree_slot(
-                    issue_number, isolated_generation
+                worktree_key, worktree_path, recovery_paths = self._next_isolated_worktree_slot(
+                    issue_number, isolated_generation, timeout=timeout
                 )
                 self._add_isolated_worktree_for_branch(
                     worktree_path,
                     branch_name,
                     timeout=timeout,
                 )
+            self.last_isolated_recovery_paths = recovery_paths
             self.worktrees[worktree_key] = worktree_path
             logger.info(
                 "Created isolated review worktree for issue #%s at %s",
@@ -450,8 +455,12 @@ class WorktreeManager:
             raise RuntimeError(f"Failed to create worktree: {e}") from e
 
     def _next_isolated_worktree_slot(
-        self, issue_number: int, requested_generation: int
-    ) -> tuple[str, Path]:
+        self,
+        issue_number: int,
+        requested_generation: int,
+        *,
+        timeout: int | None,
+    ) -> tuple[str, Path, list[Path]]:
         """Return an unused detached-review path at or after the requested generation.
 
         This runs under :meth:`_git_metadata_lock_path`, so two coordinators
@@ -459,15 +468,28 @@ class WorktreeManager:
         Existing paths are never reused: they may contain an unpublished
         address commit even when ``git status`` reports a clean tree.
         """
+        registered_paths = self._registered_worktree_paths(timeout=timeout)
         generation = requested_generation
+        recovery_paths: list[Path] = []
         while True:
             key = f"review-pr-{issue_number}"
             if generation:
                 key = f"{key}-{generation}"
             path = self.base_dir / key
-            if key not in self.worktrees and not path.exists():
-                return key, path
+            occupied = key in self.worktrees or path.exists() or path.resolve() in registered_paths
+            if not occupied:
+                return key, path, recovery_paths
+            if path not in recovery_paths:
+                recovery_paths.append(path)
             generation += 1
+
+    def _registered_worktree_paths(self, *, timeout: int | None) -> set[Path]:
+        """Return Git-registered worktree paths, failing closed on a listing error."""
+        return {
+            Path(path).resolve()
+            for worktree in self.list_worktrees(raise_on_error=True, timeout=timeout)
+            if isinstance(path := worktree.get("path"), str) and path
+        }
 
     def _reuse_or_clear_normal_worktree(
         self,

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -139,9 +139,6 @@ class WorktreeManager:
         self._base_branch_resolved: str | None = None
         self.worktrees: dict[int | str, Path] = {}
         self.preserved: list[tuple[int | str, Path]] = []
-        # The WorkerPool reads this receipt after an isolated creation so a
-        # cold-start review can surface older recovery checkouts in Finished.
-        self.last_isolated_recovery_paths: list[Path] = []
         self.lock = threading.Lock()
 
         logger.debug("Initialized WorktreeManager at %s", self.base_dir)
@@ -428,10 +425,9 @@ class WorktreeManager:
         # generation hint. This supports cold-start re-review safely.
         if refresh_base:
             self.refresh_base_branch(timeout=timeout)
-        self.last_isolated_recovery_paths = []
         try:
             with file_lock(self._git_metadata_lock_path()):
-                worktree_key, worktree_path, recovery_paths = self._next_isolated_worktree_slot(
+                worktree_key, worktree_path = self._next_isolated_worktree_slot(
                     issue_number, isolated_generation, timeout=timeout
                 )
                 self._add_isolated_worktree_for_branch(
@@ -439,7 +435,6 @@ class WorktreeManager:
                     branch_name,
                     timeout=timeout,
                 )
-            self.last_isolated_recovery_paths = recovery_paths
             self.worktrees[worktree_key] = worktree_path
             logger.info(
                 "Created isolated review worktree for issue #%s at %s",
@@ -460,7 +455,7 @@ class WorktreeManager:
         requested_generation: int,
         *,
         timeout: int | None,
-    ) -> tuple[str, Path, list[Path]]:
+    ) -> tuple[str, Path]:
         """Return an unused detached-review path at or after the requested generation.
 
         This runs under :meth:`_git_metadata_lock_path`, so two coordinators
@@ -470,7 +465,6 @@ class WorktreeManager:
         """
         registered_paths = self._registered_worktree_paths(timeout=timeout)
         generation = requested_generation
-        recovery_paths: list[Path] = []
         while True:
             key = f"review-pr-{issue_number}"
             if generation:
@@ -478,9 +472,7 @@ class WorktreeManager:
             path = self.base_dir / key
             occupied = key in self.worktrees or path.exists() or path.resolve() in registered_paths
             if not occupied:
-                return key, path, recovery_paths
-            if path not in recovery_paths:
-                recovery_paths.append(path)
+                return key, path
             generation += 1
 
     def _registered_worktree_paths(self, *, timeout: int | None) -> set[Path]:

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -300,14 +300,13 @@ class WorktreeManager:
             RuntimeError: If worktree creation fails
 
         """
-        if (
-            isinstance(isolated_generation, bool)
-            or not isinstance(isolated_generation, int)
-            or isolated_generation < 0
-        ):
-            raise RuntimeError("isolated worktree generation is invalid")
-        if isolated_generation and not isolated:
-            raise RuntimeError("isolated worktree generation requires isolation")
+        self._validate_create_worktree_request(
+            refresh_base=refresh_base,
+            base_sha=base_sha,
+            remote_branch_reserved=remote_branch_reserved,
+            isolated=isolated,
+            isolated_generation=isolated_generation,
+        )
         with self.lock:
             isolated_key = f"review-pr-{issue_number}"
             if isolated_generation:
@@ -329,6 +328,14 @@ class WorktreeManager:
                 # Refresh acquires the same metadata lock; complete it before
                 # entering the lock that serializes holder detection and add.
                 self.refresh_base_branch(timeout=timeout)
+            if isolated:
+                return self._create_isolated_worktree(
+                    issue_number,
+                    branch_name,
+                    isolated_generation=isolated_generation,
+                    refresh_base=refresh_base,
+                    timeout=timeout,
+                )
             try:
                 with file_lock(self._git_metadata_lock_path()):
                     if base_sha is None and (
@@ -337,7 +344,6 @@ class WorktreeManager:
                             worktree_key=worktree_key,
                             worktree_path=worktree_path,
                             branch_name=branch_name,
-                            isolated=isolated,
                             refresh_base=refresh_base,
                             timeout=timeout,
                         )
@@ -347,27 +353,20 @@ class WorktreeManager:
                         base_sha=base_sha,
                         remote_branch_reserved=remote_branch_reserved,
                         refresh_base=refresh_base,
-                        isolated=isolated,
+                        isolated=False,
                         worktree_key=worktree_key,
                         worktree_path=worktree_path,
                         branch_name=branch_name,
                         timeout=timeout,
                     )
                     try:
-                        if isolated:
-                            self._add_isolated_worktree_for_branch(
-                                worktree_path,
-                                branch_name,
-                                timeout=timeout,
-                            )
-                        else:
-                            self._add_worktree_for_branch(
-                                worktree_path,
-                                branch_name,
-                                base_sha=base_sha,
-                                refresh_base=refresh_base,
-                                timeout=timeout,
-                            )
+                        self._add_worktree_for_branch(
+                            worktree_path,
+                            branch_name,
+                            base_sha=base_sha,
+                            refresh_base=refresh_base,
+                            timeout=timeout,
+                        )
                     except Exception:
                         self.worktrees.pop(worktree_key, None)
                         if base_sha is None:
@@ -382,6 +381,94 @@ class WorktreeManager:
             except Exception as e:
                 raise RuntimeError(f"Failed to create worktree: {e}") from e
 
+    @staticmethod
+    def _validate_create_worktree_request(
+        *,
+        refresh_base: bool,
+        base_sha: str | None,
+        remote_branch_reserved: bool,
+        isolated: bool,
+        isolated_generation: int,
+    ) -> None:
+        """Validate non-I/O worktree request invariants before acquiring locks."""
+        if (
+            isinstance(isolated_generation, bool)
+            or not isinstance(isolated_generation, int)
+            or isolated_generation < 0
+        ):
+            raise RuntimeError("isolated worktree generation is invalid")
+        if isolated_generation and not isolated:
+            raise RuntimeError("isolated worktree generation requires isolation")
+        if base_sha is not None and (
+            refresh_base
+            or isolated
+            or not remote_branch_reserved
+            or not _is_full_commit_sha(base_sha)
+        ):
+            raise RuntimeError("direct scope base pin invalid")
+        if base_sha is None and remote_branch_reserved:
+            raise RuntimeError("direct scope reservation requires a base pin")
+
+    def _create_isolated_worktree(
+        self,
+        issue_number: int,
+        branch_name: str,
+        *,
+        isolated_generation: int,
+        refresh_base: bool,
+        timeout: int | None,
+    ) -> Path:
+        """Create a collision-free direct-review checkout without cleanup on failure."""
+        # An isolated checkout is a recovery artifact as soon as an address
+        # agent has written to it. Pick the first free path while holding the
+        # cross-process Git lock, rather than trusting one loop's in-memory
+        # generation hint. This supports cold-start re-review safely.
+        if refresh_base:
+            self.refresh_base_branch(timeout=timeout)
+        try:
+            with file_lock(self._git_metadata_lock_path()):
+                worktree_key, worktree_path = self._next_isolated_worktree_slot(
+                    issue_number, isolated_generation
+                )
+                self._add_isolated_worktree_for_branch(
+                    worktree_path,
+                    branch_name,
+                    timeout=timeout,
+                )
+            self.worktrees[worktree_key] = worktree_path
+            logger.info(
+                "Created isolated review worktree for issue #%s at %s",
+                issue_number,
+                worktree_path,
+            )
+            return worktree_path
+        except Exception as e:
+            # Do not remove this path on failure. Another coordinator may have
+            # created it while we waited for the metadata lock, or an
+            # interrupted Git command may have left the only recoverable
+            # address commit there.
+            raise RuntimeError(f"Failed to create worktree: {e}") from e
+
+    def _next_isolated_worktree_slot(
+        self, issue_number: int, requested_generation: int
+    ) -> tuple[str, Path]:
+        """Return an unused detached-review path at or after the requested generation.
+
+        This runs under :meth:`_git_metadata_lock_path`, so two coordinators
+        cannot select and create the same recovery worktree concurrently.
+        Existing paths are never reused: they may contain an unpublished
+        address commit even when ``git status`` reports a clean tree.
+        """
+        generation = requested_generation
+        while True:
+            key = f"review-pr-{issue_number}"
+            if generation:
+                key = f"{key}-{generation}"
+            path = self.base_dir / key
+            if key not in self.worktrees and not path.exists():
+                return key, path
+            generation += 1
+
     def _reuse_or_clear_normal_worktree(
         self,
         *,
@@ -389,7 +476,6 @@ class WorktreeManager:
         worktree_key: int | str,
         worktree_path: Path,
         branch_name: str,
-        isolated: bool,
         refresh_base: bool,
         timeout: int | None,
     ) -> Path | None:
@@ -397,7 +483,7 @@ class WorktreeManager:
         if worktree_key in self.worktrees:
             logger.warning("Worktree for issue #%s already exists", issue_number)
             return self.worktrees[worktree_key]
-        existing = None if isolated else self._worktree_holding_branch(branch_name, timeout=timeout)
+        existing = self._worktree_holding_branch(branch_name, timeout=timeout)
         if existing is not None:
             if existing.resolve() == worktree_path.resolve():
                 self.worktrees[worktree_key] = existing
@@ -411,12 +497,6 @@ class WorktreeManager:
         ):
             return worktree_path
         if worktree_path.exists():
-            if isolated:
-                # A detached review checkout can contain a committed but
-                # unpublished address fix, which ``git status`` reports as
-                # clean.  Removing it here would erase the only recovery
-                # artifact after a failed lease-protected push.
-                raise RuntimeError("refuses to replace existing isolated review worktree")
             logger.warning("Removing existing worktree directory: %s", worktree_path)
             self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
         return None

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -11,6 +11,7 @@ import logging
 import re
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -158,17 +159,21 @@ class TestCleanup:
         }
         assert result.on_done_state == "DONE"
 
-    def test_fresh_review_completion_retains_the_recovery_checkout(
+    def test_fresh_review_completion_retains_only_receipt_backed_recovery_checkouts(
         self,
         stage: FinishedStage,
         recovery_preserved: list[tuple[str, int, str]],
         make_ctx: Any,
     ) -> None:
-        """A successful re-review must not erase its prior failed checkout."""
-        item = _item(passed=True, worktree="/wt/fresh", state="CLEANUP")
-        item.payload["preserved_direct_worktrees"] = ["/wt/recovery"]
+        """A successful re-review must retain only durable recovery evidence."""
+        item = _item(passed=True, worktree="/wt/fresh", state="CLEANUP", pr=1001)
 
-        result = stage.step(item, make_ctx())
+        with patch.object(
+            finished_module,
+            "list_direct_review_recovery_paths",
+            return_value=[Path("/wt/recovery")],
+        ):
+            result = stage.step(item, make_ctx())
 
         assert isinstance(result, JobRequest)
         assert ("repo-a", 42, "/wt/recovery") in recovery_preserved

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -39,9 +39,19 @@ def preserved() -> list[tuple[str, int, str]]:
 
 
 @pytest.fixture
-def stage(ledger: list[ItemResult], preserved: list[tuple[str, int, str]]) -> FinishedStage:
+def recovery_preserved() -> list[tuple[str, int, str]]:
+    """Fresh recovery-checkout list retained after a later pass."""
+    return []
+
+
+@pytest.fixture
+def stage(
+    ledger: list[ItemResult],
+    preserved: list[tuple[str, int, str]],
+    recovery_preserved: list[tuple[str, int, str]],
+) -> FinishedStage:
     """FinishedStage bound to the fixture ledger/preserved lists."""
-    return FinishedStage(ledger, preserved)
+    return FinishedStage(ledger, preserved, recovery_preserved)
 
 
 def _item(
@@ -151,7 +161,7 @@ class TestCleanup:
     def test_fresh_review_completion_retains_the_recovery_checkout(
         self,
         stage: FinishedStage,
-        preserved: list[tuple[str, int, str]],
+        recovery_preserved: list[tuple[str, int, str]],
         make_ctx: Any,
     ) -> None:
         """A successful re-review must not erase its prior failed checkout."""
@@ -161,7 +171,7 @@ class TestCleanup:
         result = stage.step(item, make_ctx())
 
         assert isinstance(result, JobRequest)
-        assert ("repo-a", 42, "/wt/recovery") in preserved
+        assert ("repo-a", 42, "/wt/recovery") in recovery_preserved
 
     def test_fail_with_worktree_preserves_for_debugging(
         self,

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -148,6 +148,21 @@ class TestCleanup:
         }
         assert result.on_done_state == "DONE"
 
+    def test_fresh_review_completion_retains_the_recovery_checkout(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[str, int, str]],
+        make_ctx: Any,
+    ) -> None:
+        """A successful re-review must not erase its prior failed checkout."""
+        item = _item(passed=True, worktree="/wt/fresh", state="CLEANUP")
+        item.payload["preserved_direct_worktrees"] = ["/wt/recovery"]
+
+        result = stage.step(item, make_ctx())
+
+        assert isinstance(result, JobRequest)
+        assert ("repo-a", 42, "/wt/recovery") in preserved
+
     def test_fail_with_worktree_preserves_for_debugging(
         self,
         stage: FinishedStage,

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -192,6 +192,56 @@ class TestCleanup:
         assert isinstance(result, Continue) and result.next_state == "DONE"
         assert preserved == [("repo-a", 42, "/wt/issue-42")]
 
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            "remote_changed",
+            "remote_changed_unrecorded",
+            "remote_unchanged",
+            "remote_unconfirmed",
+            "retry_checkout_changed",
+            "retry_checkout_unconfirmed",
+        ],
+    )
+    def test_failed_detached_push_uses_inspection_only_preservation(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[str, int, str]],
+        recovery_preserved: list[tuple[str, int, str]],
+        make_ctx: Any,
+        failure: str,
+    ) -> None:
+        """Any terminal detached-push failure can contain an unpublished commit."""
+        item = _item(passed=False, worktree="/wt/review-pr-42", state="CLEANUP", pr=1001)
+        item.payload["detached_push_failure"] = failure
+
+        result = stage.step(item, make_ctx())
+
+        assert result == Continue(next_state="DONE")
+        assert preserved == []
+        assert recovery_preserved == [("repo-a", 42, "/wt/review-pr-42")]
+
+    def test_receipt_backed_failed_checkout_never_reaches_force_remove_footer(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[str, int, str]],
+        recovery_preserved: list[tuple[str, int, str]],
+        make_ctx: Any,
+    ) -> None:
+        """A capped remote-drift retry remains inspection-only after receipt discovery."""
+        item = _item(passed=False, worktree="/wt/review-pr-42", state="CLEANUP", pr=1001)
+
+        with patch.object(
+            finished_module,
+            "list_direct_review_recovery_paths",
+            return_value=[Path(item.worktree)],
+        ):
+            result = stage.step(item, make_ctx())
+
+        assert result == Continue(next_state="DONE")
+        assert preserved == []
+        assert recovery_preserved == [("repo-a", 42, "/wt/review-pr-42")]
+
     def test_fail_preserve_is_idempotent(
         self,
         stage: FinishedStage,

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -427,7 +427,14 @@ class TestPrReviewStageStep:
 
         stage.on_job_done(
             item,
-            JobResult(ok=True, value={"path": "/tmp/review-pr", "dirty": False}),
+            JobResult(
+                ok=True,
+                value={
+                    "path": "/tmp/review-pr",
+                    "dirty": False,
+                    "preserved_direct_worktrees": ["/tmp/review-pr-previous"],
+                },
+            ),
             ctx,
         )
         # ``Coordinator._handle_completion`` assigns on_done_state only after
@@ -438,6 +445,7 @@ class TestPrReviewStageStep:
         assert result == Continue(next_state="REVIEW_WAIT")
         assert item.worktree == "/tmp/review-pr"
         assert item.payload["direct_pr_worktree"] == "/tmp/review-pr"
+        assert item.payload["preserved_direct_worktrees"] == ["/tmp/review-pr-previous"]
         assert "direct_pr_worktree_pending" not in item.payload
 
     def test_enter_advances_to_review(self, make_ctx: Any, make_work_item: Any) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -2444,6 +2444,29 @@ class TestEvalVerdicts:
         )
         assert item.worktree == "/tmp/review-pr-1001"
 
+    def test_unclassified_direct_push_failure_preserves_the_checkout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Publication setup uncertainty must not orphan a detached address commit."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.worktree = "/tmp/review-pr-1001"
+        item.payload["direct_pr_worktree"] = item.worktree
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=False, error="cannot bind detached review push head"),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "detached_push_failed"
+        )
+        assert item.payload["detached_push_failure"] == "remote_unconfirmed"
+        assert "address_error" not in item.payload
+
     def test_detached_push_remote_changed_recovery_has_a_bounded_restart_budget(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -2300,7 +2300,10 @@ class TestEvalVerdicts:
             item,
             JobResult(
                 ok=False,
-                value={"detached_push_failure": "remote_unchanged"},
+                value={
+                    "detached_push_failure": "remote_unchanged",
+                    "detached_push_head_sha": "b" * 40,
+                },
                 error="detached review push failed while remote head was unchanged",
             ),
             ctx,
@@ -2311,6 +2314,7 @@ class TestEvalVerdicts:
 
         assert result == Continue(next_state="PUSH_WAIT")
         assert item.payload["direct_push_retries"] == 1
+        assert item.payload["detached_push_retry_head_sha"] == "b" * 40
         assert "address_error" not in item.payload
 
     def test_detached_push_retry_cap_preserves_the_checkout(
@@ -2320,13 +2324,17 @@ class TestEvalVerdicts:
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.worktree = "/tmp/review-pr-1001"
         item.payload["direct_push_retries"] = DIRECT_PUSH_RETRY_CAP
 
         stage.on_job_done(
             item,
             JobResult(
                 ok=False,
-                value={"detached_push_failure": "remote_unchanged"},
+                value={
+                    "detached_push_failure": "remote_unchanged",
+                    "detached_push_head_sha": "b" * 40,
+                },
                 error="detached review push failed while remote head was unchanged",
             ),
             ctx,
@@ -2338,13 +2346,43 @@ class TestEvalVerdicts:
         assert result == StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
         assert item.payload["detached_push_failure"] == "remote_unchanged"
 
+    def test_successful_detached_push_resets_the_retry_budget_for_the_next_round(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A later independent failure receives its own bounded retry."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.payload["direct_push_retries"] = DIRECT_PUSH_RETRY_CAP
+
+        stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+
+        assert "direct_push_retries" not in item.payload
+        item.state = "PUSH_WAIT"
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={
+                    "detached_push_failure": "remote_unchanged",
+                    "detached_push_head_sha": "b" * 40,
+                },
+                error="detached review push failed while remote head was unchanged",
+            ),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        assert stage.step(item, ctx) == Continue(next_state="PUSH_WAIT")
+
     def test_detached_push_with_advanced_remote_preserves_the_checkout(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """A changed remote must not be overwritten or called an agent failure."""
         stage = PrReviewStage()
-        ctx = make_ctx()
+        ctx = make_ctx(github=FakeStageGitHub(pr_head_branch="1001-auto"))
         item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.worktree = "/tmp/review-pr-1001"
 
         stage.on_job_done(
             item,
@@ -2359,8 +2397,17 @@ class TestEvalVerdicts:
 
         result = stage.step(item, ctx)
 
-        assert result == StageOutcome(Disposition.FINISH_FAIL, "detached_push_head_changed")
+        assert result == Continue(next_state="ENTER")
+        assert item.worktree == ""
+        assert item.payload["preserved_direct_worktrees"] == ["/tmp/review-pr-1001"]
+        assert item.payload["direct_pr_worktree_generation"] == 1
         assert "address_error" not in item.payload
+
+        item.state = "ENTER"
+        retry = stage.step(item, ctx)
+
+        assert isinstance(retry, JobRequest)
+        assert retry.job.kwargs["isolated_generation"] == 1
 
     # Severity-aware GO gate tests (#1856)
     def test_same_login_human_reply_to_process_advisory_thread_blocks_go(

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -432,7 +432,6 @@ class TestPrReviewStageStep:
                 value={
                     "path": "/tmp/review-pr",
                     "dirty": False,
-                    "preserved_direct_worktrees": ["/tmp/review-pr-previous"],
                 },
             ),
             ctx,
@@ -445,7 +444,6 @@ class TestPrReviewStageStep:
         assert result == Continue(next_state="REVIEW_WAIT")
         assert item.worktree == "/tmp/review-pr"
         assert item.payload["direct_pr_worktree"] == "/tmp/review-pr"
-        assert item.payload["preserved_direct_worktrees"] == ["/tmp/review-pr-previous"]
         assert "direct_pr_worktree_pending" not in item.payload
 
     def test_enter_advances_to_review(self, make_ctx: Any, make_work_item: Any) -> None:
@@ -963,6 +961,8 @@ class TestPrReviewStageStep:
         assert result.job.op == "commit_push"
         assert result.job.kwargs == {
             "issue_number": 1,
+            "pr_number": 1001,
+            "repo_root": str(ctx.paths.repo_root),
             "worktree_path": "/tmp/wt",
             "branch": "1-auto-impl",
             "agent": "claude",
@@ -2408,7 +2408,7 @@ class TestEvalVerdicts:
 
         assert result == Continue(next_state="ENTER")
         assert item.worktree == ""
-        assert item.payload["preserved_direct_worktrees"] == ["/tmp/review-pr-1001"]
+        assert "preserved_direct_worktrees" not in item.payload
         assert item.payload["direct_pr_worktree_generation"] == 1
         assert "address_error" not in item.payload
 
@@ -2418,6 +2418,31 @@ class TestEvalVerdicts:
         assert isinstance(retry, JobRequest)
         assert isinstance(retry.job, GitJob)
         assert retry.job.kwargs["isolated_generation"] == 1
+
+    def test_detached_push_without_a_durable_recovery_receipt_preserves_the_checkout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The stage must not restart if the worker could not persist provenance."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.worktree = "/tmp/review-pr-1001"
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_changed_unrecorded"},
+                error="remote changed and receipt storage failed",
+            ),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "detached_push_failed"
+        )
+        assert item.worktree == "/tmp/review-pr-1001"
 
     def test_detached_push_remote_changed_recovery_has_a_bounded_restart_budget(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -19,6 +19,7 @@ from hephaestus.automation.pipeline.stages import (
 )
 from hephaestus.automation.pipeline.stages.pr_review import (
     ADOPT_WORKTREE_WAIT,
+    DIRECT_PUSH_RETRY_CAP,
     REVIEW_CHECKOUT_WAIT,
     REVIEW_ERROR_RETRY_CAP,
     PrReviewStage,
@@ -2286,6 +2287,80 @@ class TestEvalVerdicts:
         assert result.note == "agent_error"
         assert item.attempts["pr_review_iter"] == 0  # no round burned
         assert github.mutation_log == []
+
+    def test_detached_push_with_unchanged_remote_retries_without_reinvoking_agent(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A pre-push failure retries the existing detached commit exactly once."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_unchanged"},
+                error="detached review push failed while remote head was unchanged",
+            ),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="PUSH_WAIT")
+        assert item.payload["direct_push_retries"] == 1
+        assert "address_error" not in item.payload
+
+    def test_detached_push_retry_cap_preserves_the_checkout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Repeated local push failures terminate safely instead of failing back."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.payload["direct_push_retries"] = DIRECT_PUSH_RETRY_CAP
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_unchanged"},
+                error="detached review push failed while remote head was unchanged",
+            ),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "detached_push_failed")
+        assert item.payload["detached_push_failure"] == "remote_unchanged"
+
+    def test_detached_push_with_advanced_remote_preserves_the_checkout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A changed remote must not be overwritten or called an agent failure."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_changed"},
+                error="detached review push observed a different remote head",
+            ),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "detached_push_head_changed")
+        assert "address_error" not in item.payload
 
     # Severity-aware GO gate tests (#1856)
     def test_same_login_human_reply_to_process_advisory_thread_blocks_go(

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -19,6 +19,7 @@ from hephaestus.automation.pipeline.stages import (
 )
 from hephaestus.automation.pipeline.stages.pr_review import (
     ADOPT_WORKTREE_WAIT,
+    DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP,
     DIRECT_PUSH_RETRY_CAP,
     REVIEW_CHECKOUT_WAIT,
     REVIEW_ERROR_RETRY_CAP,
@@ -2407,7 +2408,35 @@ class TestEvalVerdicts:
         retry = stage.step(item, ctx)
 
         assert isinstance(retry, JobRequest)
+        assert isinstance(retry.job, GitJob)
         assert retry.job.kwargs["isolated_generation"] == 1
+
+    def test_detached_push_remote_changed_recovery_has_a_bounded_restart_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Repeated concurrent head changes preserve the current checkout and stop."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.worktree = "/tmp/review-pr-1001-1"
+        item.payload["direct_push_remote_changed_restarts"] = DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={"detached_push_failure": "remote_changed"},
+                error="detached review push observed a different remote head",
+            ),
+            ctx,
+        )
+        item.state = "EVAL"
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "detached_push_failed"
+        )
+        assert item.worktree == "/tmp/review-pr-1001-1"
+        assert item.payload["detached_push_failure"] == "remote_changed"
 
     # Severity-aware GO gate tests (#1856)
     def test_same_login_human_reply_to_process_advisory_thread_blocks_go(

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -2483,9 +2483,24 @@ class TestDurableEventLog:
 
         coordinator._park_resumable(item)
 
-        assert coordinator._active_recovery_worktrees() == [
-            ("repo-a", 44, str(worktree.resolve()))
-        ]
+        assert coordinator._active_recovery_worktrees() == [("repo-a", 44, str(worktree.resolve()))]
+
+    def test_park_resumable_reports_an_unreceipted_detached_push_checkout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shutdown preserves inspection guidance even when receipt creation failed."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        item = _issue_item(44, StageName.PR_REVIEW)
+        item.pr = 1001
+        worktree = tmp_path / "review-pr-1001"
+        worktree.mkdir()
+        item.worktree = str(worktree)
+        item.payload["direct_pr_worktree"] = item.worktree
+        item.payload["detached_push_failure"] = "remote_changed_unrecorded"
+
+        coordinator._park_resumable(item)
+
+        assert coordinator._active_recovery_worktrees() == [("repo-a", 44, str(worktree))]
 
 
 class TestPipelineScopeWiring:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -19,6 +19,7 @@ from typing import Any, cast
 
 import pytest
 
+from hephaestus.automation.direct_review_recovery import record_direct_review_recovery
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import (
     _FAIL_BACK_CAP,
@@ -2458,6 +2459,33 @@ class TestDurableEventLog:
         coordinator._park_resumable(item)
 
         assert "_resumable" not in coordinator.__dict__
+
+    def test_park_resumable_reports_a_receipt_backed_recovery_checkout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An interrupt after remote drift keeps the current-run recovery guidance."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        repo_root = tmp_path / "repo-a"
+        worktree = repo_root / "build" / ".worktrees" / "review-pr-44"
+        worktree.mkdir(parents=True)
+        (worktree / ".git").mkdir()
+        record_direct_review_recovery(
+            repo_root=repo_root,
+            issue=44,
+            pr=1001,
+            worktree=worktree,
+            branch="44-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+        item = _issue_item(44, StageName.PR_REVIEW)
+        item.pr = 1001
+
+        coordinator._park_resumable(item)
+
+        assert coordinator._active_recovery_worktrees() == [
+            ("repo-a", 44, str(worktree.resolve()))
+        ]
 
 
 class TestPipelineScopeWiring:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -2495,6 +2495,7 @@ class TestDurableEventLog:
         worktree = tmp_path / "review-pr-1001"
         worktree.mkdir()
         item.worktree = str(worktree)
+        item.state = "PUSH_WAIT"
         item.payload["direct_pr_worktree"] = item.worktree
         item.payload["detached_push_failure"] = "remote_changed_unrecorded"
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -349,6 +349,24 @@ class TestExitCode:
 
         assert coordinator._active_preserved_worktrees() == []
 
+    def test_recovery_worktrees_remain_reported_after_a_later_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A passed fresh review must still surface its retained recovery checkout."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        recovery_path = tmp_path / "review-pr-2009"
+        recovery_path.mkdir()
+        passed = _item(2009, StageName.FINISHED)
+        passed.pr = 2010
+        passed.result = work_item_mod.ItemResult(
+            passed=True, reason="merged", final_stage=StageName.FINISHED
+        )
+        coordinator.items = [passed]
+        entry = ("repo-a", 2009, str(recovery_path))
+        coordinator.recovery_preserved.append(entry)
+
+        assert coordinator._active_preserved_worktrees() == [entry]
+
     def test_preserved_worktrees_ignore_missing_paths_for_failed_items(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -365,7 +365,8 @@ class TestExitCode:
         entry = ("repo-a", 2009, str(recovery_path))
         coordinator.recovery_preserved.append(entry)
 
-        assert coordinator._active_preserved_worktrees() == [entry]
+        assert coordinator._active_preserved_worktrees() == []
+        assert coordinator._active_recovery_worktrees() == [entry]
 
     def test_preserved_worktrees_ignore_missing_paths_for_failed_items(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -16,6 +16,7 @@ import pytest
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.summary import (
     RunStats,
+    format_direct_review_recovery_worktrees,
     format_preserved_worktrees,
     print_summary,
 )
@@ -62,6 +63,14 @@ class TestFormatPreservedWorktrees:
 
     def test_empty_list_yields_no_lines(self) -> None:
         assert format_preserved_worktrees([], "script.py") == []
+
+    def test_detached_recovery_guidance_is_inspection_only(self) -> None:
+        """Receipt-backed recoveries must never inherit force-remove commands."""
+        lines = format_direct_review_recovery_worktrees([("repo-a", 101, "/wt/review-101")])
+
+        assert "Detached-review recovery worktrees" in lines[0]
+        assert "/wt/review-101" in lines[1]
+        assert all("git worktree remove" not in line and "--issues" not in line for line in lines)
 
     def test_line_sequence_matches_legacy(self) -> None:
         preserved = [("repo-a", 101, "/wt/issue-101"), ("repo-b", 202, "/wt/issue-202")]
@@ -239,6 +248,7 @@ class TestJsonEnvelope:
         assert envelope["loops_run"] == 3
         assert envelope["resumable"] == ["repo-a#2@pr_review"]
         assert envelope["preserved_worktrees"] == [[2, "/wt/2"]]
+        assert envelope["recovery_worktrees"] == []
 
     @pytest.mark.parametrize(
         ("exit_code", "expected_message"),

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -69,7 +69,7 @@ class TestFormatPreservedWorktrees:
         lines = format_preserved_worktrees(preserved, "impl.py")
 
         assert lines == [
-            "\nPreserved worktrees (contain uncommitted changes):",
+            "\nPreserved worktrees (retained for recovery or debugging):",
             "  #101: /wt/issue-101",
             "  #202: /wt/issue-202",
             "\nRerun these issues after inspecting/cleaning the worktrees:",
@@ -210,7 +210,7 @@ class TestPrintSummaryRows:
         with caplog.at_level(logging.INFO):
             print_summary([], _stats(exit_code=1), [("repo-a", 9, "/wt/9")], json_out=False)
 
-        assert "Preserved worktrees (contain uncommitted changes):" in caplog.text
+        assert "Preserved worktrees (retained for recovery or debugging):" in caplog.text
         assert "git worktree remove --force /wt/9" in caplog.text
 
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1980,6 +1980,54 @@ class TestGitOps:
         assert result.ok is True
         assert result.value is True
 
+    @pytest.mark.parametrize(
+        ("exc", "failure_kind"),
+        [
+            (
+                git_utils.DetachedHeadPushRemoteHeadChangedError("remote changed"),
+                "remote_changed",
+            ),
+            (
+                git_utils.DetachedHeadPushRemoteHeadUnchangedError("remote unchanged"),
+                "remote_unchanged",
+            ),
+            (
+                git_utils.DetachedHeadPushRemoteProbeError("probe unavailable"),
+                "remote_unconfirmed",
+            ),
+        ],
+    )
+    def test_commit_push_classifies_verified_detached_push_failures(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+        exc: Exception,
+        failure_kind: str,
+    ) -> None:
+        """The PR-review stage receives a safe, actionable detached-push outcome."""
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "publish_detached_head": True,
+                "expected_remote_sha": "a" * 40,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch("hephaestus.automation.git_utils.push_head_to_branch", side_effect=exc),
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {"detached_push_failure": failure_kind}
+
     def test_commit_push_missing_worktree_path_is_error(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1357,6 +1357,7 @@ class TestGitOps:
         )
         instance = MagicMock()
         instance.create_worktree.return_value = review_path
+        instance.last_isolated_recovery_paths = []
         with (
             patch(f"{_WP}.WorktreeManager", return_value=instance),
             patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
@@ -1373,6 +1374,48 @@ class TestGitOps:
         )
         mock_sync.assert_called_once_with(review_path, "70-existing", pr_number=70, timeout=60)
         assert result.ok is True
+
+    def test_create_isolated_worktree_returns_cold_start_recovery_paths(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A new direct-review adoption reports older retained checkouts to the stage."""
+        review_path = tmp_path / "build" / ".worktrees" / "review-pr-70-1"
+        retained_path = tmp_path / "build" / ".worktrees" / "review-pr-70"
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 70,
+                "branch_name": "70-existing",
+                "isolated": True,
+                "repo_root": str(tmp_path),
+                "sync_to_remote": True,
+                "pr_number": 70,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = review_path
+        instance.last_isolated_recovery_paths = [retained_path]
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
+            patch(f"{_WP}.git_utils.sync_worktree_to_remote_branch"),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {
+            "path": str(review_path),
+            "dirty": False,
+            "status": "",
+            "diff": "",
+            "preserved_direct_worktrees": [str(retained_path)],
+        }
 
     def test_verify_pr_review_checkout_rejects_a_dirty_worktree(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -21,6 +21,7 @@ import pytest
 
 from hephaestus.automation import git_utils, subprocess_registry
 from hephaestus.automation._review_utils import build_automation_parser
+from hephaestus.automation.direct_review_recovery import list_direct_review_recovery_paths
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     WORKTREE_MATERIALIZED_KEY,
@@ -1375,15 +1376,14 @@ class TestGitOps:
         mock_sync.assert_called_once_with(review_path, "70-existing", pr_number=70, timeout=60)
         assert result.ok is True
 
-    def test_create_isolated_worktree_returns_cold_start_recovery_paths(
+    def test_create_isolated_worktree_does_not_infer_recovery_from_occupancy(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
     ) -> None:
-        """A new direct-review adoption reports older retained checkouts to the stage."""
+        """An occupied checkout is not itself proof of an abandoned recovery."""
         review_path = tmp_path / "build" / ".worktrees" / "review-pr-70-1"
-        retained_path = tmp_path / "build" / ".worktrees" / "review-pr-70"
         job = GitJob(
             repo="test/repo",
             op="create_worktree",
@@ -1399,7 +1399,6 @@ class TestGitOps:
         )
         instance = MagicMock()
         instance.create_worktree.return_value = review_path
-        instance.last_isolated_recovery_paths = [retained_path]
         with (
             patch(f"{_WP}.WorktreeManager", return_value=instance),
             patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
@@ -1414,7 +1413,6 @@ class TestGitOps:
             "dirty": False,
             "status": "",
             "diff": "",
-            "preserved_direct_worktrees": [str(retained_path)],
         }
 
     def test_verify_pr_review_checkout_rejects_a_dirty_worktree(
@@ -2006,6 +2004,8 @@ class TestGitOps:
                 "issue_number": 5,
                 "worktree_path": tmp_path,
                 "branch": "5-auto",
+                "pr_number": 1005,
+                "repo_root": str(tmp_path),
                 "publish_detached_head": True,
                 "expected_remote_sha": "a" * 40,
             },
@@ -2051,6 +2051,8 @@ class TestGitOps:
                 "issue_number": 5,
                 "worktree_path": tmp_path,
                 "branch": "5-auto",
+                "pr_number": 1005,
+                "repo_root": str(tmp_path),
                 "publish_detached_head": True,
                 "expected_remote_sha": "a" * 40,
                 "detached_push_retry_head_sha": source_sha,
@@ -2148,6 +2150,8 @@ class TestGitOps:
             timeout_s=60,
             kwargs={
                 "issue_number": 5,
+                "pr_number": 1005,
+                "repo_root": str(tmp_path),
                 "worktree_path": tmp_path,
                 "branch": "5-auto",
                 "publish_detached_head": True,
@@ -2161,15 +2165,113 @@ class TestGitOps:
                 return_value=subprocess.CompletedProcess([], 0, stdout="b" * 40 + "\n"),
             ),
             patch("hephaestus.automation.git_utils.push_head_to_branch", side_effect=exc),
+            patch(f"{_WP}.record_direct_review_recovery") as record_recovery,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        if failure_kind == "remote_changed":
+            record_recovery.assert_called_once()
+        else:
+            record_recovery.assert_not_called()
+        assert result.value == {
+            "detached_push_failure": failure_kind,
+            "detached_push_head_sha": "b" * 40,
+        }
+
+    def test_remote_changed_without_a_durable_receipt_stops_without_restart(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A fresh review is unsafe when the abandoned checkout cannot be recorded."""
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "pr_number": 1005,
+                "repo_root": str(tmp_path),
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "publish_detached_head": True,
+                "expected_remote_sha": "a" * 40,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch(
+                "hephaestus.automation.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="b" * 40 + "\n"),
+            ),
+            patch(
+                "hephaestus.automation.git_utils.push_head_to_branch",
+                side_effect=git_utils.DetachedHeadPushRemoteHeadChangedError("remote changed"),
+            ),
+            patch(
+                f"{_WP}.record_direct_review_recovery",
+                side_effect=OSError("state directory is unavailable"),
+            ),
         ):
             pool.submit(job, StageName.PR_REVIEW)
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
         assert result.value == {
-            "detached_push_failure": failure_kind,
+            "detached_push_failure": "remote_changed_unrecorded",
             "detached_push_head_sha": "b" * 40,
         }
+
+    def test_remote_changed_persists_a_recovery_receipt_before_restarting(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """The worker writes durable provenance before it returns remote drift."""
+        worktree = tmp_path / "build" / ".worktrees" / "review-pr-5"
+        worktree.mkdir(parents=True)
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "pr_number": 1005,
+                "repo_root": str(tmp_path),
+                "worktree_path": worktree,
+                "branch": "5-auto",
+                "publish_detached_head": True,
+                "expected_remote_sha": "a" * 40,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch(
+                "hephaestus.automation.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="b" * 40 + "\n"),
+            ),
+            patch(
+                "hephaestus.automation.git_utils.push_head_to_branch",
+                side_effect=git_utils.DetachedHeadPushRemoteHeadChangedError("remote changed"),
+            ),
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {
+            "detached_push_failure": "remote_changed",
+            "detached_push_head_sha": "b" * 40,
+        }
+        assert list_direct_review_recovery_paths(
+            repo_root=tmp_path,
+            issue=5,
+            pr=1005,
+        ) == [worktree.resolve()]
 
     def test_commit_push_missing_worktree_path_is_error(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2234,6 +2234,7 @@ class TestGitOps:
         """The worker writes durable provenance before it returns remote drift."""
         worktree = tmp_path / "build" / ".worktrees" / "review-pr-5"
         worktree.mkdir(parents=True)
+        (worktree / ".git").mkdir()
         job = GitJob(
             repo="test/repo",
             op="commit_push",

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1969,16 +1969,109 @@ class TestGitOps:
         )
         with (
             patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch(
+                "hephaestus.automation.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="b" * 40 + "\n"),
+            ),
             patch("hephaestus.automation.git_utils.push_head_to_branch") as mock_push,
             patch("hephaestus.automation.git_utils.push_branch") as normal_push,
         ):
             pool.submit(job, StageName.PR_REVIEW)
             _, result = completion_q.get(timeout=10)
 
-        mock_push.assert_called_once_with("5-auto", "a" * 40, tmp_path, timeout=60)
+        mock_push.assert_called_once_with(
+            "5-auto", "a" * 40, tmp_path, source_sha="b" * 40, timeout=60
+        )
         normal_push.assert_not_called()
         assert result.ok is True
         assert result.value is True
+
+    @pytest.mark.parametrize(
+        ("status_output", "current_head"),
+        [(" M changed.py\n", "b" * 40), ("", "c" * 40)],
+    )
+    def test_detached_push_retry_refuses_a_changed_checkout_before_publishing(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+        status_output: str,
+        current_head: str,
+    ) -> None:
+        """A retry cannot publish dirty or amended content after the first push."""
+        source_sha = "b" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "publish_detached_head": True,
+                "expected_remote_sha": "a" * 40,
+                "detached_push_retry_head_sha": source_sha,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes") as commit,
+            patch(
+                "hephaestus.automation.git_utils.run",
+                side_effect=[
+                    subprocess.CompletedProcess([], 0, stdout=status_output),
+                    subprocess.CompletedProcess([], 0, stdout=current_head + "\n"),
+                ],
+            ),
+            patch("hephaestus.automation.git_utils.push_head_to_branch") as push,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        commit.assert_not_called()
+        push.assert_not_called()
+        assert result.ok is False
+        assert result.value == {"detached_push_failure": "retry_checkout_changed"}
+
+    def test_detached_push_retry_republishes_only_the_captured_commit(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A clean retry uses the saved commit SHA rather than a mutable HEAD ref."""
+        source_sha = "b" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "publish_detached_head": True,
+                "expected_remote_sha": "a" * 40,
+                "detached_push_retry_head_sha": source_sha,
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes") as commit,
+            patch(
+                "hephaestus.automation.git_utils.run",
+                side_effect=[
+                    subprocess.CompletedProcess([], 0, stdout=""),
+                    subprocess.CompletedProcess([], 0, stdout=source_sha + "\n"),
+                ],
+            ),
+            patch("hephaestus.automation.git_utils.push_head_to_branch") as push,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        commit.assert_not_called()
+        push.assert_called_once_with(
+            "5-auto", "a" * 40, tmp_path, source_sha=source_sha, timeout=60
+        )
+        assert result.ok is True
 
     @pytest.mark.parametrize(
         ("exc", "failure_kind"),
@@ -2020,13 +2113,20 @@ class TestGitOps:
         )
         with (
             patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch(
+                "hephaestus.automation.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout="b" * 40 + "\n"),
+            ),
             patch("hephaestus.automation.git_utils.push_head_to_branch", side_effect=exc),
         ):
             pool.submit(job, StageName.PR_REVIEW)
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert result.value == {"detached_push_failure": failure_kind}
+        assert result.value == {
+            "detached_push_failure": failure_kind,
+            "detached_push_head_sha": "b" * 40,
+        }
 
     def test_commit_push_missing_worktree_path_is_error(
         self,

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -98,7 +98,7 @@ def test_receipt_rejects_worktree_git_metadata_outside_the_repository(tmp_path: 
     outside.mkdir(exist_ok=True)
     (worktree / ".git").write_text(f"gitdir: {outside}\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="outside the repository"):
+    with pytest.raises(ValueError, match="Git metadata"):
         record_direct_review_recovery(
             repo_root=tmp_path,
             issue=2500,

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -90,6 +90,53 @@ def test_receipt_rejects_a_symlinked_state_directory(tmp_path: Path) -> None:
     assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
 
 
+def test_receipt_rejects_worktree_git_metadata_outside_the_repository(tmp_path: Path) -> None:
+    """A mutable linked-worktree gitdir cannot redirect recovery marker writes."""
+    worktree = _worktree(tmp_path, 2500)
+    shutil.rmtree(worktree / ".git")
+    outside = tmp_path.parent / "outside-git-metadata"
+    outside.mkdir(exist_ok=True)
+    (worktree / ".git").write_text(f"gitdir: {outside}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside the repository"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not (outside / "hephaestus-direct-review-recovery").exists()
+
+
+def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> None:
+    """The production linked-worktree gitdir layout remains receipt-backed."""
+    worktree = _worktree(tmp_path, 2500)
+    shutil.rmtree(worktree / ".git")
+    git_dir = tmp_path / ".git" / "worktrees" / "review-pr-2500"
+    git_dir.mkdir(parents=True)
+    (worktree / ".git").write_text(
+        "gitdir: ../../../.git/worktrees/review-pr-2500\n", encoding="utf-8"
+    )
+
+    record_direct_review_recovery(
+        repo_root=tmp_path,
+        issue=2500,
+        pr=2501,
+        worktree=worktree,
+        branch="2500-auto",
+        expected_remote_sha="a" * 40,
+        source_sha="b" * 40,
+    )
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == [
+        worktree.resolve()
+    ]
+
+
 def test_receipt_write_does_not_follow_a_replaced_state_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -105,7 +152,7 @@ def test_receipt_write_does_not_follow_a_replaced_state_directory(
 
     def replace_after_swap(*args: object, **kwargs: object) -> None:
         """Swap the pathname after descriptor acquisition and before replacement."""
-        if kwargs.get("dst_dir_fd") is not None:
+        if kwargs.get("dst_dir_fd") is not None and receipt_dir.exists():
             receipt_dir.rename(displaced_dir)
             receipt_dir.symlink_to(outside, target_is_directory=True)
         cast(Any, original_replace)(*args, **kwargs)

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -160,6 +160,92 @@ def test_receipt_rejects_a_symlinked_repository_git_metadata(tmp_path: Path) -> 
     assert not (review_git_dir / "hephaestus-direct-review-recovery").exists()
 
 
+def test_receipt_rejects_forged_linked_repository_git_metadata(tmp_path: Path) -> None:
+    """A root gitfile must prove its common metadata directory before marker I/O."""
+    repo_root = tmp_path / "linked-root"
+    worktree = repo_root / "build" / ".worktrees" / "review-pr-2500"
+    worktree.mkdir(parents=True)
+    outside_git_dir = tmp_path / "outside" / ".git"
+    root_git_dir = outside_git_dir / "worktrees" / "linked-root"
+    review_git_dir = outside_git_dir / "worktrees" / "review-pr-2500"
+    root_git_dir.mkdir(parents=True)
+    review_git_dir.mkdir()
+    (repo_root / ".git").write_text(f"gitdir: {root_git_dir}\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {review_git_dir}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="repository Git metadata is unavailable"):
+        record_direct_review_recovery(
+            repo_root=repo_root,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not (review_git_dir / "hephaestus-direct-review-recovery").exists()
+
+
+def test_receipt_rejects_root_git_metadata_swapped_to_a_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The root gitfile is opened no-follow after the trusted-root descriptor exists."""
+    repo_root = tmp_path / "linked-root"
+    worktree = repo_root / "build" / ".worktrees" / "review-pr-2500"
+    worktree.mkdir(parents=True)
+    common_git_dir = tmp_path / "common" / ".git"
+    root_git_dir = common_git_dir / "worktrees" / "linked-root"
+    review_git_dir = common_git_dir / "worktrees" / "review-pr-2500"
+    root_git_dir.mkdir(parents=True)
+    review_git_dir.mkdir()
+    (root_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    root_dot_git = repo_root / ".git"
+    root_dot_git.write_text(f"gitdir: {root_git_dir}\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {review_git_dir}\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    forged_pointer = outside / "git-pointer"
+    forged_pointer.write_text(
+        f"gitdir: {outside / '.git' / 'worktrees' / 'linked-root'}\n", encoding="utf-8"
+    )
+    original_open = os.open
+    swapped = False
+
+    def open_after_swap(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        """Replace the gitfile just before its descriptor-relative open."""
+        nonlocal swapped
+        if not swapped and path == ".git" and dir_fd is not None:
+            root_dot_git.unlink()
+            root_dot_git.symlink_to(forged_pointer)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(os, "open", open_after_swap)
+
+    with pytest.raises(ValueError, match="repository Git metadata is symlinked"):
+        record_direct_review_recovery(
+            repo_root=repo_root,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    outside_marker = (
+        outside / ".git" / "worktrees" / "review-pr-2500" / "hephaestus-direct-review-recovery"
+    )
+    assert not outside_marker.exists()
+
+
 def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> None:
     """The production linked-worktree gitdir layout remains receipt-backed."""
     worktree = _worktree(tmp_path, 2500)
@@ -195,6 +281,7 @@ def test_receipt_supports_a_linked_repository_root(tmp_path: Path) -> None:
     review_git_dir = common_git_dir / "worktrees" / "review-pr-2500"
     root_git_dir.mkdir(parents=True)
     review_git_dir.mkdir()
+    (root_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
     (repo_root / ".git").write_text(f"gitdir: {root_git_dir}\n", encoding="utf-8")
     (worktree / ".git").write_text(f"gitdir: {review_git_dir}\n", encoding="utf-8")
 

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import pytest
 
+from hephaestus.automation import direct_review_recovery
 from hephaestus.automation.direct_review_recovery import (
     list_direct_review_recovery_paths,
     record_direct_review_recovery,
@@ -46,6 +47,27 @@ def test_receipt_backed_recovery_is_discoverable_across_manager_instances(tmp_pa
 def test_active_unreceipted_checkout_is_never_reported_as_recovery(tmp_path: Path) -> None:
     """Collision avoidance must not turn a live checkout into cleanup guidance."""
     _worktree(tmp_path, 2500)
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
+
+
+def test_receipts_fail_closed_without_no_follow_directory_descriptors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Portable fallbacks preserve without creating a race-prone receipt."""
+    worktree = _worktree(tmp_path, 2500)
+    monkeypatch.setattr(direct_review_recovery, "_DIR_FD_SUPPORTED", False)
+
+    with pytest.raises(ValueError, match="no-follow directory descriptors"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
 
     assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
 

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -246,12 +246,111 @@ def test_receipt_rejects_root_git_metadata_swapped_to_a_symlink(
     assert not outside_marker.exists()
 
 
+def test_receipt_rejects_worktree_git_metadata_swapped_to_a_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The review gitfile is opened no-follow after the worktree descriptor exists."""
+    worktree = _worktree(tmp_path, 2500)
+    shutil.rmtree(worktree / ".git")
+    git_dir = tmp_path / ".git" / "worktrees" / "review-pr-2500"
+    other_git_dir = tmp_path / ".git" / "worktrees" / "other"
+    git_dir.mkdir(parents=True)
+    other_git_dir.mkdir()
+    (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+    forged_pointer = tmp_path / "forged-worktree-git-pointer"
+    forged_pointer.write_text(f"gitdir: {other_git_dir}\n", encoding="utf-8")
+    original_open = os.open
+    swapped = False
+    worktree_stat = worktree.stat()
+
+    def open_after_swap(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        """Replace the review gitfile just before its descriptor-relative open."""
+        nonlocal swapped
+        if (
+            not swapped
+            and path == ".git"
+            and dir_fd is not None
+            and os.path.samestat(os.fstat(dir_fd), worktree_stat)
+        ):
+            (worktree / ".git").unlink()
+            (worktree / ".git").symlink_to(forged_pointer)
+            swapped = True
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(os, "open", open_after_swap)
+
+    with pytest.raises(ValueError, match="Git metadata is symlinked"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not (other_git_dir / "hephaestus-direct-review-recovery").exists()
+
+
+def test_receipt_rejects_normal_root_git_directory_swapped_to_a_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A verified root Git directory cannot be replaced before marker I/O."""
+    worktree = _worktree(tmp_path, 2500)
+    shutil.rmtree(worktree / ".git")
+    git_dir = tmp_path / ".git" / "worktrees" / "review-pr-2500"
+    git_dir.mkdir(parents=True)
+    (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+    root_git_dir = tmp_path / ".git"
+    displaced_git_dir = tmp_path / "displaced-git"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    original_common_git_dir = direct_review_recovery._common_git_dir
+
+    def common_git_dir_after_swap(repo_root: Path) -> Path:
+        """Swap the root metadata path after it is verified but before reopening it."""
+        common_git_dir = original_common_git_dir(repo_root)
+        root_git_dir.rename(displaced_git_dir)
+        root_git_dir.symlink_to(outside, target_is_directory=True)
+        return common_git_dir
+
+    monkeypatch.setattr(direct_review_recovery, "_common_git_dir", common_git_dir_after_swap)
+
+    with pytest.raises(ValueError, match="Git metadata is unavailable"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not (
+        outside / "worktrees" / "review-pr-2500" / "hephaestus-direct-review-recovery"
+    ).exists()
+
+
 def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> None:
     """The production linked-worktree gitdir layout remains receipt-backed."""
     worktree = _worktree(tmp_path, 2500)
     shutil.rmtree(worktree / ".git")
     git_dir = tmp_path / ".git" / "worktrees" / "review-pr-2500"
     git_dir.mkdir(parents=True)
+    (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
     (worktree / ".git").write_text(
         "gitdir: ../../../.git/worktrees/review-pr-2500\n", encoding="utf-8"
     )
@@ -282,6 +381,8 @@ def test_receipt_supports_a_linked_repository_root(tmp_path: Path) -> None:
     root_git_dir.mkdir(parents=True)
     review_git_dir.mkdir()
     (root_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (review_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (review_git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
     (repo_root / ".git").write_text(f"gitdir: {root_git_dir}\n", encoding="utf-8")
     (worktree / ".git").write_text(f"gitdir: {review_git_dir}\n", encoding="utf-8")
 

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -380,9 +380,7 @@ def test_receipt_rejects_normal_root_git_directory_swapped_to_a_regular_director
         replacement_git_dir = root_git_dir / "worktrees" / "review-pr-2500"
         replacement_git_dir.mkdir(parents=True)
         (replacement_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
-        (replacement_git_dir / "gitdir").write_text(
-            f"{worktree / '.git'}\n", encoding="utf-8"
-        )
+        (replacement_git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
         with original_open_marker_directory(repo_root, marker_path, marker_dir_stat) as opened:
             yield opened
 

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -137,6 +137,34 @@ def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> 
     ]
 
 
+def test_receipt_supports_a_linked_repository_root(tmp_path: Path) -> None:
+    """Recovery works when the loop itself runs from a linked checkout."""
+    repo_root = tmp_path / "linked-root"
+    worktree = repo_root / "build" / ".worktrees" / "review-pr-2500"
+    worktree.mkdir(parents=True)
+    common_git_dir = tmp_path / "common" / ".git"
+    root_git_dir = common_git_dir / "worktrees" / "linked-root"
+    review_git_dir = common_git_dir / "worktrees" / "review-pr-2500"
+    root_git_dir.mkdir(parents=True)
+    review_git_dir.mkdir()
+    (repo_root / ".git").write_text(f"gitdir: {root_git_dir}\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {review_git_dir}\n", encoding="utf-8")
+
+    record_direct_review_recovery(
+        repo_root=repo_root,
+        issue=2500,
+        pr=2501,
+        worktree=worktree,
+        branch="2500-auto",
+        expected_remote_sha="a" * 40,
+        source_sha="b" * 40,
+    )
+
+    assert list_direct_review_recovery_paths(repo_root=repo_root, issue=2500, pr=2501) == [
+        worktree.resolve()
+    ]
+
+
 def test_receipt_write_does_not_follow_a_replaced_state_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -10,6 +10,7 @@ from hephaestus.automation.direct_review_recovery import (
     list_direct_review_recovery_paths,
     record_direct_review_recovery,
 )
+from hephaestus.automation.models import DEFAULT_STATE_DIR
 
 
 def _worktree(repo_root: Path, issue: int) -> Path:
@@ -60,3 +61,47 @@ def test_receipt_rejects_a_worktree_outside_the_isolated_review_root(tmp_path: P
             expected_remote_sha="a" * 40,
             source_sha="b" * 40,
         )
+
+
+def test_receipt_rejects_a_symlinked_state_directory(tmp_path: Path) -> None:
+    """Receipt reads and writes never follow a state-directory symlink."""
+    worktree = _worktree(tmp_path, 2500)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    state_dir = tmp_path / DEFAULT_STATE_DIR
+    state_dir.parent.mkdir(parents=True, exist_ok=True)
+    state_dir.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="receipt directory"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
+
+
+def test_receipt_does_not_authorize_a_replacement_checkout_at_the_same_path(
+    tmp_path: Path,
+) -> None:
+    """A stale receipt cannot reclassify a later checkout as an old recovery."""
+    worktree = _worktree(tmp_path, 2500)
+    record_direct_review_recovery(
+        repo_root=tmp_path,
+        issue=2500,
+        pr=2501,
+        worktree=worktree,
+        branch="2500-auto",
+        expected_remote_sha="a" * 40,
+        source_sha="b" * 40,
+    )
+
+    worktree.rmdir()
+    worktree.mkdir()
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -1,0 +1,62 @@
+"""Tests for durable detached-review recovery receipts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.automation.direct_review_recovery import (
+    list_direct_review_recovery_paths,
+    record_direct_review_recovery,
+)
+
+
+def _worktree(repo_root: Path, issue: int) -> Path:
+    """Create a direct-review checkout fixture path."""
+    path = repo_root / "build" / ".worktrees" / f"review-pr-{issue}"
+    path.mkdir(parents=True)
+    return path
+
+
+def test_receipt_backed_recovery_is_discoverable_across_manager_instances(tmp_path: Path) -> None:
+    """Only an authoritative remote-drift receipt makes a path recoverable."""
+    worktree = _worktree(tmp_path, 2500)
+
+    record_direct_review_recovery(
+        repo_root=tmp_path,
+        issue=2500,
+        pr=2501,
+        worktree=worktree,
+        branch="2500-auto",
+        expected_remote_sha="a" * 40,
+        source_sha="b" * 40,
+    )
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == [
+        worktree.resolve()
+    ]
+
+
+def test_active_unreceipted_checkout_is_never_reported_as_recovery(tmp_path: Path) -> None:
+    """Collision avoidance must not turn a live checkout into cleanup guidance."""
+    _worktree(tmp_path, 2500)
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
+
+
+def test_receipt_rejects_a_worktree_outside_the_isolated_review_root(tmp_path: Path) -> None:
+    """A receipt cannot make an arbitrary path eligible for summary output."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    with pytest.raises(ValueError, match="worktree is invalid"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=outside,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
 
@@ -23,6 +25,18 @@ def _worktree(repo_root: Path, issue: int) -> Path:
     path.mkdir(parents=True)
     (path / ".git").mkdir()
     return path
+
+
+def _linked_worktree(repo_root: Path, issue: int) -> tuple[Path, Path]:
+    """Create a linked-worktree fixture bound to the fixture's common Git dir."""
+    worktree = _worktree(repo_root, issue)
+    shutil.rmtree(worktree / ".git")
+    git_dir = repo_root / ".git" / "worktrees" / f"review-pr-{issue}"
+    git_dir.mkdir(parents=True)
+    (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+    return worktree, git_dir
 
 
 def test_receipt_backed_recovery_is_discoverable_across_manager_instances(tmp_path: Path) -> None:
@@ -343,6 +357,94 @@ def test_receipt_rejects_normal_root_git_directory_swapped_to_a_symlink(
     ).exists()
 
 
+def test_receipt_rejects_normal_root_git_directory_swapped_to_a_regular_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A regular metadata replacement cannot receive a marker after validation."""
+    worktree, _ = _linked_worktree(tmp_path, 2500)
+    root_git_dir = tmp_path / ".git"
+    displaced_git_dir = tmp_path / "displaced-git"
+    replacement_marker = (
+        root_git_dir / "worktrees" / "review-pr-2500" / "hephaestus-direct-review-recovery"
+    )
+    original_open_marker_directory = direct_review_recovery._open_marker_directory
+
+    @contextmanager
+    def open_marker_directory_after_swap(
+        repo_root: Path,
+        marker_path: Path,
+        marker_dir_stat: os.stat_result,
+    ) -> Iterator[tuple[Path, int | None]]:
+        """Replace the common Git directory after target validation."""
+        root_git_dir.rename(displaced_git_dir)
+        replacement_git_dir = root_git_dir / "worktrees" / "review-pr-2500"
+        replacement_git_dir.mkdir(parents=True)
+        (replacement_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+        (replacement_git_dir / "gitdir").write_text(
+            f"{worktree / '.git'}\n", encoding="utf-8"
+        )
+        with original_open_marker_directory(repo_root, marker_path, marker_dir_stat) as opened:
+            yield opened
+
+    monkeypatch.setattr(
+        direct_review_recovery, "_open_marker_directory", open_marker_directory_after_swap
+    )
+
+    with pytest.raises(ValueError, match="marker directory changed"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not replacement_marker.exists()
+
+
+def test_receipt_rejects_review_admin_directory_swapped_to_a_regular_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replacement linked-worktree admin directory cannot receive a marker."""
+    worktree, git_dir = _linked_worktree(tmp_path, 2500)
+    displaced_git_dir = tmp_path / "displaced-review-git"
+    replacement_marker = git_dir / "hephaestus-direct-review-recovery"
+    original_open_marker_directory = direct_review_recovery._open_marker_directory
+
+    @contextmanager
+    def open_marker_directory_after_swap(
+        repo_root: Path,
+        marker_path: Path,
+        marker_dir_stat: os.stat_result,
+    ) -> Iterator[tuple[Path, int | None]]:
+        """Replace the final admin directory after it has been validated."""
+        git_dir.rename(displaced_git_dir)
+        git_dir.mkdir()
+        (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+        (git_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+        with original_open_marker_directory(repo_root, marker_path, marker_dir_stat) as opened:
+            yield opened
+
+    monkeypatch.setattr(
+        direct_review_recovery, "_open_marker_directory", open_marker_directory_after_swap
+    )
+
+    with pytest.raises(ValueError, match="marker directory changed"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not replacement_marker.exists()
+
+
 def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> None:
     """The production linked-worktree gitdir layout remains receipt-backed."""
     worktree = _worktree(tmp_path, 2500)
@@ -368,6 +470,32 @@ def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> 
     assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == [
         worktree.resolve()
     ]
+
+
+@pytest.mark.parametrize("metadata_name", ["commondir", "gitdir"])
+def test_receipt_discovery_rejects_tampered_linked_worktree_metadata(
+    tmp_path: Path, metadata_name: str
+) -> None:
+    """A receipt never survives a forged linked-worktree metadata binding."""
+    worktree, git_dir = _linked_worktree(tmp_path, 2500)
+    record_direct_review_recovery(
+        repo_root=tmp_path,
+        issue=2500,
+        pr=2501,
+        worktree=worktree,
+        branch="2500-auto",
+        expected_remote_sha="a" * 40,
+        source_sha="b" * 40,
+    )
+
+    if metadata_name == "commondir":
+        (git_dir / metadata_name).write_text("../../forged-common\n", encoding="utf-8")
+    else:
+        (git_dir / metadata_name).write_text(
+            f"{tmp_path / 'other-worktree' / '.git'}\n", encoding="utf-8"
+        )
+
+    assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
 
 
 def test_receipt_supports_a_linked_repository_root(tmp_path: Path) -> None:

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -134,6 +134,32 @@ def test_receipt_rejects_worktree_git_metadata_outside_the_repository(tmp_path: 
     assert not (outside / "hephaestus-direct-review-recovery").exists()
 
 
+def test_receipt_rejects_a_symlinked_repository_git_metadata(tmp_path: Path) -> None:
+    """A root Git metadata symlink cannot redirect linked-worktree markers."""
+    worktree = _worktree(tmp_path, 2500)
+    shutil.rmtree(worktree / ".git")
+    outside = tmp_path.parent / "outside-common-git"
+    review_git_dir = outside / ".git" / "worktrees" / "review-pr-2500"
+    review_git_dir.mkdir(parents=True)
+    pointer = tmp_path / "root-git-pointer"
+    pointer.write_text(f"gitdir: {outside / '.git' / 'worktrees' / 'root'}\n", encoding="utf-8")
+    (tmp_path / ".git").symlink_to(pointer)
+    (worktree / ".git").write_text(f"gitdir: {review_git_dir}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="repository Git metadata is symlinked"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert not (review_git_dir / "hephaestus-direct-review-recovery").exists()
+
+
 def test_receipt_supports_and_binds_a_linked_worktree_gitdir(tmp_path: Path) -> None:
     """The production linked-worktree gitdir layout remains receipt-backed."""
     worktree = _worktree(tmp_path, 2500)

--- a/tests/unit/automation/test_direct_review_recovery.py
+++ b/tests/unit/automation/test_direct_review_recovery.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -17,6 +20,7 @@ def _worktree(repo_root: Path, issue: int) -> Path:
     """Create a direct-review checkout fixture path."""
     path = repo_root / "build" / ".worktrees" / f"review-pr-{issue}"
     path.mkdir(parents=True)
+    (path / ".git").mkdir()
     return path
 
 
@@ -86,6 +90,42 @@ def test_receipt_rejects_a_symlinked_state_directory(tmp_path: Path) -> None:
     assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []
 
 
+def test_receipt_write_does_not_follow_a_replaced_state_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A concurrent receipt-directory swap cannot redirect the atomic write."""
+    if os.name != "posix":
+        pytest.skip("descriptor-relative receipt writes require POSIX")
+    worktree = _worktree(tmp_path, 2500)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    receipt_dir = tmp_path / DEFAULT_STATE_DIR / "direct-review-recovery"
+    displaced_dir = tmp_path / "displaced-receipts"
+    original_replace = os.replace
+
+    def replace_after_swap(*args: object, **kwargs: object) -> None:
+        """Swap the pathname after descriptor acquisition and before replacement."""
+        if kwargs.get("dst_dir_fd") is not None:
+            receipt_dir.rename(displaced_dir)
+            receipt_dir.symlink_to(outside, target_is_directory=True)
+        cast(Any, original_replace)(*args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", replace_after_swap)
+
+    with pytest.raises(ValueError, match="receipt directory changed"):
+        record_direct_review_recovery(
+            repo_root=tmp_path,
+            issue=2500,
+            pr=2501,
+            worktree=worktree,
+            branch="2500-auto",
+            expected_remote_sha="a" * 40,
+            source_sha="b" * 40,
+        )
+
+    assert list(outside.iterdir()) == []
+
+
 def test_receipt_does_not_authorize_a_replacement_checkout_at_the_same_path(
     tmp_path: Path,
 ) -> None:
@@ -101,7 +141,8 @@ def test_receipt_does_not_authorize_a_replacement_checkout_at_the_same_path(
         source_sha="b" * 40,
     )
 
-    worktree.rmdir()
+    shutil.rmtree(worktree)
     worktree.mkdir()
+    (worktree / ".git").mkdir()
 
     assert list_direct_review_recovery_paths(repo_root=tmp_path, issue=2500, pr=2501) == []

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -613,6 +613,18 @@ class TestPushDetachedHead:
 
         assert "sensitive" not in str(exc_info.value)
 
+    def test_accepts_an_ambiguous_push_after_the_exact_source_was_published(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A lost transport result is not remote drift when the source is live."""
+        source_sha = "b" * 40
+        git_utils_mocks.run.side_effect = [
+            subprocess.TimeoutExpired(["git", "push"], timeout=42),
+            Mock(stdout=source_sha + "\trefs/heads/123-auto-impl\n"),
+        ]
+
+        push_head_to_branch("123-auto-impl", "a" * 40, tmp_path, source_sha=source_sha)
+
     @pytest.mark.parametrize(
         ("observed_head", "error_type"),
         [

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hephaestus.automation.git_utils import (
+    DetachedHeadPushError,
     DetachedHeadPushRemoteHeadChangedError,
     DetachedHeadPushRemoteHeadUnchangedError,
     DetachedHeadPushRemoteProbeError,
@@ -554,6 +555,25 @@ class TestPushDetachedHead:
             timeout=42,
         )
 
+    def test_pushes_the_explicit_detached_commit_with_the_reviewed_head_lease(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A bounded retry cannot follow a later detached-HEAD update."""
+        reviewed_head = "a" * 40
+        source_sha = "b" * 40
+
+        push_head_to_branch(
+            "123-auto-impl",
+            reviewed_head,
+            tmp_path,
+            source_sha=source_sha,
+            timeout=42,
+        )
+
+        assert git_utils_mocks.run.call_args.args[0][-1] == (
+            f"{source_sha}:refs/heads/123-auto-impl"
+        )
+
     def test_reports_a_detached_push_when_the_remote_head_advanced(
         self, git_utils_mocks: Any, tmp_path: Path
     ) -> None:
@@ -593,12 +613,35 @@ class TestPushDetachedHead:
 
         assert "sensitive" not in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("observed_head", "error_type"),
+        [
+            ("a" * 40, DetachedHeadPushRemoteHeadUnchangedError),
+            ("b" * 40, DetachedHeadPushRemoteHeadChangedError),
+        ],
+    )
+    def test_classifies_a_timed_out_push_from_the_authoritative_remote_head(
+        self,
+        git_utils_mocks: Any,
+        tmp_path: Path,
+        observed_head: str,
+        error_type: type[DetachedHeadPushError],
+    ) -> None:
+        """A transport timeout receives the same safe post-failure classification."""
+        git_utils_mocks.run.side_effect = [
+            subprocess.TimeoutExpired(["git", "push"], timeout=42),
+            Mock(stdout=observed_head + "\trefs/heads/123-auto-impl\n"),
+        ]
+
+        with pytest.raises(error_type):
+            push_head_to_branch("123-auto-impl", "a" * 40, tmp_path, timeout=42)
+
     def test_reports_an_unconfirmed_failure_when_the_remote_probe_fails(
         self, git_utils_mocks: Any, tmp_path: Path
     ) -> None:
         """Transport uncertainty never masquerades as a stale lease."""
         git_utils_mocks.run.side_effect = [
-            subprocess.CalledProcessError(1, ["git", "push"]),
+            subprocess.TimeoutExpired(["git", "push"], timeout=42),
             subprocess.TimeoutExpired(["git", "ls-remote"], timeout=42),
         ]
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -11,6 +11,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hephaestus.automation.git_utils import (
+    DetachedHeadPushRemoteHeadChangedError,
+    DetachedHeadPushRemoteHeadUnchangedError,
+    DetachedHeadPushRemoteProbeError,
     _commit_policy_rebase_command,
     _remove_untracked_files_tracked_by_ref,
     clear_repo_caches,
@@ -551,17 +554,55 @@ class TestPushDetachedHead:
             timeout=42,
         )
 
-    def test_rejects_a_detached_push_when_the_remote_head_advanced(
+    def test_reports_a_detached_push_when_the_remote_head_advanced(
         self, git_utils_mocks: Any, tmp_path: Path
     ) -> None:
-        """A lease rejection remains a hard failure for the coordinator."""
-        git_utils_mocks.run.side_effect = subprocess.CalledProcessError(
-            1,
-            ["git", "push"],
-            stderr="! [rejected] HEAD -> 123-auto-impl (stale info)",
-        )
+        """Only a post-failure remote read may classify a lease as stale."""
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(1, ["git", "push"]),
+            Mock(stdout=("b" * 40) + "\trefs/heads/123-auto-impl\n"),
+        ]
 
-        with pytest.raises(RuntimeError, match="Failed to publish detached HEAD"):
+        with pytest.raises(DetachedHeadPushRemoteHeadChangedError):
+            push_head_to_branch("123-auto-impl", "a" * 40, tmp_path)
+
+        assert git_utils_mocks.run.call_args_list[1].args[0] == [
+            "git",
+            "ls-remote",
+            "--refs",
+            "origin",
+            "refs/heads/123-auto-impl",
+        ]
+
+    def test_reports_an_unchanged_remote_without_logging_push_output(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A failed local hook remains retryable when the remote is unchanged."""
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(
+                1,
+                ["git", "push"],
+                stderr="sensitive pre-push hook output must not escape",
+            ),
+            Mock(stdout=pin + "\trefs/heads/123-auto-impl\n"),
+        ]
+
+        with pytest.raises(DetachedHeadPushRemoteHeadUnchangedError) as exc_info:
+            push_head_to_branch("123-auto-impl", pin, tmp_path)
+
+        assert "sensitive" not in str(exc_info.value)
+
+    def test_reports_an_unconfirmed_failure_when_the_remote_probe_fails(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """Transport uncertainty never masquerades as a stale lease."""
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(1, ["git", "push"]),
+            subprocess.TimeoutExpired(["git", "ls-remote"], timeout=42),
+        ]
+
+        with pytest.raises(DetachedHeadPushRemoteProbeError):
             push_head_to_branch("123-auto-impl", "a" * 40, tmp_path)
 
 

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -264,17 +264,60 @@ class TestWorktreeManager:
         argvs = [call.args[0] for call in worktree_mocks.run.call_args_list]
         assert ["git", "worktree", "remove", "--force", str(worktree_path)] not in argvs
 
-    def test_isolated_review_refuses_to_replace_an_existing_checkout(
+    def test_isolated_review_uses_next_available_checkout_without_replacing_a_preserved_one(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:
-        """A preserved direct-review checkout is never overwritten on a later loop."""
+        """A cold-start direct review allocates around a preserved checkout."""
         worktree_mocks.repo_root.return_value = tmp_path
         manager = WorktreeManager()
         worktree_path = manager.base_dir / "review-pr-2500"
         worktree_path.mkdir(parents=True)
 
-        with pytest.raises(
-            RuntimeError, match="refuses to replace existing isolated review worktree"
+        created = manager.create_worktree(2500, "2500-auto-impl", isolated=True)
+
+        assert created == manager.base_dir / "review-pr-2500-1"
+        assert worktree_path.exists()
+        assert all(
+            "worktree remove" not in call.args[0] for call in worktree_mocks.run.call_args_list
+        )
+
+    def test_isolated_review_skips_clean_and_dirty_preserved_checkout_generations(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A fresh manager never reuses either kind of preserved review checkout."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        clean = manager.base_dir / "review-pr-2500"
+        dirty = manager.base_dir / "review-pr-2500-1"
+        clean.mkdir(parents=True)
+        dirty.mkdir(parents=True)
+        (dirty / "uncommitted-fix").write_text("retain me")
+
+        created = manager.create_worktree(2500, "2500-auto-impl", isolated=True)
+
+        assert created == manager.base_dir / "review-pr-2500-2"
+        assert clean.exists()
+        assert (dirty / "uncommitted-fix").read_text() == "retain me"
+
+    def test_isolated_review_add_failure_never_removes_a_concurrently_created_checkout(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A failed isolated add cannot delete a competing recovery checkout."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        worktree_path = manager.base_dir / "review-pr-2500"
+
+        def concurrent_creator(path: Path, *_: Any, **__: Any) -> None:
+            path.mkdir(parents=True)
+            raise RuntimeError("another coordinator claimed the checkout")
+
+        with (
+            patch.object(
+                manager,
+                "_add_isolated_worktree_for_branch",
+                side_effect=concurrent_creator,
+            ),
+            pytest.raises(RuntimeError, match="Failed to create worktree"),
         ):
             manager.create_worktree(2500, "2500-auto-impl", isolated=True)
 

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -283,6 +283,23 @@ class TestWorktreeManager:
             "worktree remove" not in call.args[0] for call in worktree_mocks.run.call_args_list
         )
 
+    def test_isolated_review_generation_uses_a_fresh_checkout_path(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A recovery review is distinct from its preserved predecessor."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+
+        worktree_path = manager.create_worktree(
+            2500,
+            "2500-auto-impl",
+            isolated=True,
+            isolated_generation=1,
+        )
+
+        assert worktree_path == manager.base_dir / "review-pr-2500-1"
+        assert manager.worktrees["review-pr-2500-1"] == worktree_path
+
     def test_create_worktree_default_branch_name(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test worktree creation with default branch name."""
         worktree_mocks.repo_root.return_value = tmp_path

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -299,7 +299,7 @@ class TestWorktreeManager:
         assert clean.exists()
         assert (dirty / "uncommitted-fix").read_text() == "retain me"
 
-    def test_isolated_review_skips_a_registered_missing_checkout_and_reports_it(
+    def test_isolated_review_skips_a_registered_missing_checkout(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:
         """A cold-start recovery does not collide with a prunable Git worktree."""
@@ -311,7 +311,6 @@ class TestWorktreeManager:
             created = manager.create_worktree(2500, "2500-auto-impl", isolated=True)
 
         assert created == manager.base_dir / "review-pr-2500-1"
-        assert manager.last_isolated_recovery_paths == [registered]
         assert all(
             "worktree remove" not in call.args[0] and "worktree prune" not in call.args[0]
             for call in worktree_mocks.run.call_args_list

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -264,6 +264,25 @@ class TestWorktreeManager:
         argvs = [call.args[0] for call in worktree_mocks.run.call_args_list]
         assert ["git", "worktree", "remove", "--force", str(worktree_path)] not in argvs
 
+    def test_isolated_review_refuses_to_replace_an_existing_checkout(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A preserved direct-review checkout is never overwritten on a later loop."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        worktree_path = manager.base_dir / "review-pr-2500"
+        worktree_path.mkdir(parents=True)
+
+        with pytest.raises(
+            RuntimeError, match="refuses to replace existing isolated review worktree"
+        ):
+            manager.create_worktree(2500, "2500-auto-impl", isolated=True)
+
+        assert worktree_path.exists()
+        assert all(
+            "worktree remove" not in call.args[0] for call in worktree_mocks.run.call_args_list
+        )
+
     def test_create_worktree_default_branch_name(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test worktree creation with default branch name."""
         worktree_mocks.repo_root.return_value = tmp_path

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -299,6 +299,24 @@ class TestWorktreeManager:
         assert clean.exists()
         assert (dirty / "uncommitted-fix").read_text() == "retain me"
 
+    def test_isolated_review_skips_a_registered_missing_checkout_and_reports_it(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A cold-start recovery does not collide with a prunable Git worktree."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        registered = manager.base_dir / "review-pr-2500"
+
+        with patch.object(manager, "list_worktrees", return_value=[{"path": str(registered)}]):
+            created = manager.create_worktree(2500, "2500-auto-impl", isolated=True)
+
+        assert created == manager.base_dir / "review-pr-2500-1"
+        assert manager.last_isolated_recovery_paths == [registered]
+        assert all(
+            "worktree remove" not in call.args[0] and "worktree prune" not in call.args[0]
+            for call in worktree_mocks.run.call_args_list
+        )
+
     def test_isolated_review_add_failure_never_removes_a_concurrently_created_checkout(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:


### PR DESCRIPTION
## Summary

- classify failed detached review pushes with a fresh authoritative remote-head read
- retry one unchanged-remote failure without re-invoking the address agent
- preserve the detached checkout for changed or unconfirmed remote state and refuse destructive reuse

## Verification

- uv run --all-extras --locked pytest -q
- uv run ruff check …
- uv run mypy …

Closes #2500