### PR TITLE
fix(lint): normalize union annotations

### DIFF
--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -86,7 +86,7 @@ class VersionManager:
         repo_root: Path | None = None,
         version_files: list[Path] | None = None,
         init_files: list[Path] | None = None,
-        pyproject_file: Path | None | _UnsetType = _UNSET,
+        pyproject_file: Path | _UnsetType | None = _UNSET,
     ):
         """Initialize the version manager.
 

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -74,7 +74,7 @@ class FakeStageGitHub(FakeGitHub):
         pr_impl_readbacks: list[tuple[bool, bool] | Exception] | None = None,
         unresolved: list[tuple[int, int]] | None = None,
         by_severity: list[tuple[int, int, int]] | None = None,
-        pr_state: dict[str, Any] | None | _DefaultPrState = _DEFAULT_PR_STATE,
+        pr_state: dict[str, Any] | _DefaultPrState | None = _DEFAULT_PR_STATE,
         conversation_resolution: bool = True,
         pr_review_context: dict[str, str] | None = None,
         learn_terminal: bool = False,


### PR DESCRIPTION
## Summary

Normalize two union annotations required by Ruff 0.16 without changing behavior.

## Changes

- Place `None` last in the pipeline PR-state fixture union.
- Place `None` last in the version-manager sentinel union.

## Testing

- `uv run ruff check tests/unit/automation/pipeline/stages/conftest.py hephaestus/version/manager.py`
- `uv run pytest tests/unit/version/test_manager.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py -v --override-ini=addopts=`
- `uv run pre-commit run --files tests/unit/automation/pipeline/stages/conftest.py hephaestus/version/manager.py`
- Enforced full local pre-push suite

Closes #2505
