### PR TITLE
fix(automation): resolve relative project roots

### DIFF
--- a/hephaestus/config/paths.py
+++ b/hephaestus/config/paths.py
@@ -94,7 +94,7 @@ def resolve_projects_dir(
 
     """
     if override is not None:
-        return Path(override)
+        return Path(override).resolve()
 
     env = os.environ.get("PROJECTS_ROOT")
     key: tuple[str | None, str | None] = (override, env)
@@ -102,7 +102,7 @@ def resolve_projects_dir(
     if env:
         env_path = Path(env)
         if env_path.is_dir():
-            return env_path
+            return env_path.resolve()
         if key not in _warned_keys:
             logger.warning(
                 "PROJECTS_ROOT=%s does not exist; falling back to %s",

--- a/tests/unit/config/test_paths.py
+++ b/tests/unit/config/test_paths.py
@@ -43,6 +43,33 @@ def test_override_takes_priority_no_warning(
     assert caplog.records == []
 
 
+def test_relative_override_is_resolved_from_the_invocation_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A relative CLI projects root cannot leak into Git worktree commands."""
+    monkeypatch.chdir(tmp_path)
+
+    result = resolve_projects_dir("loop-validation")
+
+    assert result == tmp_path / "loop-validation"
+    assert result.is_absolute()
+
+
+def test_relative_projects_root_environment_value_is_resolved_from_the_invocation_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A relative environment override cannot leak into Git worktree commands."""
+    projects_dir = tmp_path / "loop-validation"
+    projects_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PROJECTS_ROOT", "loop-validation")
+
+    result = resolve_projects_dir()
+
+    assert result == projects_dir
+    assert result.is_absolute()
+
+
 def test_env_var_used_when_dir_exists_no_warning(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Summary:
- normalize explicit relative projects roots before automation creates worktrees
- cover both the CLI override and PROJECTS_ROOT environment paths

Closes #2502
