### PR TITLE
[Fix] Enforce scope retractions before publish

### DIFF
--- a/hephaestus/automation/pipeline/scope_retraction.py
+++ b/hephaestus/automation/pipeline/scope_retraction.py
@@ -1,0 +1,78 @@
+"""Validated scope-retraction metadata shared by PR review and publication."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import PurePosixPath
+from typing import TypeGuard
+
+SCOPE_RETRACTION_MARKER_PREFIX = "<!-- hephaestus-scope-retraction-paths:"
+_SCOPE_ACTION_RE = re.compile(r"\b(?:drop|remove|split)\b", re.IGNORECASE)
+_SCOPE_BOUNDARY_RE = re.compile(r"\b(?:unrelated|out[\s-]*of[\s-]*scope)\b", re.IGNORECASE)
+
+
+def is_scope_retraction_finding(body: object) -> TypeGuard[str]:
+    """Return whether a finding explicitly requests removal for scope reasons."""
+    return bool(
+        isinstance(body, str) and _SCOPE_ACTION_RE.search(body) and _SCOPE_BOUNDARY_RE.search(body)
+    )
+
+
+def is_safe_scope_retraction_path(path: object) -> TypeGuard[str]:
+    """Return whether a path is safe as both a Git pathspec and prompt datum."""
+    if (
+        not isinstance(path, str)
+        or not path
+        or path == "."
+        or path.startswith(("/", "./", ":"))
+        or "\\" in path
+        or "`" in path
+        or any(ord(character) < 32 or ord(character) == 127 for character in path)
+    ):
+        return False
+    pure_path = PurePosixPath(path)
+    return (
+        not pure_path.is_absolute() and "." not in pure_path.parts and ".." not in pure_path.parts
+    )
+
+
+def normalize_scope_retraction_paths(value: object) -> tuple[str, ...] | None:
+    """Validate a non-empty complete manifest and return a stable tuple."""
+    if not isinstance(value, (list, tuple)) or not value:
+        return None
+    if not all(is_safe_scope_retraction_path(path) for path in value):
+        return None
+    return tuple(sorted(set(value)))
+
+
+def scope_retraction_marker(paths: tuple[str, ...]) -> str:
+    """Serialize validated paths into the durable review-comment marker."""
+    normalized = normalize_scope_retraction_paths(paths)
+    if normalized is None:
+        raise ValueError("scope retraction paths must be a safe non-empty manifest")
+    return f"{SCOPE_RETRACTION_MARKER_PREFIX} {json.dumps(normalized)} -->"
+
+
+def scope_retraction_paths_from_body(body: object) -> tuple[str, ...] | None:
+    """Read a complete manifest from an explicit scope-retraction finding.
+
+    ``()`` means the finding is ordinary remediation. ``None`` means the
+    finding requested a scope retraction but lacks a valid complete manifest,
+    which must stop publication rather than guess which files to preserve.
+    """
+    if not is_scope_retraction_finding(body):
+        return ()
+    if not isinstance(body, str):
+        return None
+    marker_payloads = [
+        line.strip()[len(SCOPE_RETRACTION_MARKER_PREFIX) : -3].strip()
+        for line in body.splitlines()
+        if line.strip().startswith(SCOPE_RETRACTION_MARKER_PREFIX) and line.strip().endswith("-->")
+    ]
+    if len(marker_payloads) != 1:
+        return None
+    try:
+        return normalize_scope_retraction_paths(json.loads(marker_payloads[0]))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -108,8 +108,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import PurePosixPath
-from typing import Any, TypeGuard, cast
+from typing import Any, cast
 
 from hephaestus.automation.agent_config import (
     address_review_claude_timeout,
@@ -141,6 +140,10 @@ from hephaestus.automation.session_naming import (
 )
 from hephaestus.automation.state_labels import STATE_SKIP
 
+from ..scope_retraction import (
+    is_safe_scope_retraction_path,
+    scope_retraction_paths_from_body,
+)
 from ..work_item import ItemKind
 from .base import (
     GIT_JOB_TIMEOUT_S,
@@ -171,39 +174,22 @@ _JSON_RESPONSE_BLOCK_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
-_SCOPE_RETRACTION_BODY_RE = re.compile(
-    r"\b(?:unrelated|out[\s-]*of[\s-]*scope)\b.*\b(?:split|remove)\b",
-    re.IGNORECASE | re.DOTALL,
-)
-
-
-def _is_safe_scope_retraction_path(path: object) -> TypeGuard[str]:
-    """Return whether a review-thread path is safe for a git pathspec."""
-    if (
-        not isinstance(path, str)
-        or not path
-        or path == "."
-        or path.startswith(("/", "./"))
-        or "\\" in path
-    ):
-        return False
-    pure_path = PurePosixPath(path)
-    return (
-        not pure_path.is_absolute() and "." not in pure_path.parts and ".." not in pure_path.parts
-    )
-
 
 def _scope_retraction_paths(threads: list[dict[str, Any]]) -> tuple[str, ...] | None:
     """Extract host-enforced retractions from explicit scope-control findings."""
     paths: set[str] = set()
     for thread in threads:
-        body = str(thread.get("body") or "")
-        if not _SCOPE_RETRACTION_BODY_RE.search(body):
+        scope_paths = scope_retraction_paths_from_body(thread.get("body"))
+        if scope_paths == ():
             continue
         path = thread.get("path")
-        if not _is_safe_scope_retraction_path(path):
+        if (
+            scope_paths is None
+            or not is_safe_scope_retraction_path(path)
+            or path not in scope_paths
+        ):
             return None
-        paths.add(path)
+        paths.update(scope_paths)
     return tuple(sorted(paths))
 
 
@@ -1181,7 +1167,7 @@ class PrReviewStage(Stage):
         scope_retraction_paths = item.payload.get("scope_retraction_paths")
         if scope_retraction_paths is not None:
             if not isinstance(scope_retraction_paths, tuple) or not all(
-                _is_safe_scope_retraction_path(path) for path in scope_retraction_paths
+                is_safe_scope_retraction_path(path) for path in scope_retraction_paths
             ):
                 return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_path_invalid")
             base_sha = item.payload.get("reviewed_pr_base_sha")

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -108,7 +108,8 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from pathlib import PurePosixPath
+from typing import Any, TypeGuard, cast
 
 from hephaestus.automation.agent_config import (
     address_review_claude_timeout,
@@ -169,6 +170,41 @@ _JSON_RESPONSE_BLOCK_RE = re.compile(
     r"^[ \t]*```json[ \t]*\r?\n(.*?)\r?\n^[ \t]*```[ \t]*$",
     re.DOTALL | re.MULTILINE,
 )
+
+_SCOPE_RETRACTION_BODY_RE = re.compile(
+    r"\b(?:unrelated|out[\s-]*of[\s-]*scope)\b.*\b(?:split|remove)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _is_safe_scope_retraction_path(path: object) -> TypeGuard[str]:
+    """Return whether a review-thread path is safe for a git pathspec."""
+    if (
+        not isinstance(path, str)
+        or not path
+        or path == "."
+        or path.startswith(("/", "./"))
+        or "\\" in path
+    ):
+        return False
+    pure_path = PurePosixPath(path)
+    return (
+        not pure_path.is_absolute() and "." not in pure_path.parts and ".." not in pure_path.parts
+    )
+
+
+def _scope_retraction_paths(threads: list[dict[str, Any]]) -> tuple[str, ...] | None:
+    """Extract host-enforced retractions from explicit scope-control findings."""
+    paths: set[str] = set()
+    for thread in threads:
+        body = str(thread.get("body") or "")
+        if not _SCOPE_RETRACTION_BODY_RE.search(body):
+            continue
+        path = thread.get("path")
+        if not _is_safe_scope_retraction_path(path):
+            return None
+        paths.add(path)
+    return tuple(sorted(paths))
 
 
 @dataclass(frozen=True)
@@ -268,6 +304,8 @@ _ROUND_PAYLOAD_KEYS = (
     "review_refresh_required",
     "prior_comments_json",
     "validation_process_threads",
+    "scope_retraction_paths",
+    "reviewed_pr_base_sha",
 )
 
 
@@ -1140,6 +1178,17 @@ class PrReviewStage(Stage):
                         Disposition.FINISH_FAIL, "detached_push_retry_receipt_invalid"
                     )
                 kwargs["detached_push_retry_head_sha"] = retry_head_sha
+        scope_retraction_paths = item.payload.get("scope_retraction_paths")
+        if scope_retraction_paths is not None:
+            if not isinstance(scope_retraction_paths, tuple) or not all(
+                _is_safe_scope_retraction_path(path) for path in scope_retraction_paths
+            ):
+                return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_path_invalid")
+            base_sha = item.payload.get("reviewed_pr_base_sha")
+            if not is_full_commit_sha(base_sha):
+                return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_base_unavailable")
+            kwargs["scope_retraction_paths"] = scope_retraction_paths
+            kwargs["scope_retraction_base_sha"] = base_sha
         git_job = GitJob(
             repo=item.repo,
             op="commit_push",
@@ -1252,11 +1301,14 @@ class PrReviewStage(Stage):
         value = result.value
         ready = bool(isinstance(value, dict) and value.get("ready"))
         review_diff = value.get("diff") if isinstance(value, dict) else None
+        review_base = value.get("base") if isinstance(value, dict) else None
         if ready and not isinstance(review_diff, str):
             item.payload["review_checkout_error"] = "checkout job returned no bound diff"
             ready = False
         if ready:
             item.payload["pr_diff"] = review_diff
+            if is_full_commit_sha(review_base):
+                item.payload["reviewed_pr_base_sha"] = review_base
         item.payload["review_checkout_ready"] = ready
         return True
 
@@ -1318,6 +1370,9 @@ class PrReviewStage(Stage):
             item.payload["review_failed"] = True
         elif item.state == PUSH_WAIT:
             receipt = result.value if isinstance(result.value, dict) else {}
+            if receipt.get("scope_retraction_failure") is True:
+                item.payload["scope_retraction_failure"] = True
+                return
             failure = receipt.get("detached_push_failure")
             if failure in {
                 "remote_changed",
@@ -1580,6 +1635,29 @@ class PrReviewStage(Stage):
             )
             return self._fail_back_agent_error(item)
         if item.payload.get("existing_pr"):
+            remediation_threads = item.payload.get("remediation_threads") or []
+            if not isinstance(remediation_threads, list):
+                return StageOutcome(Disposition.FINISH_FAIL, "remediation_threads_invalid")
+            scope_retraction_paths = _scope_retraction_paths(remediation_threads)
+            if scope_retraction_paths is None:
+                return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_path_invalid")
+            if scope_retraction_paths:
+                base_sha = item.payload.get("reviewed_pr_base_sha")
+                if not is_full_commit_sha(base_sha):
+                    return StageOutcome(
+                        Disposition.FINISH_FAIL,
+                        "scope_retraction_base_unavailable",
+                    )
+                item.payload["scope_retraction_paths"] = scope_retraction_paths
+            else:
+                item.payload.pop("scope_retraction_paths", None)
+            task_parts = [
+                f"Linked issue #{item.issue}: {item.payload.get('issue_title', '')}".strip(),
+                str(item.payload.get("issue_body", "")),
+            ]
+            pr_description = str(item.payload.get("pr_description", ""))
+            if pr_description:
+                task_parts.append(f"PR description:\n{pr_description}")
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue if item.issue is not None else 0,
@@ -1596,6 +1674,9 @@ class PrReviewStage(Stage):
                     "worktree_path": item.worktree,
                     "threads_json": json.dumps(item.payload.get("remediation_threads", [])),
                     "todo_block": item.payload.get("difficulty_tiers", ""),
+                    "task_block": "\n\n".join(part for part in task_parts if part),
+                    "diff_text": str(item.payload.get("pr_diff", "")),
+                    "scope_retraction_paths": scope_retraction_paths or (),
                     # No-commit retry directive (#1575): non-empty ONLY on
                     # the one retry after a no-commit address turn;
                     # get_address_review_prompt renders it via
@@ -1655,6 +1736,13 @@ class PrReviewStage(Stage):
         if item.issue is None:  # guarded by step(); kept for type narrowing
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         payload = item.payload
+
+        if payload.pop("scope_retraction_failure", False):
+            logger.warning(
+                "pr_review:%d: refusing to publish incomplete scope retraction",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_incomplete")
 
         detached_push_failure = payload.pop("detached_push_failure", None)
         if detached_push_failure == "remote_unchanged":

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1515,7 +1515,63 @@ class WorkerPool:
             )
             if status.stdout.strip():
                 return JobResult(ok=False, error="commit_push left uncommitted changes")
+        scope_retraction = self._verify_scope_retraction(job, Path(worktree_path))
+        if scope_retraction is not None:
+            return scope_retraction
         return self._publish_commit_push(job, branch, Path(worktree_path))
+
+    @staticmethod
+    def _verify_scope_retraction(job: GitJob, worktree_path: Path) -> JobResult | None:
+        """Reject publication unless host-designated paths match the reviewed base.
+
+        The coordinator derives these paths only from validated scope-control
+        review findings. Re-check their shape here before using them as Git
+        pathspecs, then compare the exact post-commit ``HEAD`` with the base
+        from the review checkout barrier. A failed check remains local-only.
+        """
+        paths = job.kwargs.get("scope_retraction_paths")
+        if paths is None:
+            return None
+        base_sha = job.kwargs.get("scope_retraction_base_sha")
+        if (
+            not _is_full_commit_sha(base_sha)
+            or not isinstance(paths, tuple)
+            or not paths
+            or not all(
+                isinstance(path, str)
+                and bool(path)
+                and path != "."
+                and not path.startswith(("/", "./"))
+                and "\\" not in path
+                and ".." not in Path(path).parts
+                for path in paths
+            )
+        ):
+            return JobResult(
+                ok=False,
+                value={"scope_retraction_failure": True},
+                error="scope retraction verification unavailable",
+            )
+        try:
+            result = git_utils.run(
+                ["git", "diff", "--name-only", f"{base_sha}...HEAD", "--", *paths],
+                cwd=worktree_path,
+                capture_output=True,
+                timeout=job.timeout_s,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return JobResult(
+                ok=False,
+                value={"scope_retraction_failure": True},
+                error="scope retraction verification unavailable",
+            )
+        if str(result.stdout or "").strip():
+            return JobResult(
+                ok=False,
+                value={"scope_retraction_failure": True},
+                error="scope retraction incomplete",
+            )
+        return None
 
     def _publish_commit_push(self, job: GitJob, branch: str, worktree_path: Path) -> JobResult:
         """Publish a newly created commit through the configured branch mode."""

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -39,6 +39,7 @@ from hephaestus.automation.pipeline.jobs import (
 )
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.scope_retraction import is_safe_scope_retraction_path
 from hephaestus.automation.pipeline.tool_scopes import (
     DEFAULT_TOOL_SCOPE,
     ToolScope,
@@ -1538,13 +1539,7 @@ class WorkerPool:
             or not isinstance(paths, tuple)
             or not paths
             or not all(
-                isinstance(path, str)
-                and bool(path)
-                and path != "."
-                and not path.startswith(("/", "./"))
-                and "\\" not in path
-                and ".." not in Path(path).parts
-                for path in paths
+                isinstance(path, str) and is_safe_scope_retraction_path(path) for path in paths
             )
         ):
             return JobResult(
@@ -1554,7 +1549,16 @@ class WorkerPool:
             )
         try:
             result = git_utils.run(
-                ["git", "diff", "--name-only", f"{base_sha}...HEAD", "--", *paths],
+                [
+                    "git",
+                    "--literal-pathspecs",
+                    "diff",
+                    "--name-only",
+                    base_sha,
+                    "HEAD",
+                    "--",
+                    *paths,
+                ],
                 cwd=worktree_path,
                 capture_output=True,
                 timeout=job.timeout_s,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -43,6 +43,11 @@ from hephaestus.automation.arming_state import (
     ArmingStateStore,
 )
 from hephaestus.automation.git_utils import issue_auto_impl_branch_name
+from hephaestus.automation.pipeline.scope_retraction import (
+    SCOPE_RETRACTION_MARKER_PREFIX,
+    normalize_scope_retraction_paths,
+    scope_retraction_marker,
+)
 from hephaestus.automation.pipeline.stages.base import (
     ConditionalMergeResult,
     ProcessThreadResolutionResult,
@@ -189,9 +194,15 @@ def _with_severity_marker(comment: dict[str, Any]) -> str:
         line
         for line in body.splitlines()
         if not line.strip().startswith(SEVERITY_MARKER_PREFIX)
+        and not line.strip().startswith(SCOPE_RETRACTION_MARKER_PREFIX)
         and not _STANDALONE_VERDICT_LINE_RE.match(line)
     )
-    return f"{SEVERITY_MARKER_PREFIX} {sev} -->\n{body}"
+    paths = normalize_scope_retraction_paths(comment.get("scope_retraction_paths"))
+    markers = [f"{SEVERITY_MARKER_PREFIX} {sev} -->"]
+    if paths:
+        markers.append(scope_retraction_marker(paths))
+    markers.append(body)
+    return "\n".join(markers)
 
 
 def _thread_severity_is_blocking(thread: dict[str, Any]) -> bool:

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -56,7 +56,11 @@ from ._shared import (
     get_terse_output_directive as get_terse_output_directive,
     get_untrusted_notice as get_untrusted_notice,
 )
-from .address_review import build_unaddressed_directive, get_address_review_prompt
+from .address_review import (
+    build_scope_retraction_directive,
+    build_unaddressed_directive,
+    get_address_review_prompt,
+)
 from .advise import (
     get_advise_prompt,
     get_advise_prompt_builder,
@@ -144,6 +148,7 @@ __all__ = [
     "PLAN_REVIEW_PROMPT",
     "PR_REVIEW_ANALYSIS_PROMPT",
     "FencedContent",
+    "build_scope_retraction_directive",
     "build_unaddressed_directive",
     "fence_content",
     "get_address_review_prompt",

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -1,12 +1,13 @@
 """Address-review prompt: apply fixes for unresolved PR review threads."""
 
+import json
 from typing import Any
 
 from ._shared import _fence_untrusted, fence_content, get_terse_output_directive
 from .catalog import PromptCatalog
 
 
-def build_scope_retraction_directive(paths: tuple[str, ...]) -> str:
+def build_scope_retraction_directive(paths: tuple[str, ...], nonce: str) -> str:
     """Render host-derived paths that must be restored to the reviewed base.
 
     A scope-control review finding is different from an ordinary code defect:
