### PR TITLE
fix(automation): wait for reply-head visibility

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1778,11 +1778,12 @@ class PrReviewStage(Stage):
         """Retry one exact post-push reply batch without invoking an agent.
 
         Returns ``none`` when no handoff exists, ``completed`` when every
-        reply has a host receipt, ``stale`` when the exact pushed head can no
-        longer safely receive the saved response, ``invalid`` for malformed
-        persisted state, and ``retry`` for a bounded transient/incomplete
-        host operation.  No outcome grants reviewer authority; normal fresh
-        review still validates and resolves the replies.
+        reply has a host receipt, ``visibility_wait`` while GitHub is briefly
+        catching up with the pushed head, ``stale`` when the exact pushed head
+        can no longer safely receive the saved response, ``invalid`` for
+        malformed persisted state, and ``retry`` for a bounded
+        transient/incomplete host operation.  No outcome grants reviewer
+        authority; normal fresh review still validates and resolves the replies.
         """
         raw_handoff = item.payload.get(_PENDING_IMPLEMENTATION_REPLY_HANDOFF)
         if raw_handoff is None:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -276,8 +276,12 @@ REVIEW_CHECKOUT_RETRY_CAP = 2
 #: it replays the exact saved thread snapshots and agent prose, never asks an
 #: implementation model to invent a new response.
 IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP = 2
+IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP = 2
 _PENDING_IMPLEMENTATION_REPLY_HANDOFF = "pending_implementation_reply_handoff"
 _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES = "pending_implementation_reply_handoff_retries"
+_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
+    "pending_implementation_reply_handoff_visibility_retries"
+)
 
 #: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
 #: later round can never replay an earlier round's results.
@@ -1794,10 +1798,40 @@ class PrReviewStage(Stage):
         threads = handoff["threads"]
         replies = handoff["replies"]
         try:
-            if not _pr_is_current_open_head(ctx.github.gh_pr_state(item.pr), head_sha):
+            state = ctx.github.gh_pr_state(item.pr)
+            if not _pr_is_current_open_head(state, head_sha):
+                if (
+                    isinstance(state, dict)
+                    and state.get("state") == "OPEN"
+                    and state.get("autoMergeRequest") is None
+                ):
+                    visibility_retries = item.payload.get(
+                        _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, 0
+                    )
+                    if (
+                        isinstance(visibility_retries, int)
+                        and not isinstance(visibility_retries, bool)
+                        and visibility_retries >= 0
+                        and visibility_retries < IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP
+                    ):
+                        visibility_retries += 1
+                        item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES] = (
+                            visibility_retries
+                        )
+                        item.payload["retry_delay_s"] = float(2 ** (visibility_retries - 1))
+                        logger.info(
+                            "pr_review:%s: waiting for pushed implementation head visibility "
+                            "before replying to review threads (%d/%d)",
+                            item.issue,
+                            visibility_retries,
+                            IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP,
+                        )
+                        return "visibility_wait"
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+                item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
                 return "stale"
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
             result = ctx.github.post_implementation_thread_replies(
                 item.pr,
                 expected_head_sha=head_sha,
@@ -1871,6 +1905,8 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_incomplete")
 
         handoff_status = self._retry_pending_implementation_reply_handoff(item, ctx)
+        if handoff_status == "visibility_wait":
+            return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
         if handoff_status == "invalid":
             logger.error(
                 "pr_review:%d: refusing to replay malformed implementation reply handoff",

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import deque
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -4102,6 +4103,151 @@ class TestRealCommitGate:
         assert github.reply_attempts == 2
         assert "pending_implementation_reply_handoff" not in item.payload
         assert item.payload["push_no_commit"] is False
+
+    def test_reply_handoff_waits_for_post_push_head_visibility(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A stale read immediately after push earns a delayed host-only retry."""
+
+        class HeadVisibilityLagGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self._states = deque(
+                    [
+                        {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None},
+                        {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None},
+                        {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
+                    ]
+                )
+                self.reply_attempts = 0
+
+            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+                del pr_number
+                return self._states.popleft() if self._states else None
+
+            def post_implementation_thread_replies(
+                self,
+                pr_number: int,
+                *,
+                expected_head_sha: str,
+                threads: list[dict[str, Any]],
+                replies: dict[str, str],
+            ) -> ImplementationThreadReplyResult:
+                self.reply_attempts += 1
+                return super().post_implementation_thread_replies(
+                    pr_number,
+                    expected_head_sha=expected_head_sha,
+                    threads=threads,
+                    replies=replies,
+                )
+
+        stage = PrReviewStage()
+        github = HeadVisibilityLagGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=40, pr=1001, state="PUSH_WAIT")
+        snapshot = {
+            "id": "thread-1",
+            "path": "a.py",
+            "line": 3,
+            "side": "RIGHT",
+            "body": "fix this",
+            "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix this"}],
+        }
+        item.payload.update(
+            {
+                "remediation_threads": [{"thread_id": "thread-1", "body": "fix this"}],
+                "remediation_thread_snapshots": [snapshot],
+                "address_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "Fixed the guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "a" * 40}),
+            ctx,
+        )
+
+        item.state = "EVAL"
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
+        )
+        assert item.payload["retry_delay_s"] == 1.0
+        assert github.reply_attempts == 0
+
+        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert github.reply_attempts == 1
+        assert "pending_implementation_reply_handoff" not in item.payload
+
+    def test_reply_handoff_stops_waiting_when_the_head_stays_drifted(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A persistent different open head cannot inherit the saved reply."""
+
+        class HeadStaysDriftedGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self.reply_attempts = 0
+
+            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+                del pr_number
+                return {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None}
+
+            def post_implementation_thread_replies(
+                self,
+                pr_number: int,
+                *,
+                expected_head_sha: str,
+                threads: list[dict[str, Any]],
+                replies: dict[str, str],
+            ) -> ImplementationThreadReplyResult:
+                self.reply_attempts += 1
+                return super().post_implementation_thread_replies(
+                    pr_number,
+                    expected_head_sha=expected_head_sha,
+                    threads=threads,
+                    replies=replies,
+                )
+
+        stage = PrReviewStage()
+        github = HeadStaysDriftedGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=40, pr=1001, state="PUSH_WAIT")
+        snapshot = {
+            "id": "thread-1",
+            "path": "a.py",
+            "line": 3,
+            "side": "RIGHT",
+            "body": "fix this",
+            "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix this"}],
+        }
+        item.payload.update(
+            {
+                "remediation_threads": [{"thread_id": "thread-1", "body": "fix this"}],
+                "remediation_thread_snapshots": [snapshot],
+                "address_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "Fixed the guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "a" * 40}),
+            ctx,
+        )
+
+        item.state = "EVAL"
+        for _ in range(2):
+            assert stage.step(item, ctx) == StageOutcome(
+                Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
+            )
+        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert github.reply_attempts == 0
+        assert "pending_implementation_reply_handoff" not in item.payload
 
     def test_stale_reply_handoff_restarts_fresh_review_without_retrying(
         self, make_ctx: Any, make_work_item: Any


### PR DESCRIPTION
Summary:
- retry a bounded number of times when GitHub has not yet exposed the just-pushed review-fix head
- preserve exact-head, open-PR, and unarmed-state checks before posting implementation replies
- add regression coverage for eventual visibility and persistent head drift

Closes #2521

Tests:
- uv run pytest tests/unit
- uv run pre-commit run --files hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py