@@ -16,10 +17,10 @@ def build_scope_retraction_directive(paths: tuple[str, ...]) -> str:
     """
     if not paths:
         return ""
-    rendered_paths = "\n".join(f"- restore `{path}` to the reviewed base" for path in paths)
+    rendered_paths = _fence_untrusted("SCOPE_RETRACTION_PATHS", json.dumps(paths), nonce)
     return (
         "**Host publication guard — required scope retraction:**\n"
-        "A review finding identified the following change as out of scope. "
+        "A review finding identified the path data below as out of scope. "
         "Remove it rather than repairing, refactoring, or retaining any part of it. "
         "The coordinator will refuse to publish while any listed path differs from "
         "the reviewed base.\n"
@@ -160,6 +161,8 @@ def get_address_review_prompt(
             unaddressed_findings or [],
             fenced.nonce,
         ),
-        scope_retraction_directive=build_scope_retraction_directive(scope_retraction_paths),
+        scope_retraction_directive=build_scope_retraction_directive(
+            scope_retraction_paths, fenced.nonce
+        ),
         terse_output_directive=get_terse_output_directive(),
     )

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -6,6 +6,27 @@ from ._shared import _fence_untrusted, fence_content, get_terse_output_directive
 from .catalog import PromptCatalog
 
 
+def build_scope_retraction_directive(paths: tuple[str, ...]) -> str:
+    """Render host-derived paths that must be restored to the reviewed base.
+
+    A scope-control review finding is different from an ordinary code defect:
+    the correct remediation is to remove the out-of-scope change, not to
+    improve it. WorkerPool independently verifies the retraction before it
+    can publish a commit.
+    """
+    if not paths:
+        return ""
+    rendered_paths = "\n".join(f"- restore `{path}` to the reviewed base" for path in paths)
+    return (
+        "**Host publication guard — required scope retraction:**\n"
+        "A review finding identified the following change as out of scope. "
+        "Remove it rather than repairing, refactoring, or retaining any part of it. "
+        "The coordinator will refuse to publish while any listed path differs from "
+        "the reviewed base.\n"
+        f"{rendered_paths}\n"
+    )
+
+
 def build_unaddressed_directive(threads: list[dict[str, Any]], nonce: str) -> str:
     """Render a "Make sure to handle <finding>" directive from unresolved threads.
 
@@ -85,6 +106,7 @@ def get_address_review_prompt(
     task_review_block: str = "",
     diff_text: str = "",
     unaddressed_findings: list[dict[str, Any]] | None = None,
+    scope_retraction_paths: tuple[str, ...] = (),
 ) -> str:
     """Get the address review prompt for fixing inline review thread feedback.
 
@@ -138,5 +160,6 @@ def get_address_review_prompt(
             unaddressed_findings or [],
             fenced.nonce,
         ),
+        scope_retraction_directive=build_scope_retraction_directive(scope_retraction_paths),
         terse_output_directive=get_terse_output_directive(),
     )

--- a/hephaestus/automation/review_audit.py
+++ b/hephaestus/automation/review_audit.py
@@ -147,15 +147,20 @@ def _normalize_finding(comment: object) -> dict[str, object] | None:
         paths = normalize_scope_retraction_paths(scope_retraction_paths)
         if paths is None:
             return None
+        # A scope retraction is a publication-safety boundary, not advisory
+        # review prose. Host-normalize it to blocking before POST filters
+        # minor/nitpick comments out of the remediation path.
+        normalized_severity = "major"
     elif scope_retraction_paths is not None:
         return None
     else:
         paths = ()
+        normalized_severity = severity.lower()
     finding: dict[str, object] = {
         "path": path.strip(),
         "line": line,
         "side": "RIGHT",
-        "severity": severity.lower(),
+        "severity": normalized_severity,
         "body": body.strip(),
     }
     if paths:

--- a/hephaestus/automation/review_audit.py
+++ b/hephaestus/automation/review_audit.py
@@ -13,6 +13,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from html import escape
 
+from hephaestus.automation.pipeline.scope_retraction import (
+    SCOPE_RETRACTION_MARKER_PREFIX,
+    is_scope_retraction_finding,
+    normalize_scope_retraction_paths,
+)
+
 _JSON_BLOCK_RE = re.compile(
     r"^[ \t]*```json[ \t]*\r?\n(.*?)\r?\n^[ \t]*```[ \t]*$",
     re.DOTALL | re.MULTILINE | re.IGNORECASE,
@@ -136,18 +142,34 @@ def _normalize_finding(comment: object) -> dict[str, object] | None:
         or has_reserved_finding_control(body)
     ):
         return None
-    return {
+    scope_retraction_paths = comment.get("scope_retraction_paths")
+    if is_scope_retraction_finding(body):
+        paths = normalize_scope_retraction_paths(scope_retraction_paths)
+        if paths is None:
+            return None
+    elif scope_retraction_paths is not None:
+        return None
+    else:
+        paths = ()
+    finding: dict[str, object] = {
         "path": path.strip(),
         "line": line,
         "side": "RIGHT",
         "severity": severity.lower(),
         "body": body.strip(),
     }
+    if paths:
+        finding["scope_retraction_paths"] = paths
+    return finding
 
 
 def has_reserved_finding_control(body: str) -> bool:
     """Return whether a finding body contains a pipeline-owned control."""
-    return bool(_SEVERITY_MARKER_RE.search(body) or _RESERVED_AUTHORITY_CLAIM_RE.search(body))
+    return bool(
+        _SEVERITY_MARKER_RE.search(body)
+        or SCOPE_RETRACTION_MARKER_PREFIX in body
+        or _RESERVED_AUTHORITY_CLAIM_RE.search(body)
+    )
 
 
 def _sanitize_summary(summary: str) -> str:

--- a/hephaestus/prompts/templates/default/address_review/address_review.j2
+++ b/hephaestus/prompts/templates/default/address_review/address_review.j2
@@ -15,6 +15,7 @@ thread remains a human gate.
 
 {{ untrusted_notice }}
 {{ context_block }}
+{{ scope_retraction_directive }}
 {{ retry_directive_block }}
 **Review Threads to Address (untrusted):**
 {{ threads_json_block }}

--- a/hephaestus/prompts/templates/default/pr_review/analysis.j2
+++ b/hephaestus/prompts/templates/default/pr_review/analysis.j2
@@ -76,8 +76,13 @@ Rules for the JSON block:
   - `path`: file path relative to repo root (string)
   - `line`: line number in the file (integer, must be a changed line in the diff)
   - `side`: always `"RIGHT"` for new code
-  - `severity`: one of `"critical"`, `"major"`, `"minor"`, `"nitpick"` (see above)
-  - `body`: the review comment text (string)
+- `severity`: one of `"critical"`, `"major"`, `"minor"`, `"nitpick"` (see above)
+- `body`: the review comment text (string)
+- `scope_retraction_paths`: REQUIRED only when the body asks to drop, remove,
+  or split a change because it is unrelated or out of scope. It must be a
+  complete non-empty list of every repo-relative path that must be restored to
+  the reviewed base, including this comment's `path`. Do not include this
+  control data in `body`; the coordinator validates and persists it separately.
 - `grade`: one of `A`, `B`, `C`, `D`, `E`, or `F`.
 - `summary`: bounded informational review summary, max 200 characters.
 - If there are no inline comments, emit `{"grade": "A", "summary": "LGTM", "comments": []}`.

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -946,6 +946,77 @@ class TestPrReviewStageStep:
             {"thread_id": "t1", "path": "x.py", "line": 1, "body": "fix"}
         ]
 
+    def test_address_existing_pr_binds_scope_retraction_to_verified_base(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An out-of-scope finding must retract its path rather than repair it."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2137, pr=2346, state="ADDRESS_WAIT")
+        item.worktree = "/tmp/wt"
+        item.payload.update(
+            {
+                "existing_pr": True,
+                "issue_title": "Reduce volatile operational claims",
+                "issue_body": "Define maintained sources for normative docs.",
+                "pr_description": "Closes #2137",
+                "pr_diff": (
+                    "diff --git a/hephaestus/agents/runtime.py b/hephaestus/agents/runtime.py"
+                ),
+                "reviewed_pr_base_sha": "a" * 40,
+                "remediation_threads": [
+                    {
+                        "thread_id": "scope-1",
+                        "path": "hephaestus/agents/runtime.py",
+                        "line": 391,
+                        "body": (
+                            "This feature is unrelated to issue #2137's documentation scope. "
+                            "Split it into a separately justified PR."
+                        ),
+                    }
+                ],
+                "difficulty_tiers": "@ runtime.py Line 391 - hard - split scope",
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.prompt_kwargs["scope_retraction_paths"] == (
+            "hephaestus/agents/runtime.py",
+        )
+        assert "Reduce volatile operational claims" in result.job.prompt_kwargs["task_block"]
+        assert result.job.prompt_kwargs["diff_text"] == item.payload["pr_diff"]
+        assert item.payload["scope_retraction_paths"] == ("hephaestus/agents/runtime.py",)
+
+    def test_address_existing_pr_rejects_unsafe_scope_retraction_path(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A scope comment must never turn the repository root into a pathspec."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2137, pr=2346, state="ADDRESS_WAIT")
+        item.worktree = "/tmp/wt"
+        item.payload.update(
+            {
+                "existing_pr": True,
+                "remediation_threads": [
+                    {
+                        "thread_id": "scope-1",
+                        "path": ".",
+                        "line": 1,
+                        "body": "This is unrelated to the issue scope; remove it.",
+                    }
+                ],
+            }
+        )
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL,
+            "scope_retraction_path_invalid",
+        )
+
     def test_push_wait_requests_commit_push(self, make_ctx: Any, make_work_item: Any) -> None:
         """PUSH_WAIT submits the commit+push job for the addressing changes."""
         stage = PrReviewStage()
@@ -991,6 +1062,31 @@ class TestPrReviewStageStep:
         assert isinstance(result.job, GitJob)
         assert result.job.kwargs["publish_detached_head"] is True
         assert result.job.kwargs["expected_remote_sha"] == "a" * 40
+
+    def test_push_wait_binds_scope_retraction_to_reviewed_base(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The worker must verify a scope cleanup before publishing it."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2137, pr=2346, state="PUSH_WAIT")
+        item.branch = "2137-auto-impl"
+        item.worktree = "/tmp/review-pr"
+        item.payload.update(
+            {
+                "direct_pr_worktree": "/tmp/review-pr",
+                "reviewed_pr_head_sha": "b" * 40,
+                "reviewed_pr_base_sha": "a" * 40,
+                "scope_retraction_paths": ("hephaestus/agents/runtime.py",),
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs["scope_retraction_base_sha"] == "a" * 40
+        assert result.job.kwargs["scope_retraction_paths"] == ("hephaestus/agents/runtime.py",)
 
     def test_address_refuses_fork_head_without_base_origin_write(
         self, make_ctx: Any, make_work_item: Any
@@ -1838,6 +1934,21 @@ class TestEvalVerdicts:
 
         assert result == StageOutcome(Disposition.RETRY, "review audit format failure")
         assert not any(name == "mark_pr_implementation_go" for name, _ in github.mutation_log)
+
+    def test_incomplete_scope_retraction_finishes_without_a_label_mutation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A locally rejected address commit never becomes an approval or push retry."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2137, pr=2346, state="EVAL")
+        item.payload["scope_retraction_failure"] = True
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_incomplete")
+        assert github.mutation_log == []
 
     def test_legacy_audit_payload_key_cannot_authorize_clean_pr(
         self, make_ctx: Any, make_work_item: Any
@@ -3097,6 +3208,27 @@ class TestPrReviewOnJobDone:
         item.state = "PUSH_WAIT"
         stage.on_job_done(item, JobResult(ok=False, error="push rejected"), ctx)
         assert item.payload["address_error"] is True
+
+    def test_scope_retraction_publish_failure_is_not_an_address_agent_failure(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The terminal safety outcome must not re-adopt and retry an unsafe draft."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2137, pr=2346, state="PUSH_WAIT")
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={"scope_retraction_failure": True},
+                error="scope retraction incomplete",
+            ),
+            ctx,
+        )
+
+        assert item.payload["scope_retraction_failure"] is True
+        assert "address_error" not in item.payload
 
 
 class TestFullWalks:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -970,6 +970,9 @@ class TestPrReviewStageStep:
                         "path": "hephaestus/agents/runtime.py",
                         "line": 391,
                         "body": (
+                            "<!-- hephaestus-scope-retraction-paths: "
+                            '["hephaestus/agents/runtime.py", '
+                            '"hephaestus/agents/model_help.py"] -->\n'
                             "This feature is unrelated to issue #2137's documentation scope. "
                             "Split it into a separately justified PR."
                         ),
@@ -984,11 +987,42 @@ class TestPrReviewStageStep:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
         assert result.job.prompt_kwargs["scope_retraction_paths"] == (
+            "hephaestus/agents/model_help.py",
             "hephaestus/agents/runtime.py",
         )
         assert "Reduce volatile operational claims" in result.job.prompt_kwargs["task_block"]
         assert result.job.prompt_kwargs["diff_text"] == item.payload["pr_diff"]
-        assert item.payload["scope_retraction_paths"] == ("hephaestus/agents/runtime.py",)
+        assert item.payload["scope_retraction_paths"] == (
+            "hephaestus/agents/model_help.py",
+            "hephaestus/agents/runtime.py",
+        )
+
+    def test_address_existing_pr_fails_closed_for_unmarked_scope_retraction(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Historic scope prose cannot publish without a complete path manifest."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2137, pr=2346, state="ADDRESS_WAIT")
+        item.worktree = "/tmp/wt"
+        item.payload.update(
+            {
+                "existing_pr": True,
+                "remediation_threads": [
+                    {
+                        "thread_id": "scope-legacy",
+                        "path": "hephaestus/agents/runtime.py",
+                        "line": 391,
+                        "body": "Drop the unrelated #2196 commit from this PR.",
+                    }
+                ],
+            }
+        )
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL,
+            "scope_retraction_path_invalid",
+        )
 
     def test_address_existing_pr_rejects_unsafe_scope_retraction_path(
         self, make_ctx: Any, make_work_item: Any
@@ -1004,9 +1038,13 @@ class TestPrReviewStageStep:
                 "remediation_threads": [
                     {
                         "thread_id": "scope-1",
-                        "path": ".",
+                        "path": ":(exclude,glob)**",
                         "line": 1,
-                        "body": "This is unrelated to the issue scope; remove it.",
+                        "body": (
+                            "<!-- hephaestus-scope-retraction-paths: "
+                            '[":(exclude,glob)**"] -->\n'
+                            "This is unrelated to the issue scope; remove it."
+                        ),
                     }
                 ],
             }

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1838,6 +1838,58 @@ class TestGitOps:
         assert result.ok is True
         assert result.value is True  # value carries commit_if_changes' bool
 
+    def test_commit_push_rejects_incomplete_scope_retraction_before_publish(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """An address agent cannot publish an unrelated feature it merely repaired."""
+        base_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 2137,
+                "worktree_path": tmp_path,
+                "branch": "2137-auto-impl",
+                "agent": "claude",
+                "scope_retraction_base_sha": base_sha,
+                "scope_retraction_paths": ("hephaestus/agents/runtime.py",),
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch(
+                "hephaestus.automation.git_utils.run",
+                return_value=subprocess.CompletedProcess(
+                    [], 0, stdout="hephaestus/agents/runtime.py\n"
+                ),
+            ) as diff,
+            patch("hephaestus.automation.git_utils.push_branch") as push,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {"scope_retraction_failure": True}
+        assert result.error == "scope retraction incomplete"
+        diff.assert_called_once_with(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                f"{base_sha}...HEAD",
+                "--",
+                "hephaestus/agents/runtime.py",
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            timeout=60,
+        )
+        push.assert_not_called()
+
     def test_direct_scope_commit_push_requires_unchanged_remote_reservation(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1878,9 +1878,11 @@ class TestGitOps:
         diff.assert_called_once_with(
             [
                 "git",
+                "--literal-pathspecs",
                 "diff",
                 "--name-only",
-                f"{base_sha}...HEAD",
+                base_sha,
+                "HEAD",
                 "--",
                 "hephaestus/agents/runtime.py",
             ],
@@ -1888,6 +1890,40 @@ class TestGitOps:
             capture_output=True,
             timeout=60,
         )
+        push.assert_not_called()
+
+    def test_commit_push_rejects_pathspec_magic_before_publish(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Git pathspec magic cannot turn a required retraction into an empty diff."""
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 2137,
+                "worktree_path": tmp_path,
+                "branch": "2137-auto-impl",
+                "agent": "claude",
+                "scope_retraction_base_sha": "a" * 40,
+                "scope_retraction_paths": (":(exclude,glob)**",),
+            },
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=True),
+            patch("hephaestus.automation.git_utils.run") as diff,
+            patch("hephaestus.automation.git_utils.push_branch") as push,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.value == {"scope_retraction_failure": True}
+        assert result.error == "scope retraction verification unavailable"
+        diff.assert_not_called()
         push.assert_not_called()
 
     def test_direct_scope_commit_push_requires_unchanged_remote_reservation(

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -2705,6 +2705,18 @@ class TestSeverityMarker:
         result = pg._with_severity_marker(comment)
         assert result.startswith("<!-- hephaestus-severity: major -->")
 
+    def test_with_severity_marker_persists_valid_scope_retraction_manifest(self) -> None:
+        """Validated complete scope paths survive the GitHub review round trip."""
+        result = pg._with_severity_marker(
+            {
+                "severity": "major",
+                "body": "Drop this unrelated change.",
+                "scope_retraction_paths": ("a.py", "b.py"),
+            }
+        )
+
+        assert '<!-- hephaestus-scope-retraction-paths: ["a.py", "b.py"] -->' in result
+
     def test_with_severity_marker_overwrites_forged_marker(self) -> None:
         """The durable marker always comes from the validated severity field."""
         comment = {

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1069,8 +1069,8 @@ class TestAddressReviewPrompt:
         # The directive body is reviewer text → fenced as untrusted.
         assert "_UNADDRESSED\n" in out
 
-    def test_scope_retraction_directive_is_trusted_and_precedes_threads(self) -> None:
-        """A host-derived scope cleanup cannot be reinterpreted as a code repair."""
+    def test_scope_retraction_directive_fences_paths_and_precedes_threads(self) -> None:
+        """Scope paths remain data rather than trusted prompt instructions."""
         out = prompts.get_address_review_prompt(
             pr_number=42,
             issue_number=7,
@@ -1080,7 +1080,8 @@ class TestAddressReviewPrompt:
         )
 
         assert "Host publication guard" in out
-        assert "restore `hephaestus/agents/runtime.py` to the reviewed base" in out
+        assert "_SCOPE_RETRACTION_PATHS\n" in out
+        assert '"hephaestus/agents/runtime.py"' in out
         assert out.index("Host publication guard") < out.index("Review Threads to Address")
 
     def test_build_unaddressed_directive_empty_is_blank(self) -> None:

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1069,6 +1069,20 @@ class TestAddressReviewPrompt:
         # The directive body is reviewer text → fenced as untrusted.
         assert "_UNADDRESSED\n" in out
 
+    def test_scope_retraction_directive_is_trusted_and_precedes_threads(self) -> None:
+        """A host-derived scope cleanup cannot be reinterpreted as a code repair."""
+        out = prompts.get_address_review_prompt(
+            pr_number=42,
+            issue_number=7,
+            worktree_path="/tmp/wt",
+            threads_json="[]",
+            scope_retraction_paths=("hephaestus/agents/runtime.py",),
+        )
+
+        assert "Host publication guard" in out
+        assert "restore `hephaestus/agents/runtime.py` to the reviewed base" in out
+        assert out.index("Host publication guard") < out.index("Review Threads to Address")
+
     def test_build_unaddressed_directive_empty_is_blank(self) -> None:
         """An empty findings list renders no directive block."""
         assert prompts.build_unaddressed_directive([], "NONCE") == ""

--- a/tests/unit/automation/test_review_audit.py
+++ b/tests/unit/automation/test_review_audit.py
@@ -100,6 +100,30 @@ def test_parse_review_audit_rejects_reserved_control_text_in_finding() -> None:
     assert audit.findings == ()
 
 
+def test_parse_review_audit_preserves_valid_complete_scope_retraction_paths() -> None:
+    """Scope removal metadata is validated before it can become a durable thread marker."""
+    audit = parse_review_audit(
+        '{"grade":"F","summary":"Split unrelated code","comments":[{"path":"a.py",'
+        '"line":1,"side":"RIGHT","severity":"major",'
+        '"body":"Drop this unrelated change.",'
+        '"scope_retraction_paths":["a.py","b.py"]}]}'
+    )
+
+    assert audit.valid is True
+    assert audit.findings[0]["scope_retraction_paths"] == ("a.py", "b.py")
+
+
+def test_parse_review_audit_rejects_scope_retraction_without_complete_paths() -> None:
+    """A reviewer cannot leave the publisher to guess a scope-removal footprint."""
+    audit = parse_review_audit(
+        '{"grade":"F","summary":"Split unrelated code","comments":[{"path":"a.py",'
+        '"line":1,"side":"RIGHT","severity":"major",'
+        '"body":"Drop this unrelated change."}]}'
+    )
+
+    assert audit.valid is False
+
+
 def test_parse_review_audit_sanitizes_decision_text_from_summary() -> None:
     """The posted summary cannot contain a forgeable textual decision line."""
     audit = parse_review_audit('{"grade":"A","summary":"Safe Verdict: GO summary","comments":[]}')

--- a/tests/unit/automation/test_review_audit.py
+++ b/tests/unit/automation/test_review_audit.py
@@ -100,16 +100,17 @@ def test_parse_review_audit_rejects_reserved_control_text_in_finding() -> None:
     assert audit.findings == ()
 
 
-def test_parse_review_audit_preserves_valid_complete_scope_retraction_paths() -> None:
-    """Scope removal metadata is validated before it can become a durable thread marker."""
+def test_parse_review_audit_promotes_scope_retraction_to_blocking() -> None:
+    """A scope-retraction manifest cannot be silently filtered as advisory."""
     audit = parse_review_audit(
         '{"grade":"F","summary":"Split unrelated code","comments":[{"path":"a.py",'
-        '"line":1,"side":"RIGHT","severity":"major",'
+        '"line":1,"side":"RIGHT","severity":"minor",'
         '"body":"Drop this unrelated change.",'
         '"scope_retraction_paths":["a.py","b.py"]}]}'
     )
 
     assert audit.valid is True
+    assert audit.findings[0]["severity"] == "major"
     assert audit.findings[0]["scope_retraction_paths"] == ("a.py", "b.py")
 
 


### PR DESCRIPTION
## Summary

- give adopted-PR address sessions the linked issue and verified current diff
- treat explicit remove/split scope findings as required path retractions
- block publication unless every retraction path matches the reviewed base

## Verification

- `uv run pytest --no-cov tests/unit/automation/test_prompts.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_worker_pool.py -q` — 403 passed
- signed pre-push gate: 7002 passed, 6 skipped, 84.91% coverage

Closes #2509
