### PR TITLE
fix(automation): batch implementation review replies

### DIFF
--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -3,9 +3,8 @@
 Issue #994: ``PRReviewer`` (``hephaestus/automation/pr_reviewer.py``) spawns
 one worker thread per PR; this module instead drives a single agent session
 whose prompt enumerates every open PR, then parses one multi-PR JSON report.
-Used for batch audits where per-PR sessions would saturate the agent
-budget. Read-only: posts a summary-only review per PR, never commits or
-pushes.
+Used for batch audits where per-PR sessions would saturate the agent budget.
+Read-only: writes and prints local audit reports, never commits or pushes.
 """
 
 from __future__ import annotations
@@ -41,7 +40,7 @@ from .agent_config import DEFAULT_AGENT_TIMEOUT
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .git_utils import get_repo_root, get_repo_slug
-from .github_api import _gh_call, fetch_open_prs, gh_pr_review_post
+from .github_api import _gh_call, fetch_open_prs
 from .session_naming import AGENT_PR_REVIEWER
 
 logger = logging.getLogger(__name__)
@@ -189,7 +188,7 @@ def run_audit_coordinator(
 
 @dataclass
 class AuditReviewer:
-    """Run the coordinator audit and post a summary review per PR."""
+    """Run the coordinator audit and retain a local report per PR."""
 
     agent: str = "claude"
     pr_numbers: list[int] = field(default_factory=list)
@@ -204,7 +203,7 @@ class AuditReviewer:
             self.state_dir = ensure_state_dir(get_repo_root())
 
     def run(self) -> tuple[int, list[dict[str, Any]]]:
-        """Run the coordinator audit and post a summary review per PR."""
+        """Run the coordinator audit and retain a local report per PR."""
         # __post_init__ guarantees state_dir is set; narrow type for mypy.
         if self.state_dir is None:  # pragma: no cover - mypy type-narrowing; unreachable, see #1426
             raise RuntimeError("state_dir unexpectedly None after __post_init__")
@@ -227,20 +226,6 @@ class AuditReviewer:
             report = write_audit_report(self.state_dir, audits)
             logger.info("Audit report written to %s", report)
         print_audit_summary(audits)
-        for a in audits:
-            if self.shutdown_event is not None and self.shutdown_event.is_set():
-                logger.warning("Interrupted; stopping before remaining PR postings.")
-                break
-            try:
-                gh_pr_review_post(
-                    pr_number=int(a["pr_number"]),
-                    comments=[],
-                    summary=a.get("summary", ""),
-                    event="COMMENT",
-                    dry_run=self.dry_run,
-                )
-            except Exception as exc:
-                logger.warning("Posting failed for PR #%s: %s", a.get("pr_number"), exc)
         return 0, audits
 
 
@@ -250,7 +235,7 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Audit ALL open PRs in one coordinator agent invocation.",
         add_max_workers=False,
         add_github_throttle=True,
-        dry_run_help="Skip the agent call and the GitHub posting step.",
+        dry_run_help="Skip the agent call and local audit-report writing.",
         verbose_help="DEBUG-level logging.",
     )
     parser.add_argument(

--- a/hephaestus/automation/github_api/reviews.py
+++ b/hephaestus/automation/github_api/reviews.py
@@ -448,16 +448,17 @@ def gh_pr_review_post(
     Args:
         pr_number: PR number
         comments: List of dicts with keys: path (str), line (int), side (str), body (str)
-        summary: Overall review summary body
+        summary: Deprecated summary text. It is deliberately not published:
+            every review publication must contain source-anchored comments only.
         event: Review event type: COMMENT, APPROVE, or REQUEST_CHANGES
         dry_run: If True, log intent and return empty list without posting
         dedupe_existing: When True (#1083), a comment whose ``(path, line)``
             already has an unresolved bot review comment is EDITED in place
             (the new body is appended) rather than posted as a duplicate thread.
             Only the genuinely new comments are posted as fresh threads. If
-            dedupe/editing consumes every inline comment, no summary-only review
-            is posted; a duplicate-only re-review should be a no-op, not another
-            review submission. Fails open: if the existing-comment index cannot
+            dedupe/editing consumes every inline comment, no review is posted;
+            a duplicate-only re-review should be a no-op, not another review
+            submission. Fails open: if the existing-comment index cannot
             be fetched, every comment is posted as before.
 
     Returns:
@@ -469,6 +470,17 @@ def gh_pr_review_post(
             "[dry_run] Would post PR review on #%s with %s inline comments",
             pr_number,
             len(comments),
+        )
+        return []
+
+    # A review body without an inline comment creates an unanchored, general
+    # review comment. The automation contract requires every published finding
+    # to identify a source path and line, so do not use ``summary`` as a
+    # fallback publication surface.
+    if not comments:
+        _api.logger.info(
+            "PR #%s: skipped review publication without source-anchored comments",
+            pr_number,
         )
         return []
 
@@ -486,7 +498,8 @@ def gh_pr_review_post(
     #   2. Even passed as a typed array, ``line``/``side`` are undefined on
     #      ``DraftPullRequestReviewComment``.
     # POST /pulls/{n}/reviews is the correct surface for ``line``/``side``
-    # comments and for summary-only (empty ``comments``) reviews alike.
+    # comments. Summary-only reviews are prohibited because GitHub would render
+    # their body as an unanchored general review comment.
     #
     # #1039: GitHub returns HTTP 422 and rejects the WHOLE review if any inline
     # comment targets a line outside the PR diff hunks. The reviewer model can
@@ -496,6 +509,13 @@ def gh_pr_review_post(
     if comments:
         diff_result = _api._gh_call(["pr", "diff", str(pr_number)], check=False)
         comments = _api._filter_comments_to_diff(comments, diff_result.stdout or "")
+
+    if not comments:
+        _api.logger.info(
+            "PR #%s: skipped review publication after no source anchors remained",
+            pr_number,
+        )
+        return []
 
     # #1083: edit-in-place instead of duplicating. If a comment targets a line
     # that already has an unresolved bot comment, append the new body to that
@@ -521,7 +541,7 @@ def gh_pr_review_post(
         for c in comments
     ]
 
-    request_body = json.dumps({"body": summary, "event": event, "comments": review_comments})
+    request_body = json.dumps({"event": event, "comments": review_comments})
     fd, input_path = tempfile.mkstemp(prefix="gh-review-", suffix=".json")
     try:
         os.close(fd)

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -304,7 +304,7 @@ class StageGitHub(Protocol):
         """
         ...
 
-    def discard_stale_implementation_thread_reply_batch(
+    def preserve_stale_implementation_thread_reply_batch(
         self,
         pr_number: int,
         *,
@@ -312,12 +312,13 @@ class StageGitHub(Protocol):
         current_head_sha: str,
         replies: dict[str, str],
         batch_nonce: str,
-    ) -> bool:
-        """Discard only a verified old-head implementation reply draft.
+    ) -> tuple[str, ...] | None:
+        """Return visible drafts preserved after an implementation handoff goes stale.
 
-        This recovery hook runs when a durable handoff becomes stale before a
-        retry.  It must never delete a current or manually authored pending
-        review, and returns False when the stale draft cannot be proved.
+        GitHub exposes no conditional review-delete mutation, so stale-draft
+        recovery is deliberately non-mutating.  The returned opaque review
+        IDs let the stage publish an idempotent manual-cleanup diagnostic;
+        ``None`` means the inventory could not be proved.
         """
         pass
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -136,8 +136,8 @@ class ImplementationThreadReplyResult:
     outcome is transport/read-ambiguous. An ordinary ``blocked_thread_ids``
     result means the saved snapshot is stale and must return through a fresh
     reviewer pass rather than replay. ``duplicate_current_draft_ids`` and
-    ``conflicting_pending_draft_ids`` are terminal ownership conflicts; no
-    current draft is deleted and the stage records a durable no-go diagnostic
+    ``conflicting_current_review_ids`` are terminal ownership conflicts; no
+    current review is mutated and the stage records a durable no-go diagnostic
     instead of retrying into its handoff cap.
     """
 
@@ -147,7 +147,7 @@ class ImplementationThreadReplyResult:
     retryable_thread_ids: tuple[str, ...] = ()
     retryable: bool = False
     duplicate_current_draft_ids: tuple[str, ...] = ()
-    conflicting_pending_draft_ids: tuple[str, ...] = ()
+    conflicting_current_review_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -369,24 +369,6 @@ class StageGitHub(Protocol):
         """
         ...
 
-    def post_pr_comment(self, pr_number: int, body: str) -> None:
-        """Durably post an explanatory comment on the PR conversation.
-
-        The coordinator maps this onto ``gh_issue_comment`` (PRs share the
-        issue comment channel). Used for neutral automation status notices
-        when an external race invalidates this process's review proof.
-        """
-        ...
-
-    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
-        """Durably create-or-update a marker-keyed PR conversation comment.
-
-        PRs share the issue comment channel, so the coordinator maps this onto
-        an issue-comment upsert scoped to the PR number. Used by lightweight
-        durable artifacts that should remain one-per-role across retries.
-        """
-        pass
-
     def mark_pr_implementation_no_go(self, pr_number: int) -> None:
         """Durably apply ``state:implementation-no-go`` to the PR.
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -135,10 +135,9 @@ class ImplementationThreadReplyResult:
     GitHub object. ``retryable_thread_ids`` identifies only replies whose host
     outcome is transport/read-ambiguous. An ordinary ``blocked_thread_ids``
     result means the saved snapshot is stale and must return through a fresh
-    reviewer pass rather than replay. ``duplicate_current_draft_ids`` and
-    ``conflicting_current_review_ids`` are terminal ownership conflicts; no
-    current review is mutated and the stage records a durable no-go diagnostic
-    instead of retrying into its handoff cap.
+    reviewer pass rather than replay. Direct thread replies never create a
+    review-level envelope, so there is no review ownership conflict state to
+    recover or preserve.
     """
 
     replied_thread_ids: tuple[str, ...] = ()
@@ -146,8 +145,6 @@ class ImplementationThreadReplyResult:
     receipts: tuple[dict[str, Any], ...] = ()
     retryable_thread_ids: tuple[str, ...] = ()
     retryable: bool = False
-    duplicate_current_draft_ids: tuple[str, ...] = ()
-    conflicting_current_review_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -303,24 +300,6 @@ class StageGitHub(Protocol):
         thread.
         """
         ...
-
-    def preserve_stale_implementation_thread_reply_batch(
-        self,
-        pr_number: int,
-        *,
-        expected_head_sha: str,
-        current_head_sha: str,
-        replies: dict[str, str],
-        batch_nonce: str,
-    ) -> tuple[str, ...] | None:
-        """Return visible drafts preserved after an implementation handoff goes stale.
-
-        GitHub exposes no conditional review-delete mutation, so stale-draft
-        recovery is deliberately non-mutating.  The returned opaque review
-        IDs let the stage publish an idempotent manual-cleanup diagnostic;
-        ``None`` means the inventory could not be proved.
-        """
-        pass
 
     def reviewer_validation_receipts(
         self,

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -298,6 +298,22 @@ class StageGitHub(Protocol):
         """
         ...
 
+    def discard_stale_implementation_thread_reply_batch(
+        self,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        current_head_sha: str,
+        replies: dict[str, str],
+    ) -> bool:
+        """Discard only a verified old-head implementation reply draft.
+
+        This recovery hook runs when a durable handoff becomes stale before a
+        retry.  It must never delete a current or manually authored pending
+        review, and returns False when the stale draft cannot be proved.
+        """
+        ...
+
     def reviewer_validation_receipts(
         self,
         pr_number: int,

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -135,10 +135,10 @@ class ImplementationThreadReplyResult:
     GitHub object. ``retryable_thread_ids`` identifies only replies whose host
     outcome is transport/read-ambiguous. An ordinary ``blocked_thread_ids``
     result means the saved snapshot is stale and must return through a fresh
-    reviewer pass rather than replay. ``duplicate_current_draft_ids`` is a
-    terminal ownership conflict from independent checkout roots; no current
-    draft is deleted and the stage records a durable no-go diagnostic instead
-    of retrying into its handoff cap.
+    reviewer pass rather than replay. ``duplicate_current_draft_ids`` and
+    ``conflicting_pending_draft_ids`` are terminal ownership conflicts; no
+    current draft is deleted and the stage records a durable no-go diagnostic
+    instead of retrying into its handoff cap.
     """
 
     replied_thread_ids: tuple[str, ...] = ()
@@ -147,6 +147,7 @@ class ImplementationThreadReplyResult:
     retryable_thread_ids: tuple[str, ...] = ()
     retryable: bool = False
     duplicate_current_draft_ids: tuple[str, ...] = ()
+    conflicting_pending_draft_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -292,6 +293,7 @@ class StageGitHub(Protocol):
         expected_head_sha: str,
         threads: list[dict[str, Any]],
         replies: dict[str, str],
+        batch_nonce: str,
     ) -> ImplementationThreadReplyResult:
         """Post host-validated implementation replies after a successful push.
 
@@ -309,6 +311,7 @@ class StageGitHub(Protocol):
         expected_head_sha: str,
         current_head_sha: str,
         replies: dict[str, str],
+        batch_nonce: str,
     ) -> bool:
         """Discard only a verified old-head implementation reply draft.
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -135,7 +135,10 @@ class ImplementationThreadReplyResult:
     GitHub object. ``retryable_thread_ids`` identifies only replies whose host
     outcome is transport/read-ambiguous. An ordinary ``blocked_thread_ids``
     result means the saved snapshot is stale and must return through a fresh
-    reviewer pass rather than replay.
+    reviewer pass rather than replay. ``duplicate_current_draft_ids`` is a
+    terminal ownership conflict from independent checkout roots; no current
+    draft is deleted and the stage records a durable no-go diagnostic instead
+    of retrying into its handoff cap.
     """
 
     replied_thread_ids: tuple[str, ...] = ()
@@ -143,6 +146,7 @@ class ImplementationThreadReplyResult:
     receipts: tuple[dict[str, Any], ...] = ()
     retryable_thread_ids: tuple[str, ...] = ()
     retryable: bool = False
+    duplicate_current_draft_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -361,7 +361,6 @@ class StageGitHub(Protocol):
         self,
         pr_number: int,
         threads: list[dict[str, Any]],
-        summary: str,
         *,
         expected_head_sha: str,
     ) -> list[dict[str, Any]]:

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -312,7 +312,7 @@ class StageGitHub(Protocol):
         retry.  It must never delete a current or manually authored pending
         review, and returns False when the stale draft cannot be proved.
         """
-        ...
+        pass
 
     def reviewer_validation_receipts(
         self,

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1859,12 +1859,14 @@ class PrReviewStage(Stage):
         ctx: StageContext,
         *,
         payload_key: str,
-        marker_kind: str,
         minimum_review_count: int,
-        explanation: str,
-        remediation: str,
     ) -> StepResult | None:
-        """Record one terminal diagnostic without mutating conflicting reviews."""
+        """Record one terminal diagnostic without mutating conflicting reviews.
+
+        A conflict has no safe existing thread to reply to. It is therefore
+        deliberately recorded in the stage outcome and logs, rather than as a
+        free-standing PR conversation comment.
+        """
         conflict = item.payload.pop(payload_key, None)
         if conflict is None:
             return None
@@ -1893,32 +1895,14 @@ class PrReviewStage(Stage):
         no_go_outcome = self._write_no_go(item, ctx)
         if no_go_outcome is not None:
             return no_go_outcome
-        marker_hash = hashlib.sha256(
-            f"{item.pr}:{head_sha}:{','.join(review_ids)}".encode()
-        ).hexdigest()[:24]
-        marker = f"<!-- hephaestus-implementation-reply-{marker_kind}:{marker_hash} -->"
-        body = (
-            f"{marker}\n\n"
-            f"Automation stopped before posting implementation replies because {explanation}.\n\n"
-            f"Head: `{head_sha}`\n\n"
-            f"Conflicting review IDs: {', '.join(f'`{review_id}`' for review_id in review_ids)}\n\n"
-            "No review thread was resolved and no conflicting review was mutated. "
-            f"{remediation}"
+        logger.warning(
+            "pr_review:%d: stopped implementation replies on PR #%d at %s because "
+            "conflicting review IDs were preserved: %s",
+            item.issue,
+            item.pr,
+            head_sha,
+            ", ".join(review_ids),
         )
-        try:
-            ctx.github.upsert_pr_comment(item.pr, marker, body)
-        except Exception as error:
-            logger.warning(
-                "pr_review:%d: failed to record implementation-reply review conflict (%s)",
-                item.issue,
-                type(error).__name__,
-            )
-            return StageOutcome(
-                Disposition.FINISH_FAIL,
-                "implementation_reply_batch_conflict_comment_failed"
-                if payload_key == _IMPLEMENTATION_REPLY_BATCH_CONFLICT
-                else "implementation_reply_review_conflict_comment_failed",
-            )
         return StageOutcome(
             Disposition.FINISH_FAIL,
             "implementation_reply_batch_conflict"
@@ -1934,10 +1918,7 @@ class PrReviewStage(Stage):
             item,
             ctx,
             payload_key=_IMPLEMENTATION_REPLY_BATCH_CONFLICT,
-            marker_kind="duplicate-review-conflict",
             minimum_review_count=2,
-            explanation="multiple current-head draft reviews claim the same reply batch",
-            remediation="Remove the duplicate drafts, then run a fresh implementation-review pass.",
         )
 
     def _consume_implementation_reply_current_review_conflict(
@@ -1948,16 +1929,7 @@ class PrReviewStage(Stage):
             item,
             ctx,
             payload_key=_IMPLEMENTATION_REPLY_REVIEW_CONFLICT,
-            marker_kind="review-conflict",
             minimum_review_count=1,
-            explanation=(
-                "a preserved incomplete or competing implementation review "
-                "prevents this reply batch"
-            ),
-            remediation=(
-                "Inspect and manually clean up the preserved review, then run a fresh "
-                "implementation-review pass."
-            ),
         )
 
     @staticmethod
@@ -2678,21 +2650,6 @@ class PrReviewStage(Stage):
             unresolved_threads,
             item.pr,
         )
-        body = (
-            "**Automation review activity changed during GO admission.**\n\n"
-            f"{unresolved_threads} review thread(s) were observed after the implementation "
-            "state write. Automation cannot prove it still owns the current labels, so it "
-            "made no further label changes. A fresh automation review will re-read the "
-            "current diff and threads before it validates, responds to, or resolves them."
-        )
-        try:
-            ctx.github.post_pr_comment(item.pr, body)
-        except Exception as error:
-            logger.warning(
-                "pr_review: failed to post late-thread race notice on PR #%d (non-fatal): %s",
-                item.pr,
-                error,
-            )
         return StageOutcome(Disposition.FINISH_FAIL, "review_activity_changed")
 
     @staticmethod

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -282,6 +282,7 @@ _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES = "pending_implementation_reply_ha
 _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
     "pending_implementation_reply_handoff_visibility_retries"
 )
+_IMPLEMENTATION_REPLY_BATCH_CONFLICT = "implementation_reply_batch_conflict"
 
 #: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
 #: later round can never replay an earlier round's results.
@@ -1257,6 +1258,19 @@ class PrReviewStage(Stage):
                         replied = set(getattr(reply_result, "replied_thread_ids", ()))
                         blocked = set(getattr(reply_result, "blocked_thread_ids", ()))
                         receipts = list(getattr(reply_result, "receipts", ()))
+                        duplicate_drafts = tuple(
+                            sorted(
+                                str(review_id)
+                                for review_id in getattr(
+                                    reply_result, "duplicate_current_draft_ids", ()
+                                )
+                            )
+                        )
+                        if duplicate_drafts:
+                            item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
+                                "head_sha": published_head,
+                                "draft_ids": duplicate_drafts,
+                            }
                         retryable = bool(getattr(reply_result, "retryable", False))
                         expected_ids = set(replies)
                         remaining_ids = expected_ids - replied
@@ -1938,6 +1952,59 @@ class PrReviewStage(Stage):
         if item.issue is None:  # guarded by step(); kept for type narrowing
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         payload = item.payload
+
+        conflict = payload.pop(_IMPLEMENTATION_REPLY_BATCH_CONFLICT, None)
+        if conflict is not None:
+            if not isinstance(conflict, dict):
+                return StageOutcome(
+                    Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+                )
+            head_sha = conflict.get("head_sha")
+            draft_ids = conflict.get("draft_ids")
+            if (
+                not is_full_commit_sha(head_sha)
+                or not isinstance(draft_ids, tuple)
+                or len(draft_ids) < 2
+                or any(
+                    not isinstance(review_id, str)
+                    or not review_id
+                    or len(review_id) > 256
+                    or re.fullmatch(r"[A-Za-z0-9_=-]+", review_id) is None
+                    for review_id in draft_ids
+                )
+            ):
+                return StageOutcome(
+                    Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+                )
+            item.payload["reviewed_pr_head_sha"] = head_sha
+            no_go_outcome = self._write_no_go(item, ctx)
+            if no_go_outcome is not None:
+                return no_go_outcome
+            marker_hash = hashlib.sha256(
+                f"{item.pr}:{head_sha}:{','.join(draft_ids)}".encode()
+            ).hexdigest()[:24]
+            marker = f"<!-- hephaestus-implementation-reply-draft-conflict:{marker_hash} -->"
+            body = (
+                f"{marker}\n\n"
+                "Automation stopped before posting implementation replies because multiple "
+                "current-head draft reviews claim the same reply batch.\n\n"
+                f"Head: `{head_sha}`\n\n"
+                f"Draft review IDs: {', '.join(f'`{review_id}`' for review_id in draft_ids)}\n\n"
+                "No review thread was resolved and no current draft was deleted. "
+                "Remove the duplicate drafts, then run a fresh implementation-review pass."
+            )
+            try:
+                ctx.github.upsert_pr_comment(item.pr, marker, body)
+            except Exception as error:
+                logger.warning(
+                    "pr_review:%d: failed to record duplicate-draft conflict (%s)",
+                    item.issue,
+                    type(error).__name__,
+                )
+                return StageOutcome(
+                    Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_comment_failed"
+                )
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_batch_conflict")
 
         if payload.pop("scope_retraction_failure", False):
             logger.warning(

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1812,7 +1812,7 @@ class PrReviewStage(Stage):
         return None
 
     @staticmethod
-    def _discard_stale_implementation_reply_draft(
+    def _preserve_stale_implementation_reply_draft(
         item: WorkItem,
         ctx: StageContext,
         *,
@@ -1821,7 +1821,7 @@ class PrReviewStage(Stage):
         replies: dict[str, str],
         batch_nonce: str,
     ) -> None:
-        """Best-effort cleanup after a saved implementation head was replaced."""
+        """Preserve visible stale drafts after a saved implementation head was replaced."""
         if not (
             isinstance(current_state, dict)
             and current_state.get("state") == "OPEN"
@@ -1833,7 +1833,7 @@ class PrReviewStage(Stage):
         ):
             return
         try:
-            ctx.github.discard_stale_implementation_thread_reply_batch(
+            preserved_review_ids = ctx.github.preserve_stale_implementation_thread_reply_batch(
                 item.pr,
                 expected_head_sha=expected_head_sha,
                 current_head_sha=current_state["headRefOid"],
@@ -1842,10 +1842,16 @@ class PrReviewStage(Stage):
             )
         except Exception as error:
             logger.warning(
-                "pr_review:%s: could not discard stale implementation reply draft (%s)",
+                "pr_review:%s: could not preserve stale implementation reply draft (%s)",
                 item.issue,
                 type(error).__name__,
             )
+            return
+        if preserved_review_ids:
+            item.payload[_IMPLEMENTATION_REPLY_REVIEW_CONFLICT] = {
+                "head_sha": current_state["headRefOid"],
+                "review_ids": tuple(sorted(str(review_id) for review_id in preserved_review_ids)),
+            }
 
     def _consume_implementation_reply_review_conflict(
         self,
@@ -1937,16 +1943,20 @@ class PrReviewStage(Stage):
     def _consume_implementation_reply_current_review_conflict(
         self, item: WorkItem, ctx: StageContext
     ) -> StepResult | None:
-        """Diagnose a non-owned current review without taking ownership of it."""
+        """Diagnose a preserved current review without taking ownership of it."""
         return self._consume_implementation_reply_review_conflict(
             item,
             ctx,
             payload_key=_IMPLEMENTATION_REPLY_REVIEW_CONFLICT,
             marker_kind="review-conflict",
             minimum_review_count=1,
-            explanation="a non-owned current implementation review prevents this reply batch",
+            explanation=(
+                "a preserved incomplete or competing implementation review "
+                "prevents this reply batch"
+            ),
             remediation=(
-                "Inspect the conflicting review, then run a fresh implementation-review pass."
+                "Inspect and manually clean up the preserved review, then run a fresh "
+                "implementation-review pass."
             ),
         )
 
@@ -2009,7 +2019,7 @@ class PrReviewStage(Stage):
                             IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP,
                         )
                         return "visibility_wait"
-                PrReviewStage._discard_stale_implementation_reply_draft(
+                PrReviewStage._preserve_stale_implementation_reply_draft(
                     item,
                     ctx,
                     expected_head_sha=head_sha,
@@ -2147,6 +2157,10 @@ class PrReviewStage(Stage):
             return StageOutcome(
                 Disposition.FINISH_FAIL, "implementation_reply_review_conflict_invalid"
             )
+        if handoff_status == "stale":
+            conflict_outcome = self._consume_implementation_reply_current_review_conflict(item, ctx)
+            if conflict_outcome is not None:
+                return conflict_outcome
         if handoff_status == "visibility_wait":
             return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
         if handoff_status == "invalid":

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1774,6 +1774,40 @@ class PrReviewStage(Stage):
         return None
 
     @staticmethod
+    def _discard_stale_implementation_reply_draft(
+        item: WorkItem,
+        ctx: StageContext,
+        *,
+        expected_head_sha: str,
+        current_state: object,
+        replies: dict[str, str],
+    ) -> None:
+        """Best-effort cleanup after a saved implementation head was replaced."""
+        if not (
+            isinstance(current_state, dict)
+            and current_state.get("state") == "OPEN"
+            and current_state.get("autoMergeRequest") is None
+            and isinstance(current_state.get("headRefOid"), str)
+            and is_full_commit_sha(current_state["headRefOid"])
+            and current_state["headRefOid"] != expected_head_sha
+            and item.pr is not None
+        ):
+            return
+        try:
+            ctx.github.discard_stale_implementation_thread_reply_batch(
+                item.pr,
+                expected_head_sha=expected_head_sha,
+                current_head_sha=current_state["headRefOid"],
+                replies=replies,
+            )
+        except Exception as error:
+            logger.warning(
+                "pr_review:%s: could not discard stale implementation reply draft (%s)",
+                item.issue,
+                type(error).__name__,
+            )
+
+    @staticmethod
     def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
         """Retry one exact post-push reply batch without invoking an agent.
 
@@ -1828,6 +1862,13 @@ class PrReviewStage(Stage):
                             IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP,
                         )
                         return "visibility_wait"
+                PrReviewStage._discard_stale_implementation_reply_draft(
+                    item,
+                    ctx,
+                    expected_head_sha=head_sha,
+                    current_state=state,
+                    replies=replies,
+                )
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -283,8 +283,6 @@ _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES = "pending_implementation_reply_ha
 _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
     "pending_implementation_reply_handoff_visibility_retries"
 )
-_IMPLEMENTATION_REPLY_BATCH_CONFLICT = "implementation_reply_batch_conflict"
-_IMPLEMENTATION_REPLY_REVIEW_CONFLICT = "implementation_reply_review_conflict"
 _IMPLEMENTATION_REPLY_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
 
 #: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
@@ -1268,32 +1266,6 @@ class PrReviewStage(Stage):
                         replied = set(getattr(reply_result, "replied_thread_ids", ()))
                         blocked = set(getattr(reply_result, "blocked_thread_ids", ()))
                         receipts = list(getattr(reply_result, "receipts", ()))
-                        duplicate_drafts = tuple(
-                            sorted(
-                                str(review_id)
-                                for review_id in getattr(
-                                    reply_result, "duplicate_current_draft_ids", ()
-                                )
-                            )
-                        )
-                        if duplicate_drafts:
-                            item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
-                                "head_sha": published_head,
-                                "review_ids": duplicate_drafts,
-                            }
-                        conflicting_current_reviews = tuple(
-                            sorted(
-                                str(review_id)
-                                for review_id in getattr(
-                                    reply_result, "conflicting_current_review_ids", ()
-                                )
-                            )
-                        )
-                        if conflicting_current_reviews:
-                            item.payload[_IMPLEMENTATION_REPLY_REVIEW_CONFLICT] = {
-                                "head_sha": published_head,
-                                "review_ids": conflicting_current_reviews,
-                            }
                         retryable = bool(getattr(reply_result, "retryable", False))
                         expected_ids = set(replies)
                         remaining_ids = expected_ids - replied
@@ -1338,7 +1310,7 @@ class PrReviewStage(Stage):
                             else:
                                 # A verified mismatch means the conversation changed.  Replaying
                                 # a stale snapshot can never repair it and eventually wedges the
-                                # work item; the pending review refresh will obtain new facts.
+                                # work item; the fresh reviewer cycle will obtain new facts.
                                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
                                 item.payload.pop(
                                     _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None
@@ -1812,130 +1784,7 @@ class PrReviewStage(Stage):
         return None
 
     @staticmethod
-    def _preserve_stale_implementation_reply_draft(
-        item: WorkItem,
-        ctx: StageContext,
-        *,
-        expected_head_sha: str,
-        current_state: object,
-        replies: dict[str, str],
-        batch_nonce: str,
-    ) -> None:
-        """Preserve visible stale drafts after a saved implementation head was replaced."""
-        if not (
-            isinstance(current_state, dict)
-            and current_state.get("state") == "OPEN"
-            and current_state.get("autoMergeRequest") is None
-            and isinstance(current_state.get("headRefOid"), str)
-            and is_full_commit_sha(current_state["headRefOid"])
-            and current_state["headRefOid"] != expected_head_sha
-            and item.pr is not None
-        ):
-            return
-        try:
-            preserved_review_ids = ctx.github.preserve_stale_implementation_thread_reply_batch(
-                item.pr,
-                expected_head_sha=expected_head_sha,
-                current_head_sha=current_state["headRefOid"],
-                replies=replies,
-                batch_nonce=batch_nonce,
-            )
-        except Exception as error:
-            logger.warning(
-                "pr_review:%s: could not preserve stale implementation reply draft (%s)",
-                item.issue,
-                type(error).__name__,
-            )
-            return
-        if preserved_review_ids:
-            item.payload[_IMPLEMENTATION_REPLY_REVIEW_CONFLICT] = {
-                "head_sha": current_state["headRefOid"],
-                "review_ids": tuple(sorted(str(review_id) for review_id in preserved_review_ids)),
-            }
-
-    def _consume_implementation_reply_review_conflict(
-        self,
-        item: WorkItem,
-        ctx: StageContext,
-        *,
-        payload_key: str,
-        minimum_review_count: int,
-    ) -> StepResult | None:
-        """Record one terminal diagnostic without mutating conflicting reviews.
-
-        A conflict has no safe existing thread to reply to. It is therefore
-        deliberately recorded in the stage outcome and logs, rather than as a
-        free-standing PR conversation comment.
-        """
-        conflict = item.payload.pop(payload_key, None)
-        if conflict is None:
-            return None
-        if item.pr is None or item.issue is None or not isinstance(conflict, dict):
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
-            )
-        head_sha = conflict.get("head_sha")
-        review_ids = conflict.get("review_ids")
-        if (
-            not is_full_commit_sha(head_sha)
-            or not isinstance(review_ids, tuple)
-            or len(review_ids) < minimum_review_count
-            or any(
-                not isinstance(review_id, str)
-                or not review_id
-                or len(review_id) > 256
-                or re.fullmatch(r"[A-Za-z0-9_=-]+", review_id) is None
-                for review_id in review_ids
-            )
-        ):
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_review_conflict_invalid"
-            )
-        item.payload["reviewed_pr_head_sha"] = head_sha
-        no_go_outcome = self._write_no_go(item, ctx)
-        if no_go_outcome is not None:
-            return no_go_outcome
-        logger.warning(
-            "pr_review:%d: stopped implementation replies on PR #%d at %s because "
-            "conflicting review IDs were preserved: %s",
-            item.issue,
-            item.pr,
-            head_sha,
-            ", ".join(review_ids),
-        )
-        return StageOutcome(
-            Disposition.FINISH_FAIL,
-            "implementation_reply_batch_conflict"
-            if payload_key == _IMPLEMENTATION_REPLY_BATCH_CONFLICT
-            else "implementation_reply_review_conflict",
-        )
-
-    def _consume_implementation_reply_batch_conflict(
-        self, item: WorkItem, ctx: StageContext
-    ) -> StepResult | None:
-        """Diagnose a duplicate exact batch without deleting either draft."""
-        return self._consume_implementation_reply_review_conflict(
-            item,
-            ctx,
-            payload_key=_IMPLEMENTATION_REPLY_BATCH_CONFLICT,
-            minimum_review_count=2,
-        )
-
-    def _consume_implementation_reply_current_review_conflict(
-        self, item: WorkItem, ctx: StageContext
-    ) -> StepResult | None:
-        """Diagnose a preserved current review without taking ownership of it."""
-        return self._consume_implementation_reply_review_conflict(
-            item,
-            ctx,
-            payload_key=_IMPLEMENTATION_REPLY_REVIEW_CONFLICT,
-            minimum_review_count=1,
-        )
-
-    @staticmethod
-    def _retry_pending_implementation_reply_handoff(  # noqa: C901 - recovery state machine
-        item: WorkItem, ctx: StageContext
-    ) -> str:
+    def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
         """Retry one exact post-push reply batch without invoking an agent.
 
         Returns ``none`` when no handoff exists, ``completed`` when every
@@ -1991,14 +1840,6 @@ class PrReviewStage(Stage):
                             IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP,
                         )
                         return "visibility_wait"
-                PrReviewStage._preserve_stale_implementation_reply_draft(
-                    item,
-                    ctx,
-                    expected_head_sha=head_sha,
-                    current_state=state,
-                    replies=replies,
-                    batch_nonce=batch_nonce,
-                )
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
@@ -2022,35 +1863,6 @@ class PrReviewStage(Stage):
         expected_ids = set(replies)
         replied = set(getattr(result, "replied_thread_ids", ()))
         receipts = list(getattr(result, "receipts", ()))
-        duplicate_drafts = tuple(
-            sorted(
-                str(review_id) for review_id in getattr(result, "duplicate_current_draft_ids", ())
-            )
-        )
-        if duplicate_drafts:
-            item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
-                "head_sha": head_sha,
-                "review_ids": duplicate_drafts,
-            }
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
-            return "duplicate_conflict"
-        conflicting_current_reviews = tuple(
-            sorted(
-                str(review_id)
-                for review_id in getattr(result, "conflicting_current_review_ids", ())
-            )
-        )
-        if conflicting_current_reviews:
-            item.payload[_IMPLEMENTATION_REPLY_REVIEW_CONFLICT] = {
-                "head_sha": head_sha,
-                "review_ids": conflicting_current_reviews,
-            }
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
-            return "review_conflict"
         if replied == expected_ids and len(receipts) == len(replied):
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
@@ -2100,13 +1912,6 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         payload = item.payload
 
-        conflict_outcome = self._consume_implementation_reply_batch_conflict(item, ctx)
-        if conflict_outcome is not None:
-            return conflict_outcome
-        conflict_outcome = self._consume_implementation_reply_current_review_conflict(item, ctx)
-        if conflict_outcome is not None:
-            return conflict_outcome
-
         if payload.pop("scope_retraction_failure", False):
             logger.warning(
                 "pr_review:%d: refusing to publish incomplete scope retraction",
@@ -2115,24 +1920,6 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_incomplete")
 
         handoff_status = self._retry_pending_implementation_reply_handoff(item, ctx)
-        if handoff_status == "duplicate_conflict":
-            conflict_outcome = self._consume_implementation_reply_batch_conflict(item, ctx)
-            if conflict_outcome is not None:
-                return conflict_outcome
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
-            )
-        if handoff_status == "review_conflict":
-            conflict_outcome = self._consume_implementation_reply_current_review_conflict(item, ctx)
-            if conflict_outcome is not None:
-                return conflict_outcome
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_review_conflict_invalid"
-            )
-        if handoff_status == "stale":
-            conflict_outcome = self._consume_implementation_reply_current_review_conflict(item, ctx)
-            if conflict_outcome is not None:
-                return conflict_outcome
         if handoff_status == "visibility_wait":
             return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
         if handoff_status == "invalid":

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -284,7 +284,7 @@ _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
     "pending_implementation_reply_handoff_visibility_retries"
 )
 _IMPLEMENTATION_REPLY_BATCH_CONFLICT = "implementation_reply_batch_conflict"
-_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT = "implementation_reply_pending_draft_conflict"
+_IMPLEMENTATION_REPLY_REVIEW_CONFLICT = "implementation_reply_review_conflict"
 _IMPLEMENTATION_REPLY_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
 
 #: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
@@ -540,7 +540,7 @@ def _implementation_reply_handoff(
     head_sha: object,
     threads: object,
     replies: object,
-    batch_nonce: object | None = None,
+    batch_nonce: object,
 ) -> dict[str, Any] | None:
     """Return a replay-safe outstanding implementation-reply handoff.
 
@@ -549,8 +549,6 @@ def _implementation_reply_handoff(
     nor an authority to mutate: the adapter rechecks the live PR and thread
     state before each retry.
     """
-    if batch_nonce is None:
-        batch_nonce = secrets.token_hex(16)
     if (
         not is_full_commit_sha(head_sha)
         or not isinstance(threads, list)
@@ -1229,6 +1227,7 @@ class PrReviewStage(Stage):
                         published_head,
                         thread_snapshots,
                         replies,
+                        secrets.token_hex(16),
                     )
                     if handoff is None:
                         logger.warning(
@@ -1280,20 +1279,20 @@ class PrReviewStage(Stage):
                         if duplicate_drafts:
                             item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
                                 "head_sha": published_head,
-                                "draft_ids": duplicate_drafts,
+                                "review_ids": duplicate_drafts,
                             }
-                        pending_draft_conflicts = tuple(
+                        conflicting_current_reviews = tuple(
                             sorted(
                                 str(review_id)
                                 for review_id in getattr(
-                                    reply_result, "conflicting_pending_draft_ids", ()
+                                    reply_result, "conflicting_current_review_ids", ()
                                 )
                             )
                         )
-                        if pending_draft_conflicts:
-                            item.payload[_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT] = {
+                        if conflicting_current_reviews:
+                            item.payload[_IMPLEMENTATION_REPLY_REVIEW_CONFLICT] = {
                                 "head_sha": published_head,
-                                "draft_ids": pending_draft_conflicts,
+                                "review_ids": conflicting_current_reviews,
                             }
                         retryable = bool(getattr(reply_result, "retryable", False))
                         expected_ids = set(replies)
@@ -1848,18 +1847,18 @@ class PrReviewStage(Stage):
                 type(error).__name__,
             )
 
-    def _consume_implementation_reply_draft_conflict(
+    def _consume_implementation_reply_review_conflict(
         self,
         item: WorkItem,
         ctx: StageContext,
         *,
         payload_key: str,
         marker_kind: str,
-        minimum_draft_count: int,
+        minimum_review_count: int,
         explanation: str,
         remediation: str,
     ) -> StepResult | None:
-        """Record one terminal diagnostic without mutating unowned drafts."""
+        """Record one terminal diagnostic without mutating conflicting reviews."""
         conflict = item.payload.pop(payload_key, None)
         if conflict is None:
             return None
@@ -1868,43 +1867,43 @@ class PrReviewStage(Stage):
                 Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
             )
         head_sha = conflict.get("head_sha")
-        draft_ids = conflict.get("draft_ids")
+        review_ids = conflict.get("review_ids")
         if (
             not is_full_commit_sha(head_sha)
-            or not isinstance(draft_ids, tuple)
-            or len(draft_ids) < minimum_draft_count
+            or not isinstance(review_ids, tuple)
+            or len(review_ids) < minimum_review_count
             or any(
                 not isinstance(review_id, str)
                 or not review_id
                 or len(review_id) > 256
                 or re.fullmatch(r"[A-Za-z0-9_=-]+", review_id) is None
-                for review_id in draft_ids
+                for review_id in review_ids
             )
         ):
             return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+                Disposition.FINISH_FAIL, "implementation_reply_review_conflict_invalid"
             )
         item.payload["reviewed_pr_head_sha"] = head_sha
         no_go_outcome = self._write_no_go(item, ctx)
         if no_go_outcome is not None:
             return no_go_outcome
         marker_hash = hashlib.sha256(
-            f"{item.pr}:{head_sha}:{','.join(draft_ids)}".encode()
+            f"{item.pr}:{head_sha}:{','.join(review_ids)}".encode()
         ).hexdigest()[:24]
         marker = f"<!-- hephaestus-implementation-reply-{marker_kind}:{marker_hash} -->"
         body = (
             f"{marker}\n\n"
             f"Automation stopped before posting implementation replies because {explanation}.\n\n"
             f"Head: `{head_sha}`\n\n"
-            f"Draft review IDs: {', '.join(f'`{review_id}`' for review_id in draft_ids)}\n\n"
-            "No review thread was resolved and no current draft was deleted. "
+            f"Conflicting review IDs: {', '.join(f'`{review_id}`' for review_id in review_ids)}\n\n"
+            "No review thread was resolved and no conflicting review was mutated. "
             f"{remediation}"
         )
         try:
             ctx.github.upsert_pr_comment(item.pr, marker, body)
         except Exception as error:
             logger.warning(
-                "pr_review:%d: failed to record implementation-reply draft conflict (%s)",
+                "pr_review:%d: failed to record implementation-reply review conflict (%s)",
                 item.issue,
                 type(error).__name__,
             )
@@ -1912,42 +1911,42 @@ class PrReviewStage(Stage):
                 Disposition.FINISH_FAIL,
                 "implementation_reply_batch_conflict_comment_failed"
                 if payload_key == _IMPLEMENTATION_REPLY_BATCH_CONFLICT
-                else "implementation_reply_draft_conflict_comment_failed",
+                else "implementation_reply_review_conflict_comment_failed",
             )
         return StageOutcome(
             Disposition.FINISH_FAIL,
             "implementation_reply_batch_conflict"
             if payload_key == _IMPLEMENTATION_REPLY_BATCH_CONFLICT
-            else "implementation_reply_draft_conflict",
+            else "implementation_reply_review_conflict",
         )
 
     def _consume_implementation_reply_batch_conflict(
         self, item: WorkItem, ctx: StageContext
     ) -> StepResult | None:
         """Diagnose a duplicate exact batch without deleting either draft."""
-        return self._consume_implementation_reply_draft_conflict(
+        return self._consume_implementation_reply_review_conflict(
             item,
             ctx,
             payload_key=_IMPLEMENTATION_REPLY_BATCH_CONFLICT,
-            marker_kind="draft-conflict",
-            minimum_draft_count=2,
+            marker_kind="duplicate-review-conflict",
+            minimum_review_count=2,
             explanation="multiple current-head draft reviews claim the same reply batch",
             remediation="Remove the duplicate drafts, then run a fresh implementation-review pass.",
         )
 
-    def _consume_implementation_reply_pending_draft_conflict(
+    def _consume_implementation_reply_current_review_conflict(
         self, item: WorkItem, ctx: StageContext
     ) -> StepResult | None:
-        """Diagnose a non-owned pending draft without taking ownership of it."""
-        return self._consume_implementation_reply_draft_conflict(
+        """Diagnose a non-owned current review without taking ownership of it."""
+        return self._consume_implementation_reply_review_conflict(
             item,
             ctx,
-            payload_key=_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT,
-            marker_kind="pending-draft-conflict",
-            minimum_draft_count=1,
-            explanation="a non-owned pending review prevents this reply batch",
+            payload_key=_IMPLEMENTATION_REPLY_REVIEW_CONFLICT,
+            marker_kind="review-conflict",
+            minimum_review_count=1,
+            explanation="a non-owned current implementation review prevents this reply batch",
             remediation=(
-                "Remove or submit the pending review, then run a fresh implementation-review pass."
+                "Inspect the conflicting review, then run a fresh implementation-review pass."
             ),
         )
 
@@ -2049,26 +2048,27 @@ class PrReviewStage(Stage):
         if duplicate_drafts:
             item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
                 "head_sha": head_sha,
-                "draft_ids": duplicate_drafts,
+                "review_ids": duplicate_drafts,
             }
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
             return "duplicate_conflict"
-        pending_draft_conflicts = tuple(
+        conflicting_current_reviews = tuple(
             sorted(
-                str(review_id) for review_id in getattr(result, "conflicting_pending_draft_ids", ())
+                str(review_id)
+                for review_id in getattr(result, "conflicting_current_review_ids", ())
             )
         )
-        if pending_draft_conflicts:
-            item.payload[_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT] = {
+        if conflicting_current_reviews:
+            item.payload[_IMPLEMENTATION_REPLY_REVIEW_CONFLICT] = {
                 "head_sha": head_sha,
-                "draft_ids": pending_draft_conflicts,
+                "review_ids": conflicting_current_reviews,
             }
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
-            return "pending_draft_conflict"
+            return "review_conflict"
         if replied == expected_ids and len(receipts) == len(replied):
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
@@ -2121,7 +2121,7 @@ class PrReviewStage(Stage):
         conflict_outcome = self._consume_implementation_reply_batch_conflict(item, ctx)
         if conflict_outcome is not None:
             return conflict_outcome
-        conflict_outcome = self._consume_implementation_reply_pending_draft_conflict(item, ctx)
+        conflict_outcome = self._consume_implementation_reply_current_review_conflict(item, ctx)
         if conflict_outcome is not None:
             return conflict_outcome
 
@@ -2140,12 +2140,12 @@ class PrReviewStage(Stage):
             return StageOutcome(
                 Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
             )
-        if handoff_status == "pending_draft_conflict":
-            conflict_outcome = self._consume_implementation_reply_pending_draft_conflict(item, ctx)
+        if handoff_status == "review_conflict":
+            conflict_outcome = self._consume_implementation_reply_current_review_conflict(item, ctx)
             if conflict_outcome is not None:
                 return conflict_outcome
             return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_draft_conflict_invalid"
+                Disposition.FINISH_FAIL, "implementation_reply_review_conflict_invalid"
             )
         if handoff_status == "visibility_wait":
             return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1821,6 +1821,64 @@ class PrReviewStage(Stage):
                 type(error).__name__,
             )
 
+    def _consume_implementation_reply_batch_conflict(
+        self, item: WorkItem, ctx: StageContext
+    ) -> StepResult | None:
+        """Record one terminal diagnostic for an ambiguous current batch."""
+        conflict = item.payload.pop(_IMPLEMENTATION_REPLY_BATCH_CONFLICT, None)
+        if conflict is None:
+            return None
+        if item.pr is None or item.issue is None or not isinstance(conflict, dict):
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+            )
+        head_sha = conflict.get("head_sha")
+        draft_ids = conflict.get("draft_ids")
+        if (
+            not is_full_commit_sha(head_sha)
+            or not isinstance(draft_ids, tuple)
+            or len(draft_ids) < 2
+            or any(
+                not isinstance(review_id, str)
+                or not review_id
+                or len(review_id) > 256
+                or re.fullmatch(r"[A-Za-z0-9_=-]+", review_id) is None
+                for review_id in draft_ids
+            )
+        ):
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+            )
+        item.payload["reviewed_pr_head_sha"] = head_sha
+        no_go_outcome = self._write_no_go(item, ctx)
+        if no_go_outcome is not None:
+            return no_go_outcome
+        marker_hash = hashlib.sha256(
+            f"{item.pr}:{head_sha}:{','.join(draft_ids)}".encode()
+        ).hexdigest()[:24]
+        marker = f"<!-- hephaestus-implementation-reply-draft-conflict:{marker_hash} -->"
+        body = (
+            f"{marker}\n\n"
+            "Automation stopped before posting implementation replies because multiple "
+            "current-head draft reviews claim the same reply batch.\n\n"
+            f"Head: `{head_sha}`\n\n"
+            f"Draft review IDs: {', '.join(f'`{review_id}`' for review_id in draft_ids)}\n\n"
+            "No review thread was resolved and no current draft was deleted. "
+            "Remove the duplicate drafts, then run a fresh implementation-review pass."
+        )
+        try:
+            ctx.github.upsert_pr_comment(item.pr, marker, body)
+        except Exception as error:
+            logger.warning(
+                "pr_review:%d: failed to record duplicate-draft conflict (%s)",
+                item.issue,
+                type(error).__name__,
+            )
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_comment_failed"
+            )
+        return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_batch_conflict")
+
     @staticmethod
     def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
         """Retry one exact post-push reply batch without invoking an agent.
@@ -1905,6 +1963,20 @@ class PrReviewStage(Stage):
         expected_ids = set(replies)
         replied = set(getattr(result, "replied_thread_ids", ()))
         receipts = list(getattr(result, "receipts", ()))
+        duplicate_drafts = tuple(
+            sorted(
+                str(review_id) for review_id in getattr(result, "duplicate_current_draft_ids", ())
+            )
+        )
+        if duplicate_drafts:
+            item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
+                "head_sha": head_sha,
+                "draft_ids": duplicate_drafts,
+            }
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
+            return "duplicate_conflict"
         if replied == expected_ids and len(receipts) == len(replied):
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
@@ -1953,58 +2025,9 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         payload = item.payload
 
-        conflict = payload.pop(_IMPLEMENTATION_REPLY_BATCH_CONFLICT, None)
-        if conflict is not None:
-            if not isinstance(conflict, dict):
-                return StageOutcome(
-                    Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
-                )
-            head_sha = conflict.get("head_sha")
-            draft_ids = conflict.get("draft_ids")
-            if (
-                not is_full_commit_sha(head_sha)
-                or not isinstance(draft_ids, tuple)
-                or len(draft_ids) < 2
-                or any(
-                    not isinstance(review_id, str)
-                    or not review_id
-                    or len(review_id) > 256
-                    or re.fullmatch(r"[A-Za-z0-9_=-]+", review_id) is None
-                    for review_id in draft_ids
-                )
-            ):
-                return StageOutcome(
-                    Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
-                )
-            item.payload["reviewed_pr_head_sha"] = head_sha
-            no_go_outcome = self._write_no_go(item, ctx)
-            if no_go_outcome is not None:
-                return no_go_outcome
-            marker_hash = hashlib.sha256(
-                f"{item.pr}:{head_sha}:{','.join(draft_ids)}".encode()
-            ).hexdigest()[:24]
-            marker = f"<!-- hephaestus-implementation-reply-draft-conflict:{marker_hash} -->"
-            body = (
-                f"{marker}\n\n"
-                "Automation stopped before posting implementation replies because multiple "
-                "current-head draft reviews claim the same reply batch.\n\n"
-                f"Head: `{head_sha}`\n\n"
-                f"Draft review IDs: {', '.join(f'`{review_id}`' for review_id in draft_ids)}\n\n"
-                "No review thread was resolved and no current draft was deleted. "
-                "Remove the duplicate drafts, then run a fresh implementation-review pass."
-            )
-            try:
-                ctx.github.upsert_pr_comment(item.pr, marker, body)
-            except Exception as error:
-                logger.warning(
-                    "pr_review:%d: failed to record duplicate-draft conflict (%s)",
-                    item.issue,
-                    type(error).__name__,
-                )
-                return StageOutcome(
-                    Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_comment_failed"
-                )
-            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_batch_conflict")
+        conflict_outcome = self._consume_implementation_reply_batch_conflict(item, ctx)
+        if conflict_outcome is not None:
+            return conflict_outcome
 
         if payload.pop("scope_retraction_failure", False):
             logger.warning(
@@ -2014,6 +2037,13 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_incomplete")
 
         handoff_status = self._retry_pending_implementation_reply_handoff(item, ctx)
+        if handoff_status == "duplicate_conflict":
+            conflict_outcome = self._consume_implementation_reply_batch_conflict(item, ctx)
+            if conflict_outcome is not None:
+                return conflict_outcome
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+            )
         if handoff_status == "visibility_wait":
             return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
         if handoff_status == "invalid":

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -98,6 +98,7 @@ import hashlib
 import json
 import logging
 import re
+import secrets
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
@@ -283,6 +284,8 @@ _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
     "pending_implementation_reply_handoff_visibility_retries"
 )
 _IMPLEMENTATION_REPLY_BATCH_CONFLICT = "implementation_reply_batch_conflict"
+_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT = "implementation_reply_pending_draft_conflict"
+_IMPLEMENTATION_REPLY_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
 
 #: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
 #: later round can never replay an earlier round's results.
@@ -537,6 +540,7 @@ def _implementation_reply_handoff(
     head_sha: object,
     threads: object,
     replies: object,
+    batch_nonce: object | None = None,
 ) -> dict[str, Any] | None:
     """Return a replay-safe outstanding implementation-reply handoff.
 
@@ -545,10 +549,14 @@ def _implementation_reply_handoff(
     nor an authority to mutate: the adapter rechecks the live PR and thread
     state before each retry.
     """
+    if batch_nonce is None:
+        batch_nonce = secrets.token_hex(16)
     if (
         not is_full_commit_sha(head_sha)
         or not isinstance(threads, list)
         or not isinstance(replies, dict)
+        or not isinstance(batch_nonce, str)
+        or _IMPLEMENTATION_REPLY_BATCH_NONCE_RE.fullmatch(batch_nonce) is None
     ):
         return None
     snapshots = [dict(thread) for thread in threads if isinstance(thread, dict)]
@@ -566,6 +574,7 @@ def _implementation_reply_handoff(
         "head_sha": head_sha,
         "threads": deepcopy(snapshots),
         "replies": dict(normalized_replies),
+        "batch_nonce": batch_nonce,
     }
 
 
@@ -1234,6 +1243,7 @@ class PrReviewStage(Stage):
                         # code commit has already changed the review head.
                         item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF] = handoff
                         item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+                    batch_nonce = handoff["batch_nonce"] if handoff is not None else ""
                     try:
                         # The worker returns the local commit it actually
                         # published.  A later arbitrary remote push must not
@@ -1247,6 +1257,7 @@ class PrReviewStage(Stage):
                             expected_head_sha=published_head,
                             threads=thread_snapshots,
                             replies=replies,
+                            batch_nonce=batch_nonce,
                         )
                     except Exception as error:
                         logger.warning(
@@ -1270,6 +1281,19 @@ class PrReviewStage(Stage):
                             item.payload[_IMPLEMENTATION_REPLY_BATCH_CONFLICT] = {
                                 "head_sha": published_head,
                                 "draft_ids": duplicate_drafts,
+                            }
+                        pending_draft_conflicts = tuple(
+                            sorted(
+                                str(review_id)
+                                for review_id in getattr(
+                                    reply_result, "conflicting_pending_draft_ids", ()
+                                )
+                            )
+                        )
+                        if pending_draft_conflicts:
+                            item.payload[_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT] = {
+                                "head_sha": published_head,
+                                "draft_ids": pending_draft_conflicts,
                             }
                         retryable = bool(getattr(reply_result, "retryable", False))
                         expected_ids = set(replies)
@@ -1303,6 +1327,7 @@ class PrReviewStage(Stage):
                                             for thread_id, reply in replies.items()
                                             if thread_id in retryable_ids
                                         },
+                                        batch_nonce,
                                     )
                                 )
                             elif retryable_ids:
@@ -1795,6 +1820,7 @@ class PrReviewStage(Stage):
         expected_head_sha: str,
         current_state: object,
         replies: dict[str, str],
+        batch_nonce: str,
     ) -> None:
         """Best-effort cleanup after a saved implementation head was replaced."""
         if not (
@@ -1813,6 +1839,7 @@ class PrReviewStage(Stage):
                 expected_head_sha=expected_head_sha,
                 current_head_sha=current_state["headRefOid"],
                 replies=replies,
+                batch_nonce=batch_nonce,
             )
         except Exception as error:
             logger.warning(
@@ -1821,11 +1848,19 @@ class PrReviewStage(Stage):
                 type(error).__name__,
             )
 
-    def _consume_implementation_reply_batch_conflict(
-        self, item: WorkItem, ctx: StageContext
+    def _consume_implementation_reply_draft_conflict(
+        self,
+        item: WorkItem,
+        ctx: StageContext,
+        *,
+        payload_key: str,
+        marker_kind: str,
+        minimum_draft_count: int,
+        explanation: str,
+        remediation: str,
     ) -> StepResult | None:
-        """Record one terminal diagnostic for an ambiguous current batch."""
-        conflict = item.payload.pop(_IMPLEMENTATION_REPLY_BATCH_CONFLICT, None)
+        """Record one terminal diagnostic without mutating unowned drafts."""
+        conflict = item.payload.pop(payload_key, None)
         if conflict is None:
             return None
         if item.pr is None or item.issue is None or not isinstance(conflict, dict):
@@ -1837,7 +1872,7 @@ class PrReviewStage(Stage):
         if (
             not is_full_commit_sha(head_sha)
             or not isinstance(draft_ids, tuple)
-            or len(draft_ids) < 2
+            or len(draft_ids) < minimum_draft_count
             or any(
                 not isinstance(review_id, str)
                 or not review_id
@@ -1856,31 +1891,70 @@ class PrReviewStage(Stage):
         marker_hash = hashlib.sha256(
             f"{item.pr}:{head_sha}:{','.join(draft_ids)}".encode()
         ).hexdigest()[:24]
-        marker = f"<!-- hephaestus-implementation-reply-draft-conflict:{marker_hash} -->"
+        marker = f"<!-- hephaestus-implementation-reply-{marker_kind}:{marker_hash} -->"
         body = (
             f"{marker}\n\n"
-            "Automation stopped before posting implementation replies because multiple "
-            "current-head draft reviews claim the same reply batch.\n\n"
+            f"Automation stopped before posting implementation replies because {explanation}.\n\n"
             f"Head: `{head_sha}`\n\n"
             f"Draft review IDs: {', '.join(f'`{review_id}`' for review_id in draft_ids)}\n\n"
             "No review thread was resolved and no current draft was deleted. "
-            "Remove the duplicate drafts, then run a fresh implementation-review pass."
+            f"{remediation}"
         )
         try:
             ctx.github.upsert_pr_comment(item.pr, marker, body)
         except Exception as error:
             logger.warning(
-                "pr_review:%d: failed to record duplicate-draft conflict (%s)",
+                "pr_review:%d: failed to record implementation-reply draft conflict (%s)",
                 item.issue,
                 type(error).__name__,
             )
             return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_comment_failed"
+                Disposition.FINISH_FAIL,
+                "implementation_reply_batch_conflict_comment_failed"
+                if payload_key == _IMPLEMENTATION_REPLY_BATCH_CONFLICT
+                else "implementation_reply_draft_conflict_comment_failed",
             )
-        return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_batch_conflict")
+        return StageOutcome(
+            Disposition.FINISH_FAIL,
+            "implementation_reply_batch_conflict"
+            if payload_key == _IMPLEMENTATION_REPLY_BATCH_CONFLICT
+            else "implementation_reply_draft_conflict",
+        )
+
+    def _consume_implementation_reply_batch_conflict(
+        self, item: WorkItem, ctx: StageContext
+    ) -> StepResult | None:
+        """Diagnose a duplicate exact batch without deleting either draft."""
+        return self._consume_implementation_reply_draft_conflict(
+            item,
+            ctx,
+            payload_key=_IMPLEMENTATION_REPLY_BATCH_CONFLICT,
+            marker_kind="draft-conflict",
+            minimum_draft_count=2,
+            explanation="multiple current-head draft reviews claim the same reply batch",
+            remediation="Remove the duplicate drafts, then run a fresh implementation-review pass.",
+        )
+
+    def _consume_implementation_reply_pending_draft_conflict(
+        self, item: WorkItem, ctx: StageContext
+    ) -> StepResult | None:
+        """Diagnose a non-owned pending draft without taking ownership of it."""
+        return self._consume_implementation_reply_draft_conflict(
+            item,
+            ctx,
+            payload_key=_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT,
+            marker_kind="pending-draft-conflict",
+            minimum_draft_count=1,
+            explanation="a non-owned pending review prevents this reply batch",
+            remediation=(
+                "Remove or submit the pending review, then run a fresh implementation-review pass."
+            ),
+        )
 
     @staticmethod
-    def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
+    def _retry_pending_implementation_reply_handoff(  # noqa: C901 - recovery state machine
+        item: WorkItem, ctx: StageContext
+    ) -> str:
         """Retry one exact post-push reply batch without invoking an agent.
 
         Returns ``none`` when no handoff exists, ``completed`` when every
@@ -1898,12 +1972,14 @@ class PrReviewStage(Stage):
             raw_handoff.get("head_sha") if isinstance(raw_handoff, dict) else None,
             raw_handoff.get("threads") if isinstance(raw_handoff, dict) else None,
             raw_handoff.get("replies") if isinstance(raw_handoff, dict) else None,
+            raw_handoff.get("batch_nonce") if isinstance(raw_handoff, dict) else None,
         )
         if handoff is None or item.pr is None:
             return "invalid"
         head_sha = handoff["head_sha"]
         threads = handoff["threads"]
         replies = handoff["replies"]
+        batch_nonce = handoff["batch_nonce"]
         try:
             state = ctx.github.gh_pr_state(item.pr)
             if not _pr_is_current_open_head(state, head_sha):
@@ -1940,6 +2016,7 @@ class PrReviewStage(Stage):
                     expected_head_sha=head_sha,
                     current_state=state,
                     replies=replies,
+                    batch_nonce=batch_nonce,
                 )
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
                 item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
@@ -1951,6 +2028,7 @@ class PrReviewStage(Stage):
                 expected_head_sha=head_sha,
                 threads=threads,
                 replies=replies,
+                batch_nonce=batch_nonce,
             )
         except Exception as error:
             logger.warning(
@@ -1977,6 +2055,20 @@ class PrReviewStage(Stage):
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
             return "duplicate_conflict"
+        pending_draft_conflicts = tuple(
+            sorted(
+                str(review_id) for review_id in getattr(result, "conflicting_pending_draft_ids", ())
+            )
+        )
+        if pending_draft_conflicts:
+            item.payload[_IMPLEMENTATION_REPLY_PENDING_DRAFT_CONFLICT] = {
+                "head_sha": head_sha,
+                "draft_ids": pending_draft_conflicts,
+            }
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
+            return "pending_draft_conflict"
         if replied == expected_ids and len(receipts) == len(replied):
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
             item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
@@ -2005,6 +2097,7 @@ class PrReviewStage(Stage):
                 for thread_id, reply in replies.items()
                 if thread_id in retryable_ids
             },
+            batch_nonce,
         )
         if replacement is None:
             return "invalid"
@@ -2028,6 +2121,9 @@ class PrReviewStage(Stage):
         conflict_outcome = self._consume_implementation_reply_batch_conflict(item, ctx)
         if conflict_outcome is not None:
             return conflict_outcome
+        conflict_outcome = self._consume_implementation_reply_pending_draft_conflict(item, ctx)
+        if conflict_outcome is not None:
+            return conflict_outcome
 
         if payload.pop("scope_retraction_failure", False):
             logger.warning(
@@ -2043,6 +2139,13 @@ class PrReviewStage(Stage):
                 return conflict_outcome
             return StageOutcome(
                 Disposition.FINISH_FAIL, "implementation_reply_batch_conflict_invalid"
+            )
+        if handoff_status == "pending_draft_conflict":
+            conflict_outcome = self._consume_implementation_reply_pending_draft_conflict(item, ctx)
+            if conflict_outcome is not None:
+                return conflict_outcome
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_draft_conflict_invalid"
             )
         if handoff_status == "visibility_wait":
             return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -125,7 +125,6 @@ from hephaestus.automation.review_audit import (
     ReviewAudit,
     has_reserved_finding_control,
     parse_review_audit,
-    render_review_audit,
 )
 from hephaestus.automation.session_naming import (
     AGENT_ADDRESS_REVIEW,
@@ -1614,23 +1613,24 @@ class PrReviewStage(Stage):
             publication_guard = self._require_reviewed_unarmed(item, ctx)
             if publication_guard is not None:
                 return publication_guard
-        try:
-            post_receipts = list(
-                ctx.github.post_review_threads(
-                    item.pr,
-                    list(threads),
-                    self._final_review_comment(audit),
-                    expected_head_sha=reviewed_head,
+        post_receipts: list[dict[str, Any]] = []
+        if threads:
+            try:
+                post_receipts = list(
+                    ctx.github.post_review_threads(
+                        item.pr,
+                        list(threads),
+                        expected_head_sha=reviewed_head,
+                    )
                 )
-            )
-        except Exception as error:
-            logger.warning(
-                "pr_review:%s: review finding publication failed (%s)",
-                item.issue,
-                type(error).__name__,
-            )
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
+            except Exception as error:
+                logger.warning(
+                    "pr_review:%s: review finding publication failed (%s)",
+                    item.issue,
+                    type(error).__name__,
+                )
+                item.payload["review_audit_failure"] = True
+                return Continue(next_state=EVAL)
         if len(post_receipts) != len(threads):
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
@@ -2553,8 +2553,3 @@ class PrReviewStage(Stage):
         if postwrite_outcome is not None:
             return postwrite_outcome
         return StageOutcome(Disposition.ADVANCE, "review audit; merge wait pending")
-
-    @staticmethod
-    def _final_review_comment(audit: ReviewAudit) -> str:
-        """Build an audit-only review comment; labels carry eligibility."""
-        return render_review_audit(audit)

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1364,13 +1364,38 @@ class PipelineGitHub:
         return second[0]
 
     def _implementation_reply_lock_path(self, pr_number: int) -> Path:
-        """Return the cross-process lock for one repository PR reply batch."""
+        """Return a local worktree-shared lock for one repository PR reply batch.
+
+        A linked worktree has a ``.git`` file pointing at the common
+        repository's ``.git/worktrees/<name>`` directory.  Reply publication
+        must use the common directory rather than the worktree-local state
+        directory, otherwise separate loop processes can both pass the
+        snapshot read and attach duplicate responses.  A standalone checkout
+        retains its repository-local state fallback.
+        """
         repo_key = hashlib.sha256((self._repo_slug or self.org).encode("utf-8")).hexdigest()[:16]
-        return (
-            ensure_state_dir(self._repo_root)
-            / "locks"
-            / (f"implementation-replies-{repo_key}-{pr_number}.lock")
-        )
+        git_metadata = self._repo_root / ".git"
+        lock_root = ensure_state_dir(self._repo_root) / "locks"
+        try:
+            if git_metadata.is_dir():
+                lock_root = git_metadata / "hephaestus-automation-locks"
+            elif git_metadata.is_file():
+                first_line = git_metadata.read_text(encoding="utf-8").splitlines()[0]
+                prefix, separator, raw_git_dir = first_line.partition(":")
+                if prefix == "gitdir" and separator and raw_git_dir.strip():
+                    git_dir = Path(raw_git_dir.strip())
+                    if not git_dir.is_absolute():
+                        git_dir = git_metadata.parent / git_dir
+                    if git_dir.parent.name == "worktrees":
+                        lock_root = git_dir.parent.parent / "hephaestus-automation-locks"
+                    else:
+                        lock_root = git_dir / "hephaestus-automation-locks"
+        except (IndexError, OSError, UnicodeDecodeError):
+            logger.warning(
+                "could not read Git metadata for implementation reply lock at %s",
+                git_metadata,
+            )
+        return lock_root / f"implementation-replies-{repo_key}-{pr_number}.lock"
 
     def post_implementation_thread_replies(
         self,
@@ -1385,8 +1410,8 @@ class PipelineGitHub:
 
         GitHub's client mutation id is a tracing field rather than a
         compare-and-swap primitive.  Cooperating loop processes therefore
-        hold one PR-scoped lock across discovery, draft creation, replies, and
-        submission.  The adapter fails closed on platforms without an
+        hold one worktree-shared PR-scoped lock across discovery and direct
+        thread replies.  The adapter fails closed on platforms without an
         exclusive lock instead of risking duplicate thread replies.
         """
         candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
@@ -2347,7 +2372,6 @@ class PipelineGitHub:
         self,
         pr_number: int,
         threads: list[dict[str, Any]],
-        summary: str,
         *,
         expected_head_sha: str,
     ) -> list[dict[str, Any]]:

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1046,7 +1046,7 @@ class PipelineGitHub:
                     ):
                         matches.append((review_id, state))
                     elif (
-                        self._is_implementation_reply_review_body(body)
+                        body == review_body
                         and isinstance(commit_oid, str)
                         and re.fullmatch(r"[0-9a-f]{40}", commit_oid) is not None
                         and commit_oid != expected_head_sha
@@ -1278,7 +1278,15 @@ class PipelineGitHub:
             return None
         reply_id, reply_body = snapshot[-1]
         final_comment = comments[-1]
-        if not isinstance(final_comment, dict) or not final_comment.get("viewer_did_author"):
+        if (
+            not isinstance(final_comment, dict)
+            or not final_comment.get("viewer_did_author")
+            or not isinstance(final_comment.get("review_id"), str)
+            or not final_comment["review_id"]
+            or final_comment.get("review_state") != "COMMENTED"
+            or not self._is_implementation_reply_review_body(final_comment.get("review_body"))
+            or final_comment.get("review_commit_sha") != reviewed_head_sha
+        ):
             return None
         marker_match = re.fullmatch(
             r"(?s)(.*)\n\n<!-- hephaestus-implementation-reply:[0-9a-f]{24} -->",
@@ -1424,7 +1432,7 @@ class PipelineGitHub:
             "id number repository{name owner{login}}}"
             "comments(first:100,after:$after){pageInfo{hasNextPage endCursor}"
             "nodes{id body viewerDidAuthor author{login __typename} "
-            "pullRequestReview{id body commit{oid}}}}}}}"
+            "pullRequestReview{id state body commit{oid}}}}}}}"
         )
 
         def read_once() -> tuple[dict[str, Any], bool] | None:  # noqa: C901
@@ -1546,6 +1554,7 @@ class PipelineGitHub:
                     comment_id = comment.get("id")
                     body = comment.get("body")
                     review_id = review.get("id") if isinstance(review, dict) else ""
+                    review_state = review.get("state") if isinstance(review, dict) else ""
                     review_body = review.get("body") if isinstance(review, dict) else ""
                     review_commit_sha = commit.get("oid") if isinstance(commit, dict) else ""
                     if (
@@ -1556,6 +1565,7 @@ class PipelineGitHub:
                         or not isinstance(author_type, str)
                         or not isinstance(comment.get("viewerDidAuthor"), bool)
                         or not isinstance(review_id, str)
+                        or not isinstance(review_state, str)
                         or not isinstance(review_body, str)
                         or not isinstance(review_commit_sha, str)
                     ):
@@ -1571,6 +1581,7 @@ class PipelineGitHub:
                             "author_type": author_type,
                             "viewer_did_author": comment["viewerDidAuthor"],
                             "review_id": review_id,
+                            "review_state": review_state,
                             "review_body": review_body,
                             "review_commit_sha": review_commit_sha,
                         }
@@ -1681,6 +1692,8 @@ class PipelineGitHub:
         manual pending review; those are returned as a conflict by the
         inventory and left for an operator.
         """
+        if self._skip(f"discard stale implementation reply draft on PR #{pr_number}"):
+            return True
         if (
             not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
             or not re.fullmatch(r"[0-9a-f]{40}", current_head_sha)
@@ -1829,13 +1842,11 @@ class PipelineGitHub:
                 )
             if existing_review is None:
                 # A reply from an old per-comment review is not a successful
-                # batch receipt.  Do not duplicate it by creating a new batch
-                # over the same thread; a fresh review pass must establish a
-                # coherent current handoff.
+                # batch receipt.  A fresh review pass must establish a
+                # coherent current handoff without retrying this stale one.
                 if recovered:
                     return ImplementationThreadReplyResult(
-                        retryable_thread_ids=candidate_ids,
-                        retryable=True,
+                        blocked_thread_ids=candidate_ids,
                     )
                 review_id = self._create_implementation_reply_review(
                     pr_id, expected_head_sha, review_body

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -95,6 +95,15 @@ _IMPLEMENTATION_REPLY_REVIEW_BODY_RE = re.compile(
 )
 
 
+class DuplicateImplementationReplyDraftsError(RuntimeError):
+    """Two current pending drafts make cross-checkout ownership unprovable."""
+
+    def __init__(self, review_ids: tuple[str, ...]) -> None:
+        """Record the opaque draft review IDs that made ownership ambiguous."""
+        super().__init__("multiple current implementation reply drafts")
+        self.review_ids = review_ids
+
+
 def _parse_included_http_response(
     stdout: str,
 ) -> tuple[int | None, dict[str, Any] | None, bool]:
@@ -997,7 +1006,8 @@ class PipelineGitHub:
             "pageInfo{hasNextPage endCursor} nodes{id state body viewerDidAuthor commit{oid}}}}}}"
         )
         expected_pr_id: str | None = None
-        matches: list[tuple[str, str]] = []
+        pending_matches: list[tuple[str, str]] = []
+        commented_matches: list[tuple[str, str]] = []
         stale_pending_ids: list[str] = []
         has_pending_conflict = False
         seen_cursors: set[str] = set()
@@ -1044,7 +1054,7 @@ class PipelineGitHub:
                         and isinstance(commit_oid, str)
                         and commit_oid == expected_head_sha
                     ):
-                        matches.append((review_id, state))
+                        pending_matches.append((review_id, state))
                     elif (
                         body == review_body
                         and isinstance(commit_oid, str)
@@ -1063,7 +1073,7 @@ class PipelineGitHub:
                     or commit_oid != expected_head_sha
                 ):
                     return None
-                matches.append((review_id, state))
+                commented_matches.append((review_id, state))
             page_info = reviews.get("pageInfo")
             if not isinstance(page_info, dict) or not isinstance(
                 page_info.get("hasNextPage"), bool
@@ -1076,11 +1086,26 @@ class PipelineGitHub:
                 return None
             seen_cursors.add(next_cursor)
             after = next_cursor
-        if expected_pr_id is None or len(matches) > 1:
+        if expected_pr_id is None or len(commented_matches) > 1:
             return None
+        if commented_matches:
+            # A completed batch remains durable proof even when a losing
+            # cross-checkout process left a current-head pending draft. The
+            # adapter never deletes that draft, but it must not force the
+            # already-submitted review back through a retry loop.
+            return (
+                expected_pr_id,
+                commented_matches[0],
+                tuple(sorted(set(stale_pending_ids))),
+                has_pending_conflict,
+            )
+        if len(pending_matches) > 1:
+            raise DuplicateImplementationReplyDraftsError(
+                tuple(sorted(review_id for review_id, _ in pending_matches))
+            )
         return (
             expected_pr_id,
-            matches[0] if matches else None,
+            pending_matches[0] if pending_matches else None,
             tuple(sorted(set(stale_pending_ids))),
             has_pending_conflict,
         )
@@ -1304,6 +1329,63 @@ class PipelineGitHub:
             return None
         return reply_id, reply_body
 
+    def _validated_implementation_reply_batch(
+        self,
+        pr_number: int,
+        reviewed_head_sha: str,
+        threads: list[dict[str, Any]],
+    ) -> list[tuple[dict[str, Any], str, str]]:
+        """Return one complete, submitted implementation reply batch.
+
+        A per-thread reply marker only establishes that one response is bound
+        to a thread and head.  It cannot establish that an implementation pass
+        used a single review.  Before the reviewer may act, every eligible
+        final reply must therefore belong to one submitted review whose
+        deterministic summary covers the complete live group.
+        """
+        candidates: list[tuple[dict[str, Any], str, str, str, str]] = []
+        seen_thread_ids: set[str] = set()
+        for thread in threads:
+            if not isinstance(thread, dict):
+                return []
+            thread_id = thread.get("id")
+            comments = thread.get("comments")
+            implementation_reply = self._validated_implementation_reply(
+                pr_number, reviewed_head_sha, thread
+            )
+            if implementation_reply is None:
+                continue
+            if (
+                not isinstance(thread_id, str)
+                or not thread_id
+                or thread_id in seen_thread_ids
+                or not isinstance(comments, list)
+                or not comments
+                or not isinstance(comments[-1], dict)
+            ):
+                return []
+            review_id = comments[-1].get("review_id")
+            review_body = comments[-1].get("review_body")
+            if not isinstance(review_id, str) or not review_id or not isinstance(review_body, str):
+                return []
+            seen_thread_ids.add(thread_id)
+            reply_id, reply_body = implementation_reply
+            candidates.append((thread, reply_id, reply_body, review_id, review_body))
+        if not candidates:
+            return []
+        review_ids = {candidate[3] for candidate in candidates}
+        review_bodies = {candidate[4] for candidate in candidates}
+        if len(review_ids) != 1 or len(review_bodies) != 1:
+            return []
+        expected_body = self._implementation_reply_review_body(
+            pr_number,
+            reviewed_head_sha,
+            {str(candidate[0]["id"]): candidate[2] for candidate in candidates},
+        )
+        if review_bodies.pop() != expected_body:
+            return []
+        return [(thread, reply_id, reply_body) for thread, reply_id, reply_body, _, _ in candidates]
+
     def reviewer_validation_receipts(
         self,
         pr_number: int,
@@ -1334,12 +1416,9 @@ class PipelineGitHub:
             ):
                 raise RuntimeError("malformed live review-thread snapshot")
             seen.add(thread_id)
-            implementation_reply = self._validated_implementation_reply(
-                pr_number, reviewed_head_sha, thread
-            )
-            if implementation_reply is None:
-                continue
-            reply_id, reply_body = implementation_reply
+        for thread, reply_id, reply_body in self._validated_implementation_reply_batch(
+            pr_number, reviewed_head_sha, threads
+        ):
             receipts.append(
                 {
                     **thread,
@@ -1924,6 +2003,16 @@ class PipelineGitHub:
                     retryable_thread_ids=candidate_ids,
                     retryable=True,
                 )
+        except DuplicateImplementationReplyDraftsError as error:
+            logger.error(
+                "Implementation reply batch on PR #%s stopped: duplicate current drafts %s",
+                pr_number,
+                ", ".join(error.review_ids),
+            )
+            return ImplementationThreadReplyResult(
+                blocked_thread_ids=candidate_ids,
+                duplicate_current_draft_ids=error.review_ids,
+            )
         except (
             AttributeError,
             OSError,
@@ -1963,6 +2052,21 @@ class PipelineGitHub:
             or self._skip(
                 f"reconcile {len(candidate_ids)} reviewer-validated threads on PR #{pr_number}"
             )
+        ):
+            return ReviewerThreadReconciliationResult(blocked_thread_ids=candidate_ids)
+        batch = self._validated_implementation_reply_batch(pr_number, reviewed_head_sha, receipts)
+        batch_by_id = {
+            str(thread.get("id") or ""): (reply_id, reply_body)
+            for thread, reply_id, reply_body in batch
+        }
+        if set(batch_by_id) != expected_ids or any(
+            not isinstance(receipt, dict)
+            or batch_by_id.get(str(receipt.get("id") or ""))
+            != (
+                receipt.get("implementation_reply_id"),
+                receipt.get("implementation_reply_body"),
+            )
+            for receipt in receipts
         ):
             return ReviewerThreadReconciliationResult(blocked_thread_ids=candidate_ids)
         by_id: dict[str, dict[str, Any]] = {}

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -89,20 +89,10 @@ logger = logging.getLogger(__name__)
 _CLOSES_ISSUE_LINE_RE = re.compile(r"^Closes #(\d+)\s*$", re.MULTILINE)
 _STANDALONE_VERDICT_LINE_RE = re.compile(r"(?i)^\s*verdict\s*:")
 _HTTP_STATUS_RE = re.compile(r"^HTTP/\S+\s+(\d{3})\b", re.MULTILINE)
-_IMPLEMENTATION_REPLY_REVIEW_BODY_RE = re.compile(
-    r"\AImplementation responses for [1-9]\d* review thread\(s\)\.\n\n"
-    r"<!-- hephaestus-implementation-review:[0-9a-f]{24} -->\n"
+_IMPLEMENTATION_REPLY_BODY_RE = re.compile(
+    r"(?s)\A(.*)\n\n<!-- hephaestus-implementation-reply:[0-9a-f]{24} -->\n"
     r"<!-- hephaestus-implementation-batch:([0-9a-f]{32}) -->\Z"
 )
-
-
-class DuplicateImplementationReplyDraftsError(RuntimeError):
-    """Two current pending drafts make cross-checkout ownership unprovable."""
-
-    def __init__(self, review_ids: tuple[str, ...]) -> None:
-        """Record the opaque draft review IDs that made ownership ambiguous."""
-        super().__init__("multiple current implementation reply drafts")
-        self.review_ids = review_ids
 
 
 def _parse_included_http_response(
@@ -914,7 +904,6 @@ class PipelineGitHub:
         live: dict[str, Any],
         reply_body: str,
         expected_comment_id: str | None = None,
-        expected_review_id: str | None = None,
     ) -> str | None:
         """Return a proven coordinator reply appended to one exact snapshot.
 
@@ -937,11 +926,6 @@ class PipelineGitHub:
         comment_id = after[-1][0]
         if expected_comment_id is not None and comment_id != expected_comment_id:
             return None
-        if (
-            expected_review_id is not None
-            and cls._final_comment_review_id(live) != expected_review_id
-        ):
-            return None
         return (
             comment_id
             if cls._same_snapshot_with_reply(receipt, live, reply_body, comment_id)
@@ -957,337 +941,30 @@ class PipelineGitHub:
         return reply if 0 < len(reply) <= 4_000 else None
 
     def _implementation_thread_reply_body(
-        self, pr_number: int, head_sha: str, thread_id: str, reply: str
+        self, pr_number: int, head_sha: str, thread_id: str, reply: str, batch_nonce: str
     ) -> str:
-        """Bind an implementation reply to one exact thread and pushed head."""
-        seed = ":".join([self._repo_slug or self.org, str(pr_number), thread_id, head_sha, reply])
-        marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
-        return f"{reply}\n\n<!-- hephaestus-implementation-reply:{marker} -->"
-
-    def _implementation_reply_review_body(
-        self,
-        pr_number: int,
-        head_sha: str,
-        replies: dict[str, str],
-        batch_nonce: str | None = None,
-    ) -> str:
-        """Return the durable summary marker for one implementation reply batch."""
-        if not isinstance(batch_nonce, str) or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
+        """Bind an implementation reply to one exact thread, head, and batch."""
+        if re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
             raise ValueError(
                 "implementation reply batch nonce must be 32 lowercase hexadecimal chars"
             )
         seed = ":".join(
-            [
-                self._repo_slug or self.org,
-                str(pr_number),
-                head_sha,
-                batch_nonce,
-                *(f"{thread_id}:{reply}" for thread_id, reply in sorted(replies.items())),
-            ]
+            [self._repo_slug or self.org, str(pr_number), thread_id, head_sha, reply, batch_nonce]
         )
         marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
         return (
-            f"Implementation responses for {len(replies)} review thread(s).\n\n"
-            f"<!-- hephaestus-implementation-review:{marker} -->\n"
+            f"{reply}\n\n"
+            f"<!-- hephaestus-implementation-reply:{marker} -->\n"
             f"<!-- hephaestus-implementation-batch:{batch_nonce} -->"
         )
 
     @staticmethod
     def _implementation_reply_batch_nonce(review_body: object) -> str | None:
-        """Return the opaque nonce from one valid implementation batch body."""
+        """Return the nonce carried by one source-attached implementation reply."""
         if not isinstance(review_body, str):
             return None
-        match = _IMPLEMENTATION_REPLY_REVIEW_BODY_RE.fullmatch(review_body)
-        return match.group(1) if match is not None else None
-
-    @staticmethod
-    def _is_implementation_reply_review_body(body: object) -> bool:
-        """Return whether ``body`` is a coordinator-owned batch marker."""
-        return (
-            isinstance(body, str)
-            and _IMPLEMENTATION_REPLY_REVIEW_BODY_RE.fullmatch(body) is not None
-        )
-
-    def _implementation_reply_review_inventory(  # noqa: C901 - paginated GraphQL proof is fail-closed
-        self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> (
-        tuple[str, tuple[str, str] | None, tuple[str, ...], tuple[str, ...], tuple[str, ...]] | None
-    ):
-        """Return the exact batch review plus stale and conflicting current reviews.
-
-        Every visible current pending review and every visible marked current
-        implementation review is a conflict unless it is this exact batch.
-        Stale drafts are preserved for manual cleanup; GitHub offers no
-        conditional delete that could prove a later actor had not changed one.
-        """
-        query = (
-            "query($owner:String!,$name:String!,$number:Int!,$after:String){"
-            "repository(owner:$owner,name:$name){pullRequest(number:$number){"
-            "id state headRefOid autoMergeRequest{enabledAt} reviews(first:100,after:$after){"
-            "pageInfo{hasNextPage endCursor} nodes{id state body viewerDidAuthor commit{oid}}}}}}"
-        )
-        expected_pr_id: str | None = None
-        pending_matches: list[tuple[str, str]] = []
-        commented_matches: list[tuple[str, str]] = []
-        stale_pending_ids: list[str] = []
-        pending_conflict_ids: list[str] = []
-        commented_conflict_ids: list[str] = []
-        seen_cursors: set[str] = set()
-        after: str | None = None
-        while True:
-            fields: dict[str, int | str] = {"number": pr_number}
-            if after is not None:
-                fields["after"] = after
-            data = self._graphql(query, **fields)
-            data_node = data.get("data") if isinstance(data, dict) else None
-            repository = data_node.get("repository") if isinstance(data_node, dict) else None
-            pull_request = repository.get("pullRequest") if isinstance(repository, dict) else None
-            if not isinstance(pull_request, dict):
-                return None
-            pr_id = pull_request.get("id")
-            if (
-                not isinstance(pr_id, str)
-                or not pr_id
-                or not self._pr_is_current_open_head(pull_request, expected_head_sha)
-            ):
-                return None
-            if expected_pr_id is None:
-                expected_pr_id = pr_id
-            elif expected_pr_id != pr_id:
-                return None
-            reviews = pull_request.get("reviews")
-            if not isinstance(reviews, dict) or not isinstance(reviews.get("nodes"), list):
-                return None
-            for review in reviews["nodes"]:
-                if not isinstance(review, dict):
-                    return None
-                review_id = review.get("id")
-                state = review.get("state")
-                body = review.get("body")
-                commit = review.get("commit")
-                commit_oid = commit.get("oid") if isinstance(commit, dict) else None
-                if not isinstance(review_id, str) or not review_id or not isinstance(state, str):
-                    return None
-                if review.get("viewerDidAuthor") is not True:
-                    if state == "PENDING":
-                        pending_conflict_ids.append(review_id)
-                    elif (
-                        state == "COMMENTED"
-                        and isinstance(commit_oid, str)
-                        and commit_oid == expected_head_sha
-                        and self._is_implementation_reply_review_body(body)
-                    ):
-                        commented_conflict_ids.append(review_id)
-                    continue
-                if state == "PENDING":
-                    if (
-                        body == review_body
-                        and isinstance(commit_oid, str)
-                        and commit_oid == expected_head_sha
-                    ):
-                        pending_matches.append((review_id, state))
-                    elif (
-                        body == review_body
-                        and isinstance(commit_oid, str)
-                        and re.fullmatch(r"[0-9a-f]{40}", commit_oid) is not None
-                        and commit_oid != expected_head_sha
-                    ):
-                        stale_pending_ids.append(review_id)
-                    else:
-                        pending_conflict_ids.append(review_id)
-                    continue
-                if body != review_body:
-                    if (
-                        state == "COMMENTED"
-                        and isinstance(commit_oid, str)
-                        and commit_oid == expected_head_sha
-                        and self._is_implementation_reply_review_body(body)
-                    ):
-                        commented_conflict_ids.append(review_id)
-                    continue
-                if (
-                    state == "COMMENTED"
-                    and isinstance(commit_oid, str)
-                    and re.fullmatch(r"[0-9a-f]{40}", commit_oid) is not None
-                    and commit_oid != expected_head_sha
-                ):
-                    # A submitted old-head batch is immutable history, not a
-                    # recoverable pending draft.  Keep inventorying so a
-                    # current incomplete review cannot be hidden behind it.
-                    continue
-                if (
-                    state != "COMMENTED"
-                    or not isinstance(commit_oid, str)
-                    or commit_oid != expected_head_sha
-                ):
-                    return None
-                commented_matches.append((review_id, state))
-            page_info = reviews.get("pageInfo")
-            if not isinstance(page_info, dict) or not isinstance(
-                page_info.get("hasNextPage"), bool
-            ):
-                return None
-            if not page_info["hasNextPage"]:
-                break
-            next_cursor = page_info.get("endCursor")
-            if not isinstance(next_cursor, str) or not next_cursor or next_cursor in seen_cursors:
-                return None
-            seen_cursors.add(next_cursor)
-            after = next_cursor
-        if expected_pr_id is None or len(commented_matches) > 1:
-            return None
-        if commented_matches:
-            # A completed batch remains durable proof even when a losing
-            # cross-checkout process left a current-head pending draft. The
-            # adapter never deletes that draft, but it must not force the
-            # already-submitted review back through a retry loop.
-            return (
-                expected_pr_id,
-                commented_matches[0],
-                tuple(sorted(set(stale_pending_ids))),
-                tuple(sorted(set(pending_conflict_ids))),
-                tuple(sorted(set(commented_conflict_ids))),
-            )
-        if len(pending_matches) > 1:
-            raise DuplicateImplementationReplyDraftsError(
-                tuple(sorted(review_id for review_id, _ in pending_matches))
-            )
-        return (
-            expected_pr_id,
-            pending_matches[0] if pending_matches else None,
-            tuple(sorted(set(stale_pending_ids))),
-            tuple(sorted(set(pending_conflict_ids))),
-            tuple(sorted(set(commented_conflict_ids))),
-        )
-
-    def _find_implementation_reply_review(
-        self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> tuple[str, tuple[str, str] | None] | None:
-        """Find the current actor's durable batch review for an exact PR head.
-
-        The pending review is the restart-safe receipt for an interrupted
-        implementation-reply pass.  A matching submitted review proves that a
-        prior call completed after its transport response was lost.
-        """
-        inventory = self._implementation_reply_review_inventory(
-            pr_number, expected_head_sha, review_body
-        )
-        if inventory is None:
-            return None
-        pr_id, review, stale_pending_ids, pending_conflict_ids, commented_conflict_ids = inventory
-        if stale_pending_ids or (
-            (pending_conflict_ids or commented_conflict_ids)
-            and (review is None or review[1] != "COMMENTED")
-        ):
-            return None
-        return pr_id, review
-
-    def _create_implementation_reply_review(
-        self, pr_id: str, expected_head_sha: str, review_body: str
-    ) -> str | None:
-        """Create one pending review that will own every implementation reply."""
-        query = (
-            "mutation($prId:ID!,$commitOid:GitObjectID!,$body:String!,$clientMutationId:String!){"
-            "addPullRequestReview(input:{pullRequestId:$prId,commitOID:$commitOid,body:$body,"
-            "clientMutationId:$clientMutationId}){pullRequestReview{id state body commit{oid}}}}"
-        )
-        data = self._graphql(
-            query,
-            prId=pr_id,
-            commitOid=expected_head_sha,
-            body=review_body,
-            clientMutationId=hashlib.sha256(review_body.encode("utf-8")).hexdigest(),
-        )
-        response_data = data.get("data") if isinstance(data, dict) else None
-        mutation = (
-            response_data.get("addPullRequestReview") if isinstance(response_data, dict) else None
-        )
-        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
-        commit = review.get("commit") if isinstance(review, dict) else None
-        if (
-            not isinstance(review, dict)
-            or not isinstance(review.get("id"), str)
-            or not review["id"]
-            or review.get("state") != "PENDING"
-            or review.get("body") != review_body
-            or not isinstance(commit, dict)
-            or commit.get("oid") != expected_head_sha
-        ):
-            return None
-        return str(review["id"])
-
-    def _submit_implementation_reply_review(
-        self, pr_id: str, review_id: str, review_body: str
-    ) -> bool:
-        """Submit the fully proven reply batch as one COMMENTED review."""
-        query = (
-            "mutation($prId:ID!,$reviewId:ID!,$body:String!,$clientMutationId:String!){"
-            "submitPullRequestReview(input:{pullRequestId:$prId,pullRequestReviewId:$reviewId,"
-            "event:COMMENT,body:$body,clientMutationId:$clientMutationId})"
-            "{pullRequestReview{id state body}}}"
-        )
-        data = self._graphql(
-            query,
-            prId=pr_id,
-            reviewId=review_id,
-            body=review_body,
-            clientMutationId=hashlib.sha256(
-                f"{review_id}:{review_body}:submit".encode()
-            ).hexdigest(),
-        )
-        response_data = data.get("data") if isinstance(data, dict) else None
-        mutation = (
-            response_data.get("submitPullRequestReview")
-            if isinstance(response_data, dict)
-            else None
-        )
-        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
-        return bool(
-            isinstance(review, dict)
-            and review.get("id") == review_id
-            and review.get("state") == "COMMENTED"
-            and review.get("body") == review_body
-        )
-
-    def _implementation_reply_review_state(
-        self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> tuple[str, tuple[str, str] | None, tuple[str, ...]] | None:
-        """Return the exact batch and every visible preserved-review conflict.
-
-        This accessor is intentionally read-only.  It never tries to recover
-        from an interrupted batch by deleting a draft, because GitHub's review
-        API supplies no compare-and-swap precondition for that mutation.
-        """
-        inventory = self._implementation_reply_review_inventory(
-            pr_number, expected_head_sha, review_body
-        )
-        if inventory is None:
-            return None
-        (
-            pr_id,
-            review,
-            stale_pending_ids,
-            pending_conflict_ids,
-            commented_conflict_ids,
-        ) = inventory
-        return (
-            pr_id,
-            review,
-            tuple(
-                sorted(
-                    set(stale_pending_ids).union(pending_conflict_ids).union(commented_conflict_ids)
-                )
-            ),
-        )
-
-    @staticmethod
-    def _final_comment_review_id(thread: dict[str, Any]) -> str | None:
-        """Return the review owning a complete thread's final comment."""
-        comments = thread.get("comments")
-        if not isinstance(comments, list) or not comments or not isinstance(comments[-1], dict):
-            return None
-        review_id = comments[-1].get("review_id")
-        return review_id if isinstance(review_id, str) and review_id else None
+        match = _IMPLEMENTATION_REPLY_BODY_RE.fullmatch(review_body)
+        return match.group(2) if match is not None else None
 
     def _validated_implementation_reply(
         self, pr_number: int, reviewed_head_sha: str, thread: dict[str, Any]
@@ -1312,21 +989,18 @@ class PipelineGitHub:
             or not isinstance(final_comment.get("review_id"), str)
             or not final_comment["review_id"]
             or final_comment.get("review_state") != "COMMENTED"
-            or not self._is_implementation_reply_review_body(final_comment.get("review_body"))
             or final_comment.get("review_commit_sha") != reviewed_head_sha
         ):
             return None
-        marker_match = re.fullmatch(
-            r"(?s)(.*)\n\n<!-- hephaestus-implementation-reply:[0-9a-f]{24} -->",
-            reply_body,
-        )
+        marker_match = _IMPLEMENTATION_REPLY_BODY_RE.fullmatch(reply_body)
         if marker_match is None:
             return None
         reply = self._safe_thread_reply(marker_match.group(1))
-        if reply is None:
+        batch_nonce = marker_match.group(2)
+        if reply is None or batch_nonce is None:
             return None
         expected_body = self._implementation_thread_reply_body(
-            pr_number, reviewed_head_sha, thread_id, reply
+            pr_number, reviewed_head_sha, thread_id, reply, batch_nonce
         )
         if reply_body != expected_body:
             return None
@@ -1340,13 +1014,11 @@ class PipelineGitHub:
     ) -> list[tuple[dict[str, Any], str, str]]:
         """Return one complete, submitted implementation reply batch.
 
-        A per-thread reply marker only establishes that one response is bound
-        to a thread and head.  It cannot establish that an implementation pass
-        used a single review.  Before the reviewer may act, every eligible
-        final reply must therefore belong to one submitted review whose
-        deterministic summary covers the complete live group.
+        A per-thread reply marker binds one response to a thread and head. The
+        shared CSPRNG batch nonce binds the complete implementation pass without
+        publishing an unanchored review-level summary.
         """
-        candidates: list[tuple[dict[str, Any], str, str, str, str]] = []
+        candidates: list[tuple[dict[str, Any], str, str, str]] = []
         seen_thread_ids: set[str] = set()
         for thread in threads:
             if not isinstance(thread, dict):
@@ -1367,32 +1039,18 @@ class PipelineGitHub:
                 or not isinstance(comments[-1], dict)
             ):
                 return []
-            review_id = comments[-1].get("review_id")
-            review_body = comments[-1].get("review_body")
-            if not isinstance(review_id, str) or not review_id or not isinstance(review_body, str):
+            reply_id, reply_body = implementation_reply
+            batch_nonce = self._implementation_reply_batch_nonce(reply_body)
+            if batch_nonce is None:
                 return []
             seen_thread_ids.add(thread_id)
-            reply_id, reply_body = implementation_reply
-            candidates.append((thread, reply_id, reply_body, review_id, review_body))
+            candidates.append((thread, reply_id, reply_body, batch_nonce))
         if not candidates:
             return []
-        review_ids = {candidate[3] for candidate in candidates}
-        review_bodies = {candidate[4] for candidate in candidates}
-        if len(review_ids) != 1 or len(review_bodies) != 1:
+        batch_nonces = {candidate[3] for candidate in candidates}
+        if len(batch_nonces) != 1:
             return []
-        review_body = review_bodies.pop()
-        batch_nonce = self._implementation_reply_batch_nonce(review_body)
-        if batch_nonce is None:
-            return []
-        expected_body = self._implementation_reply_review_body(
-            pr_number,
-            reviewed_head_sha,
-            {str(candidate[0]["id"]): candidate[2] for candidate in candidates},
-            batch_nonce,
-        )
-        if review_body != expected_body:
-            return []
-        return [(thread, reply_id, reply_body) for thread, reply_id, reply_body, _, _ in candidates]
+        return [(thread, reply_id, reply_body) for thread, reply_id, reply_body, _ in candidates]
 
     def reviewer_validation_receipts(
         self,
@@ -1450,37 +1108,23 @@ class PipelineGitHub:
             f"<!-- hephaestus-reviewer-validation:{marker} -->"
         )
 
-    def _add_thread_reply(
-        self, thread_id: str, body: str, *, review_id: str | None = None
-    ) -> str | None:
-        """Post one coordinator-owned reply and return its opaque comment ID.
+    def _add_thread_reply(self, thread_id: str, body: str) -> str | None:
+        """Post one response on an existing review thread.
 
-        Implementation replies supply a pending review id so GitHub associates
-        every reply from one implementation pass with the same review.  Fresh
-        reviewer feedback remains a standalone thread reply.
+        Both implementation receipts and fresh reviewer feedback use this one
+        mutation.  It intentionally cannot attach a reply to a review-level
+        envelope: every response is anchored by ``pullRequestReviewThreadId``.
         """
-        if review_id is None:
-            query = (
-                "mutation($threadId:ID!,$body:String!,$clientMutationId:String!){"
-                "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body,"
-                "clientMutationId:$clientMutationId}){comment{id}}}"
-            )
-        else:
-            query = (
-                "mutation($threadId:ID!,$reviewId:ID!,$body:String!,$clientMutationId:String!){"
-                "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,"
-                "pullRequestReviewId:$reviewId,body:$body,clientMutationId:$clientMutationId})"
-                "{comment{id}}}"
-            )
+        query = (
+            "mutation($threadId:ID!,$body:String!,$clientMutationId:String!){"
+            "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body,"
+            "clientMutationId:$clientMutationId}){comment{id}}}"
+        )
         mutation_fields: dict[str, str] = {
             "threadId": thread_id,
             "body": body,
-            "clientMutationId": hashlib.sha256(
-                f"{review_id or ''}:{thread_id}:{body}".encode()
-            ).hexdigest(),
+            "clientMutationId": hashlib.sha256(f"{thread_id}:{body}".encode()).hexdigest(),
         }
-        if review_id is not None:
-            mutation_fields["reviewId"] = review_id
         data = self._graphql(
             query,
             **mutation_fields,
@@ -1743,7 +1387,7 @@ class PipelineGitHub:
         compare-and-swap primitive.  Cooperating loop processes therefore
         hold one PR-scoped lock across discovery, draft creation, replies, and
         submission.  The adapter fails closed on platforms without an
-        exclusive lock instead of risking duplicate draft reviews.
+        exclusive lock instead of risking duplicate thread replies.
         """
         candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
         if not isinstance(batch_nonce, str) or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
@@ -1767,63 +1411,6 @@ class PipelineGitHub:
                 retryable_thread_ids=candidate_ids,
                 retryable=True,
             )
-
-    def preserve_stale_implementation_thread_reply_batch(
-        self,
-        pr_number: int,
-        *,
-        expected_head_sha: str,
-        current_head_sha: str,
-        replies: dict[str, str],
-        batch_nonce: str | None = None,
-    ) -> tuple[str, ...] | None:
-        """Return visible reviews preserved after an old-head handoff goes stale.
-
-        GitHub has no conditional review-delete mutation, so this recovery
-        hook is deliberately read-only.  The stage uses the returned IDs to
-        stop the work item and request manual cleanup before a fresh pass.
-        """
-        if self._skip(f"preserve stale implementation reply drafts on PR #{pr_number}"):
-            return ()
-        if (
-            not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
-            or not re.fullmatch(r"[0-9a-f]{40}", current_head_sha)
-            or expected_head_sha == current_head_sha
-            or not replies
-            or not isinstance(batch_nonce, str)
-            or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None
-        ):
-            return None
-        bodies: dict[str, str] = {}
-        for thread_id, reply in replies.items():
-            if not isinstance(thread_id, str) or not thread_id:
-                return None
-            safe_reply = self._safe_thread_reply(reply)
-            if safe_reply is None:
-                return None
-            bodies[thread_id] = self._implementation_thread_reply_body(
-                pr_number, expected_head_sha, thread_id, safe_reply
-            )
-        review_body = self._implementation_reply_review_body(
-            pr_number, expected_head_sha, bodies, batch_nonce
-        )
-        try:
-            with file_lock(self._implementation_reply_lock_path(pr_number), require_exclusive=True):
-                state = self._implementation_reply_review_state(
-                    pr_number, current_head_sha, review_body
-                )
-        except (LockUnavailableError, OSError) as error:
-            logger.warning(
-                "Stale implementation reply draft lock failed on PR #%s: %s", pr_number, error
-            )
-            return None
-        if state is None:
-            return None
-        _pr_id, review, conflict_ids = state
-        preserved = set(conflict_ids)
-        if review is not None and review[1] == "PENDING":
-            preserved.add(review[0])
-        return tuple(sorted(preserved))
 
     def _post_implementation_thread_replies_locked(  # noqa: C901
         self,
@@ -1869,7 +1456,6 @@ class PipelineGitHub:
 
         prepared: list[tuple[str, dict[str, Any], str]] = []
         recovered: dict[str, dict[str, Any]] = {}
-        reply_bodies: dict[str, str] = {}
         try:
             for thread_id in candidate_ids:
                 reply = self._safe_thread_reply(replies.get(thread_id))
@@ -1878,9 +1464,8 @@ class PipelineGitHub:
                     blocked.append(thread_id)
                     continue
                 body = self._implementation_thread_reply_body(
-                    pr_number, expected_head_sha, thread_id, reply
+                    pr_number, expected_head_sha, thread_id, reply, batch_nonce
                 )
-                reply_bodies[thread_id] = body
                 live = self._review_thread_snapshot(pr_number, thread_id)
                 if (
                     not isinstance(live, dict)
@@ -1901,139 +1486,12 @@ class PipelineGitHub:
                     continue
                 prepared.append((thread_id, snapshot, body))
 
-            review_body = (
-                self._implementation_reply_review_body(
-                    pr_number, expected_head_sha, reply_bodies, batch_nonce
-                )
-                if len(reply_bodies) == len(candidate_ids)
-                else None
-            )
-            current_batch = (
-                self._implementation_reply_review_state(pr_number, expected_head_sha, review_body)
-                if review_body is not None
-                else None
-            )
-            if review_body is None or current_batch is None:
-                return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
-                )
-            pr_id, existing_review, conflicting_review_ids = current_batch
-            if conflicting_review_ids and (
-                existing_review is None or existing_review[1] != "COMMENTED"
-            ):
-                # A blocked target must not trigger cleanup once a competing
-                # current review exists: GitHub cannot conditionally delete
-                # this draft, and the competing actor may still append to it.
-                # Include the local pending draft so operators can identify
-                # every review preserved by the terminal conflict.
-                reported_conflict_ids = set(conflicting_review_ids)
-                if existing_review is not None and existing_review[1] == "PENDING":
-                    reported_conflict_ids.add(existing_review[0])
-                return ImplementationThreadReplyResult(
-                    blocked_thread_ids=candidate_ids,
-                    conflicting_current_review_ids=tuple(sorted(reported_conflict_ids)),
-                )
             if blocked:
-                # A PENDING review is not a receipt.  Preserve it for manual
-                # cleanup instead of deleting it: GitHub cannot prove that a
-                # concurrent writer has not appended content after inventory.
-                if existing_review is not None and existing_review[1] == "PENDING":
-                    return ImplementationThreadReplyResult(
-                        blocked_thread_ids=candidate_ids,
-                        conflicting_current_review_ids=(existing_review[0],),
-                    )
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),
                 )
-            if existing_review is None:
-                # A reply from an old per-comment review is not a successful
-                # batch receipt.  A fresh review pass must establish a
-                # coherent current handoff without retrying this stale one.
-                if recovered:
-                    return ImplementationThreadReplyResult(
-                        blocked_thread_ids=candidate_ids,
-                    )
-                review_id = self._create_implementation_reply_review(
-                    pr_id, expected_head_sha, review_body
-                )
-                if review_id is None:
-                    return ImplementationThreadReplyResult(
-                        retryable_thread_ids=candidate_ids,
-                        retryable=True,
-                    )
-                review_state = "PENDING"
-                post_create_batch = self._implementation_reply_review_inventory(
-                    pr_number, expected_head_sha, review_body
-                )
-                if post_create_batch is None:
-                    return ImplementationThreadReplyResult(
-                        retryable_thread_ids=candidate_ids,
-                        retryable=True,
-                    )
-                (
-                    confirmed_pr_id,
-                    post_create_review,
-                    _stale_pending_ids,
-                    post_create_pending_conflicts,
-                    post_create_commented_conflicts,
-                ) = post_create_batch
-                post_create_conflicts = tuple(
-                    sorted(
-                        set(post_create_pending_conflicts).union(post_create_commented_conflicts)
-                    )
-                )
-                if post_create_conflicts:
-                    if confirmed_pr_id != pr_id or post_create_review != (review_id, "PENDING"):
-                        return ImplementationThreadReplyResult(
-                            retryable_thread_ids=candidate_ids,
-                            retryable=True,
-                        )
-                    # GitHub exposes no compare-and-swap delete. A competing
-                    # actor could attach a reply after this inventory, so a
-                    # conflict must preserve every draft. Include this
-                    # operation's otherwise-empty review in the diagnostic
-                    # rather than deleting it on stale ownership evidence.
-                    return ImplementationThreadReplyResult(
-                        blocked_thread_ids=candidate_ids,
-                        conflicting_current_review_ids=tuple(
-                            sorted(set(post_create_conflicts).union({review_id}))
-                        ),
-                    )
-                if post_create_review != (review_id, "PENDING") or confirmed_pr_id != pr_id:
-                    return ImplementationThreadReplyResult(
-                        retryable_thread_ids=candidate_ids,
-                        retryable=True,
-                    )
-            else:
-                review_id, review_state = existing_review
-
-            recovered_review_ids = {
-                self._final_comment_review_id(recovered[thread_id]) for thread_id in recovered
-            }
-            if recovered_review_ids and recovered_review_ids != {review_id}:
-                return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
-                )
-            if review_state == "COMMENTED":
-                if not prepared and len(recovered) == len(candidate_ids):
-                    return ImplementationThreadReplyResult(
-                        replied_thread_ids=candidate_ids,
-                        receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
-                    )
-                return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
-                )
-            if review_state != "PENDING":
-                return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
-                )
-
             for thread_id, snapshot, body in prepared:
-                comment_id = self._add_thread_reply(thread_id, body, review_id=review_id)
+                comment_id = self._add_thread_reply(thread_id, body)
                 replied_live = self._review_thread_snapshot(pr_number, thread_id)
                 if (
                     not isinstance(replied_live, dict)
@@ -2051,7 +1509,6 @@ class PipelineGitHub:
                     replied_live,
                     body,
                     comment_id,
-                    expected_review_id=review_id,
                 )
                 if proved_comment_id is None:
                     return ImplementationThreadReplyResult(
@@ -2059,29 +1516,6 @@ class PipelineGitHub:
                         retryable=True,
                     )
                 recovered[thread_id] = receipt(replied_live, proved_comment_id, body)
-
-            confirmed_review = self._find_implementation_reply_review(
-                pr_number, expected_head_sha, review_body
-            )
-            if (
-                len(recovered) != len(candidate_ids)
-                or confirmed_review != (pr_id, (review_id, "PENDING"))
-                or not self._submit_implementation_reply_review(pr_id, review_id, review_body)
-            ):
-                return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
-                )
-        except DuplicateImplementationReplyDraftsError as error:
-            logger.error(
-                "Implementation reply batch on PR #%s stopped: duplicate current drafts %s",
-                pr_number,
-                ", ".join(error.review_ids),
-            )
-            return ImplementationThreadReplyResult(
-                blocked_thread_ids=candidate_ids,
-                duplicate_current_draft_ids=error.review_ids,
-            )
         except (
             AttributeError,
             OSError,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1125,7 +1125,9 @@ class PipelineGitHub:
         if inventory is None:
             return None
         pr_id, review, stale_pending_ids, has_pending_conflict = inventory
-        if stale_pending_ids or has_pending_conflict:
+        if stale_pending_ids or (
+            has_pending_conflict and (review is None or review[1] != "COMMENTED")
+        ):
             return None
         return pr_id, review
 
@@ -1262,20 +1264,15 @@ class PipelineGitHub:
         )
         if current is None:
             return False
-        current_pr_id, review, has_pending_conflict = current
-        if current_pr_id != pr_id or has_pending_conflict or review != (review_id, "PENDING"):
+        current_pr_id, review, _has_pending_conflict = current
+        if current_pr_id != pr_id or review != (review_id, "PENDING"):
             return False
         if self._delete_implementation_reply_review(review_id):
             return True
         recovered = self._reconcile_implementation_reply_reviews(
             pr_number, expected_head_sha, review_body
         )
-        return bool(
-            recovered is not None
-            and recovered[0] == pr_id
-            and recovered[1] is None
-            and not recovered[2]
-        )
+        return bool(recovered is not None and recovered[0] == pr_id and recovered[1] is None)
 
     @staticmethod
     def _final_comment_review_id(thread: dict[str, Any]) -> str | None:
@@ -1892,11 +1889,6 @@ class PipelineGitHub:
                     retryable=True,
                 )
             pr_id, existing_review, has_pending_conflict = current_batch
-            if has_pending_conflict:
-                return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
-                )
             if blocked:
                 # A PENDING review is not a receipt.  Abort the exact
                 # coordinator draft if any target changed, rather than
@@ -1918,6 +1910,13 @@ class PipelineGitHub:
                     )
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),
+                )
+            if has_pending_conflict and (
+                existing_review is None or existing_review[1] != "COMMENTED"
+            ):
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
                 )
             if existing_review is None:
                 # A reply from an old per-comment review is not a successful

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1259,9 +1259,9 @@ class PipelineGitHub:
         """Discard only proven stale drafts and return the current batch state.
 
         The review inventory is reread before every deletion, so a head move
-        or a new manual pending review turns into a retry instead of deleting
-        a draft whose identity is no longer proved.  A PENDING review for the
-        current head but another body is intentionally left alone.
+        or a new current review preserves every draft instead of deleting one
+        whose identity is no longer proved.  A PENDING review for the current
+        head but another body is intentionally left alone.
         """
         while True:
             inventory = self._implementation_reply_review_inventory(
@@ -1279,7 +1279,11 @@ class PipelineGitHub:
             conflicting_review_ids = tuple(
                 sorted(set(pending_conflict_ids).union(commented_conflict_ids))
             )
-            if not stale_pending_ids:
+            # GitHub offers no compare-and-swap delete.  Once a conflicting
+            # current review exists, a stale-looking coordinator draft might
+            # receive content before a deletion reaches GitHub.  Preserve all
+            # reviews and let the caller report the conflict instead.
+            if conflicting_review_ids or not stale_pending_ids:
                 return pr_id, review, conflicting_review_ids
             stale_review_id = stale_pending_ids[0]
             if not self._delete_implementation_reply_review(stale_review_id):
@@ -1305,8 +1309,8 @@ class PipelineGitHub:
         )
         if current is None:
             return False
-        current_pr_id, review, _conflicting_review_ids = current
-        if current_pr_id != pr_id or review != (review_id, "PENDING"):
+        current_pr_id, review, conflicting_review_ids = current
+        if current_pr_id != pr_id or review != (review_id, "PENDING") or conflicting_review_ids:
             return False
         if self._delete_implementation_reply_review(review_id):
             return True
@@ -1951,6 +1955,21 @@ class PipelineGitHub:
                     retryable=True,
                 )
             pr_id, existing_review, conflicting_review_ids = current_batch
+            if conflicting_review_ids and (
+                existing_review is None or existing_review[1] != "COMMENTED"
+            ):
+                # A blocked target must not trigger cleanup once a competing
+                # current review exists: GitHub cannot conditionally delete
+                # this draft, and the competing actor may still append to it.
+                # Include the local pending draft so operators can identify
+                # every review preserved by the terminal conflict.
+                reported_conflict_ids = set(conflicting_review_ids)
+                if blocked and existing_review is not None and existing_review[1] == "PENDING":
+                    reported_conflict_ids.add(existing_review[0])
+                return ImplementationThreadReplyResult(
+                    blocked_thread_ids=candidate_ids,
+                    conflicting_current_review_ids=tuple(sorted(reported_conflict_ids)),
+                )
             if blocked:
                 # A PENDING review is not a receipt.  Abort the exact
                 # coordinator draft if any target changed, rather than
@@ -1972,13 +1991,6 @@ class PipelineGitHub:
                     )
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),
-                )
-            if conflicting_review_ids and (
-                existing_review is None or existing_review[1] != "COMMENTED"
-            ):
-                return ImplementationThreadReplyResult(
-                    blocked_thread_ids=candidate_ids,
-                    conflicting_current_review_ids=conflicting_review_ids,
                 )
             if existing_review is None:
                 # A reply from an old per-comment review is not a successful

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1106,6 +1106,16 @@ class PipelineGitHub:
                         commented_conflict_ids.append(review_id)
                     continue
                 if (
+                    state == "COMMENTED"
+                    and isinstance(commit_oid, str)
+                    and re.fullmatch(r"[0-9a-f]{40}", commit_oid) is not None
+                    and commit_oid != expected_head_sha
+                ):
+                    # A submitted old-head batch is immutable history, not a
+                    # recoverable pending draft.  Keep inventorying so a
+                    # current incomplete review cannot be hidden behind it.
+                    continue
+                if (
                     state != "COMMENTED"
                     or not isinstance(commit_oid, str)
                     or commit_oid != expected_head_sha

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -2018,6 +2018,26 @@ class PipelineGitHub:
                     )
                 )
                 if post_create_conflicts:
+                    # This draft is proven to be this invocation's exact,
+                    # still-empty PENDING review.  Retain every competing
+                    # review, but remove our own orphan before issuing the
+                    # terminal diagnostic so a fresh pass is not blocked by
+                    # an unreported local draft.
+                    if (
+                        confirmed_pr_id != pr_id
+                        or post_create_review != (review_id, "PENDING")
+                        or not self._discard_current_implementation_reply_review(
+                            pr_number,
+                            expected_head_sha,
+                            review_body,
+                            pr_id,
+                            review_id,
+                        )
+                    ):
+                        return ImplementationThreadReplyResult(
+                            retryable_thread_ids=candidate_ids,
+                            retryable=True,
+                        )
                     return ImplementationThreadReplyResult(
                         blocked_thread_ids=candidate_ids,
                         conflicting_current_review_ids=post_create_conflicts,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -900,6 +900,7 @@ class PipelineGitHub:
         live: dict[str, Any],
         reply_body: str,
         expected_comment_id: str | None = None,
+        expected_review_id: str | None = None,
     ) -> str | None:
         """Return a proven coordinator reply appended to one exact snapshot.
 
@@ -922,6 +923,11 @@ class PipelineGitHub:
         comment_id = after[-1][0]
         if expected_comment_id is not None and comment_id != expected_comment_id:
             return None
+        if (
+            expected_review_id is not None
+            and cls._final_comment_review_id(live) != expected_review_id
+        ):
+            return None
         return (
             comment_id
             if cls._same_snapshot_with_reply(receipt, live, reply_body, comment_id)
@@ -943,6 +949,178 @@ class PipelineGitHub:
         seed = ":".join([self._repo_slug or self.org, str(pr_number), thread_id, head_sha, reply])
         marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
         return f"{reply}\n\n<!-- hephaestus-implementation-reply:{marker} -->"
+
+    def _implementation_reply_review_body(
+        self, pr_number: int, head_sha: str, replies: dict[str, str]
+    ) -> str:
+        """Return the durable summary marker for one implementation reply batch."""
+        seed = ":".join(
+            [
+                self._repo_slug or self.org,
+                str(pr_number),
+                head_sha,
+                *(f"{thread_id}:{reply}" for thread_id, reply in sorted(replies.items())),
+            ]
+        )
+        marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
+        return (
+            f"Implementation responses for {len(replies)} review thread(s).\n\n"
+            f"<!-- hephaestus-implementation-review:{marker} -->"
+        )
+
+    def _find_implementation_reply_review(  # noqa: C901 - paginated GraphQL proof is fail-closed
+        self, pr_number: int, expected_head_sha: str, review_body: str
+    ) -> tuple[str, tuple[str, str] | None] | None:
+        """Find the current actor's durable batch review for an exact PR head.
+
+        The pending review is the restart-safe receipt for an interrupted
+        implementation-reply pass.  A matching submitted review proves that a
+        prior call completed after its transport response was lost.
+        """
+        query = (
+            "query($owner:String!,$name:String!,$number:Int!,$after:String){"
+            "repository(owner:$owner,name:$name){pullRequest(number:$number){"
+            "id state headRefOid autoMergeRequest{enabledAt} reviews(first:100,after:$after){"
+            "pageInfo{hasNextPage endCursor} nodes{id state body viewerDidAuthor commit{oid}}}}}}"
+        )
+        expected_pr_id: str | None = None
+        matches: list[tuple[str, str]] = []
+        seen_cursors: set[str] = set()
+        after: str | None = None
+        while True:
+            fields: dict[str, int | str] = {"number": pr_number}
+            if after is not None:
+                fields["after"] = after
+            data = self._graphql(query, **fields)
+            data_node = data.get("data") if isinstance(data, dict) else None
+            repository = data_node.get("repository") if isinstance(data_node, dict) else None
+            pull_request = repository.get("pullRequest") if isinstance(repository, dict) else None
+            if not isinstance(pull_request, dict):
+                return None
+            pr_id = pull_request.get("id")
+            if (
+                not isinstance(pr_id, str)
+                or not pr_id
+                or not self._pr_is_current_open_head(pull_request, expected_head_sha)
+            ):
+                return None
+            if expected_pr_id is None:
+                expected_pr_id = pr_id
+            elif expected_pr_id != pr_id:
+                return None
+            reviews = pull_request.get("reviews")
+            if not isinstance(reviews, dict) or not isinstance(reviews.get("nodes"), list):
+                return None
+            for review in reviews["nodes"]:
+                if not isinstance(review, dict):
+                    return None
+                if review.get("body") != review_body or review.get("viewerDidAuthor") is not True:
+                    continue
+                review_id = review.get("id")
+                state = review.get("state")
+                commit = review.get("commit")
+                commit_oid = commit.get("oid") if isinstance(commit, dict) else None
+                if (
+                    not isinstance(review_id, str)
+                    or not review_id
+                    or not isinstance(state, str)
+                    or state not in {"PENDING", "COMMENTED"}
+                    or not isinstance(commit_oid, str)
+                    or commit_oid != expected_head_sha
+                ):
+                    return None
+                matches.append((review_id, state))
+            page_info = reviews.get("pageInfo")
+            if not isinstance(page_info, dict) or not isinstance(
+                page_info.get("hasNextPage"), bool
+            ):
+                return None
+            if not page_info["hasNextPage"]:
+                break
+            next_cursor = page_info.get("endCursor")
+            if not isinstance(next_cursor, str) or not next_cursor or next_cursor in seen_cursors:
+                return None
+            seen_cursors.add(next_cursor)
+            after = next_cursor
+        if expected_pr_id is None or len(matches) > 1:
+            return None
+        return expected_pr_id, matches[0] if matches else None
+
+    def _create_implementation_reply_review(
+        self, pr_id: str, expected_head_sha: str, review_body: str
+    ) -> str | None:
+        """Create one pending review that will own every implementation reply."""
+        query = (
+            "mutation($prId:ID!,$commitOid:GitObjectID!,$body:String!,$clientMutationId:String!){"
+            "addPullRequestReview(input:{pullRequestId:$prId,commitOID:$commitOid,body:$body,"
+            "clientMutationId:$clientMutationId}){pullRequestReview{id state body commit{oid}}}}"
+        )
+        data = self._graphql(
+            query,
+            prId=pr_id,
+            commitOid=expected_head_sha,
+            body=review_body,
+            clientMutationId=hashlib.sha256(review_body.encode("utf-8")).hexdigest(),
+        )
+        response_data = data.get("data") if isinstance(data, dict) else None
+        mutation = (
+            response_data.get("addPullRequestReview") if isinstance(response_data, dict) else None
+        )
+        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
+        commit = review.get("commit") if isinstance(review, dict) else None
+        if (
+            not isinstance(review, dict)
+            or not isinstance(review.get("id"), str)
+            or not review["id"]
+            or review.get("state") != "PENDING"
+            or review.get("body") != review_body
+            or not isinstance(commit, dict)
+            or commit.get("oid") != expected_head_sha
+        ):
+            return None
+        return str(review["id"])
+
+    def _submit_implementation_reply_review(
+        self, pr_id: str, review_id: str, review_body: str
+    ) -> bool:
+        """Submit the fully proven reply batch as one COMMENTED review."""
+        query = (
+            "mutation($prId:ID!,$reviewId:ID!,$body:String!,$clientMutationId:String!){"
+            "submitPullRequestReview(input:{pullRequestId:$prId,pullRequestReviewId:$reviewId,"
+            "event:COMMENT,body:$body,clientMutationId:$clientMutationId})"
+            "{pullRequestReview{id state body}}}"
+        )
+        data = self._graphql(
+            query,
+            prId=pr_id,
+            reviewId=review_id,
+            body=review_body,
+            clientMutationId=hashlib.sha256(
+                f"{review_id}:{review_body}:submit".encode()
+            ).hexdigest(),
+        )
+        response_data = data.get("data") if isinstance(data, dict) else None
+        mutation = (
+            response_data.get("submitPullRequestReview")
+            if isinstance(response_data, dict)
+            else None
+        )
+        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
+        return bool(
+            isinstance(review, dict)
+            and review.get("id") == review_id
+            and review.get("state") == "COMMENTED"
+            and review.get("body") == review_body
+        )
+
+    @staticmethod
+    def _final_comment_review_id(thread: dict[str, Any]) -> str | None:
+        """Return the review owning a complete thread's final comment."""
+        comments = thread.get("comments")
+        if not isinstance(comments, list) or not comments or not isinstance(comments[-1], dict):
+            return None
+        review_id = comments[-1].get("review_id")
+        return review_id if isinstance(review_id, str) and review_id else None
 
     def _validated_implementation_reply(
         self, pr_number: int, reviewed_head_sha: str, thread: dict[str, Any]
@@ -1038,18 +1216,40 @@ class PipelineGitHub:
             f"<!-- hephaestus-reviewer-validation:{marker} -->"
         )
 
-    def _add_thread_reply(self, thread_id: str, body: str) -> str | None:
-        """Post one coordinator-owned reply and return its opaque comment ID."""
-        query = (
-            "mutation($threadId:ID!,$body:String!,$clientMutationId:String!){"
-            "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body,"
-            "clientMutationId:$clientMutationId}){comment{id}}}"
-        )
+    def _add_thread_reply(
+        self, thread_id: str, body: str, *, review_id: str | None = None
+    ) -> str | None:
+        """Post one coordinator-owned reply and return its opaque comment ID.
+
+        Implementation replies supply a pending review id so GitHub associates
+        every reply from one implementation pass with the same review.  Fresh
+        reviewer feedback remains a standalone thread reply.
+        """
+        if review_id is None:
+            query = (
+                "mutation($threadId:ID!,$body:String!,$clientMutationId:String!){"
+                "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body,"
+                "clientMutationId:$clientMutationId}){comment{id}}}"
+            )
+        else:
+            query = (
+                "mutation($threadId:ID!,$reviewId:ID!,$body:String!,$clientMutationId:String!){"
+                "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,"
+                "pullRequestReviewId:$reviewId,body:$body,clientMutationId:$clientMutationId})"
+                "{comment{id}}}"
+            )
+        mutation_fields: dict[str, str] = {
+            "threadId": thread_id,
+            "body": body,
+            "clientMutationId": hashlib.sha256(
+                f"{review_id or ''}:{thread_id}:{body}".encode()
+            ).hexdigest(),
+        }
+        if review_id is not None:
+            mutation_fields["reviewId"] = review_id
         data = self._graphql(
             query,
-            threadId=thread_id,
-            body=body,
-            clientMutationId=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+            **mutation_fields,
         )
         response_data = data.get("data") if isinstance(data, dict) else None
         mutation = (
@@ -1313,13 +1513,21 @@ class PipelineGitHub:
             snapshots[thread_id] = dict(thread)
         if not set(candidate_ids).issubset(snapshots):
             return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
-        replied: list[str] = []
         blocked: list[str] = []
-        receipts: list[dict[str, Any]] = []
-        pending_candidate_ids = candidate_ids
+
+        def receipt(live: dict[str, Any], comment_id: str, body: str) -> dict[str, Any]:
+            return {
+                **live,
+                "implementation_reply_id": comment_id,
+                "implementation_reply_body": body,
+                "implementation_head_sha": expected_head_sha,
+            }
+
+        prepared: list[tuple[str, dict[str, Any], str]] = []
+        recovered: dict[str, dict[str, Any]] = {}
+        reply_bodies: dict[str, str] = {}
         try:
-            for next_candidate_index, thread_id in enumerate(candidate_ids):
-                pending_candidate_ids = candidate_ids[next_candidate_index:]
+            for thread_id in candidate_ids:
                 reply = self._safe_thread_reply(replies.get(thread_id))
                 snapshot = snapshots[thread_id]
                 live = self._review_thread_snapshot(pr_number, thread_id)
@@ -1334,25 +1542,94 @@ class PipelineGitHub:
                 body = self._implementation_thread_reply_body(
                     pr_number, expected_head_sha, thread_id, reply
                 )
+                reply_bodies[thread_id] = body
                 # A prior transport failure may have applied this exact reply.
                 # Recover its host proof before treating the saved snapshot as
                 # stale or attempting a duplicate mutation.
                 recovered_id = self._host_reply_receipt(snapshot, live, body)
                 if recovered_id is not None:
-                    receipts.append(
-                        {
-                            **live,
-                            "implementation_reply_id": recovered_id,
-                            "implementation_reply_body": body,
-                            "implementation_head_sha": expected_head_sha,
-                        }
-                    )
-                    replied.append(thread_id)
+                    recovered[thread_id] = receipt(live, recovered_id, body)
                     continue
                 if not self._same_thread_snapshot(snapshot, live):
                     blocked.append(thread_id)
                     continue
-                comment_id = self._add_thread_reply(thread_id, body)
+                prepared.append((thread_id, snapshot, body))
+
+            if blocked:
+                return ImplementationThreadReplyResult(
+                    replied_thread_ids=tuple(sorted(recovered)),
+                    blocked_thread_ids=tuple(blocked),
+                    receipts=tuple(recovered[thread_id] for thread_id in sorted(recovered)),
+                )
+
+            review_body = self._implementation_reply_review_body(
+                pr_number, expected_head_sha, reply_bodies
+            )
+            found_review = self._find_implementation_reply_review(
+                pr_number, expected_head_sha, review_body
+            )
+            if found_review is None:
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            pr_id, existing_review = found_review
+            if existing_review is None:
+                # A fully recovered old-format response predates batched
+                # reviews.  Never duplicate a valid host-owned reply merely
+                # to rewrite its historic review association.
+                if not prepared:
+                    return ImplementationThreadReplyResult(
+                        replied_thread_ids=candidate_ids,
+                        receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
+                    )
+                # Some old-format replies plus new replies cannot be made one
+                # atomic review.  Preserve the existing comments and let the
+                # caller obtain a fresh implementation pass instead of
+                # publishing a misleading partial batch.
+                if recovered:
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
+                review_id = self._create_implementation_reply_review(
+                    pr_id, expected_head_sha, review_body
+                )
+                if review_id is None:
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
+                review_state = "PENDING"
+            else:
+                review_id, review_state = existing_review
+
+            recovered_review_ids = {
+                self._final_comment_review_id(recovered[thread_id]) for thread_id in recovered
+            }
+            if recovered_review_ids and recovered_review_ids != {review_id}:
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            if review_state == "COMMENTED":
+                if not prepared and len(recovered) == len(candidate_ids):
+                    return ImplementationThreadReplyResult(
+                        replied_thread_ids=candidate_ids,
+                        receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
+                    )
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            if review_state != "PENDING":
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+
+            for thread_id, snapshot, body in prepared:
+                comment_id = self._add_thread_reply(thread_id, body, review_id=review_id)
                 replied_live = self._review_thread_snapshot(pr_number, thread_id)
                 if (
                     not isinstance(replied_live, dict)
@@ -1361,23 +1638,36 @@ class PipelineGitHub:
                         replied_live.get("pr_state"), expected_head_sha
                     )
                 ):
-                    blocked.append(thread_id)
-                    continue
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
                 proved_comment_id = self._host_reply_receipt(
-                    snapshot, replied_live, body, comment_id
+                    snapshot,
+                    replied_live,
+                    body,
+                    comment_id,
+                    expected_review_id=review_id,
                 )
                 if proved_comment_id is None:
-                    blocked.append(thread_id)
-                    continue
-                receipts.append(
-                    {
-                        **replied_live,
-                        "implementation_reply_id": proved_comment_id,
-                        "implementation_reply_body": body,
-                        "implementation_head_sha": expected_head_sha,
-                    }
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
+                recovered[thread_id] = receipt(replied_live, proved_comment_id, body)
+
+            confirmed_review = self._find_implementation_reply_review(
+                pr_number, expected_head_sha, review_body
+            )
+            if (
+                len(recovered) != len(candidate_ids)
+                or confirmed_review != (pr_id, (review_id, "PENDING"))
+                or not self._submit_implementation_reply_review(pr_id, review_id, review_body)
+            ):
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
                 )
-                replied.append(thread_id)
         except (
             AttributeError,
             OSError,
@@ -1387,20 +1677,13 @@ class PipelineGitHub:
             json.JSONDecodeError,
         ) as error:
             logger.warning("Implementation thread replies failed on PR #%s: %s", pr_number, error)
-            retryable_ids = tuple(
-                thread_id for thread_id in pending_candidate_ids if thread_id not in set(replied)
-            )
             return ImplementationThreadReplyResult(
-                replied_thread_ids=tuple(replied),
-                blocked_thread_ids=tuple(blocked),
-                receipts=tuple(receipts),
-                retryable_thread_ids=retryable_ids,
-                retryable=bool(retryable_ids),
+                retryable_thread_ids=candidate_ids,
+                retryable=True,
             )
         return ImplementationThreadReplyResult(
-            replied_thread_ids=tuple(replied),
-            blocked_thread_ids=tuple(blocked),
-            receipts=tuple(receipts),
+            replied_thread_ids=candidate_ids,
+            receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
         )
 
     def reconcile_reviewer_validated_threads(  # noqa: C901

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -2018,29 +2018,21 @@ class PipelineGitHub:
                     )
                 )
                 if post_create_conflicts:
-                    # This draft is proven to be this invocation's exact,
-                    # still-empty PENDING review.  Retain every competing
-                    # review, but remove our own orphan before issuing the
-                    # terminal diagnostic so a fresh pass is not blocked by
-                    # an unreported local draft.
-                    if (
-                        confirmed_pr_id != pr_id
-                        or post_create_review != (review_id, "PENDING")
-                        or not self._discard_current_implementation_reply_review(
-                            pr_number,
-                            expected_head_sha,
-                            review_body,
-                            pr_id,
-                            review_id,
-                        )
-                    ):
+                    if confirmed_pr_id != pr_id or post_create_review != (review_id, "PENDING"):
                         return ImplementationThreadReplyResult(
                             retryable_thread_ids=candidate_ids,
                             retryable=True,
                         )
+                    # GitHub exposes no compare-and-swap delete. A competing
+                    # actor could attach a reply after this inventory, so a
+                    # conflict must preserve every draft. Include this
+                    # operation's otherwise-empty review in the diagnostic
+                    # rather than deleting it on stale ownership evidence.
                     return ImplementationThreadReplyResult(
                         blocked_thread_ids=candidate_ids,
-                        conflicting_current_review_ids=post_create_conflicts,
+                        conflicting_current_review_ids=tuple(
+                            sorted(set(post_create_conflicts).union({review_id}))
+                        ),
                     )
                 if post_create_review != (review_id, "PENDING") or confirmed_pr_id != pr_id:
                     return ImplementationThreadReplyResult(

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import subprocess
 import time
 from pathlib import Path
@@ -91,7 +92,8 @@ _STANDALONE_VERDICT_LINE_RE = re.compile(r"(?i)^\s*verdict\s*:")
 _HTTP_STATUS_RE = re.compile(r"^HTTP/\S+\s+(\d{3})\b", re.MULTILINE)
 _IMPLEMENTATION_REPLY_REVIEW_BODY_RE = re.compile(
     r"\AImplementation responses for [1-9]\d* review thread\(s\)\.\n\n"
-    r"<!-- hephaestus-implementation-review:[0-9a-f]{24} -->\Z"
+    r"<!-- hephaestus-implementation-review:[0-9a-f]{24} -->\n"
+    r"<!-- hephaestus-implementation-batch:([0-9a-f]{32}) -->\Z"
 )
 
 
@@ -964,22 +966,42 @@ class PipelineGitHub:
         return f"{reply}\n\n<!-- hephaestus-implementation-reply:{marker} -->"
 
     def _implementation_reply_review_body(
-        self, pr_number: int, head_sha: str, replies: dict[str, str]
+        self,
+        pr_number: int,
+        head_sha: str,
+        replies: dict[str, str],
+        batch_nonce: str | None = None,
     ) -> str:
         """Return the durable summary marker for one implementation reply batch."""
+        if batch_nonce is None:
+            batch_nonce = secrets.token_hex(16)
+        if re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
+            raise ValueError(
+                "implementation reply batch nonce must be 32 lowercase hexadecimal chars"
+            )
         seed = ":".join(
             [
                 self._repo_slug or self.org,
                 str(pr_number),
                 head_sha,
+                batch_nonce,
                 *(f"{thread_id}:{reply}" for thread_id, reply in sorted(replies.items())),
             ]
         )
         marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
         return (
             f"Implementation responses for {len(replies)} review thread(s).\n\n"
-            f"<!-- hephaestus-implementation-review:{marker} -->"
+            f"<!-- hephaestus-implementation-review:{marker} -->\n"
+            f"<!-- hephaestus-implementation-batch:{batch_nonce} -->"
         )
+
+    @staticmethod
+    def _implementation_reply_batch_nonce(review_body: object) -> str | None:
+        """Return the opaque nonce from one valid implementation batch body."""
+        if not isinstance(review_body, str):
+            return None
+        match = _IMPLEMENTATION_REPLY_REVIEW_BODY_RE.fullmatch(review_body)
+        return match.group(1) if match is not None else None
 
     @staticmethod
     def _is_implementation_reply_review_body(body: object) -> bool:
@@ -991,7 +1013,7 @@ class PipelineGitHub:
 
     def _implementation_reply_review_inventory(  # noqa: C901 - paginated GraphQL proof is fail-closed
         self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> tuple[str, tuple[str, str] | None, tuple[str, ...], bool] | None:
+    ) -> tuple[str, tuple[str, str] | None, tuple[str, ...], tuple[str, ...]] | None:
         """Return the exact batch review plus stale and conflicting pending drafts.
 
         Only a viewer-owned pending review carrying the opaque implementation
@@ -1009,7 +1031,7 @@ class PipelineGitHub:
         pending_matches: list[tuple[str, str]] = []
         commented_matches: list[tuple[str, str]] = []
         stale_pending_ids: list[str] = []
-        has_pending_conflict = False
+        pending_conflict_ids: list[str] = []
         seen_cursors: set[str] = set()
         after: str | None = None
         while True:
@@ -1063,7 +1085,7 @@ class PipelineGitHub:
                     ):
                         stale_pending_ids.append(review_id)
                     else:
-                        has_pending_conflict = True
+                        pending_conflict_ids.append(review_id)
                     continue
                 if body != review_body:
                     continue
@@ -1097,7 +1119,7 @@ class PipelineGitHub:
                 expected_pr_id,
                 commented_matches[0],
                 tuple(sorted(set(stale_pending_ids))),
-                has_pending_conflict,
+                tuple(sorted(set(pending_conflict_ids))),
             )
         if len(pending_matches) > 1:
             raise DuplicateImplementationReplyDraftsError(
@@ -1107,7 +1129,7 @@ class PipelineGitHub:
             expected_pr_id,
             pending_matches[0] if pending_matches else None,
             tuple(sorted(set(stale_pending_ids))),
-            has_pending_conflict,
+            tuple(sorted(set(pending_conflict_ids))),
         )
 
     def _find_implementation_reply_review(
@@ -1124,9 +1146,9 @@ class PipelineGitHub:
         )
         if inventory is None:
             return None
-        pr_id, review, stale_pending_ids, has_pending_conflict = inventory
+        pr_id, review, stale_pending_ids, pending_conflict_ids = inventory
         if stale_pending_ids or (
-            has_pending_conflict and (review is None or review[1] != "COMMENTED")
+            pending_conflict_ids and (review is None or review[1] != "COMMENTED")
         ):
             return None
         return pr_id, review
@@ -1223,7 +1245,7 @@ class PipelineGitHub:
 
     def _reconcile_implementation_reply_reviews(
         self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> tuple[str, tuple[str, str] | None, bool] | None:
+    ) -> tuple[str, tuple[str, str] | None, tuple[str, ...]] | None:
         """Discard only proven stale drafts and return the current batch state.
 
         The review inventory is reread before every deletion, so a head move
@@ -1237,9 +1259,9 @@ class PipelineGitHub:
             )
             if inventory is None:
                 return None
-            pr_id, review, stale_pending_ids, has_pending_conflict = inventory
+            pr_id, review, stale_pending_ids, pending_conflict_ids = inventory
             if not stale_pending_ids:
-                return pr_id, review, has_pending_conflict
+                return pr_id, review, pending_conflict_ids
             stale_review_id = stale_pending_ids[0]
             if not self._delete_implementation_reply_review(stale_review_id):
                 # GitHub may have applied the delete before losing its response.
@@ -1264,7 +1286,7 @@ class PipelineGitHub:
         )
         if current is None:
             return False
-        current_pr_id, review, _has_pending_conflict = current
+        current_pr_id, review, _pending_conflict_ids = current
         if current_pr_id != pr_id or review != (review_id, "PENDING"):
             return False
         if self._delete_implementation_reply_review(review_id):
@@ -1374,12 +1396,17 @@ class PipelineGitHub:
         review_bodies = {candidate[4] for candidate in candidates}
         if len(review_ids) != 1 or len(review_bodies) != 1:
             return []
+        review_body = review_bodies.pop()
+        batch_nonce = self._implementation_reply_batch_nonce(review_body)
+        if batch_nonce is None:
+            return []
         expected_body = self._implementation_reply_review_body(
             pr_number,
             reviewed_head_sha,
             {str(candidate[0]["id"]): candidate[2] for candidate in candidates},
+            batch_nonce,
         )
-        if review_bodies.pop() != expected_body:
+        if review_body != expected_body:
             return []
         return [(thread, reply_id, reply_body) for thread, reply_id, reply_body, _, _ in candidates]
 
@@ -1724,6 +1751,7 @@ class PipelineGitHub:
         expected_head_sha: str,
         threads: list[dict[str, Any]],
         replies: dict[str, str],
+        batch_nonce: str | None = None,
     ) -> ImplementationThreadReplyResult:
         """Serialize one repository-local implementation reply batch per PR.
 
@@ -1734,6 +1762,8 @@ class PipelineGitHub:
         exclusive lock instead of risking duplicate draft reviews.
         """
         candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
+        if not isinstance(batch_nonce, str) or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
+            return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
         if self._skip(
             f"post {len(candidate_ids)} implementation review-thread replies on PR #{pr_number}"
         ):
@@ -1745,6 +1775,7 @@ class PipelineGitHub:
                     expected_head_sha=expected_head_sha,
                     threads=threads,
                     replies=replies,
+                    batch_nonce=batch_nonce,
                 )
         except (LockUnavailableError, OSError) as error:
             logger.warning("Implementation reply batch lock failed on PR #%s: %s", pr_number, error)
@@ -1760,6 +1791,7 @@ class PipelineGitHub:
         expected_head_sha: str,
         current_head_sha: str,
         replies: dict[str, str],
+        batch_nonce: str | None = None,
     ) -> bool:
         """Discard verified old-head drafts after a handoff becomes stale.
 
@@ -1775,6 +1807,8 @@ class PipelineGitHub:
             or not re.fullmatch(r"[0-9a-f]{40}", current_head_sha)
             or expected_head_sha == current_head_sha
             or not replies
+            or not isinstance(batch_nonce, str)
+            or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None
         ):
             return False
         bodies: dict[str, str] = {}
@@ -1787,7 +1821,9 @@ class PipelineGitHub:
             bodies[thread_id] = self._implementation_thread_reply_body(
                 pr_number, expected_head_sha, thread_id, safe_reply
             )
-        review_body = self._implementation_reply_review_body(pr_number, expected_head_sha, bodies)
+        review_body = self._implementation_reply_review_body(
+            pr_number, expected_head_sha, bodies, batch_nonce
+        )
         try:
             with file_lock(self._implementation_reply_lock_path(pr_number), require_exclusive=True):
                 reconciled = self._reconcile_implementation_reply_reviews(
@@ -1807,6 +1843,7 @@ class PipelineGitHub:
         expected_head_sha: str,
         threads: list[dict[str, Any]],
         replies: dict[str, str],
+        batch_nonce: str,
     ) -> ImplementationThreadReplyResult:
         """Post implementation-agent replies after a real fix commit reached GitHub.
 
@@ -1815,7 +1852,11 @@ class PipelineGitHub:
         performs a fresh review and owns that decision.
         """
         candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
-        if not candidate_ids or not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha):
+        if (
+            not candidate_ids
+            or not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
+            or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None
+        ):
             return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
         snapshots: dict[str, dict[str, Any]] = {}
         for thread in threads:
@@ -1872,7 +1913,9 @@ class PipelineGitHub:
                 prepared.append((thread_id, snapshot, body))
 
             review_body = (
-                self._implementation_reply_review_body(pr_number, expected_head_sha, reply_bodies)
+                self._implementation_reply_review_body(
+                    pr_number, expected_head_sha, reply_bodies, batch_nonce
+                )
                 if len(reply_bodies) == len(candidate_ids)
                 else None
             )
@@ -1888,7 +1931,7 @@ class PipelineGitHub:
                     retryable_thread_ids=candidate_ids,
                     retryable=True,
                 )
-            pr_id, existing_review, has_pending_conflict = current_batch
+            pr_id, existing_review, pending_conflict_ids = current_batch
             if blocked:
                 # A PENDING review is not a receipt.  Abort the exact
                 # coordinator draft if any target changed, rather than
@@ -1911,12 +1954,12 @@ class PipelineGitHub:
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),
                 )
-            if has_pending_conflict and (
+            if pending_conflict_ids and (
                 existing_review is None or existing_review[1] != "COMMENTED"
             ):
                 return ImplementationThreadReplyResult(
-                    retryable_thread_ids=candidate_ids,
-                    retryable=True,
+                    blocked_thread_ids=candidate_ids,
+                    conflicting_pending_draft_ids=pending_conflict_ids,
                 )
             if existing_review is None:
                 # A reply from an old per-comment review is not a successful

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -24,7 +24,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import subprocess
 import time
 from pathlib import Path
@@ -973,9 +972,7 @@ class PipelineGitHub:
         batch_nonce: str | None = None,
     ) -> str:
         """Return the durable summary marker for one implementation reply batch."""
-        if batch_nonce is None:
-            batch_nonce = secrets.token_hex(16)
-        if re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
+        if not isinstance(batch_nonce, str) or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None:
             raise ValueError(
                 "implementation reply batch nonce must be 32 lowercase hexadecimal chars"
             )
@@ -1013,8 +1010,10 @@ class PipelineGitHub:
 
     def _implementation_reply_review_inventory(  # noqa: C901 - paginated GraphQL proof is fail-closed
         self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> tuple[str, tuple[str, str] | None, tuple[str, ...], tuple[str, ...]] | None:
-        """Return the exact batch review plus stale and conflicting pending drafts.
+    ) -> (
+        tuple[str, tuple[str, str] | None, tuple[str, ...], tuple[str, ...], tuple[str, ...]] | None
+    ):
+        """Return the exact batch review plus stale and conflicting current reviews.
 
         Only a viewer-owned pending review carrying the opaque implementation
         marker and an *older* commit is eligible for automatic discard.  A
@@ -1032,6 +1031,7 @@ class PipelineGitHub:
         commented_matches: list[tuple[str, str]] = []
         stale_pending_ids: list[str] = []
         pending_conflict_ids: list[str] = []
+        commented_conflict_ids: list[str] = []
         seen_cursors: set[str] = set()
         after: str | None = None
         while True:
@@ -1088,6 +1088,13 @@ class PipelineGitHub:
                         pending_conflict_ids.append(review_id)
                     continue
                 if body != review_body:
+                    if (
+                        state == "COMMENTED"
+                        and isinstance(commit_oid, str)
+                        and commit_oid == expected_head_sha
+                        and self._is_implementation_reply_review_body(body)
+                    ):
+                        commented_conflict_ids.append(review_id)
                     continue
                 if (
                     state != "COMMENTED"
@@ -1120,6 +1127,7 @@ class PipelineGitHub:
                 commented_matches[0],
                 tuple(sorted(set(stale_pending_ids))),
                 tuple(sorted(set(pending_conflict_ids))),
+                tuple(sorted(set(commented_conflict_ids))),
             )
         if len(pending_matches) > 1:
             raise DuplicateImplementationReplyDraftsError(
@@ -1130,6 +1138,7 @@ class PipelineGitHub:
             pending_matches[0] if pending_matches else None,
             tuple(sorted(set(stale_pending_ids))),
             tuple(sorted(set(pending_conflict_ids))),
+            tuple(sorted(set(commented_conflict_ids))),
         )
 
     def _find_implementation_reply_review(
@@ -1146,9 +1155,10 @@ class PipelineGitHub:
         )
         if inventory is None:
             return None
-        pr_id, review, stale_pending_ids, pending_conflict_ids = inventory
+        pr_id, review, stale_pending_ids, pending_conflict_ids, commented_conflict_ids = inventory
         if stale_pending_ids or (
-            pending_conflict_ids and (review is None or review[1] != "COMMENTED")
+            (pending_conflict_ids or commented_conflict_ids)
+            and (review is None or review[1] != "COMMENTED")
         ):
             return None
         return pr_id, review
@@ -1259,9 +1269,18 @@ class PipelineGitHub:
             )
             if inventory is None:
                 return None
-            pr_id, review, stale_pending_ids, pending_conflict_ids = inventory
+            (
+                pr_id,
+                review,
+                stale_pending_ids,
+                pending_conflict_ids,
+                commented_conflict_ids,
+            ) = inventory
+            conflicting_review_ids = tuple(
+                sorted(set(pending_conflict_ids).union(commented_conflict_ids))
+            )
             if not stale_pending_ids:
-                return pr_id, review, pending_conflict_ids
+                return pr_id, review, conflicting_review_ids
             stale_review_id = stale_pending_ids[0]
             if not self._delete_implementation_reply_review(stale_review_id):
                 # GitHub may have applied the delete before losing its response.
@@ -1286,7 +1305,7 @@ class PipelineGitHub:
         )
         if current is None:
             return False
-        current_pr_id, review, _pending_conflict_ids = current
+        current_pr_id, review, _conflicting_review_ids = current
         if current_pr_id != pr_id or review != (review_id, "PENDING"):
             return False
         if self._delete_implementation_reply_review(review_id):
@@ -1931,7 +1950,7 @@ class PipelineGitHub:
                     retryable_thread_ids=candidate_ids,
                     retryable=True,
                 )
-            pr_id, existing_review, pending_conflict_ids = current_batch
+            pr_id, existing_review, conflicting_review_ids = current_batch
             if blocked:
                 # A PENDING review is not a receipt.  Abort the exact
                 # coordinator draft if any target changed, rather than
@@ -1954,12 +1973,12 @@ class PipelineGitHub:
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),
                 )
-            if pending_conflict_ids and (
+            if conflicting_review_ids and (
                 existing_review is None or existing_review[1] != "COMMENTED"
             ):
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=candidate_ids,
-                    conflicting_pending_draft_ids=pending_conflict_ids,
+                    conflicting_current_review_ids=conflicting_review_ids,
                 )
             if existing_review is None:
                 # A reply from an old per-comment review is not a successful
@@ -1978,6 +1997,36 @@ class PipelineGitHub:
                         retryable=True,
                     )
                 review_state = "PENDING"
+                post_create_batch = self._implementation_reply_review_inventory(
+                    pr_number, expected_head_sha, review_body
+                )
+                if post_create_batch is None:
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
+                (
+                    confirmed_pr_id,
+                    post_create_review,
+                    _stale_pending_ids,
+                    post_create_pending_conflicts,
+                    post_create_commented_conflicts,
+                ) = post_create_batch
+                post_create_conflicts = tuple(
+                    sorted(
+                        set(post_create_pending_conflicts).union(post_create_commented_conflicts)
+                    )
+                )
+                if post_create_conflicts:
+                    return ImplementationThreadReplyResult(
+                        blocked_thread_ids=candidate_ids,
+                        conflicting_current_review_ids=post_create_conflicts,
+                    )
+                if post_create_review != (review_id, "PENDING") or confirmed_pr_id != pr_id:
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
             else:
                 review_id, review_state = existing_review
 

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -2883,67 +2883,6 @@ class PipelineGitHub:
             )
         return github_api.gh_pr_create(branch, title, body)
 
-    def post_pr_comment(self, pr_number: int, body: str) -> None:
-        """Post an explanatory PR comment (``gh_issue_comment`` channel)."""
-        if self._skip(f"post comment on PR #{pr_number}"):
-            return
-        if self._repo_slug is not None:
-            with github_api._body_file(body) as path:
-                self._gh(["issue", "comment", str(pr_number), "--body-file", path])
-            return
-        github_api.gh_issue_comment(pr_number, body)
-
-    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
-        """Create-or-update a marker-keyed PR comment (issue comment channel)."""
-        if self._skip(f"upsert comment on PR #{pr_number}"):
-            return False
-        if self._repo_slug is None:
-            github_api.gh_issue_upsert_comment(pr_number, marker_prefix, body)
-            return True
-        self._upsert_repo_issue_comment(pr_number, marker_prefix, body)
-        return True
-
-    def _upsert_repo_issue_comment(
-        self, issue_number: int, marker_prefix: str, body: str
-    ) -> int | None:
-        """Repo-scoped version of ``gh_issue_upsert_comment``."""
-        comments = self._repo_issue_comments(issue_number)
-        matching = [
-            comment
-            for comment in comments
-            if str(comment.get("body", "")).startswith(marker_prefix)
-            and comment.get("databaseId") is not None
-        ]
-        if not matching:
-            self.post_pr_comment(issue_number, body)
-            return None
-
-        owner, name = self._owner_name()
-        target_id = int(matching[-1]["databaseId"])
-        for duplicate in matching[:-1]:
-            duplicate_id = duplicate.get("databaseId")
-            if duplicate_id is not None:
-                gh_call(
-                    [
-                        "api",
-                        "--method",
-                        "DELETE",
-                        f"/repos/{owner}/{name}/issues/comments/{int(duplicate_id)}",
-                    ]
-                )
-        with github_api._body_file(body) as path:
-            gh_call(
-                [
-                    "api",
-                    "--method",
-                    "PATCH",
-                    f"/repos/{owner}/{name}/issues/comments/{target_id}",
-                    "-F",
-                    f"body=@{path}",
-                ]
-            )
-        return target_id
-
     def mark_pr_implementation_no_go(self, pr_number: int) -> None:
         """Apply and read back exclusive ``state:implementation-no-go``."""
         if self._skip(f"mark PR #{pr_number} implementation-no-go"):
@@ -2979,6 +2918,14 @@ class PipelineGitHub:
         expected_head_sha: str,
     ) -> list[dict[str, Any]]:
         """Post review threads only on a fresh, exact reviewed PR head."""
+        # GitHub renders a review-level ``body`` as an unanchored general
+        # comment. Publish only reviews that contain source-positioned threads.
+        if not threads:
+            logger.info(
+                "PR #%s: skipped review publication without source-anchored threads",
+                pr_number,
+            )
+            return []
         if self._skip(f"post {len(threads)} review thread(s) on PR #{pr_number}"):
             return []
         if not self._pr_is_current_open_head(self.gh_pr_state(pr_number), expected_head_sha):
@@ -3006,7 +2953,6 @@ class PipelineGitHub:
             owner, name = self._owner_name()
             request_body = json.dumps(
                 {
-                    "body": summary,
                     "commit_id": expected_head_sha,
                     "event": "COMMENT",
                     "comments": review_comments,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1376,25 +1376,27 @@ class PipelineGitHub:
         repo_key = hashlib.sha256((self._repo_slug or self.org).encode("utf-8")).hexdigest()[:16]
         git_metadata = self._repo_root / ".git"
         lock_root = ensure_state_dir(self._repo_root) / "locks"
-        try:
-            if git_metadata.is_dir():
-                lock_root = git_metadata / "hephaestus-automation-locks"
-            elif git_metadata.is_file():
+        if git_metadata.is_dir():
+            lock_root = git_metadata / "hephaestus-automation-locks"
+        elif git_metadata.is_file():
+            try:
                 first_line = git_metadata.read_text(encoding="utf-8").splitlines()[0]
-                prefix, separator, raw_git_dir = first_line.partition(":")
-                if prefix == "gitdir" and separator and raw_git_dir.strip():
-                    git_dir = Path(raw_git_dir.strip())
-                    if not git_dir.is_absolute():
-                        git_dir = git_metadata.parent / git_dir
-                    if git_dir.parent.name == "worktrees":
-                        lock_root = git_dir.parent.parent / "hephaestus-automation-locks"
-                    else:
-                        lock_root = git_dir / "hephaestus-automation-locks"
-        except (IndexError, OSError, UnicodeDecodeError):
-            logger.warning(
-                "could not read Git metadata for implementation reply lock at %s",
-                git_metadata,
-            )
+            except (IndexError, OSError, UnicodeDecodeError) as error:
+                raise LockUnavailableError(
+                    f"could not read Git metadata for implementation reply lock at {git_metadata}"
+                ) from error
+            prefix, separator, raw_git_dir = first_line.partition(":")
+            if prefix != "gitdir" or not separator or not raw_git_dir.strip():
+                raise LockUnavailableError(
+                    f"invalid Git metadata for implementation reply lock at {git_metadata}"
+                )
+            git_dir = Path(raw_git_dir.strip())
+            if not git_dir.is_absolute():
+                git_dir = git_metadata.parent / git_dir
+            if git_dir.parent.name == "worktrees":
+                lock_root = git_dir.parent.parent / "hephaestus-automation-locks"
+            else:
+                lock_root = git_dir / "hephaestus-automation-locks"
         return lock_root / f"implementation-replies-{repo_key}-{pr_number}.lock"
 
     def post_implementation_thread_replies(

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -82,13 +82,17 @@ from hephaestus.automation.state_labels import (
 )
 from hephaestus.constants import read_timeout_env
 from hephaestus.github.client import gh_call
-from hephaestus.utils.file_lock import file_lock
+from hephaestus.utils.file_lock import LockUnavailableError, file_lock
 
 logger = logging.getLogger(__name__)
 
 _CLOSES_ISSUE_LINE_RE = re.compile(r"^Closes #(\d+)\s*$", re.MULTILINE)
 _STANDALONE_VERDICT_LINE_RE = re.compile(r"(?i)^\s*verdict\s*:")
 _HTTP_STATUS_RE = re.compile(r"^HTTP/\S+\s+(\d{3})\b", re.MULTILINE)
+_IMPLEMENTATION_REPLY_REVIEW_BODY_RE = re.compile(
+    r"\AImplementation responses for [1-9]\d* review thread\(s\)\.\n\n"
+    r"<!-- hephaestus-implementation-review:[0-9a-f]{24} -->\Z"
+)
 
 
 def _parse_included_http_response(
@@ -968,14 +972,23 @@ class PipelineGitHub:
             f"<!-- hephaestus-implementation-review:{marker} -->"
         )
 
-    def _find_implementation_reply_review(  # noqa: C901 - paginated GraphQL proof is fail-closed
-        self, pr_number: int, expected_head_sha: str, review_body: str
-    ) -> tuple[str, tuple[str, str] | None] | None:
-        """Find the current actor's durable batch review for an exact PR head.
+    @staticmethod
+    def _is_implementation_reply_review_body(body: object) -> bool:
+        """Return whether ``body`` is a coordinator-owned batch marker."""
+        return (
+            isinstance(body, str)
+            and _IMPLEMENTATION_REPLY_REVIEW_BODY_RE.fullmatch(body) is not None
+        )
 
-        The pending review is the restart-safe receipt for an interrupted
-        implementation-reply pass.  A matching submitted review proves that a
-        prior call completed after its transport response was lost.
+    def _implementation_reply_review_inventory(  # noqa: C901 - paginated GraphQL proof is fail-closed
+        self, pr_number: int, expected_head_sha: str, review_body: str
+    ) -> tuple[str, tuple[str, str] | None, tuple[str, ...], bool] | None:
+        """Return the exact batch review plus stale and conflicting pending drafts.
+
+        Only a viewer-owned pending review carrying the opaque implementation
+        marker and an *older* commit is eligible for automatic discard.  A
+        manual or malformed pending review is a conflict: leave it untouched
+        and fail closed rather than taking ownership of another actor's work.
         """
         query = (
             "query($owner:String!,$name:String!,$number:Int!,$after:String){"
@@ -985,6 +998,8 @@ class PipelineGitHub:
         )
         expected_pr_id: str | None = None
         matches: list[tuple[str, str]] = []
+        stale_pending_ids: list[str] = []
+        has_pending_conflict = False
         seen_cursors: set[str] = set()
         after: str | None = None
         while True:
@@ -1014,17 +1029,36 @@ class PipelineGitHub:
             for review in reviews["nodes"]:
                 if not isinstance(review, dict):
                     return None
-                if review.get("body") != review_body or review.get("viewerDidAuthor") is not True:
+                if review.get("viewerDidAuthor") is not True:
                     continue
                 review_id = review.get("id")
                 state = review.get("state")
+                body = review.get("body")
                 commit = review.get("commit")
                 commit_oid = commit.get("oid") if isinstance(commit, dict) else None
+                if not isinstance(review_id, str) or not review_id or not isinstance(state, str):
+                    return None
+                if state == "PENDING":
+                    if (
+                        body == review_body
+                        and isinstance(commit_oid, str)
+                        and commit_oid == expected_head_sha
+                    ):
+                        matches.append((review_id, state))
+                    elif (
+                        self._is_implementation_reply_review_body(body)
+                        and isinstance(commit_oid, str)
+                        and re.fullmatch(r"[0-9a-f]{40}", commit_oid) is not None
+                        and commit_oid != expected_head_sha
+                    ):
+                        stale_pending_ids.append(review_id)
+                    else:
+                        has_pending_conflict = True
+                    continue
+                if body != review_body:
+                    continue
                 if (
-                    not isinstance(review_id, str)
-                    or not review_id
-                    or not isinstance(state, str)
-                    or state not in {"PENDING", "COMMENTED"}
+                    state != "COMMENTED"
                     or not isinstance(commit_oid, str)
                     or commit_oid != expected_head_sha
                 ):
@@ -1044,7 +1078,31 @@ class PipelineGitHub:
             after = next_cursor
         if expected_pr_id is None or len(matches) > 1:
             return None
-        return expected_pr_id, matches[0] if matches else None
+        return (
+            expected_pr_id,
+            matches[0] if matches else None,
+            tuple(sorted(set(stale_pending_ids))),
+            has_pending_conflict,
+        )
+
+    def _find_implementation_reply_review(
+        self, pr_number: int, expected_head_sha: str, review_body: str
+    ) -> tuple[str, tuple[str, str] | None] | None:
+        """Find the current actor's durable batch review for an exact PR head.
+
+        The pending review is the restart-safe receipt for an interrupted
+        implementation-reply pass.  A matching submitted review proves that a
+        prior call completed after its transport response was lost.
+        """
+        inventory = self._implementation_reply_review_inventory(
+            pr_number, expected_head_sha, review_body
+        )
+        if inventory is None:
+            return None
+        pr_id, review, stale_pending_ids, has_pending_conflict = inventory
+        if stale_pending_ids or has_pending_conflict:
+            return None
+        return pr_id, review
 
     def _create_implementation_reply_review(
         self, pr_id: str, expected_head_sha: str, review_body: str
@@ -1111,6 +1169,87 @@ class PipelineGitHub:
             and review.get("id") == review_id
             and review.get("state") == "COMMENTED"
             and review.get("body") == review_body
+        )
+
+    def _delete_implementation_reply_review(self, review_id: str) -> bool:
+        """Delete one proven coordinator-owned pending review draft."""
+        query = (
+            "mutation($reviewId:ID!,$clientMutationId:String!){"
+            "deletePullRequestReview(input:{pullRequestReviewId:$reviewId,"
+            "clientMutationId:$clientMutationId}){pullRequestReview{id}}}"
+        )
+        data = self._graphql(
+            query,
+            reviewId=review_id,
+            clientMutationId=hashlib.sha256(
+                f"{review_id}:discard-implementation-replies".encode()
+            ).hexdigest(),
+        )
+        response_data = data.get("data") if isinstance(data, dict) else None
+        mutation = (
+            response_data.get("deletePullRequestReview")
+            if isinstance(response_data, dict)
+            else None
+        )
+        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
+        return bool(isinstance(review, dict) and review.get("id") == review_id)
+
+    def _reconcile_implementation_reply_reviews(
+        self, pr_number: int, expected_head_sha: str, review_body: str
+    ) -> tuple[str, tuple[str, str] | None, bool] | None:
+        """Discard only proven stale drafts and return the current batch state.
+
+        The review inventory is reread before every deletion, so a head move
+        or a new manual pending review turns into a retry instead of deleting
+        a draft whose identity is no longer proved.  A PENDING review for the
+        current head but another body is intentionally left alone.
+        """
+        while True:
+            inventory = self._implementation_reply_review_inventory(
+                pr_number, expected_head_sha, review_body
+            )
+            if inventory is None:
+                return None
+            pr_id, review, stale_pending_ids, has_pending_conflict = inventory
+            if not stale_pending_ids:
+                return pr_id, review, has_pending_conflict
+            stale_review_id = stale_pending_ids[0]
+            if not self._delete_implementation_reply_review(stale_review_id):
+                # GitHub may have applied the delete before losing its response.
+                # The next inventory read is the only safe recovery proof.
+                recovered = self._implementation_reply_review_inventory(
+                    pr_number, expected_head_sha, review_body
+                )
+                if recovered is None or stale_review_id in recovered[2]:
+                    return None
+
+    def _discard_current_implementation_reply_review(
+        self,
+        pr_number: int,
+        expected_head_sha: str,
+        review_body: str,
+        pr_id: str,
+        review_id: str,
+    ) -> bool:
+        """Abort a current batch which cannot atomically cover every thread."""
+        current = self._reconcile_implementation_reply_reviews(
+            pr_number, expected_head_sha, review_body
+        )
+        if current is None:
+            return False
+        current_pr_id, review, has_pending_conflict = current
+        if current_pr_id != pr_id or has_pending_conflict or review != (review_id, "PENDING"):
+            return False
+        if self._delete_implementation_reply_review(review_id):
+            return True
+        recovered = self._reconcile_implementation_reply_reviews(
+            pr_number, expected_head_sha, review_body
+        )
+        return bool(
+            recovered is not None
+            and recovered[0] == pr_id
+            and recovered[1] is None
+            and not recovered[2]
         )
 
     @staticmethod
@@ -1482,7 +1621,97 @@ class PipelineGitHub:
             return None
         return second[0]
 
-    def post_implementation_thread_replies(  # noqa: C901
+    def _implementation_reply_lock_path(self, pr_number: int) -> Path:
+        """Return the cross-process lock for one repository PR reply batch."""
+        repo_key = hashlib.sha256((self._repo_slug or self.org).encode("utf-8")).hexdigest()[:16]
+        return (
+            ensure_state_dir(self._repo_root)
+            / "locks"
+            / (f"implementation-replies-{repo_key}-{pr_number}.lock")
+        )
+
+    def post_implementation_thread_replies(
+        self,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        threads: list[dict[str, Any]],
+        replies: dict[str, str],
+    ) -> ImplementationThreadReplyResult:
+        """Serialize one repository-local implementation reply batch per PR.
+
+        GitHub's client mutation id is a tracing field rather than a
+        compare-and-swap primitive.  Cooperating loop processes therefore
+        hold one PR-scoped lock across discovery, draft creation, replies, and
+        submission.  The adapter fails closed on platforms without an
+        exclusive lock instead of risking duplicate draft reviews.
+        """
+        candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
+        if self._skip(
+            f"post {len(candidate_ids)} implementation review-thread replies on PR #{pr_number}"
+        ):
+            return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
+        try:
+            with file_lock(self._implementation_reply_lock_path(pr_number), require_exclusive=True):
+                return self._post_implementation_thread_replies_locked(
+                    pr_number,
+                    expected_head_sha=expected_head_sha,
+                    threads=threads,
+                    replies=replies,
+                )
+        except (LockUnavailableError, OSError) as error:
+            logger.warning("Implementation reply batch lock failed on PR #%s: %s", pr_number, error)
+            return ImplementationThreadReplyResult(
+                retryable_thread_ids=candidate_ids,
+                retryable=True,
+            )
+
+    def discard_stale_implementation_thread_reply_batch(
+        self,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        current_head_sha: str,
+        replies: dict[str, str],
+    ) -> bool:
+        """Discard verified old-head drafts after a handoff becomes stale.
+
+        The review stage calls this only after it has proved the PR remains
+        open and unarmed at ``current_head_sha``.  It never deletes a current
+        manual pending review; those are returned as a conflict by the
+        inventory and left for an operator.
+        """
+        if (
+            not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
+            or not re.fullmatch(r"[0-9a-f]{40}", current_head_sha)
+            or expected_head_sha == current_head_sha
+            or not replies
+        ):
+            return False
+        bodies: dict[str, str] = {}
+        for thread_id, reply in replies.items():
+            if not isinstance(thread_id, str) or not thread_id:
+                return False
+            safe_reply = self._safe_thread_reply(reply)
+            if safe_reply is None:
+                return False
+            bodies[thread_id] = self._implementation_thread_reply_body(
+                pr_number, expected_head_sha, thread_id, safe_reply
+            )
+        review_body = self._implementation_reply_review_body(pr_number, expected_head_sha, bodies)
+        try:
+            with file_lock(self._implementation_reply_lock_path(pr_number), require_exclusive=True):
+                reconciled = self._reconcile_implementation_reply_reviews(
+                    pr_number, current_head_sha, review_body
+                )
+        except (LockUnavailableError, OSError) as error:
+            logger.warning(
+                "Stale implementation reply draft lock failed on PR #%s: %s", pr_number, error
+            )
+            return False
+        return reconciled is not None
+
+    def _post_implementation_thread_replies_locked(  # noqa: C901
         self,
         pr_number: int,
         *,
@@ -1497,10 +1726,6 @@ class PipelineGitHub:
         performs a fresh review and owns that decision.
         """
         candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
-        if self._skip(
-            f"post {len(candidate_ids)} implementation review-thread replies on PR #{pr_number}"
-        ):
-            return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
         if not candidate_ids or not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha):
             return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
         snapshots: dict[str, dict[str, Any]] = {}
@@ -1530,19 +1755,21 @@ class PipelineGitHub:
             for thread_id in candidate_ids:
                 reply = self._safe_thread_reply(replies.get(thread_id))
                 snapshot = snapshots[thread_id]
-                live = self._review_thread_snapshot(pr_number, thread_id)
-                if (
-                    reply is None
-                    or not isinstance(live, dict)
-                    or live.get("isResolved") is not False
-                    or not self._pr_is_current_open_head(live.get("pr_state"), expected_head_sha)
-                ):
+                if reply is None:
                     blocked.append(thread_id)
                     continue
                 body = self._implementation_thread_reply_body(
                     pr_number, expected_head_sha, thread_id, reply
                 )
                 reply_bodies[thread_id] = body
+                live = self._review_thread_snapshot(pr_number, thread_id)
+                if (
+                    not isinstance(live, dict)
+                    or live.get("isResolved") is not False
+                    or not self._pr_is_current_open_head(live.get("pr_state"), expected_head_sha)
+                ):
+                    blocked.append(thread_id)
+                    continue
                 # A prior transport failure may have applied this exact reply.
                 # Recover its host proof before treating the saved snapshot as
                 # stale or attempting a duplicate mutation.
@@ -1555,38 +1782,56 @@ class PipelineGitHub:
                     continue
                 prepared.append((thread_id, snapshot, body))
 
-            if blocked:
-                return ImplementationThreadReplyResult(
-                    replied_thread_ids=tuple(sorted(recovered)),
-                    blocked_thread_ids=tuple(blocked),
-                    receipts=tuple(recovered[thread_id] for thread_id in sorted(recovered)),
+            review_body = (
+                self._implementation_reply_review_body(pr_number, expected_head_sha, reply_bodies)
+                if len(reply_bodies) == len(candidate_ids)
+                else None
+            )
+            current_batch = (
+                self._reconcile_implementation_reply_reviews(
+                    pr_number, expected_head_sha, review_body
                 )
-
-            review_body = self._implementation_reply_review_body(
-                pr_number, expected_head_sha, reply_bodies
+                if review_body is not None
+                else None
             )
-            found_review = self._find_implementation_reply_review(
-                pr_number, expected_head_sha, review_body
-            )
-            if found_review is None:
+            if review_body is None or current_batch is None:
                 return ImplementationThreadReplyResult(
                     retryable_thread_ids=candidate_ids,
                     retryable=True,
                 )
-            pr_id, existing_review = found_review
-            if existing_review is None:
-                # A fully recovered old-format response predates batched
-                # reviews.  Never duplicate a valid host-owned reply merely
-                # to rewrite its historic review association.
-                if not prepared:
-                    return ImplementationThreadReplyResult(
-                        replied_thread_ids=candidate_ids,
-                        receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
+            pr_id, existing_review, has_pending_conflict = current_batch
+            if has_pending_conflict:
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            if blocked:
+                # A PENDING review is not a receipt.  Abort the exact
+                # coordinator draft if any target changed, rather than
+                # reporting a hidden partial batch as delivered.
+                if (
+                    existing_review is not None
+                    and existing_review[1] == "PENDING"
+                    and not self._discard_current_implementation_reply_review(
+                        pr_number,
+                        expected_head_sha,
+                        review_body,
+                        pr_id,
+                        existing_review[0],
                     )
-                # Some old-format replies plus new replies cannot be made one
-                # atomic review.  Preserve the existing comments and let the
-                # caller obtain a fresh implementation pass instead of
-                # publishing a misleading partial batch.
+                ):
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
+                return ImplementationThreadReplyResult(
+                    blocked_thread_ids=tuple(sorted(blocked)),
+                )
+            if existing_review is None:
+                # A reply from an old per-comment review is not a successful
+                # batch receipt.  Do not duplicate it by creating a new batch
+                # over the same thread; a fresh review pass must establish a
+                # coherent current handoff.
                 if recovered:
                     return ImplementationThreadReplyResult(
                         retryable_thread_ids=candidate_ids,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1015,10 +1015,10 @@ class PipelineGitHub:
     ):
         """Return the exact batch review plus stale and conflicting current reviews.
 
-        Only a viewer-owned pending review carrying the opaque implementation
-        marker and an *older* commit is eligible for automatic discard.  A
-        manual or malformed pending review is a conflict: leave it untouched
-        and fail closed rather than taking ownership of another actor's work.
+        Every visible current pending review and every visible marked current
+        implementation review is a conflict unless it is this exact batch.
+        Stale drafts are preserved for manual cleanup; GitHub offers no
+        conditional delete that could prove a later actor had not changed one.
         """
         query = (
             "query($owner:String!,$name:String!,$number:Int!,$after:String){"
@@ -1061,8 +1061,6 @@ class PipelineGitHub:
             for review in reviews["nodes"]:
                 if not isinstance(review, dict):
                     return None
-                if review.get("viewerDidAuthor") is not True:
-                    continue
                 review_id = review.get("id")
                 state = review.get("state")
                 body = review.get("body")
@@ -1070,6 +1068,17 @@ class PipelineGitHub:
                 commit_oid = commit.get("oid") if isinstance(commit, dict) else None
                 if not isinstance(review_id, str) or not review_id or not isinstance(state, str):
                     return None
+                if review.get("viewerDidAuthor") is not True:
+                    if state == "PENDING":
+                        pending_conflict_ids.append(review_id)
+                    elif (
+                        state == "COMMENTED"
+                        and isinstance(commit_oid, str)
+                        and commit_oid == expected_head_sha
+                        and self._is_implementation_reply_review_body(body)
+                    ):
+                        commented_conflict_ids.append(review_id)
+                    continue
                 if state == "PENDING":
                     if (
                         body == review_body
@@ -1230,94 +1239,36 @@ class PipelineGitHub:
             and review.get("body") == review_body
         )
 
-    def _delete_implementation_reply_review(self, review_id: str) -> bool:
-        """Delete one proven coordinator-owned pending review draft."""
-        query = (
-            "mutation($reviewId:ID!,$clientMutationId:String!){"
-            "deletePullRequestReview(input:{pullRequestReviewId:$reviewId,"
-            "clientMutationId:$clientMutationId}){pullRequestReview{id}}}"
-        )
-        data = self._graphql(
-            query,
-            reviewId=review_id,
-            clientMutationId=hashlib.sha256(
-                f"{review_id}:discard-implementation-replies".encode()
-            ).hexdigest(),
-        )
-        response_data = data.get("data") if isinstance(data, dict) else None
-        mutation = (
-            response_data.get("deletePullRequestReview")
-            if isinstance(response_data, dict)
-            else None
-        )
-        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
-        return bool(isinstance(review, dict) and review.get("id") == review_id)
-
-    def _reconcile_implementation_reply_reviews(
+    def _implementation_reply_review_state(
         self, pr_number: int, expected_head_sha: str, review_body: str
     ) -> tuple[str, tuple[str, str] | None, tuple[str, ...]] | None:
-        """Discard only proven stale drafts and return the current batch state.
+        """Return the exact batch and every visible preserved-review conflict.
 
-        The review inventory is reread before every deletion, so a head move
-        or a new current review preserves every draft instead of deleting one
-        whose identity is no longer proved.  A PENDING review for the current
-        head but another body is intentionally left alone.
+        This accessor is intentionally read-only.  It never tries to recover
+        from an interrupted batch by deleting a draft, because GitHub's review
+        API supplies no compare-and-swap precondition for that mutation.
         """
-        while True:
-            inventory = self._implementation_reply_review_inventory(
-                pr_number, expected_head_sha, review_body
-            )
-            if inventory is None:
-                return None
-            (
-                pr_id,
-                review,
-                stale_pending_ids,
-                pending_conflict_ids,
-                commented_conflict_ids,
-            ) = inventory
-            conflicting_review_ids = tuple(
-                sorted(set(pending_conflict_ids).union(commented_conflict_ids))
-            )
-            # GitHub offers no compare-and-swap delete.  Once a conflicting
-            # current review exists, a stale-looking coordinator draft might
-            # receive content before a deletion reaches GitHub.  Preserve all
-            # reviews and let the caller report the conflict instead.
-            if conflicting_review_ids or not stale_pending_ids:
-                return pr_id, review, conflicting_review_ids
-            stale_review_id = stale_pending_ids[0]
-            if not self._delete_implementation_reply_review(stale_review_id):
-                # GitHub may have applied the delete before losing its response.
-                # The next inventory read is the only safe recovery proof.
-                recovered = self._implementation_reply_review_inventory(
-                    pr_number, expected_head_sha, review_body
+        inventory = self._implementation_reply_review_inventory(
+            pr_number, expected_head_sha, review_body
+        )
+        if inventory is None:
+            return None
+        (
+            pr_id,
+            review,
+            stale_pending_ids,
+            pending_conflict_ids,
+            commented_conflict_ids,
+        ) = inventory
+        return (
+            pr_id,
+            review,
+            tuple(
+                sorted(
+                    set(stale_pending_ids).union(pending_conflict_ids).union(commented_conflict_ids)
                 )
-                if recovered is None or stale_review_id in recovered[2]:
-                    return None
-
-    def _discard_current_implementation_reply_review(
-        self,
-        pr_number: int,
-        expected_head_sha: str,
-        review_body: str,
-        pr_id: str,
-        review_id: str,
-    ) -> bool:
-        """Abort a current batch which cannot atomically cover every thread."""
-        current = self._reconcile_implementation_reply_reviews(
-            pr_number, expected_head_sha, review_body
+            ),
         )
-        if current is None:
-            return False
-        current_pr_id, review, conflicting_review_ids = current
-        if current_pr_id != pr_id or review != (review_id, "PENDING") or conflicting_review_ids:
-            return False
-        if self._delete_implementation_reply_review(review_id):
-            return True
-        recovered = self._reconcile_implementation_reply_reviews(
-            pr_number, expected_head_sha, review_body
-        )
-        return bool(recovered is not None and recovered[0] == pr_id and recovered[1] is None)
 
     @staticmethod
     def _final_comment_review_id(thread: dict[str, Any]) -> str | None:
@@ -1807,7 +1758,7 @@ class PipelineGitHub:
                 retryable=True,
             )
 
-    def discard_stale_implementation_thread_reply_batch(
+    def preserve_stale_implementation_thread_reply_batch(
         self,
         pr_number: int,
         *,
@@ -1815,16 +1766,15 @@ class PipelineGitHub:
         current_head_sha: str,
         replies: dict[str, str],
         batch_nonce: str | None = None,
-    ) -> bool:
-        """Discard verified old-head drafts after a handoff becomes stale.
+    ) -> tuple[str, ...] | None:
+        """Return visible reviews preserved after an old-head handoff goes stale.
 
-        The review stage calls this only after it has proved the PR remains
-        open and unarmed at ``current_head_sha``.  It never deletes a current
-        manual pending review; those are returned as a conflict by the
-        inventory and left for an operator.
+        GitHub has no conditional review-delete mutation, so this recovery
+        hook is deliberately read-only.  The stage uses the returned IDs to
+        stop the work item and request manual cleanup before a fresh pass.
         """
-        if self._skip(f"discard stale implementation reply draft on PR #{pr_number}"):
-            return True
+        if self._skip(f"preserve stale implementation reply drafts on PR #{pr_number}"):
+            return ()
         if (
             not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
             or not re.fullmatch(r"[0-9a-f]{40}", current_head_sha)
@@ -1833,14 +1783,14 @@ class PipelineGitHub:
             or not isinstance(batch_nonce, str)
             or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None
         ):
-            return False
+            return None
         bodies: dict[str, str] = {}
         for thread_id, reply in replies.items():
             if not isinstance(thread_id, str) or not thread_id:
-                return False
+                return None
             safe_reply = self._safe_thread_reply(reply)
             if safe_reply is None:
-                return False
+                return None
             bodies[thread_id] = self._implementation_thread_reply_body(
                 pr_number, expected_head_sha, thread_id, safe_reply
             )
@@ -1849,15 +1799,21 @@ class PipelineGitHub:
         )
         try:
             with file_lock(self._implementation_reply_lock_path(pr_number), require_exclusive=True):
-                reconciled = self._reconcile_implementation_reply_reviews(
+                state = self._implementation_reply_review_state(
                     pr_number, current_head_sha, review_body
                 )
         except (LockUnavailableError, OSError) as error:
             logger.warning(
                 "Stale implementation reply draft lock failed on PR #%s: %s", pr_number, error
             )
-            return False
-        return reconciled is not None
+            return None
+        if state is None:
+            return None
+        _pr_id, review, conflict_ids = state
+        preserved = set(conflict_ids)
+        if review is not None and review[1] == "PENDING":
+            preserved.add(review[0])
+        return tuple(sorted(preserved))
 
     def _post_implementation_thread_replies_locked(  # noqa: C901
         self,
@@ -1943,9 +1899,7 @@ class PipelineGitHub:
                 else None
             )
             current_batch = (
-                self._reconcile_implementation_reply_reviews(
-                    pr_number, expected_head_sha, review_body
-                )
+                self._implementation_reply_review_state(pr_number, expected_head_sha, review_body)
                 if review_body is not None
                 else None
             )
@@ -1964,30 +1918,20 @@ class PipelineGitHub:
                 # Include the local pending draft so operators can identify
                 # every review preserved by the terminal conflict.
                 reported_conflict_ids = set(conflicting_review_ids)
-                if blocked and existing_review is not None and existing_review[1] == "PENDING":
+                if existing_review is not None and existing_review[1] == "PENDING":
                     reported_conflict_ids.add(existing_review[0])
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=candidate_ids,
                     conflicting_current_review_ids=tuple(sorted(reported_conflict_ids)),
                 )
             if blocked:
-                # A PENDING review is not a receipt.  Abort the exact
-                # coordinator draft if any target changed, rather than
-                # reporting a hidden partial batch as delivered.
-                if (
-                    existing_review is not None
-                    and existing_review[1] == "PENDING"
-                    and not self._discard_current_implementation_reply_review(
-                        pr_number,
-                        expected_head_sha,
-                        review_body,
-                        pr_id,
-                        existing_review[0],
-                    )
-                ):
+                # A PENDING review is not a receipt.  Preserve it for manual
+                # cleanup instead of deleting it: GitHub cannot prove that a
+                # concurrent writer has not appended content after inventory.
+                if existing_review is not None and existing_review[1] == "PENDING":
                     return ImplementationThreadReplyResult(
-                        retryable_thread_ids=candidate_ids,
-                        retryable=True,
+                        blocked_thread_ids=candidate_ids,
+                        conflicting_current_review_ids=(existing_review[0],),
                     )
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1393,10 +1393,39 @@ class PipelineGitHub:
             git_dir = Path(raw_git_dir.strip())
             if not git_dir.is_absolute():
                 git_dir = git_metadata.parent / git_dir
-            if git_dir.parent.name == "worktrees":
-                lock_root = git_dir.parent.parent / "hephaestus-automation-locks"
-            else:
-                lock_root = git_dir / "hephaestus-automation-locks"
+            common_git_dir = git_dir.parent.parent
+            common_dir_file = git_dir / "commondir"
+            if (
+                git_dir.parent.name != "worktrees"
+                or not git_dir.is_dir()
+                or not (git_dir / "HEAD").is_file()
+                or not common_git_dir.is_dir()
+                or not (common_git_dir / "HEAD").is_file()
+                or not common_dir_file.is_file()
+            ):
+                raise LockUnavailableError(
+                    "invalid linked-worktree Git metadata for implementation reply lock at "
+                    f"{git_metadata}"
+                )
+            try:
+                common_dir_text = common_dir_file.read_text(encoding="utf-8").strip()
+                common_dir_from_metadata = Path(common_dir_text)
+                if not common_dir_from_metadata.is_absolute():
+                    common_dir_from_metadata = git_dir / common_dir_from_metadata
+                if (
+                    not common_dir_text
+                    or common_dir_from_metadata.resolve() != common_git_dir.resolve()
+                ):
+                    raise LockUnavailableError(
+                        "invalid common Git directory for implementation reply lock at "
+                        f"{git_metadata}"
+                    )
+            except (OSError, UnicodeDecodeError) as error:
+                raise LockUnavailableError(
+                    "could not read common Git directory for implementation reply lock at "
+                    f"{git_metadata}"
+                ) from error
+            lock_root = common_git_dir / "hephaestus-automation-locks"
         return lock_root / f"implementation-replies-{repo_key}-{pr_number}.lock"
 
     def post_implementation_thread_replies(

--- a/tests/integration/test_audit_reviewer_integration.py
+++ b/tests/integration/test_audit_reviewer_integration.py
@@ -83,27 +83,23 @@ Overall, we have 2 PRs ready to review."""
         assert "generated_at" in loaded
         assert len(loaded["audits"]) == 2
 
-    def test_audit_reviewer_run_posting_failure_isolated(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Verify posting failure does not prevent run completion."""
+    def test_audit_reviewer_run_keeps_summary_local(self, tmp_path: Path) -> None:
+        """Verify an audit completes without creating an unanchored PR review."""
         with mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs") as mock_fetch:
             with mock.patch(
                 "hephaestus.automation.audit_reviewer.run_audit_coordinator"
             ) as mock_coord:
-                with mock.patch(
-                    "hephaestus.automation.audit_reviewer.gh_pr_review_post"
-                ) as mock_post:
-                    mock_fetch.return_value = [{"number": 100, "title": "Test"}]
-                    mock_coord.return_value = [
-                        {"pr_number": 100, "verdict": "GO", "summary": "Good"}
-                    ]
-                    mock_post.side_effect = Exception("GitHub error")
-                    reviewer = AuditReviewer(state_dir=tmp_path)
-                    rc, audits = reviewer.run()
-                    assert rc == 0
-                    assert len(audits) == 1
-                    assert mock_post.called
+                mock_fetch.return_value = [{"number": 100, "title": "Test"}]
+                mock_coord.return_value = [{"pr_number": 100, "verdict": "GO", "summary": "Good"}]
+                reviewer = AuditReviewer(state_dir=tmp_path)
+                rc, audits = reviewer.run()
+
+        assert rc == 0
+        assert len(audits) == 1
+        reports = list(tmp_path.glob("audit-report-*.json"))
+        assert len(reports) == 1
+        report = json.loads(reports[0].read_text())
+        assert report["audits"] == audits
 
     def test_print_audit_summary_per_pr_log_line(self, caplog: pytest.LogCaptureFixture) -> None:
         """Verify one log line per PR with key info."""

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -467,6 +467,24 @@ class FakeStageGitHub(FakeGitHub):
         blocked = tuple(sorted(set(replies) - set(replied)))
         return ImplementationThreadReplyResult(replied, blocked, tuple(receipts))
 
+    def discard_stale_implementation_thread_reply_batch(
+        self,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        current_head_sha: str,
+        replies: dict[str, str],
+    ) -> bool:
+        """Record stale draft cleanup without modelling GitHub pending reviews."""
+        self._log(
+            "discard_stale_implementation_thread_reply_batch",
+            pr_number,
+            expected_head_sha,
+            current_head_sha,
+            tuple(sorted(replies)),
+        )
+        return True
+
     def reviewer_validation_receipts(
         self,
         pr_number: int,

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -397,13 +397,12 @@ class FakeStageGitHub(FakeGitHub):
         self,
         pr_number: int,
         threads: list[dict[str, Any]],
-        summary: str,
         *,
         expected_head_sha: str,
     ) -> list[dict[str, Any]]:
         """Mirror a post-time immutable receipt returned by the coordinator."""
         del expected_head_sha
-        ids = self.gh_pr_review_post(pr_number, threads, summary)
+        ids = self.gh_pr_review_post(pr_number, threads, "")
         self._posted_thread_ids[pr_number] = list(ids)
         review_id = f"review-{pr_number}-{len(self.reviews.get(pr_number, []))}"
         return [

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -435,9 +435,10 @@ class FakeStageGitHub(FakeGitHub):
         expected_head_sha: str,
         threads: list[dict[str, Any]],
         replies: dict[str, str],
+        batch_nonce: str,
     ) -> ImplementationThreadReplyResult:
         """Record commit-gated implementation replies for stage tests."""
-        del expected_head_sha
+        del expected_head_sha, batch_nonce
         by_id = {
             str(thread.get("thread_id") or thread.get("id") or ""): thread for thread in threads
         }
@@ -474,6 +475,7 @@ class FakeStageGitHub(FakeGitHub):
         expected_head_sha: str,
         current_head_sha: str,
         replies: dict[str, str],
+        batch_nonce: str,
     ) -> bool:
         """Record stale draft cleanup without modelling GitHub pending reviews."""
         self._log(
@@ -482,6 +484,7 @@ class FakeStageGitHub(FakeGitHub):
             expected_head_sha,
             current_head_sha,
             tuple(sorted(replies)),
+            batch_nonce,
         )
         return True
 

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -468,7 +468,7 @@ class FakeStageGitHub(FakeGitHub):
         blocked = tuple(sorted(set(replies) - set(replied)))
         return ImplementationThreadReplyResult(replied, blocked, tuple(receipts))
 
-    def discard_stale_implementation_thread_reply_batch(
+    def preserve_stale_implementation_thread_reply_batch(
         self,
         pr_number: int,
         *,
@@ -476,17 +476,17 @@ class FakeStageGitHub(FakeGitHub):
         current_head_sha: str,
         replies: dict[str, str],
         batch_nonce: str,
-    ) -> bool:
-        """Record stale draft cleanup without modelling GitHub pending reviews."""
+    ) -> tuple[str, ...] | None:
+        """Record non-mutating stale-draft preservation for stage tests."""
         self._log(
-            "discard_stale_implementation_thread_reply_batch",
+            "preserve_stale_implementation_thread_reply_batch",
             pr_number,
             expected_head_sha,
             current_head_sha,
             tuple(sorted(replies)),
             batch_nonce,
         )
-        return True
+        return ()
 
     def reviewer_validation_receipts(
         self,

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -563,20 +563,6 @@ class FakeStageGitHub(FakeGitHub):
         self._pr_impl_state = (False, True)
         self._log("mark_pr_implementation_no_go", pr_number)
 
-    def post_pr_comment(self, pr_number: int, body: str) -> None:
-        """Mirror the coordinator PR-comment post (delegates to gh_issue_comment).
-
-        PRs share the issue comment channel, so the canonical
-        ``gh_issue_comment`` recorder keeps the mutation_log format and
-        stores the body for content assertions.
-        """
-        self.gh_issue_comment(pr_number, body)
-
-    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
-        """Mirror the coordinator PR-comment upsert (delegates to issue comments)."""
-        self.gh_issue_upsert_comment(pr_number, marker_prefix, body)
-        return True
-
     def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
         """Mirror ci_driver.CIDriver._gh_pr_state (canned answer)."""
         del pr_number  # single canned answer; not per-PR keyed

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -468,26 +468,6 @@ class FakeStageGitHub(FakeGitHub):
         blocked = tuple(sorted(set(replies) - set(replied)))
         return ImplementationThreadReplyResult(replied, blocked, tuple(receipts))
 
-    def preserve_stale_implementation_thread_reply_batch(
-        self,
-        pr_number: int,
-        *,
-        expected_head_sha: str,
-        current_head_sha: str,
-        replies: dict[str, str],
-        batch_nonce: str,
-    ) -> tuple[str, ...] | None:
-        """Record non-mutating stale-draft preservation for stage tests."""
-        self._log(
-            "preserve_stale_implementation_thread_reply_batch",
-            pr_number,
-            expected_head_sha,
-            current_head_sha,
-            tuple(sorted(replies)),
-            batch_nonce,
-        )
-        return ()
-
     def reviewer_validation_receipts(
         self,
         pr_number: int,

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -795,10 +795,10 @@ class TestPrReviewStageStep:
         assert item.payload["posted_thread_ids"] == ["thread-1001-0", "thread-1001-1"]
         assert item.payload["unresolved_threads_before_address"] == 2
 
-    def test_post_with_zero_open_automation_threads_skips_to_eval(
+    def test_post_with_zero_open_automation_threads_is_a_publication_no_op(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A zero-finding review still posts its final structured audit."""
+        """A zero-finding review emits no unanchored review-level response."""
         stage = PrReviewStage()
         github = FakeStageGitHub(unresolved=[(0, 0)])
         ctx = make_ctx(github=github)
@@ -815,9 +815,8 @@ class TestPrReviewStageStep:
 
         assert isinstance(result, Continue)
         assert result.next_state == "EVAL"
-        assert github.mutation_log == [("gh_pr_review_post", (1001, "COMMENT"))]
-        assert github.reviews[1001][0]["comments"] == []
-        assert "Total grade: A" in github.reviews[1001][0]["summary"]
+        assert github.mutation_log == []
+        assert 1001 not in github.reviews
 
     @pytest.mark.parametrize("existing_pr", [False, True], ids=["fresh-pr", "existing-pr"])
     def test_empty_audit_addresses_pre_existing_live_blocking_thread(
@@ -844,7 +843,7 @@ class TestPrReviewStageStep:
         post_result = stage.step(item, ctx)
 
         assert post_result == Continue(next_state="DIFFICULTY_WAIT")
-        assert github.reviews[1001][0]["comments"] == []
+        assert 1001 not in github.reviews
         remediation = [
             {
                 "thread_id": "live-thread-1001-0",
@@ -1725,11 +1724,10 @@ class TestReviewThreadLifecycle:
                 self,
                 pr_number: int,
                 threads: list[dict[str, Any]],
-                summary: str,
                 *,
                 expected_head_sha: str,
             ) -> list[dict[str, Any]]:
-                del summary, expected_head_sha
+                del expected_head_sha
                 self.posted_batches.append([dict(thread) for thread in threads])
                 thread_ids: list[str] = []
                 for thread in threads:
@@ -1878,13 +1876,12 @@ class TestReviewThreadLifecycle:
                 self,
                 pr_number: int,
                 threads: list[dict[str, Any]],
-                summary: str,
                 *,
                 expected_head_sha: str,
             ) -> list[dict[str, Any]]:
                 self.posted_batches.append([dict(thread) for thread in threads])
                 return super().post_review_threads(
-                    pr_number, threads, summary, expected_head_sha=expected_head_sha
+                    pr_number, threads, expected_head_sha=expected_head_sha
                 )
 
         github = CapturePostsGitHub()
@@ -1907,7 +1904,7 @@ class TestReviewThreadLifecycle:
         result = PrReviewStage().step(item, make_ctx(github=github))
 
         assert result == Continue(next_state="EVAL")
-        assert github.posted_batches == [[]]
+        assert github.posted_batches == []
 
     def test_validation_receives_all_live_thread_facts(
         self, make_ctx: Any, make_work_item: Any
@@ -1961,11 +1958,10 @@ class TestReviewThreadLifecycle:
                 self,
                 pr_number: int,
                 threads: list[dict[str, Any]],
-                summary: str,
                 *,
                 expected_head_sha: str,
             ) -> list[dict[str, Any]]:
-                del summary, expected_head_sha
+                del expected_head_sha
                 self.posted = [dict(thread) for thread in threads]
                 posted_ids = [f"reopened-{index}" for index, _ in enumerate(threads)]
                 for thread_id, thread in zip(posted_ids, threads, strict=True):
@@ -2024,11 +2020,10 @@ class TestReviewThreadLifecycle:
                 self,
                 pr_number: int,
                 threads: list[dict[str, Any]],
-                summary: str,
                 *,
                 expected_head_sha: str,
             ) -> list[dict[str, Any]]:
-                del summary, expected_head_sha
+                del expected_head_sha
                 self.posted = [dict(thread) for thread in threads]
                 posted_ids = [f"reopened-{index}" for index, _ in enumerate(threads)]
                 for thread_id, thread in zip(posted_ids, threads, strict=True):
@@ -2188,7 +2183,6 @@ class TestReviewThreadLifecycle:
                 self,
                 pr_number: int,
                 threads: list[dict[str, Any]],
-                summary: str,
                 *,
                 expected_head_sha: str,
             ) -> list[dict[str, Any]]:
@@ -2391,22 +2385,6 @@ class TestEvalVerdicts:
 
         assert result == StageOutcome(Disposition.RETRY, "review audit format failure")
         assert not any(name == "mark_pr_implementation_go" for name, _ in github.mutation_log)
-
-    def test_final_comment_contains_audit_only(self) -> None:
-        """The durable review comment contains no textual decision field."""
-        body = PrReviewStage._final_review_comment(
-            ReviewAudit(
-                grade="A",
-                summary="Safe summary",
-                findings=(),
-                raw_feedback="Private reviewer detail",
-                valid=True,
-            )
-        )
-
-        assert "Total grade: A" in body
-        assert "Safe summary" in body
-        assert "private reviewer detail" not in body
 
     def test_go_with_zero_threads_marks_implementation_go_and_advances_to_merge_wait(
         self, make_ctx: Any, make_work_item: Any
@@ -3691,7 +3669,7 @@ class TestFullWalks:
         assert item.attempts["pr_review_iter"] == 1  # only the fresh-head round counts
         assert not any(name == "mark_pr_implementation_no_go" for name, _ in github.mutation_log)
         assert ("mark_pr_implementation_go", (1001,)) in github.mutation_log
-        assert github.mutation_log.count(("gh_pr_review_post", (1001, "COMMENT"))) == 2
+        assert github.mutation_log.count(("gh_pr_review_post", (1001, "COMMENT"))) == 0
 
     def test_unresolved_thread_walk_exhausts_without_terminal_handoff(
         self, make_ctx: Any, make_work_item: Any
@@ -4649,11 +4627,10 @@ class TestAuditPublication:
                 self,
                 pr_number: int,
                 threads: list[dict[str, Any]],
-                summary: str,
                 *,
                 expected_head_sha: str,
             ) -> list[dict[str, Any]]:
-                del pr_number, threads, summary, expected_head_sha
+                del pr_number, threads, expected_head_sha
                 self.publish_calls += 1
                 pytest.fail("fresh-audit publication must verify the reviewed PR head first")
 

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import deque
 from types import SimpleNamespace
 from typing import Any
@@ -1348,12 +1349,14 @@ class TestReviewThreadLifecycle:
             "a" * 40,
             [thread],
             {"thread-1": "  Fixed the first concern.  "},
+            "b" * 32,
         )
 
         assert handoff == {
             "head_sha": "a" * 40,
             "threads": [thread],
             "replies": {"thread-1": "Fixed the first concern."},
+            "batch_nonce": "b" * 32,
         }
         thread["body"] = "mutated after the handoff"
         assert handoff["threads"][0]["body"] != thread["body"]
@@ -2329,6 +2332,29 @@ class TestEvalVerdicts:
         )
         body = github.comments[1001][-1]
         assert "No review thread was resolved and no current draft was deleted." in body
+
+    def test_pending_reply_draft_conflict_is_terminally_diagnosed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A foreign pending draft is retained and explained, never retried as transport failure."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["implementation_reply_pending_draft_conflict"] = {
+            "head_sha": "a" * 40,
+            "draft_ids": ("foreign-pending-draft",),
+        }
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(
+            Disposition.FINISH_FAIL, "implementation_reply_draft_conflict"
+        )
+        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+        body = github.comments[1001][-1]
+        assert "No review thread was resolved and no current draft was deleted." in body
+        assert "foreign-pending-draft" in body
 
     def test_on_enter_stands_down_without_auto_merge_mutation(
         self, make_ctx: Any, make_work_item: Any
@@ -4083,6 +4109,7 @@ class TestRealCommitGate:
                 expected_head_sha: str,
                 threads: list[dict[str, Any]],
                 replies: dict[str, str],
+                batch_nonce: str,
             ) -> Any:
                 self.reply_attempts += 1
                 if self.reply_attempts == 1:
@@ -4092,6 +4119,7 @@ class TestRealCommitGate:
                     expected_head_sha=expected_head_sha,
                     threads=threads,
                     replies=replies,
+                    batch_nonce=batch_nonce,
                 )
 
         stage = PrReviewStage()
@@ -4160,6 +4188,7 @@ class TestRealCommitGate:
                 expected_head_sha: str,
                 threads: list[dict[str, Any]],
                 replies: dict[str, str],
+                batch_nonce: str,
             ) -> ImplementationThreadReplyResult:
                 self.reply_attempts += 1
                 return super().post_implementation_thread_replies(
@@ -4167,6 +4196,7 @@ class TestRealCommitGate:
                     expected_head_sha=expected_head_sha,
                     threads=threads,
                     replies=replies,
+                    batch_nonce=batch_nonce,
                 )
 
         stage = PrReviewStage()
@@ -4230,6 +4260,7 @@ class TestRealCommitGate:
                 expected_head_sha: str,
                 threads: list[dict[str, Any]],
                 replies: dict[str, str],
+                batch_nonce: str,
             ) -> ImplementationThreadReplyResult:
                 self.reply_attempts += 1
                 return super().post_implementation_thread_replies(
@@ -4237,6 +4268,7 @@ class TestRealCommitGate:
                     expected_head_sha=expected_head_sha,
                     threads=threads,
                     replies=replies,
+                    batch_nonce=batch_nonce,
                 )
 
         stage = PrReviewStage()
@@ -4276,10 +4308,10 @@ class TestRealCommitGate:
         assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
         assert github.reply_attempts == 0
         assert "pending_implementation_reply_handoff" not in item.payload
-        assert github.mutation_log[-1] == (
-            "discard_stale_implementation_thread_reply_batch",
-            (1001, "a" * 40, "b" * 40, ("thread-1",)),
-        )
+        name, args = github.mutation_log[-1]
+        assert name == "discard_stale_implementation_thread_reply_batch"
+        assert args[:4] == (1001, "a" * 40, "b" * 40, ("thread-1",))
+        assert re.fullmatch(r"[0-9a-f]{32}", args[4]) is not None
 
     def test_stale_reply_handoff_restarts_fresh_review_without_retrying(
         self, make_ctx: Any, make_work_item: Any
@@ -4294,8 +4326,9 @@ class TestRealCommitGate:
                 expected_head_sha: str,
                 threads: list[dict[str, Any]],
                 replies: dict[str, str],
+                batch_nonce: str,
             ) -> ImplementationThreadReplyResult:
-                del pr_number, expected_head_sha, threads, replies
+                del pr_number, expected_head_sha, threads, replies, batch_nonce
                 # The reply may already be visible, but a reviewer comment
                 # raced the post-read.  This is a factual stale handoff, not
                 # a transport ambiguity that can be replayed.
@@ -4350,8 +4383,9 @@ class TestRealCommitGate:
                 expected_head_sha: str,
                 threads: list[dict[str, Any]],
                 replies: dict[str, str],
+                batch_nonce: str,
             ) -> ImplementationThreadReplyResult:
-                del pr_number, expected_head_sha, threads, replies
+                del pr_number, expected_head_sha, threads, replies, batch_nonce
                 self.reply_attempts += 1
                 if self.reply_attempts == 1:
                     raise OSError("temporary GitHub transport failure")
@@ -4415,8 +4449,9 @@ class TestRealCommitGate:
                 expected_head_sha: str,
                 threads: list[dict[str, Any]],
                 replies: dict[str, str],
+                batch_nonce: str,
             ) -> ImplementationThreadReplyResult:
-                del pr_number, expected_head_sha, threads
+                del pr_number, expected_head_sha, threads, batch_nonce
                 self.reply_batches.append(tuple(sorted(replies)))
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=("stale-thread",),

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1361,11 +1361,15 @@ class TestReviewThreadLifecycle:
         thread["body"] = "mutated after the handoff"
         assert handoff["threads"][0]["body"] != thread["body"]
         assert (
-            _implementation_reply_handoff("not-a-sha", [self._thread("thread-1", 3, "x")], {})
+            _implementation_reply_handoff(
+                "not-a-sha", [self._thread("thread-1", 3, "x")], {}, "b" * 32
+            )
             is None
         )
-        assert _implementation_reply_handoff("a" * 40, ["not-a-thread"], {}) is None
-        assert _implementation_reply_handoff("a" * 40, [{"id": ""}], {"": "fixed"}) is None
+        assert _implementation_reply_handoff("a" * 40, ["not-a-thread"], {}, "b" * 32) is None
+        assert (
+            _implementation_reply_handoff("a" * 40, [{"id": ""}], {"": "fixed"}, "b" * 32) is None
+        )
 
     def test_validation_receipts_require_one_complete_immutable_thread_snapshot(self) -> None:
         """Validation binds a thread decision to its exact host-read reply."""
@@ -2315,7 +2319,7 @@ class TestEvalVerdicts:
         item = make_work_item(issue=1, pr=1001, state="EVAL")
         item.payload["implementation_reply_batch_conflict"] = {
             "head_sha": "a" * 40,
-            "draft_ids": ("draft-one", "draft-two"),
+            "review_ids": ("draft-one", "draft-two"),
         }
 
         result = stage.step(item, ctx)
@@ -2327,33 +2331,38 @@ class TestEvalVerdicts:
         assert any(
             name == "gh_issue_upsert_comment"
             and args[0] == 1001
-            and args[1].startswith("<!-- hephaestus-implementation-reply-draft-conflict:")
+            and args[1].startswith(
+                "<!-- hephaestus-implementation-reply-duplicate-review-conflict:"
+            )
             for name, args in github.mutation_log
         )
         body = github.comments[1001][-1]
-        assert "No review thread was resolved and no current draft was deleted." in body
+        assert "No review thread was resolved and no conflicting review was mutated." in body
 
-    def test_pending_reply_draft_conflict_is_terminally_diagnosed(
+    def test_current_reply_review_conflict_is_terminally_diagnosed(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A foreign pending draft is retained and explained, never retried as transport failure."""
+        """A foreign current review is retained and explained, never retried as transport failure.
+
+        The terminal record covers both pending drafts and completed conflicting batches.
+        """
         stage = PrReviewStage()
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
         item = make_work_item(issue=1, pr=1001, state="EVAL")
-        item.payload["implementation_reply_pending_draft_conflict"] = {
+        item.payload["implementation_reply_review_conflict"] = {
             "head_sha": "a" * 40,
-            "draft_ids": ("foreign-pending-draft",),
+            "review_ids": ("foreign-pending-draft",),
         }
 
         result = stage.step(item, ctx)
 
         assert result == StageOutcome(
-            Disposition.FINISH_FAIL, "implementation_reply_draft_conflict"
+            Disposition.FINISH_FAIL, "implementation_reply_review_conflict"
         )
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
         body = github.comments[1001][-1]
-        assert "No review thread was resolved and no current draft was deleted." in body
+        assert "No review thread was resolved and no conflicting review was mutated." in body
         assert "foreign-pending-draft" in body
 
     def test_on_enter_stands_down_without_auto_merge_mutation(
@@ -4159,6 +4168,33 @@ class TestRealCommitGate:
         assert github.reply_attempts == 2
         assert "pending_implementation_reply_handoff" not in item.payload
         assert item.payload["push_no_commit"] is False
+
+    def test_retry_rejects_handoff_without_a_persisted_batch_nonce(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A recovered handoff cannot mint a replacement ownership nonce."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        item = make_work_item(issue=40, pr=1001, state="EVAL")
+        item.payload["pending_implementation_reply_handoff"] = {
+            "head_sha": "a" * 40,
+            "threads": [
+                {
+                    "id": "thread-1",
+                    "path": "a.py",
+                    "line": 3,
+                    "side": "RIGHT",
+                    "body": "fix this",
+                    "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix this"}],
+                }
+            ],
+            "replies": {"thread-1": "Fixed the guard."},
+        }
+
+        assert stage.step(item, make_ctx(github=github)) == StageOutcome(
+            Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid"
+        )
+        assert github.mutation_log == []
 
     def test_reply_handoff_waits_for_post_push_head_visibility(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -4333,6 +4333,71 @@ class TestRealCommitGate:
         item.state = "EVAL"
         assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
 
+    def test_retry_duplicate_reply_drafts_are_terminally_diagnosed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A duplicate found on host-only retry cannot become ordinary stale work."""
+
+        class ReplyFailsThenFindsDuplicatesGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self.reply_attempts = 0
+
+            def post_implementation_thread_replies(
+                self,
+                pr_number: int,
+                *,
+                expected_head_sha: str,
+                threads: list[dict[str, Any]],
+                replies: dict[str, str],
+            ) -> ImplementationThreadReplyResult:
+                del pr_number, expected_head_sha, threads, replies
+                self.reply_attempts += 1
+                if self.reply_attempts == 1:
+                    raise OSError("temporary GitHub transport failure")
+                return ImplementationThreadReplyResult(
+                    blocked_thread_ids=("thread-1",),
+                    duplicate_current_draft_ids=("draft-one", "draft-two"),
+                )
+
+        stage = PrReviewStage()
+        github = ReplyFailsThenFindsDuplicatesGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=40, pr=1001, state="PUSH_WAIT")
+        snapshot = {
+            "id": "thread-1",
+            "path": "a.py",
+            "line": 3,
+            "side": "RIGHT",
+            "body": "fix this",
+            "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix this"}],
+        }
+        item.payload.update(
+            {
+                "remediation_threads": [{"thread_id": "thread-1", "body": "fix this"}],
+                "remediation_thread_snapshots": [snapshot],
+                "address_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "Fixed the guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "a" * 40}),
+            ctx,
+        )
+
+        assert "pending_implementation_reply_handoff" in item.payload
+        item.state = "EVAL"
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "implementation_reply_batch_conflict"
+        )
+        assert github.reply_attempts == 2
+        assert "pending_implementation_reply_handoff" not in item.payload
+        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+
     def test_mixed_stale_and_transport_reply_batch_retries_only_ambiguous_thread(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -2302,6 +2302,34 @@ class TestPrReviewRestartSafetyGuards:
 class TestEvalVerdicts:
     """EVAL: re-housed _evaluate_go_verdict semantics + the budget gate."""
 
+    def test_duplicate_current_reply_drafts_are_terminally_diagnosed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Cross-checkout ownership ambiguity stops without retrying or deleting drafts."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["implementation_reply_batch_conflict"] = {
+            "head_sha": "a" * 40,
+            "draft_ids": ("draft-one", "draft-two"),
+        }
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(
+            Disposition.FINISH_FAIL, "implementation_reply_batch_conflict"
+        )
+        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+        assert any(
+            name == "gh_issue_upsert_comment"
+            and args[0] == 1001
+            and args[1].startswith("<!-- hephaestus-implementation-reply-draft-conflict:")
+            for name, args in github.mutation_log
+        )
+        body = github.comments[1001][-1]
+        assert "No review thread was resolved and no current draft was deleted." in body
+
     def test_on_enter_stands_down_without_auto_merge_mutation(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -4345,7 +4345,7 @@ class TestRealCommitGate:
         assert github.reply_attempts == 0
         assert "pending_implementation_reply_handoff" not in item.payload
         name, args = github.mutation_log[-1]
-        assert name == "discard_stale_implementation_thread_reply_batch"
+        assert name == "preserve_stale_implementation_thread_reply_batch"
         assert args[:4] == (1001, "a" * 40, "b" * 40, ("thread-1",))
         assert re.fullmatch(r"[0-9a-f]{32}", args[4]) is not None
 
@@ -4401,6 +4401,62 @@ class TestRealCommitGate:
         assert "pending_implementation_reply_handoff" not in item.payload
         item.state = "EVAL"
         assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+
+    def test_stale_reply_handoff_with_preserved_draft_is_terminally_diagnosed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A visible stale draft requires manual cleanup before another reply pass."""
+
+        class PreservedStaleDraftGitHub(FakeStageGitHub):
+            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+                del pr_number
+                return {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None}
+
+            def preserve_stale_implementation_thread_reply_batch(
+                self,
+                pr_number: int,
+                *,
+                expected_head_sha: str,
+                current_head_sha: str,
+                replies: dict[str, str],
+                batch_nonce: str,
+            ) -> tuple[str, ...] | None:
+                super().preserve_stale_implementation_thread_reply_batch(
+                    pr_number,
+                    expected_head_sha=expected_head_sha,
+                    current_head_sha=current_head_sha,
+                    replies=replies,
+                    batch_nonce=batch_nonce,
+                )
+                return ("preserved-stale-draft",)
+
+        stage = PrReviewStage()
+        github = PreservedStaleDraftGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=40, pr=1001, state="EVAL")
+        item.payload["pending_implementation_reply_handoff"] = {
+            "head_sha": "a" * 40,
+            "threads": [
+                {
+                    "id": "thread-1",
+                    "comments": [{"id": "comment-1", "body": "fix this"}],
+                }
+            ],
+            "replies": {"thread-1": "Fixed the guard."},
+            "batch_nonce": "c" * 32,
+        }
+
+        for _ in range(2):
+            assert stage.step(item, ctx) == StageOutcome(
+                Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
+            )
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "implementation_reply_review_conflict"
+        )
+        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+        comment_bodies = [str(comment) for comment in github.comments[1001]]
+        assert any("preserved-stale-draft" in body for body in comment_bodies)
+        assert any("manually clean up" in body for body in comment_bodies)
 
     def test_retry_duplicate_reply_drafts_are_terminally_diagnosed(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from collections import deque
 from types import SimpleNamespace
 from typing import Any
@@ -2309,53 +2308,6 @@ class TestPrReviewRestartSafetyGuards:
 class TestEvalVerdicts:
     """EVAL: re-housed _evaluate_go_verdict semantics + the budget gate."""
 
-    def test_duplicate_current_reply_drafts_are_terminally_diagnosed(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """Cross-checkout ownership ambiguity stops without retrying or deleting drafts."""
-        stage = PrReviewStage()
-        github = FakeStageGitHub()
-        ctx = make_ctx(github=github)
-        item = make_work_item(issue=1, pr=1001, state="EVAL")
-        item.payload["implementation_reply_batch_conflict"] = {
-            "head_sha": "a" * 40,
-            "review_ids": ("draft-one", "draft-two"),
-        }
-
-        result = stage.step(item, ctx)
-
-        assert result == StageOutcome(
-            Disposition.FINISH_FAIL, "implementation_reply_batch_conflict"
-        )
-        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
-        assert github.comments.get(1001, []) == []
-        assert not any(name == "gh_issue_upsert_comment" for name, _args in github.mutation_log)
-
-    def test_current_reply_review_conflict_is_terminally_diagnosed(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """A foreign current review is retained and explained, never retried as transport failure.
-
-        The terminal record covers both pending drafts and completed conflicting batches.
-        """
-        stage = PrReviewStage()
-        github = FakeStageGitHub()
-        ctx = make_ctx(github=github)
-        item = make_work_item(issue=1, pr=1001, state="EVAL")
-        item.payload["implementation_reply_review_conflict"] = {
-            "head_sha": "a" * 40,
-            "review_ids": ("foreign-pending-draft",),
-        }
-
-        result = stage.step(item, ctx)
-
-        assert result == StageOutcome(
-            Disposition.FINISH_FAIL, "implementation_reply_review_conflict"
-        )
-        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
-        assert github.comments.get(1001, []) == []
-        assert not any(name == "gh_issue_upsert_comment" for name, _args in github.mutation_log)
-
     def test_on_enter_stands_down_without_auto_merge_mutation(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -4270,7 +4222,7 @@ class TestRealCommitGate:
     def test_reply_handoff_stops_waiting_when_the_head_stays_drifted(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A persistent different open head cannot inherit the saved reply."""
+        """A persistent different open head drops its stale direct-reply handoff."""
 
         class HeadStaysDriftedGitHub(FakeStageGitHub):
             def __init__(self) -> None:
@@ -4336,10 +4288,7 @@ class TestRealCommitGate:
         assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
         assert github.reply_attempts == 0
         assert "pending_implementation_reply_handoff" not in item.payload
-        name, args = github.mutation_log[-1]
-        assert name == "preserve_stale_implementation_thread_reply_batch"
-        assert args[:4] == (1001, "a" * 40, "b" * 40, ("thread-1",))
-        assert re.fullmatch(r"[0-9a-f]{32}", args[4]) is not None
+        assert github.mutation_log == []
 
     def test_stale_reply_handoff_restarts_fresh_review_without_retrying(
         self, make_ctx: Any, make_work_item: Any
@@ -4393,127 +4342,6 @@ class TestRealCommitGate:
         assert "pending_implementation_reply_handoff" not in item.payload
         item.state = "EVAL"
         assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
-
-    def test_stale_reply_handoff_with_preserved_draft_is_terminally_diagnosed(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """A visible stale draft requires manual cleanup before another reply pass."""
-
-        class PreservedStaleDraftGitHub(FakeStageGitHub):
-            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
-                del pr_number
-                return {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None}
-
-            def preserve_stale_implementation_thread_reply_batch(
-                self,
-                pr_number: int,
-                *,
-                expected_head_sha: str,
-                current_head_sha: str,
-                replies: dict[str, str],
-                batch_nonce: str,
-            ) -> tuple[str, ...] | None:
-                super().preserve_stale_implementation_thread_reply_batch(
-                    pr_number,
-                    expected_head_sha=expected_head_sha,
-                    current_head_sha=current_head_sha,
-                    replies=replies,
-                    batch_nonce=batch_nonce,
-                )
-                return ("preserved-stale-draft",)
-
-        stage = PrReviewStage()
-        github = PreservedStaleDraftGitHub()
-        ctx = make_ctx(github=github)
-        item = make_work_item(issue=40, pr=1001, state="EVAL")
-        item.payload["pending_implementation_reply_handoff"] = {
-            "head_sha": "a" * 40,
-            "threads": [
-                {
-                    "id": "thread-1",
-                    "comments": [{"id": "comment-1", "body": "fix this"}],
-                }
-            ],
-            "replies": {"thread-1": "Fixed the guard."},
-            "batch_nonce": "c" * 32,
-        }
-
-        for _ in range(2):
-            assert stage.step(item, ctx) == StageOutcome(
-                Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
-            )
-        assert stage.step(item, ctx) == StageOutcome(
-            Disposition.FINISH_FAIL, "implementation_reply_review_conflict"
-        )
-        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
-        assert github.comments.get(1001, []) == []
-        assert not any(name == "gh_issue_upsert_comment" for name, _args in github.mutation_log)
-
-    def test_retry_duplicate_reply_drafts_are_terminally_diagnosed(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """A duplicate found on host-only retry cannot become ordinary stale work."""
-
-        class ReplyFailsThenFindsDuplicatesGitHub(FakeStageGitHub):
-            def __init__(self) -> None:
-                super().__init__()
-                self.reply_attempts = 0
-
-            def post_implementation_thread_replies(
-                self,
-                pr_number: int,
-                *,
-                expected_head_sha: str,
-                threads: list[dict[str, Any]],
-                replies: dict[str, str],
-                batch_nonce: str,
-            ) -> ImplementationThreadReplyResult:
-                del pr_number, expected_head_sha, threads, replies, batch_nonce
-                self.reply_attempts += 1
-                if self.reply_attempts == 1:
-                    raise OSError("temporary GitHub transport failure")
-                return ImplementationThreadReplyResult(
-                    blocked_thread_ids=("thread-1",),
-                    duplicate_current_draft_ids=("draft-one", "draft-two"),
-                )
-
-        stage = PrReviewStage()
-        github = ReplyFailsThenFindsDuplicatesGitHub()
-        ctx = make_ctx(github=github)
-        item = make_work_item(issue=40, pr=1001, state="PUSH_WAIT")
-        snapshot = {
-            "id": "thread-1",
-            "path": "a.py",
-            "line": 3,
-            "side": "RIGHT",
-            "body": "fix this",
-            "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix this"}],
-        }
-        item.payload.update(
-            {
-                "remediation_threads": [{"thread_id": "thread-1", "body": "fix this"}],
-                "remediation_thread_snapshots": [snapshot],
-                "address_output": {
-                    "addressed": ["thread-1"],
-                    "replies": {"thread-1": "Fixed the guard."},
-                },
-            }
-        )
-
-        stage.on_job_done(
-            item,
-            JobResult(ok=True, value={"pushed": True, "head_sha": "a" * 40}),
-            ctx,
-        )
-
-        assert "pending_implementation_reply_handoff" in item.payload
-        item.state = "EVAL"
-        assert stage.step(item, ctx) == StageOutcome(
-            Disposition.FINISH_FAIL, "implementation_reply_batch_conflict"
-        )
-        assert github.reply_attempts == 2
-        assert "pending_implementation_reply_handoff" not in item.payload
-        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
 
     def test_mixed_stale_and_transport_reply_batch_retries_only_ambiguous_thread(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -4248,6 +4248,10 @@ class TestRealCommitGate:
         assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
         assert github.reply_attempts == 0
         assert "pending_implementation_reply_handoff" not in item.payload
+        assert github.mutation_log[-1] == (
+            "discard_stale_implementation_thread_reply_batch",
+            (1001, "a" * 40, "b" * 40, ("thread-1",)),
+        )
 
     def test_stale_reply_handoff_restarts_fresh_review_without_retrying(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -2328,16 +2328,8 @@ class TestEvalVerdicts:
             Disposition.FINISH_FAIL, "implementation_reply_batch_conflict"
         )
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
-        assert any(
-            name == "gh_issue_upsert_comment"
-            and args[0] == 1001
-            and args[1].startswith(
-                "<!-- hephaestus-implementation-reply-duplicate-review-conflict:"
-            )
-            for name, args in github.mutation_log
-        )
-        body = github.comments[1001][-1]
-        assert "No review thread was resolved and no conflicting review was mutated." in body
+        assert github.comments.get(1001, []) == []
+        assert not any(name == "gh_issue_upsert_comment" for name, _args in github.mutation_log)
 
     def test_current_reply_review_conflict_is_terminally_diagnosed(
         self, make_ctx: Any, make_work_item: Any
@@ -2361,9 +2353,8 @@ class TestEvalVerdicts:
             Disposition.FINISH_FAIL, "implementation_reply_review_conflict"
         )
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
-        body = github.comments[1001][-1]
-        assert "No review thread was resolved and no conflicting review was mutated." in body
-        assert "foreign-pending-draft" in body
+        assert github.comments.get(1001, []) == []
+        assert not any(name == "gh_issue_upsert_comment" for name, _args in github.mutation_log)
 
     def test_on_enter_stands_down_without_auto_merge_mutation(
         self, make_ctx: Any, make_work_item: Any
@@ -2530,7 +2521,8 @@ class TestEvalVerdicts:
             for name, _args in github.mutation_log
         )
         assert github.pr_has_implementation_state_label(1001) == (False, True)
-        assert "review activity changed" in github.comments[1001][0].lower()
+        assert github.comments.get(1001, []) == []
+        assert not any(name == "gh_issue_comment" for name, _args in github.mutation_log)
 
     def test_clean_go_does_not_call_the_removed_auto_merge_mutator(
         self, make_ctx: Any, make_work_item: Any
@@ -4454,9 +4446,8 @@ class TestRealCommitGate:
             Disposition.FINISH_FAIL, "implementation_reply_review_conflict"
         )
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
-        comment_bodies = [str(comment) for comment in github.comments[1001]]
-        assert any("preserved-stale-draft" in body for body in comment_bodies)
-        assert any("manually clean up" in body for body in comment_bodies)
+        assert github.comments.get(1001, []) == []
+        assert not any(name == "gh_issue_upsert_comment" for name, _args in github.mutation_log)
 
     def test_retry_duplicate_reply_drafts_are_terminally_diagnosed(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -339,9 +339,8 @@ class TestAuditReviewerRun:
 
     @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
     @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
-    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
-    def test_happy_path_posts_summary_review(
-        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    def test_happy_path_does_not_post_an_unanchored_summary_review(
+        self, mock_coord: mock.Mock, mock_fetch: mock.Mock
     ) -> None:
         mock_fetch.return_value = [{"number": 100, "title": "Test"}]
         mock_coord.return_value = [{"pr_number": 100, "verdict": "GO", "summary": "Good"}]
@@ -349,7 +348,6 @@ class TestAuditReviewerRun:
         rc, audits = reviewer.run()
         assert rc == 0
         assert len(audits) == 1
-        assert mock_post.called
 
     def test_post_init_always_sets_state_dir(self, tmp_path: Path) -> None:
         """#1426: ``__post_init__`` guarantees ``state_dir`` is non-None.
@@ -392,13 +390,11 @@ class TestAuditReviewerRun:
 
     @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
     @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
-    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
-    def test_posting_failure_logged_run_continues(
-        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    def test_audit_run_does_not_attempt_an_unanchored_summary_post(
+        self, mock_coord: mock.Mock, mock_fetch: mock.Mock
     ) -> None:
         mock_fetch.return_value = [{"number": 100, "title": "Test"}]
         mock_coord.return_value = [{"pr_number": 100, "verdict": "GO", "summary": "Good"}]
-        mock_post.side_effect = Exception("GitHub error")
         reviewer = AuditReviewer()
         rc, audits = reviewer.run()
         assert rc == 0
@@ -415,19 +411,16 @@ class TestAuditReviewerRun:
         _, _ = reviewer.run()
         assert mock_fetch_nums.called
 
-    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
     @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
     @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
-    def test_dry_run_passes_dry_run_to_gh_pr_review_post(
-        self, mock_coord: mock.Mock, mock_fetch: mock.Mock, mock_post: mock.Mock
+    def test_dry_run_does_not_attempt_an_unanchored_summary_post(
+        self, mock_coord: mock.Mock, mock_fetch: mock.Mock
     ) -> None:
         mock_fetch.return_value = [{"number": 100, "title": "Test"}]
         mock_coord.return_value = [{"pr_number": 100, "verdict": "GO", "summary": "Good"}]
         reviewer = AuditReviewer(dry_run=True)
         _, _ = reviewer.run()
         assert mock_coord.call_args[1]["dry_run"] is True
-        mock_post.assert_called_once()
-        assert mock_post.call_args[1]["dry_run"] is True
 
     def test_state_dir_default_under_build(self, tmp_path: Path) -> None:
         with mock.patch(
@@ -441,11 +434,10 @@ class TestAuditReviewerRun:
 
     @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
     @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
-    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
-    def test_shutdown_event_stops_remaining_postings(
-        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    def test_shutdown_event_does_not_publish_unanchored_reviews(
+        self, mock_coord: mock.Mock, mock_fetch: mock.Mock
     ) -> None:
-        """A set shutdown_event stops posting further PR reviews mid-loop."""
+        """A shutdown request never causes review summaries to be published."""
         import threading
 
         mock_fetch.return_value = [{"number": 100}, {"number": 101}]
@@ -458,16 +450,14 @@ class TestAuditReviewerRun:
         reviewer = AuditReviewer(shutdown_event=shutdown)
         rc, audits = reviewer.run()
         assert rc == 0
-        assert len(audits) == 2  # audits themselves still returned
-        mock_post.assert_not_called()  # but posting loop stopped immediately
+        assert len(audits) == 2
 
     @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
     @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
-    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
-    def test_unset_shutdown_event_posts_all(
-        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    def test_unset_shutdown_event_keeps_reports_local(
+        self, mock_coord: mock.Mock, mock_fetch: mock.Mock
     ) -> None:
-        """An unset shutdown_event does not interrupt the posting loop."""
+        """An unset shutdown event does not publish general review comments."""
         import threading
 
         mock_fetch.return_value = [{"number": 100}]
@@ -475,7 +465,6 @@ class TestAuditReviewerRun:
         reviewer = AuditReviewer(shutdown_event=threading.Event())
         rc, _audits = reviewer.run()
         assert rc == 0
-        mock_post.assert_called_once()
 
 
 class TestAuditReviewerMainSignalWiring:
@@ -483,9 +472,8 @@ class TestAuditReviewerMainSignalWiring:
 
     @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
     @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
-    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
     def test_main_installs_cooperative_terminal_guard(
-        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+        self, mock_coord: mock.Mock, mock_fetch: mock.Mock
     ) -> None:
         from hephaestus.automation.audit_reviewer import main
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -3075,22 +3075,32 @@ class TestGhPrReviewPost:
 
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_empty_comments_still_posts_summary_review(
+    def test_empty_comments_never_post_an_unanchored_review(
         self, mock_gh_call: Any, _mock_repo: Any
     ) -> None:
-        """An empty ``comments`` list must post a summary-only review, not crash.
+        """A review needs at least one source-anchored inline comment."""
+        assert gh_pr_review_post(pr_number=7, comments=[], summary="Summary only") == []
 
-        Regression: even ``comments=[]`` failed under the stringified GraphQL form
-        (``Expected "[]" to be a key-value object``), so summary-only NOGO reviews
-        could never post and the loop always saw a spurious failure.
-        """
+        mock_gh_call.assert_not_called()
+
+    @patch("hephaestus.automation.github_api.write_secure")
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_inline_review_omits_an_unanchored_summary_body(
+        self, mock_gh_call: Any, _mock_repo: Any, mock_write: Any
+    ) -> None:
+        """Only source-anchored finding bodies are published to a review."""
         mock_gh_call.side_effect = self._gh_call_side_effect("REVIEW_1", [])
 
-        # Must not raise.
-        gh_pr_review_post(pr_number=7, comments=[], summary="Summary only")
+        gh_pr_review_post(
+            pr_number=7,
+            comments=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "fix"}],
+            summary="This must not become a general review comment.",
+        )
 
-        # The review POST was still sent.
-        self._review_post_call(mock_gh_call)
+        payload = json.loads(mock_write.call_args.args[1])
+        assert "body" not in payload
+        assert payload["comments"] == [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "fix"}]
 
     # ------------------------------------------------------------------
     # #1039: filter inline comments to lines present in the diff hunks.
@@ -3146,10 +3156,10 @@ class TestGhPrReviewPost:
     @patch("hephaestus.automation.github_api.write_secure")
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_all_comments_out_of_hunk_posts_summary_only(
+    def test_all_comments_out_of_hunk_never_posts_an_unanchored_summary(
         self, mock_gh_call: Any, _mock_repo: Any, mock_write: Any
     ) -> None:
-        """If every comment is out of hunk, the review still posts (summary only)."""
+        """If every comment is out of hunk, no unanchored review is posted."""
         mock_gh_call.side_effect = self._gh_call_side_effect(
             "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
         )
@@ -3160,10 +3170,11 @@ class TestGhPrReviewPost:
             summary="Findings",
         )
 
-        posted = self._posted_comments(mock_write)
-        assert posted == []
-        # The review POST was still sent.
-        self._review_post_call(mock_gh_call)
+        mock_write.assert_not_called()
+        assert not any(
+            call.args[:4] == ("api", "-X", "POST", "repos/owner/repo/pulls/7/reviews")
+            for call in mock_gh_call.call_args_list
+        )
 
     @patch("hephaestus.automation.github_api.write_secure")
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -194,6 +194,7 @@ class TestAllThreadReplyAndReviewerResolution:
                     }
                 }
             if "addPullRequestReviewThreadReply" in query:
+                assert "pullRequestReviewId:$reviewId" in query
                 thread_id = str(fields["threadId"])
                 review_id = str(fields["reviewId"])
                 reply_review_ids.append(review_id)
@@ -255,15 +256,15 @@ class TestAllThreadReplyAndReviewerResolution:
         second = _external_reviewer_thread("thread-two")
         live_by_id = {first["id"]: first, second["id"]: second}
         review_body = ""
-        review_created = False
-        reply_calls: list[str] = []
+        created_review_ids: list[str] = []
+        reply_calls: list[tuple[str, str]] = []
         submit_calls: list[str] = []
 
         def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            nonlocal review_body, review_created
+            nonlocal review_body
             if "reviews(first:100" in query:
                 nodes = (
                     [
@@ -275,7 +276,7 @@ class TestAllThreadReplyAndReviewerResolution:
                             "commit": {"oid": "a" * 40},
                         }
                     ]
-                    if review_created
+                    if created_review_ids
                     else []
                 )
                 return {
@@ -295,7 +296,8 @@ class TestAllThreadReplyAndReviewerResolution:
                     }
                 }
             if "addPullRequestReview(input" in query:
-                review_created = True
+                assert not created_review_ids
+                created_review_ids.append("implementation-review")
                 review_body = str(fields["body"])
                 return {
                     "data": {
@@ -310,9 +312,14 @@ class TestAllThreadReplyAndReviewerResolution:
                     }
                 }
             if "addPullRequestReviewThreadReply" in query:
+                assert "pullRequestReviewId:$reviewId" in query
                 thread_id = str(fields["threadId"])
-                reply_calls.append(thread_id)
-                if thread_id == second["id"] and reply_calls.count(thread_id) == 1:
+                review_id = str(fields["reviewId"])
+                reply_calls.append((thread_id, review_id))
+                if (
+                    thread_id == second["id"]
+                    and [call[0] for call in reply_calls].count(thread_id) == 1
+                ):
                     raise OSError("transient GitHub reply failure")
                 comment_id = f"implementation-{thread_id}"
                 live_by_id[thread_id] = {
@@ -324,7 +331,7 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": fields["reviewId"],
+                            "review_id": review_id,
                         },
                     ],
                 }
@@ -369,8 +376,480 @@ class TestAllThreadReplyAndReviewerResolution:
         assert failed.replied_thread_ids == ()
         assert failed.retryable_thread_ids == (first["id"], second["id"])
         assert retried.replied_thread_ids == (first["id"], second["id"])
-        assert reply_calls == [first["id"], second["id"], second["id"]]
+        assert created_review_ids == ["implementation-review"]
+        assert reply_calls == [
+            (first["id"], "implementation-review"),
+            (second["id"], "implementation-review"),
+            (second["id"], "implementation-review"),
+        ]
         assert submit_calls == ["implementation-review"]
+
+    @pytest.mark.parametrize("lost_response", ["create", "submit"])
+    def test_reply_batch_recovers_after_a_lost_create_or_submit_response(
+        self,
+        adapter: pg.PipelineGitHub,
+        monkeypatch: pytest.MonkeyPatch,
+        lost_response: str,
+    ) -> None:
+        """A mutation may apply before its response is lost without replaying it."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        review_body = ""
+        review_state: str | None = None
+        created_review_ids: list[str] = []
+        reply_calls: list[tuple[str, str]] = []
+        submit_calls: list[str] = []
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal review_body, review_state
+            if "reviews(first:100" in query:
+                nodes = (
+                    [
+                        {
+                            "id": "implementation-review",
+                            "state": review_state,
+                            "body": review_body,
+                            "viewerDidAuthor": True,
+                            "commit": {"oid": "a" * 40},
+                        }
+                    ]
+                    if review_state is not None
+                    else []
+                )
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": "a" * 40,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": nodes,
+                                },
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReview(input" in query:
+                created_review_ids.append("implementation-review")
+                review_body = str(fields["body"])
+                review_state = "PENDING"
+                review = {
+                    "id": "implementation-review",
+                    "state": "PENDING",
+                    "body": review_body,
+                    "commit": {"oid": "a" * 40},
+                }
+                return {
+                    "data": {
+                        "addPullRequestReview": {
+                            "pullRequestReview": None if lost_response == "create" else review
+                        }
+                    }
+                }
+            if "addPullRequestReviewThreadReply" in query:
+                assert "pullRequestReviewId:$reviewId" in query
+                thread_id = str(fields["threadId"])
+                review_id = str(fields["reviewId"])
+                reply_calls.append((thread_id, review_id))
+                comment_id = f"implementation-{thread_id}"
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": comment_id,
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": review_id,
+                        },
+                    ],
+                }
+                return {
+                    "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                submit_calls.append(str(fields["reviewId"]))
+                review_state = "COMMENTED"
+                review = {
+                    "id": fields["reviewId"],
+                    "state": "COMMENTED",
+                    "body": fields["body"],
+                }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": None if lost_response == "submit" else review
+                        }
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+        replies = {
+            first["id"]: "Fixed the first finding.",
+            second["id"]: "Fixed the second finding.",
+        }
+
+        first_attempt = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies=replies,
+        )
+        second_attempt = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies=replies,
+        )
+
+        assert first_attempt.retryable is True
+        assert second_attempt.replied_thread_ids == (first["id"], second["id"])
+        assert created_review_ids == ["implementation-review"]
+        assert reply_calls == [
+            (first["id"], "implementation-review"),
+            (second["id"], "implementation-review"),
+        ]
+        assert submit_calls == ["implementation-review"]
+
+    def test_parallel_reply_batches_share_one_draft_review(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The PR-scoped lock prevents two local loops creating competing drafts."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        review_body = ""
+        review_state: str | None = None
+        create_calls: list[str] = []
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal review_body, review_state
+            if "reviews(first:100" in query:
+                nodes = (
+                    [
+                        {
+                            "id": "implementation-review",
+                            "state": review_state,
+                            "body": review_body,
+                            "viewerDidAuthor": True,
+                            "commit": {"oid": "a" * 40},
+                        }
+                    ]
+                    if review_state is not None
+                    else []
+                )
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": "a" * 40,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": nodes,
+                                },
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReview(input" in query:
+                create_calls.append(str(fields["body"]))
+                review_body = str(fields["body"])
+                review_state = "PENDING"
+                sleep(0.05)
+                return {
+                    "data": {
+                        "addPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": "implementation-review",
+                                "state": "PENDING",
+                                "body": review_body,
+                                "commit": {"oid": "a" * 40},
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReviewThreadReply" in query:
+                assert "pullRequestReviewId:$reviewId" in query
+                thread_id = str(fields["threadId"])
+                comment_id = f"implementation-{thread_id}"
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": comment_id,
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": fields["reviewId"],
+                        },
+                    ],
+                }
+                return {
+                    "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                review_state = "COMMENTED"
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": fields["reviewId"],
+                                "state": "COMMENTED",
+                                "body": fields["body"],
+                            }
+                        }
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+        replies = {
+            first["id"]: "Fixed the first finding.",
+            second["id"]: "Fixed the second finding.",
+        }
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(
+                pool.map(
+                    lambda _: adapter.post_implementation_thread_replies(
+                        7,
+                        expected_head_sha="a" * 40,
+                        threads=[first, second],
+                        replies=replies,
+                    ),
+                    range(2),
+                )
+            )
+
+        assert [result.replied_thread_ids for result in results] == [
+            (first["id"], second["id"]),
+            (first["id"], second["id"]),
+        ]
+        assert len(create_calls) == 1
+
+    def test_stale_target_aborts_a_partial_pending_reply_batch(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A changed target cannot leave a recovered reply trapped in a draft."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        review_body = ""
+        review_exists = False
+        reply_calls: list[str] = []
+        deleted_review_ids: list[str] = []
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal review_body, review_exists
+            if "reviews(first:100" in query:
+                nodes = (
+                    [
+                        {
+                            "id": "implementation-review",
+                            "state": "PENDING",
+                            "body": review_body,
+                            "viewerDidAuthor": True,
+                            "commit": {"oid": "a" * 40},
+                        }
+                    ]
+                    if review_exists
+                    else []
+                )
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": "a" * 40,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": nodes,
+                                },
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReview(input" in query:
+                review_exists = True
+                review_body = str(fields["body"])
+                return {
+                    "data": {
+                        "addPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": "implementation-review",
+                                "state": "PENDING",
+                                "body": review_body,
+                                "commit": {"oid": "a" * 40},
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReviewThreadReply" in query:
+                assert "pullRequestReviewId:$reviewId" in query
+                thread_id = str(fields["threadId"])
+                reply_calls.append(thread_id)
+                if thread_id == second["id"]:
+                    raise OSError("transient second reply failure")
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": "implementation-first",
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": "implementation-review",
+                        },
+                    ],
+                }
+                return {
+                    "data": {
+                        "addPullRequestReviewThreadReply": {
+                            "comment": {"id": "implementation-first"}
+                        }
+                    }
+                }
+            if "deletePullRequestReview" in query:
+                deleted_review_ids.append(str(fields["reviewId"]))
+                review_exists = False
+                return {
+                    "data": {
+                        "deletePullRequestReview": {"pullRequestReview": {"id": fields["reviewId"]}}
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+        replies = {
+            first["id"]: "Fixed the first finding.",
+            second["id"]: "Fixed the second finding.",
+        }
+
+        first_attempt = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies=replies,
+        )
+        live_by_id[second["id"]] = {
+            **live_by_id[second["id"]],
+            "comments": [
+                *live_by_id[second["id"]]["comments"],
+                {
+                    "id": "new-reviewer-comment",
+                    "author": "maintainer",
+                    "body": "Please also test it.",
+                },
+            ],
+        }
+        second_attempt = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies=replies,
+        )
+
+        assert first_attempt.retryable is True
+        assert second_attempt.replied_thread_ids == ()
+        assert second_attempt.receipts == ()
+        assert second_attempt.blocked_thread_ids == (second["id"],)
+        assert reply_calls == [first["id"], second["id"]]
+        assert deleted_review_ids == ["implementation-review"]
+
+    def test_head_drift_discards_only_the_owned_stale_pending_batch(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Old automation drafts are cleaned up without touching a manual draft."""
+        replies = {"thread-one": "Fixed the finding."}
+        old_body = adapter._implementation_reply_review_body(
+            7,
+            "a" * 40,
+            {
+                "thread-one": adapter._implementation_thread_reply_body(
+                    7, "a" * 40, "thread-one", replies["thread-one"]
+                )
+            },
+        )
+        reviews = [
+            {
+                "id": "old-automation-draft",
+                "state": "PENDING",
+                "body": old_body,
+                "viewerDidAuthor": True,
+                "commit": {"oid": "a" * 40},
+            },
+            {
+                "id": "manual-draft",
+                "state": "PENDING",
+                "body": "Notes for a human review",
+                "viewerDidAuthor": True,
+                "commit": {"oid": "b" * 40},
+            },
+        ]
+        deleted_review_ids: list[str] = []
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" in query:
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": "b" * 40,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": list(reviews),
+                                },
+                            }
+                        }
+                    }
+                }
+            if "deletePullRequestReview" in query:
+                review_id = str(fields["reviewId"])
+                deleted_review_ids.append(review_id)
+                reviews[:] = [review for review in reviews if review["id"] != review_id]
+                return {
+                    "data": {"deletePullRequestReview": {"pullRequestReview": {"id": review_id}}}
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        assert adapter.discard_stale_implementation_thread_reply_batch(
+            7,
+            expected_head_sha="a" * 40,
+            current_head_sha="b" * 40,
+            replies=replies,
+        )
+        assert deleted_review_ids == ["old-automation-draft"]
+        assert [review["id"] for review in reviews] == ["manual-draft"]
 
     def test_external_thread_is_replied_to_then_resolved_by_fresh_reviewer(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -425,6 +904,11 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
         monkeypatch.setattr(adapter, "_graphql", graphql)
+        monkeypatch.setattr(
+            adapter,
+            "_reconcile_implementation_reply_reviews",
+            lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
+        )
         monkeypatch.setattr(
             adapter,
             "_find_implementation_reply_review",
@@ -537,6 +1021,11 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
         monkeypatch.setattr(adapter, "_graphql", graphql)
+        monkeypatch.setattr(
+            adapter,
+            "_reconcile_implementation_reply_reviews",
+            lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
+        )
         monkeypatch.setattr(
             adapter,
             "_find_implementation_reply_review",
@@ -704,6 +1193,11 @@ class TestAllThreadReplyAndReviewerResolution:
             return _open_thread_snapshot(thread if snapshot_reads == 1 else after)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(
+            adapter,
+            "_reconcile_implementation_reply_reviews",
+            lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
+        )
         monkeypatch.setattr(
             adapter,
             "_find_implementation_reply_review",

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -1428,6 +1428,65 @@ class TestAllThreadReplyAndReviewerResolution:
             "manual-draft",
         ]
 
+    def test_old_submitted_batch_does_not_hide_a_current_preserved_draft(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An old completed batch is inert while current drafts remain terminally visible."""
+        replies = {"thread-one": "Fixed the finding."}
+        old_body = adapter._implementation_reply_review_body(
+            7,
+            "a" * 40,
+            {
+                "thread-one": adapter._implementation_thread_reply_body(
+                    7, "a" * 40, "thread-one", replies["thread-one"]
+                )
+            },
+        )
+
+        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" not in query:
+                pytest.fail("stale preservation must not mutate any review")
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "id": "pr-7",
+                            "state": "OPEN",
+                            "headRefOid": "b" * 40,
+                            "autoMergeRequest": None,
+                            "reviews": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "old-submitted-review",
+                                        "state": "COMMENTED",
+                                        "body": old_body,
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": "a" * 40},
+                                    },
+                                    {
+                                        "id": "current-pending-draft",
+                                        "state": "PENDING",
+                                        "body": "Incomplete current draft.",
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": "b" * 40},
+                                    },
+                                ],
+                            },
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        assert adapter.preserve_stale_implementation_thread_reply_batch(
+            7,
+            expected_head_sha="a" * 40,
+            current_head_sha="b" * 40,
+            replies=replies,
+        ) == ("current-pending-draft",)
+
     def test_dry_run_never_inventories_or_mutates_stale_reply_drafts(
         self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -132,6 +132,246 @@ def _open_thread_snapshot(thread: dict[str, Any], *, resolved: bool = False) -> 
 class TestAllThreadReplyAndReviewerResolution:
     """The implementation/reviewer split applies to every open thread author."""
 
+    def test_implementation_replies_share_one_submitted_review(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One implementation pass submits every thread reply in one review."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        review_ids: list[str] = []
+        reply_review_ids: list[str] = []
+        submitted_review_ids: list[str] = []
+        review_body = ""
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal review_body
+            if "reviews(first:100" in query:
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": "a" * 40,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": (
+                                        [
+                                            {
+                                                "id": "implementation-review",
+                                                "state": "PENDING",
+                                                "body": review_body,
+                                                "viewerDidAuthor": True,
+                                                "commit": {"oid": "a" * 40},
+                                            }
+                                        ]
+                                        if review_body
+                                        else []
+                                    ),
+                                },
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReview(input" in query:
+                review_ids.append("implementation-review")
+                review_body = str(fields["body"])
+                return {
+                    "data": {
+                        "addPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": "implementation-review",
+                                "state": "PENDING",
+                                "body": review_body,
+                                "commit": {"oid": "a" * 40},
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReviewThreadReply" in query:
+                thread_id = str(fields["threadId"])
+                review_id = str(fields["reviewId"])
+                reply_review_ids.append(review_id)
+                comment_id = f"implementation-{thread_id}"
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": comment_id,
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": review_id,
+                        },
+                    ],
+                }
+                return {
+                    "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                submitted_review_ids.append(str(fields["reviewId"]))
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": fields["reviewId"],
+                                "state": "COMMENTED",
+                                "body": fields["body"],
+                            }
+                        }
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies={
+                first["id"]: "Fixed the first finding.",
+                second["id"]: "Fixed the second finding.",
+            },
+        )
+
+        assert result.replied_thread_ids == (first["id"], second["id"])
+        assert review_ids == ["implementation-review"]
+        assert reply_review_ids == ["implementation-review", "implementation-review"]
+        assert submitted_review_ids == ["implementation-review"]
+
+    def test_reply_batch_retry_reuses_pending_review_and_adds_only_missing_replies(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed batch resumes the same draft review without duplicate replies."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        review_body = ""
+        review_created = False
+        reply_calls: list[str] = []
+        submit_calls: list[str] = []
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal review_body, review_created
+            if "reviews(first:100" in query:
+                nodes = (
+                    [
+                        {
+                            "id": "implementation-review",
+                            "state": "PENDING",
+                            "body": review_body,
+                            "viewerDidAuthor": True,
+                            "commit": {"oid": "a" * 40},
+                        }
+                    ]
+                    if review_created
+                    else []
+                )
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": "a" * 40,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": nodes,
+                                },
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReview(input" in query:
+                review_created = True
+                review_body = str(fields["body"])
+                return {
+                    "data": {
+                        "addPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": "implementation-review",
+                                "state": "PENDING",
+                                "body": review_body,
+                                "commit": {"oid": "a" * 40},
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReviewThreadReply" in query:
+                thread_id = str(fields["threadId"])
+                reply_calls.append(thread_id)
+                if thread_id == second["id"] and reply_calls.count(thread_id) == 1:
+                    raise OSError("transient GitHub reply failure")
+                comment_id = f"implementation-{thread_id}"
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": comment_id,
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": fields["reviewId"],
+                        },
+                    ],
+                }
+                return {
+                    "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                submit_calls.append(str(fields["reviewId"]))
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": fields["reviewId"],
+                                "state": "COMMENTED",
+                                "body": fields["body"],
+                            }
+                        }
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+        replies = {
+            first["id"]: "Fixed the first finding.",
+            second["id"]: "Fixed the second finding.",
+        }
+
+        failed = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies=replies,
+        )
+        retried = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies=replies,
+        )
+
+        assert failed.replied_thread_ids == ()
+        assert failed.retryable_thread_ids == (first["id"], second["id"])
+        assert retried.replied_thread_ids == (first["id"], second["id"])
+        assert reply_calls == [first["id"], second["id"], second["id"]]
+        assert submit_calls == ["implementation-review"]
+
     def test_external_thread_is_replied_to_then_resolved_by_fresh_reviewer(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -152,6 +392,7 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
+                            "review_id": "implementation-review",
                         },
                     ],
                 }
@@ -184,6 +425,17 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
         monkeypatch.setattr(adapter, "_graphql", graphql)
+        monkeypatch.setattr(
+            adapter,
+            "_find_implementation_reply_review",
+            lambda *_args: ("pr-7", ("implementation-review", "PENDING")),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_create_implementation_reply_review",
+            lambda *_args: "implementation-review",
+        )
+        monkeypatch.setattr(adapter, "_submit_implementation_reply_review", lambda *_args: True)
 
         implementation = adapter.post_implementation_thread_replies(
             7,
@@ -254,6 +506,11 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
+                            "review_id": (
+                                "implementation-review"
+                                if "reviewId" in fields
+                                else "reviewer-review"
+                            ),
                         },
                     ],
                 }
@@ -280,6 +537,17 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
         monkeypatch.setattr(adapter, "_graphql", graphql)
+        monkeypatch.setattr(
+            adapter,
+            "_find_implementation_reply_review",
+            lambda *_args: ("pr-7", ("implementation-review", "PENDING")),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_create_implementation_reply_review",
+            lambda *_args: "implementation-review",
+        )
+        monkeypatch.setattr(adapter, "_submit_implementation_reply_review", lambda *_args: True)
         implementation = adapter.post_implementation_thread_replies(
             7,
             expected_head_sha="a" * 40,
@@ -424,6 +692,7 @@ class TestAllThreadReplyAndReviewerResolution:
                     "author": "hephaestus[bot]",
                     "body": body,
                     "viewer_did_author": True,
+                    "review_id": "implementation-review",
                 },
             ],
         }
@@ -435,6 +704,17 @@ class TestAllThreadReplyAndReviewerResolution:
             return _open_thread_snapshot(thread if snapshot_reads == 1 else after)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(
+            adapter,
+            "_find_implementation_reply_review",
+            lambda *_args: ("pr-7", ("implementation-review", "PENDING")),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_create_implementation_reply_review",
+            lambda *_args: "implementation-review",
+        )
+        monkeypatch.setattr(adapter, "_submit_implementation_reply_review", lambda *_args: True)
         monkeypatch.setattr(
             adapter,
             "_graphql",

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -945,13 +945,7 @@ class TestAllThreadReplyAndReviewerResolution:
                 submitted_reviews.append(str(fields["reviewId"]))
                 pytest.fail("must not submit a competing batch")
             if "deletePullRequestReview" in query:
-                review_id = str(fields["reviewId"])
-                assert review_id == "worker-b-draft"
-                deleted_reviews.append(review_id)
-                reviews[:] = [review for review in reviews if review["id"] != review_id]
-                return {
-                    "data": {"deletePullRequestReview": {"pullRequestReview": {"id": review_id}}}
-                }
+                pytest.fail("a current-review conflict must not delete any draft")
             raise AssertionError(query)
 
         monkeypatch.setattr(
@@ -970,10 +964,10 @@ class TestAllThreadReplyAndReviewerResolution:
 
         assert result.replied_thread_ids == ()
         assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_current_review_ids == ("worker-a-review",)
+        assert result.conflicting_current_review_ids == ("worker-a-review", "worker-b-draft")
         assert added_replies == []
         assert submitted_reviews == []
-        assert deleted_reviews == ["worker-b-draft"]
+        assert deleted_reviews == []
 
     def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -886,6 +886,7 @@ class TestAllThreadReplyAndReviewerResolution:
         reviews: list[dict[str, Any]] = []
         added_replies: list[str] = []
         submitted_reviews: list[str] = []
+        deleted_reviews: list[str] = []
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
             if "reviews(first:100" in query:
@@ -943,6 +944,14 @@ class TestAllThreadReplyAndReviewerResolution:
             if "submitPullRequestReview" in query:
                 submitted_reviews.append(str(fields["reviewId"]))
                 pytest.fail("must not submit a competing batch")
+            if "deletePullRequestReview" in query:
+                review_id = str(fields["reviewId"])
+                assert review_id == "worker-b-draft"
+                deleted_reviews.append(review_id)
+                reviews[:] = [review for review in reviews if review["id"] != review_id]
+                return {
+                    "data": {"deletePullRequestReview": {"pullRequestReview": {"id": review_id}}}
+                }
             raise AssertionError(query)
 
         monkeypatch.setattr(
@@ -964,6 +973,7 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.conflicting_current_review_ids == ("worker-a-review",)
         assert added_replies == []
         assert submitted_reviews == []
+        assert deleted_reviews == ["worker-b-draft"]
 
     def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -2837,13 +2837,6 @@ _MUTATOR_CASES = [
     ("add_labels", (5, ["x"]), "github_api", "gh_issue_add_labels"),
     ("remove_labels", (5, ["x"]), "github_api", "gh_issue_remove_labels"),
     ("close_issue_as_covered", (5, 7), "module", "close_issue_as_covered"),
-    ("post_pr_comment", (7, "why"), "github_api", "gh_issue_comment"),
-    (
-        "upsert_pr_comment",
-        (7, "<!-- marker -->", "<!-- marker -->\nbody"),
-        "github_api",
-        "gh_issue_upsert_comment",
-    ),
     ("mark_pr_implementation_go", (7,), "pr_manager", "mark_pr_implementation_go"),
     ("mark_pr_implementation_no_go", (7,), "pr_manager", "mark_pr_implementation_no_go"),
     ("skip_epics", ({5: ["epic"]},), "github_api", "skip_epics"),
@@ -2909,19 +2902,6 @@ class TestMutatorMapping:
 
         mock.assert_not_called()
         assert any("[dry-run] would" in record.message for record in caplog.records)
-
-    def test_dry_run_pr_comment_upsert_reports_not_written(
-        self,
-        dry_adapter: pg.PipelineGitHub,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Dry-run artifacts must be reported as absent in durable stage events."""
-        mock = _patch_target(monkeypatch, "github_api", "gh_issue_upsert_comment")
-
-        written = dry_adapter.upsert_pr_comment(7, "<!-- marker -->", "body")
-
-        assert written is False
-        mock.assert_not_called()
 
     def test_upsert_plan_comment_keys_on_marker(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -3320,34 +3300,6 @@ class TestRepoScoping:
                 "org/repo-a",
             ],
         ]
-
-    def test_repo_scoped_pr_comment_upsert_reads_pr_comments_via_rest_issue_channel(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """PR numbers are valid issue-comment REST targets but not GraphQL issue nodes."""
-        calls: list[list[str]] = []
-
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            calls.append(argv)
-            if argv == [
-                "api",
-                "/repos/org/repo-a/issues/1001/comments?per_page=100&page=1",
-            ]:
-                payload = [{"id": 42, "body": "<!-- marker -->\nstale"}]
-                return SimpleNamespace(stdout=json.dumps(payload))
-            return SimpleNamespace(stdout="")
-
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
-
-        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).upsert_pr_comment(
-            1001, "<!-- marker -->", "<!-- marker -->\nupdated"
-        )
-
-        assert calls[0] == [
-            "api",
-            "/repos/org/repo-a/issues/1001/comments?per_page=100&page=1",
-        ]
-        assert all("graphql" not in call for call in calls)
 
     def test_repo_scoped_has_existing_plan_detects_plan_comment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -4200,33 +4152,7 @@ class TestRepoScoping:
         assert any("/repos/org/repo-a/issues/comments/9" in call for call in calls)
         assert not any(call[:2] == ["issue", "comment"] for call in calls)
 
-    def test_repo_scoped_upsert_pr_comment_updates_marker_comment(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        calls: list[list[str]] = []
-        marker = "<!-- hephaestus-pr-review-go -->"
-
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            calls.append(argv)
-            if argv == [
-                "api",
-                "/repos/org/repo-a/issues/7/comments?per_page=100&page=1",
-            ]:
-                payload = [{"id": 12, "body": f"{marker}\nold"}]
-                return SimpleNamespace(stdout=json.dumps(payload))
-            return SimpleNamespace(stdout="")
-
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
-
-        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).upsert_pr_comment(
-            7, marker, f"{marker}\nnew"
-        )
-
-        assert any(call[:3] == ["api", "--method", "PATCH"] for call in calls)
-        assert any("/repos/org/repo-a/issues/comments/12" in call for call in calls)
-        assert not any(call[:2] == ["issue", "comment"] for call in calls)
-
-    def test_repo_scoped_review_post_uses_repo_endpoint(
+    def test_repo_scoped_review_post_skips_an_unanchored_summary(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         calls: list[list[str]] = []
@@ -4271,7 +4197,57 @@ class TestRepoScoping:
         posted = adapter.post_review_threads(7, [], "summary", expected_head_sha="a" * 40)
 
         assert posted == []
-        assert any("repos/org/repo-a/pulls/7/reviews" in call for call in calls)
+        assert calls == []
+
+    def test_repo_scoped_review_post_omits_the_unanchored_summary_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A source-anchored finding must not carry a review-level body."""
+        diff = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1 @@\n+ok\n"
+        review_payloads: list[dict[str, object]] = []
+
+        def fake_gh_call(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+            if argv[:2] == ["pr", "diff"]:
+                return SimpleNamespace(stdout=diff)
+            if argv[:3] == ["api", "-X", "POST"]:
+                review_payloads.append(json.loads(Path(argv[-1]).read_text()))
+                return SimpleNamespace(stdout=json.dumps({"node_id": "review-node"}))
+            raise AssertionError(f"unexpected GitHub call: {argv}")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "gh_pr_state",
+            lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_repo_review_thread_receipts_for_review",
+            lambda *_args: [],
+        )
+
+        adapter.post_review_threads(
+            7,
+            [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "finding"}],
+            "This summary must never become a general review comment.",
+            expected_head_sha="a" * 40,
+        )
+
+        assert review_payloads == [
+            {
+                "commit_id": "a" * 40,
+                "event": "COMMENT",
+                "comments": [
+                    {
+                        "path": "a.py",
+                        "line": 1,
+                        "side": "RIGHT",
+                        "body": "<!-- hephaestus-severity: major -->\nfinding",
+                    }
+                ],
+            }
+        ]
 
     def test_repo_scoped_review_post_rejects_mixed_anchor_batch_before_write(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -4687,6 +4663,13 @@ class TestRepoScopedAutoMerge:
 
         assert not hasattr(adapter, "arm_auto_merge")
         assert not hasattr(adapter, "defer_auto_merge")
+
+    def test_pipeline_adapter_has_no_unanchored_pr_comment_surface(self, tmp_path: Path) -> None:
+        """PR responses must be review-thread replies, never issue comments."""
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+
+        assert not hasattr(adapter, "post_pr_comment")
+        assert not hasattr(adapter, "upsert_pr_comment")
 
 
 class TestCreatePr:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -868,8 +868,102 @@ class TestAllThreadReplyAndReviewerResolution:
 
         assert result.replied_thread_ids == ()
         assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_pending_draft_ids == ("foreign-pending-draft",)
+        assert result.conflicting_current_review_ids == ("foreign-pending-draft",)
         assert result.retryable is False
+
+    def test_cross_checkout_submitted_batch_between_inventory_and_create_is_a_conflict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A competing completed batch prevents this worker from adding a draft reply."""
+        thread = _external_reviewer_thread()
+        reply = "Fixed the missing guard."
+        head_sha = "a" * 40
+        adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "two")
+        reply_body = adapter._implementation_thread_reply_body(7, head_sha, thread["id"], reply)
+        submitted_body = adapter._implementation_reply_review_body(
+            7, head_sha, {thread["id"]: reply_body}, "c" * 32
+        )
+        reviews: list[dict[str, Any]] = []
+        added_replies: list[str] = []
+        submitted_reviews: list[str] = []
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" in query:
+                return {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "id": "pr-7",
+                                "state": "OPEN",
+                                "headRefOid": head_sha,
+                                "autoMergeRequest": None,
+                                "reviews": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": reviews,
+                                },
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReview(input" in query:
+                batch_body = str(fields["body"])
+                # Worker A submits a distinct nonce batch after worker B's
+                # inventory but before B has created its own draft.
+                reviews[:] = [
+                    {
+                        "id": "worker-a-review",
+                        "state": "COMMENTED",
+                        "body": submitted_body,
+                        "viewerDidAuthor": True,
+                        "commit": {"oid": head_sha},
+                    },
+                    {
+                        "id": "worker-b-draft",
+                        "state": "PENDING",
+                        "body": batch_body,
+                        "viewerDidAuthor": True,
+                        "commit": {"oid": head_sha},
+                    },
+                ]
+                return {
+                    "data": {
+                        "addPullRequestReview": {
+                            "pullRequestReview": {
+                                "id": "worker-b-draft",
+                                "state": "PENDING",
+                                "body": batch_body,
+                                "commit": {"oid": head_sha},
+                            }
+                        }
+                    }
+                }
+            if "addPullRequestReviewThreadReply" in query:
+                added_replies.append(str(fields["threadId"]))
+                pytest.fail("must not add a reply after a competing submitted batch")
+            if "submitPullRequestReview" in query:
+                submitted_reviews.append(str(fields["reviewId"]))
+                pytest.fail("must not submit a competing batch")
+            raise AssertionError(query)
+
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, _thread: _open_thread_snapshot(thread),
+        )
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha=head_sha,
+            threads=[thread],
+            replies={thread["id"]: reply},
+        )
+
+        assert result.replied_thread_ids == ()
+        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.conflicting_current_review_ids == ("worker-a-review",)
+        assert added_replies == []
+        assert submitted_reviews == []
 
     def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -515,6 +515,9 @@ class TestAllThreadReplyAndReviewerResolution:
             root.mkdir()
             git_dir = common_git_dir / "worktrees" / name
             git_dir.mkdir(parents=True)
+            (common_git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+            (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+            (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
             (root / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
 
         first_adapter = PipelineGitHubForTest("org", repo="repo-a", repo_root=first_root)
@@ -596,6 +599,41 @@ class TestAllThreadReplyAndReviewerResolution:
                 adapter,
                 "_graphql",
                 lambda *_args, **_kwargs: pytest.fail("invalid metadata must not reply"),
+            )
+
+        results = [
+            adapter.post_implementation_thread_replies(
+                7,
+                expected_head_sha="a" * 40,
+                threads=[thread],
+                replies={thread["id"]: "Fixed the finding."},
+                batch_nonce="c" * 32,
+            )
+            for adapter in adapters
+        ]
+
+        assert all(result.retryable_thread_ids == (thread["id"],) for result in results)
+        assert all(result.retryable for result in results)
+
+    def test_linked_worktrees_with_unusable_git_dir_fail_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shaped-but-invalid worktree target cannot create a private lock."""
+        adapters: list[PipelineGitHubForTest] = []
+        for name in ("first", "second"):
+            root = tmp_path / f"worktree-{name}"
+            root.mkdir()
+            (root / ".git").write_text(
+                f"gitdir: /missing/.git/worktrees/{name}\n", encoding="utf-8"
+            )
+            adapters.append(PipelineGitHubForTest("org", repo="repo-a", repo_root=root))
+
+        thread = _external_reviewer_thread("thread-one")
+        for adapter in adapters:
+            monkeypatch.setattr(
+                adapter,
+                "_graphql",
+                lambda *_args, **_kwargs: pytest.fail("unusable gitdir must not reply"),
             )
 
         results = [

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -504,6 +504,80 @@ class TestAllThreadReplyAndReviewerResolution:
         ]
         assert reply_calls == [first["id"], second["id"]]
 
+    def test_linked_worktrees_share_one_reply_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Separate worktree roots serialize direct replies through common Git metadata."""
+        common_git_dir = tmp_path / "repository" / ".git"
+        first_root = tmp_path / "worktree-first"
+        second_root = tmp_path / "worktree-second"
+        for root, name in ((first_root, "first"), (second_root, "second")):
+            root.mkdir()
+            git_dir = common_git_dir / "worktrees" / name
+            git_dir.mkdir(parents=True)
+            (root / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+
+        first_adapter = PipelineGitHubForTest("org", repo="repo-a", repo_root=first_root)
+        second_adapter = PipelineGitHubForTest("org", repo="repo-a", repo_root=second_root)
+        assert first_adapter._implementation_reply_lock_path(7) == (
+            second_adapter._implementation_reply_lock_path(7)
+        )
+
+        thread = _external_reviewer_thread("thread-one")
+        live = thread
+        reply_calls: list[str] = []
+
+        def snapshot(_pr: int, _thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live)
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal live
+            assert "addPullRequestReviewThreadReply" in query
+            reply_calls.append(str(fields["body"]))
+            sleep(0.05)
+            live = {
+                **live,
+                "comments": [
+                    *live["comments"],
+                    {
+                        "id": "implementation-comment",
+                        "author": "hephaestus[bot]",
+                        "body": fields["body"],
+                        "viewer_did_author": True,
+                    },
+                ],
+            }
+            return {
+                "data": {
+                    "addPullRequestReviewThreadReply": {"comment": {"id": "implementation-comment"}}
+                }
+            }
+
+        for candidate in (first_adapter, second_adapter):
+            monkeypatch.setattr(candidate, "_review_thread_snapshot", snapshot)
+            monkeypatch.setattr(candidate, "_graphql", graphql)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = [
+                pool.submit(
+                    candidate.post_implementation_thread_replies,
+                    7,
+                    expected_head_sha="a" * 40,
+                    threads=[thread],
+                    replies={thread["id"]: "Fixed the finding."},
+                    batch_nonce=batch_nonce,
+                )
+                for candidate, batch_nonce in (
+                    (first_adapter, "c" * 32),
+                    (second_adapter, "d" * 32),
+                )
+            ]
+            resolved = [result.result() for result in results]
+
+        assert len(reply_calls) == 1
+        assert sum(result.replied_thread_ids == (thread["id"],) for result in resolved) == 1
+        assert sum(result.blocked_thread_ids == (thread["id"],) for result in resolved) == 1
+
     def test_external_thread_is_replied_to_then_resolved_by_fresh_reviewer(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -3115,15 +3189,15 @@ class TestRepoScoping:
             "gh_pr_state",
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
-        posted = adapter.post_review_threads(7, [], "summary", expected_head_sha="a" * 40)
+        posted = adapter.post_review_threads(7, [], expected_head_sha="a" * 40)
 
         assert posted == []
         assert calls == []
 
-    def test_repo_scoped_review_post_omits_the_unanchored_summary_body(
+    def test_repo_scoped_review_post_has_no_review_level_response_parameter(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A source-anchored finding must not carry a review-level body."""
+        """A source-anchored finding has no review-level response pathway."""
         diff = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1 @@\n+ok\n"
         review_payloads: list[dict[str, object]] = []
 
@@ -3151,7 +3225,6 @@ class TestRepoScoping:
         adapter.post_review_threads(
             7,
             [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "finding"}],
-            "This summary must never become a general review comment.",
             expected_head_sha="a" * 40,
         )
 
@@ -3198,7 +3271,6 @@ class TestRepoScoping:
                     {"path": "a.py", "line": 1, "side": "RIGHT", "body": "valid"},
                     {"path": "a.py", "line": 2, "side": "RIGHT", "body": "stale"},
                 ],
-                "summary",
                 expected_head_sha="a" * 40,
             )
 
@@ -3237,7 +3309,6 @@ class TestRepoScoping:
             adapter.post_review_threads(
                 7,
                 [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "finding"}],
-                "summary",
                 expected_head_sha="a" * 40,
             )
 
@@ -3303,7 +3374,6 @@ class TestRepoScoping:
             posted = adapter.post_review_threads(
                 7,
                 [{"path": "a.py", "line": 1, "body": "x"}],
-                "summary",
                 expected_head_sha="a" * 40,
             )
 
@@ -3376,7 +3446,6 @@ class TestRepoScoping:
         posted = adapter.post_review_threads(
             7,
             [{"path": "a.py", "line": 1, "side": "RIGHT", "severity": "major", "body": "finding"}],
-            "summary",
             expected_head_sha="a" * 40,
         )
 

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -1027,10 +1027,10 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.receipts[0]["implementation_reply_id"] == "implementation-comment"
         assert result.retryable is False
 
-    def test_stale_target_aborts_a_partial_pending_reply_batch(
+    def test_stale_target_preserves_a_partial_pending_batch_on_a_current_conflict(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A changed target cannot leave a recovered reply trapped in a draft."""
+        """A current-review conflict prevents cleanup of an otherwise-owned pending batch."""
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
         live_by_id = {first["id"]: first, second["id"]: second}
@@ -1127,13 +1127,7 @@ class TestAllThreadReplyAndReviewerResolution:
                     }
                 }
             if "deletePullRequestReview" in query:
-                deleted_review_ids.append(str(fields["reviewId"]))
-                review_exists = False
-                return {
-                    "data": {
-                        "deletePullRequestReview": {"pullRequestReview": {"id": fields["reviewId"]}}
-                    }
-                }
+                pytest.fail("a current-review conflict must not delete any draft")
             raise AssertionError(query)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
@@ -1171,14 +1165,18 @@ class TestAllThreadReplyAndReviewerResolution:
         assert first_attempt.retryable is True
         assert second_attempt.replied_thread_ids == ()
         assert second_attempt.receipts == ()
-        assert second_attempt.blocked_thread_ids == (second["id"],)
+        assert second_attempt.blocked_thread_ids == (first["id"], second["id"])
+        assert second_attempt.conflicting_current_review_ids == (
+            "implementation-review",
+            "manual-draft",
+        )
         assert reply_calls == [first["id"], second["id"]]
-        assert deleted_review_ids == ["implementation-review"]
+        assert deleted_review_ids == []
 
-    def test_head_drift_discards_only_the_owned_stale_pending_batch(
+    def test_head_drift_preserves_stale_batches_when_current_conflicts_exist(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Old automation drafts are cleaned up without touching a manual draft."""
+        """Any current conflict prevents stale-draft cleanup from mutating reviews."""
         replies = {"thread-one": "Fixed the finding."}
         old_body = adapter._implementation_reply_review_body(
             7,
@@ -1267,8 +1265,12 @@ class TestAllThreadReplyAndReviewerResolution:
             current_head_sha="b" * 40,
             replies=replies,
         )
-        assert deleted_review_ids == ["old-automation-draft"]
-        assert [review["id"] for review in reviews] == ["foreign-old-draft", "manual-draft"]
+        assert deleted_review_ids == []
+        assert [review["id"] for review in reviews] == [
+            "old-automation-draft",
+            "foreign-old-draft",
+            "manual-draft",
+        ]
 
     def test_dry_run_never_inventories_or_deletes_stale_reply_drafts(
         self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -67,7 +67,7 @@ class PipelineGitHubForTest(pg.PipelineGitHub):
             batch_nonce=batch_nonce,
         )
 
-    def discard_stale_implementation_thread_reply_batch(
+    def preserve_stale_implementation_thread_reply_batch(
         self,
         pr_number: int,
         *,
@@ -75,8 +75,8 @@ class PipelineGitHubForTest(pg.PipelineGitHub):
         current_head_sha: str,
         replies: dict[str, str],
         batch_nonce: str | None = _BATCH_NONCE,
-    ) -> bool:
-        return super().discard_stale_implementation_thread_reply_batch(
+    ) -> tuple[str, ...] | None:
+        return super().preserve_stale_implementation_thread_reply_batch(
             pr_number,
             expected_head_sha=expected_head_sha,
             current_head_sha=current_head_sha,
@@ -871,6 +871,119 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.conflicting_current_review_ids == ("foreign-pending-draft",)
         assert result.retryable is False
 
+    def test_visible_foreign_pending_review_blocks_without_mutation(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A visible foreign pending review cannot be reused or bypassed."""
+        thread = _external_reviewer_thread()
+        mutations: list[str] = []
+
+        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" not in query:
+                mutations.append(query)
+                pytest.fail("a visible foreign pending review must stop before mutation")
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "id": "pr-7",
+                            "state": "OPEN",
+                            "headRefOid": "a" * 40,
+                            "autoMergeRequest": None,
+                            "reviews": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "foreign-pending-draft",
+                                        "state": "PENDING",
+                                        "body": "Visible foreign draft.",
+                                        "viewerDidAuthor": False,
+                                        "commit": {"oid": "a" * 40},
+                                    }
+                                ],
+                            },
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, _thread: _open_thread_snapshot(thread),
+        )
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: "Fixed the missing guard."},
+        )
+
+        assert result.replied_thread_ids == ()
+        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.conflicting_current_review_ids == ("foreign-pending-draft",)
+        assert mutations == []
+
+    def test_visible_foreign_marked_review_blocks_without_mutation(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A visible foreign submitted implementation batch cannot be bypassed."""
+        thread = _external_reviewer_thread()
+        reply_body = adapter._implementation_thread_reply_body(
+            7, "a" * 40, thread["id"], "Fixed the missing guard."
+        )
+        foreign_body = adapter._implementation_reply_review_body(
+            7, "a" * 40, {thread["id"]: reply_body}, "d" * 32
+        )
+
+        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" not in query:
+                pytest.fail("a visible foreign batch must stop before mutation")
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "id": "pr-7",
+                            "state": "OPEN",
+                            "headRefOid": "a" * 40,
+                            "autoMergeRequest": None,
+                            "reviews": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "foreign-submitted-review",
+                                        "state": "COMMENTED",
+                                        "body": foreign_body,
+                                        "viewerDidAuthor": False,
+                                        "commit": {"oid": "a" * 40},
+                                    }
+                                ],
+                            },
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, _thread: _open_thread_snapshot(thread),
+        )
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: "Fixed the missing guard."},
+        )
+
+        assert result.replied_thread_ids == ()
+        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.conflicting_current_review_ids == ("foreign-submitted-review",)
+
     def test_cross_checkout_submitted_batch_between_inventory_and_create_is_a_conflict(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -968,6 +1081,54 @@ class TestAllThreadReplyAndReviewerResolution:
         assert added_replies == []
         assert submitted_reviews == []
         assert deleted_reviews == []
+
+    def test_resumed_pending_batch_reports_its_own_review_with_a_competitor(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A resumed draft and a competing batch are both preserved and reported."""
+        thread = _external_reviewer_thread()
+        reply = "Fixed the missing guard."
+        mutations: list[str] = []
+
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, _thread: _open_thread_snapshot(thread),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_implementation_reply_review_state",
+            lambda *_args: (
+                "pr-7",
+                ("local-pending-draft", "PENDING"),
+                ("competing-current-review",),
+            ),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_add_thread_reply",
+            lambda *_args, **_kwargs: mutations.append("reply"),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_submit_implementation_reply_review",
+            lambda *_args: mutations.append("submit"),
+        )
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: reply},
+        )
+
+        assert result.replied_thread_ids == ()
+        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.conflicting_current_review_ids == (
+            "competing-current-review",
+            "local-pending-draft",
+        )
+        assert mutations == []
 
     def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -1173,10 +1334,10 @@ class TestAllThreadReplyAndReviewerResolution:
         assert reply_calls == [first["id"], second["id"]]
         assert deleted_review_ids == []
 
-    def test_head_drift_preserves_stale_batches_when_current_conflicts_exist(
+    def test_head_drift_reports_every_preserved_stale_batch(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Any current conflict prevents stale-draft cleanup from mutating reviews."""
+        """Stale handoff preservation reports every visible pending review without mutation."""
         replies = {"thread-one": "Fixed the finding."}
         old_body = adapter._implementation_reply_review_body(
             7,
@@ -1249,22 +1410,17 @@ class TestAllThreadReplyAndReviewerResolution:
                     }
                 }
             if "deletePullRequestReview" in query:
-                review_id = str(fields["reviewId"])
-                deleted_review_ids.append(review_id)
-                reviews[:] = [review for review in reviews if review["id"] != review_id]
-                return {
-                    "data": {"deletePullRequestReview": {"pullRequestReview": {"id": review_id}}}
-                }
+                pytest.fail("stale draft preservation must not delete any review")
             raise AssertionError(query)
 
         monkeypatch.setattr(adapter, "_graphql", graphql)
 
-        assert adapter.discard_stale_implementation_thread_reply_batch(
+        assert adapter.preserve_stale_implementation_thread_reply_batch(
             7,
             expected_head_sha="a" * 40,
             current_head_sha="b" * 40,
             replies=replies,
-        )
+        ) == ("foreign-old-draft", "manual-draft", "old-automation-draft")
         assert deleted_review_ids == []
         assert [review["id"] for review in reviews] == [
             "old-automation-draft",
@@ -1272,18 +1428,21 @@ class TestAllThreadReplyAndReviewerResolution:
             "manual-draft",
         ]
 
-    def test_dry_run_never_inventories_or_deletes_stale_reply_drafts(
+    def test_dry_run_never_inventories_or_mutates_stale_reply_drafts(
         self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Dry-run stale cleanup must not read or mutate review drafts."""
+        """Dry-run stale preservation must not inventory or mutate review drafts."""
         graphql = MagicMock()
         monkeypatch.setattr(dry_adapter, "_graphql", graphql)
 
-        assert dry_adapter.discard_stale_implementation_thread_reply_batch(
-            7,
-            expected_head_sha="a" * 40,
-            current_head_sha="b" * 40,
-            replies={"thread-one": "Fixed the finding."},
+        assert (
+            dry_adapter.preserve_stale_implementation_thread_reply_batch(
+                7,
+                expected_head_sha="a" * 40,
+                current_head_sha="b" * 40,
+                replies={"thread-one": "Fixed the finding."},
+            )
+            == ()
         )
         graphql.assert_not_called()
 
@@ -1348,7 +1507,7 @@ class TestAllThreadReplyAndReviewerResolution:
         monkeypatch.setattr(adapter, "_graphql", graphql)
         monkeypatch.setattr(
             adapter,
-            "_reconcile_implementation_reply_reviews",
+            "_implementation_reply_review_state",
             lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
         )
         monkeypatch.setattr(
@@ -1476,7 +1635,7 @@ class TestAllThreadReplyAndReviewerResolution:
         monkeypatch.setattr(adapter, "_graphql", graphql)
         monkeypatch.setattr(
             adapter,
-            "_reconcile_implementation_reply_reviews",
+            "_implementation_reply_review_state",
             lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
         )
         monkeypatch.setattr(
@@ -1801,7 +1960,7 @@ class TestAllThreadReplyAndReviewerResolution:
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
         monkeypatch.setattr(
             adapter,
-            "_reconcile_implementation_reply_reviews",
+            "_implementation_reply_review_state",
             lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
         )
         monkeypatch.setattr(
@@ -1862,7 +2021,7 @@ class TestAllThreadReplyAndReviewerResolution:
         )
         monkeypatch.setattr(
             adapter,
-            "_reconcile_implementation_reply_reviews",
+            "_implementation_reply_review_state",
             lambda *_args: ("pr-7", None, False),
         )
         graphql = MagicMock()

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -35,6 +35,55 @@ from hephaestus.automation.review_journal import (
 )
 from hephaestus.utils.file_lock import LockUnavailableError
 
+_BATCH_NONCE = "b" * 32
+
+
+class PipelineGitHubForTest(pg.PipelineGitHub):
+    """Production adapter with an explicit test-only operation nonce default."""
+
+    def _implementation_reply_review_body(
+        self,
+        pr_number: int,
+        head_sha: str,
+        replies: dict[str, str],
+        batch_nonce: str | None = _BATCH_NONCE,
+    ) -> str:
+        return super()._implementation_reply_review_body(pr_number, head_sha, replies, batch_nonce)
+
+    def post_implementation_thread_replies(
+        self,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        threads: list[dict[str, Any]],
+        replies: dict[str, str],
+        batch_nonce: str | None = _BATCH_NONCE,
+    ) -> Any:
+        return super().post_implementation_thread_replies(
+            pr_number,
+            expected_head_sha=expected_head_sha,
+            threads=threads,
+            replies=replies,
+            batch_nonce=batch_nonce,
+        )
+
+    def discard_stale_implementation_thread_reply_batch(
+        self,
+        pr_number: int,
+        *,
+        expected_head_sha: str,
+        current_head_sha: str,
+        replies: dict[str, str],
+        batch_nonce: str | None = _BATCH_NONCE,
+    ) -> bool:
+        return super().discard_stale_implementation_thread_reply_batch(
+            pr_number,
+            expected_head_sha=expected_head_sha,
+            current_head_sha=current_head_sha,
+            replies=replies,
+            batch_nonce=batch_nonce,
+        )
+
 
 def _claim_drive_green_learn_from_process(repo_root: str, start_barrier: Any, results: Any) -> None:
     """Race one real adapter claim from a separate process for lock coverage."""
@@ -51,15 +100,15 @@ def _claim_drive_green_learn_from_process(repo_root: str, start_barrier: Any, re
 
 
 @pytest.fixture
-def adapter(tmp_path: Path) -> pg.PipelineGitHub:
+def adapter(tmp_path: Path) -> PipelineGitHubForTest:
     """Live-mutator adapter anchored at a temp repo root."""
-    return pg.PipelineGitHub("org", dry_run=False, repo_root=tmp_path)
+    return PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path)
 
 
 @pytest.fixture
-def dry_adapter(tmp_path: Path) -> pg.PipelineGitHub:
+def dry_adapter(tmp_path: Path) -> PipelineGitHubForTest:
     """Dry-run adapter: every mutator must log-and-skip."""
-    return pg.PipelineGitHub("org", dry_run=True, repo_root=tmp_path)
+    return PipelineGitHubForTest("org", dry_run=True, repo_root=tmp_path)
 
 
 @pytest.fixture
@@ -683,8 +732,8 @@ class TestAllThreadReplyAndReviewerResolution:
         thread = _external_reviewer_thread()
         reply = "Fixed the missing guard."
         head_sha = "a" * 40
-        first_adapter = pg.PipelineGitHub("org", dry_run=False, repo_root=tmp_path / "one")
-        second_adapter = pg.PipelineGitHub("org", dry_run=False, repo_root=tmp_path / "two")
+        first_adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "one")
+        second_adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "two")
         review_body = first_adapter._implementation_reply_review_body(
             7,
             head_sha,
@@ -754,6 +803,73 @@ class TestAllThreadReplyAndReviewerResolution:
         ]
         assert all(result.retryable is False for result in results)
         assert all(result.blocked_thread_ids == (thread["id"],) for result in results)
+
+    def test_cross_checkout_foreign_nonce_draft_stops_without_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A different work item cannot reuse a pending draft from another checkout."""
+        thread = _external_reviewer_thread()
+        reply = "Fixed the missing guard."
+        head_sha = "a" * 40
+        adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "two")
+        foreign_body = adapter._implementation_reply_review_body(
+            7,
+            head_sha,
+            {
+                thread["id"]: adapter._implementation_thread_reply_body(
+                    7, head_sha, thread["id"], reply
+                )
+            },
+            "c" * 32,
+        )
+
+        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" not in query:
+                pytest.fail(f"foreign pending draft must not mutate: {query}")
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "id": "pr-7",
+                            "state": "OPEN",
+                            "headRefOid": head_sha,
+                            "autoMergeRequest": None,
+                            "reviews": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "foreign-pending-draft",
+                                        "state": "PENDING",
+                                        "body": foreign_body,
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": head_sha},
+                                    }
+                                ],
+                            },
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, _thread: _open_thread_snapshot(thread),
+        )
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha=head_sha,
+            threads=[thread],
+            replies={thread["id"]: reply},
+            batch_nonce="d" * 32,
+        )
+
+        assert result.replied_thread_ids == ()
+        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.conflicting_pending_draft_ids == ("foreign-pending-draft",)
+        assert result.retryable is False
 
     def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -975,11 +1091,30 @@ class TestAllThreadReplyAndReviewerResolution:
                 )
             },
         )
+        foreign_old_body = adapter._implementation_reply_review_body(
+            7,
+            "a" * 40,
+            {
+                "thread-one": adapter._implementation_thread_reply_body(
+                    7, "a" * 40, "thread-one", replies["thread-one"]
+                )
+            },
+            "c" * 32,
+        )
         reviews = [
             {
                 "id": "old-automation-draft",
                 "state": "PENDING",
                 "body": old_body,
+                "viewerDidAuthor": True,
+                "commit": {"oid": "a" * 40},
+            },
+            {
+                "id": "foreign-old-draft",
+                "state": "PENDING",
+                # A valid body from another opaque operation must remain
+                # untouched even when its reply text and commit match.
+                "body": foreign_old_body,
                 "viewerDidAuthor": True,
                 "commit": {"oid": "a" * 40},
             },
@@ -1035,7 +1170,7 @@ class TestAllThreadReplyAndReviewerResolution:
             replies=replies,
         )
         assert deleted_review_ids == ["old-automation-draft"]
-        assert [review["id"] for review in reviews] == ["manual-draft"]
+        assert [review["id"] for review in reviews] == ["foreign-old-draft", "manual-draft"]
 
     def test_dry_run_never_inventories_or_deletes_stale_reply_drafts(
         self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -578,6 +578,40 @@ class TestAllThreadReplyAndReviewerResolution:
         assert sum(result.replied_thread_ids == (thread["id"],) for result in resolved) == 1
         assert sum(result.blocked_thread_ids == (thread["id"],) for result in resolved) == 1
 
+    def test_linked_worktrees_with_invalid_git_metadata_fail_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed linked-worktree metadata cannot fall back to private locks."""
+        first_root = tmp_path / "worktree-first"
+        second_root = tmp_path / "worktree-second"
+        adapters: list[PipelineGitHubForTest] = []
+        for root in (first_root, second_root):
+            root.mkdir()
+            (root / ".git").write_text("not valid git metadata\n", encoding="utf-8")
+            adapters.append(PipelineGitHubForTest("org", repo="repo-a", repo_root=root))
+
+        thread = _external_reviewer_thread("thread-one")
+        for adapter in adapters:
+            monkeypatch.setattr(
+                adapter,
+                "_graphql",
+                lambda *_args, **_kwargs: pytest.fail("invalid metadata must not reply"),
+            )
+
+        results = [
+            adapter.post_implementation_thread_replies(
+                7,
+                expected_head_sha="a" * 40,
+                threads=[thread],
+                replies={thread["id"]: "Fixed the finding."},
+                batch_nonce="c" * 32,
+            )
+            for adapter in adapters
+        ]
+
+        assert all(result.retryable_thread_ids == (thread["id"],) for result in results)
+        assert all(result.retryable for result in results)
+
     def test_external_thread_is_replied_to_then_resolved_by_fresh_reviewer(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -676,6 +676,85 @@ class TestAllThreadReplyAndReviewerResolution:
         ]
         assert len(create_calls) == 1
 
+    def test_cross_checkout_duplicate_current_drafts_stop_without_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Independent lock roots do not retry or delete ambiguous current drafts."""
+        thread = _external_reviewer_thread()
+        reply = "Fixed the missing guard."
+        head_sha = "a" * 40
+        first_adapter = pg.PipelineGitHub("org", dry_run=False, repo_root=tmp_path / "one")
+        second_adapter = pg.PipelineGitHub("org", dry_run=False, repo_root=tmp_path / "two")
+        review_body = first_adapter._implementation_reply_review_body(
+            7,
+            head_sha,
+            {
+                thread["id"]: first_adapter._implementation_thread_reply_body(
+                    7, head_sha, thread["id"], reply
+                )
+            },
+        )
+
+        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" not in query:
+                pytest.fail(f"duplicate-draft conflict must not mutate: {query}")
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "id": "pr-7",
+                            "state": "OPEN",
+                            "headRefOid": head_sha,
+                            "autoMergeRequest": None,
+                            "reviews": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "draft-one",
+                                        "state": "PENDING",
+                                        "body": review_body,
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": head_sha},
+                                    },
+                                    {
+                                        "id": "draft-two",
+                                        "state": "PENDING",
+                                        "body": review_body,
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": head_sha},
+                                    },
+                                ],
+                            },
+                        }
+                    }
+                }
+            }
+
+        for current in (first_adapter, second_adapter):
+            monkeypatch.setattr(
+                current,
+                "_review_thread_snapshot",
+                lambda _pr, _thread: _open_thread_snapshot(thread),
+            )
+            monkeypatch.setattr(current, "_graphql", graphql)
+
+        results = [
+            current.post_implementation_thread_replies(
+                7,
+                expected_head_sha=head_sha,
+                threads=[thread],
+                replies={thread["id"]: reply},
+            )
+            for current in (first_adapter, second_adapter)
+        ]
+
+        assert [result.duplicate_current_draft_ids for result in results] == [
+            ("draft-one", "draft-two"),
+            ("draft-one", "draft-two"),
+        ]
+        assert all(result.retryable is False for result in results)
+        assert all(result.blocked_thread_ids == (thread["id"],) for result in results)
+
     def test_stale_target_aborts_a_partial_pending_reply_batch(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1300,6 +1379,91 @@ class TestAllThreadReplyAndReviewerResolution:
         assert [receipt["implementation_reply_id"] for receipt in receipts] == [
             "implementation-comment"
         ]
+
+    def test_split_submitted_reviews_cannot_become_validation_receipts(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two singleton reviews cannot masquerade as one implementation batch."""
+        head_sha = "a" * 40
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+
+        def singleton(thread: dict[str, Any], reply: str, review_id: str) -> dict[str, Any]:
+            reply_body = adapter._implementation_thread_reply_body(7, head_sha, thread["id"], reply)
+            return {
+                **thread,
+                "comments": [
+                    *thread["comments"],
+                    {
+                        "id": f"implementation-{thread['id']}",
+                        "author": "hephaestus[bot]",
+                        "body": reply_body,
+                        "viewer_did_author": True,
+                        "review_id": review_id,
+                        "review_state": "COMMENTED",
+                        "review_body": adapter._implementation_reply_review_body(
+                            7, head_sha, {thread["id"]: reply_body}
+                        ),
+                        "review_commit_sha": head_sha,
+                    },
+                ],
+            }
+
+        monkeypatch.setattr(
+            adapter,
+            "gh_pr_state",
+            lambda _pr: {"state": "OPEN", "headRefOid": head_sha, "autoMergeRequest": None},
+        )
+        assert (
+            adapter.reviewer_validation_receipts(
+                7,
+                reviewed_head_sha=head_sha,
+                threads=[
+                    singleton(first, "Fixed the first finding.", "review-one"),
+                    singleton(second, "Fixed the second finding.", "review-two"),
+                ],
+            )
+            == []
+        )
+
+    def test_noncanonical_batch_summary_cannot_become_validation_receipt(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A syntactically valid but wrong batch marker cannot authorize resolution."""
+        thread = _external_reviewer_thread()
+        head_sha = "a" * 40
+        reply_body = adapter._implementation_thread_reply_body(
+            7, head_sha, thread["id"], "Fixed the missing guard."
+        )
+        malformed = {
+            **thread,
+            "comments": [
+                *thread["comments"],
+                {
+                    "id": "implementation-comment",
+                    "author": "hephaestus[bot]",
+                    "body": reply_body,
+                    "viewer_did_author": True,
+                    "review_id": "implementation-review",
+                    "review_state": "COMMENTED",
+                    "review_body": (
+                        "Implementation responses for 1 review thread(s).\n\n"
+                        "<!-- hephaestus-implementation-review:000000000000000000000000 -->"
+                    ),
+                    "review_commit_sha": head_sha,
+                },
+            ],
+        }
+        monkeypatch.setattr(
+            adapter,
+            "gh_pr_state",
+            lambda _pr: {"state": "OPEN", "headRefOid": head_sha, "autoMergeRequest": None},
+        )
+
+        assert (
+            adapter.reviewer_validation_receipts(7, reviewed_head_sha=head_sha, threads=[malformed])
+            == []
+        )
 
     def test_malformed_reply_response_recovers_an_exact_host_read_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -41,14 +41,17 @@ _BATCH_NONCE = "b" * 32
 class PipelineGitHubForTest(pg.PipelineGitHub):
     """Production adapter with an explicit test-only operation nonce default."""
 
-    def _implementation_reply_review_body(
+    def _implementation_thread_reply_body(
         self,
         pr_number: int,
         head_sha: str,
-        replies: dict[str, str],
-        batch_nonce: str | None = _BATCH_NONCE,
+        thread_id: str,
+        reply: str,
+        batch_nonce: str = _BATCH_NONCE,
     ) -> str:
-        return super()._implementation_reply_review_body(pr_number, head_sha, replies, batch_nonce)
+        return super()._implementation_thread_reply_body(
+            pr_number, head_sha, thread_id, reply, batch_nonce
+        )
 
     def post_implementation_thread_replies(
         self,
@@ -63,23 +66,6 @@ class PipelineGitHubForTest(pg.PipelineGitHub):
             pr_number,
             expected_head_sha=expected_head_sha,
             threads=threads,
-            replies=replies,
-            batch_nonce=batch_nonce,
-        )
-
-    def preserve_stale_implementation_thread_reply_batch(
-        self,
-        pr_number: int,
-        *,
-        expected_head_sha: str,
-        current_head_sha: str,
-        replies: dict[str, str],
-        batch_nonce: str | None = _BATCH_NONCE,
-    ) -> tuple[str, ...] | None:
-        return super().preserve_stale_implementation_thread_reply_batch(
-            pr_number,
-            expected_head_sha=expected_head_sha,
-            current_head_sha=current_head_sha,
             replies=replies,
             batch_nonce=batch_nonce,
         )
@@ -185,9 +171,10 @@ def _submitted_implementation_receipt(
     *,
     head_sha: str = "a" * 40,
 ) -> dict[str, Any]:
-    """Return a complete host snapshot for one submitted implementation batch."""
-    reply_body = adapter._implementation_thread_reply_body(7, head_sha, thread["id"], reply)
-    review_body = adapter._implementation_reply_review_body(7, head_sha, {thread["id"]: reply_body})
+    """Return a complete host snapshot for one source-attached reply."""
+    reply_body = adapter._implementation_thread_reply_body(
+        7, head_sha, thread["id"], reply, _BATCH_NONCE
+    )
     return {
         **thread,
         "comments": [
@@ -199,7 +186,6 @@ def _submitted_implementation_receipt(
                 "viewer_did_author": True,
                 "review_id": "implementation-review",
                 "review_state": "COMMENTED",
-                "review_body": review_body,
                 "review_commit_sha": head_sha,
             },
         ],
@@ -212,72 +198,75 @@ def _submitted_implementation_receipt(
 class TestAllThreadReplyAndReviewerResolution:
     """The implementation/reviewer split applies to every open thread author."""
 
-    def test_implementation_replies_share_one_submitted_review(
+    def test_implementation_responses_use_only_thread_reply_mutations(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """One implementation pass submits every thread reply in one review."""
+        """Implementation output has no general PullRequestReview body."""
+        thread = _external_reviewer_thread("thread-one")
+        live = thread
+        queries: list[str] = []
+
+        def snapshot(_pr: int, _thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live)
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal live
+            queries.append(query)
+            if "addPullRequestReviewThreadReply" not in query:
+                raise AssertionError(f"unexpected review-envelope mutation: {query}")
+            assert "pullRequestReviewId" not in query
+            body = str(fields["body"])
+            live = {
+                **live,
+                "comments": [
+                    *live["comments"],
+                    {
+                        "id": "implementation-comment",
+                        "author": "hephaestus[bot]",
+                        "body": body,
+                        "viewer_did_author": True,
+                    },
+                ],
+            }
+            return {
+                "data": {
+                    "addPullRequestReviewThreadReply": {"comment": {"id": "implementation-comment"}}
+                }
+            }
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: "Fixed the missing guard."},
+            batch_nonce="b" * 32,
+        )
+
+        assert result.replied_thread_ids == (thread["id"],)
+        assert len(result.receipts) == 1
+        assert len(queries) == 1
+
+    def test_implementation_replies_share_one_source_attached_batch(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One implementation pass attaches every response to its own thread."""
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
         live_by_id = {first["id"]: first, second["id"]: second}
-        review_ids: list[str] = []
-        reply_review_ids: list[str] = []
-        submitted_review_ids: list[str] = []
-        review_body = ""
+        reply_bodies: list[str] = []
 
         def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            nonlocal review_body
-            if "reviews(first:100" in query:
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": "a" * 40,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": (
-                                        [
-                                            {
-                                                "id": "implementation-review",
-                                                "state": "PENDING",
-                                                "body": review_body,
-                                                "viewerDidAuthor": True,
-                                                "commit": {"oid": "a" * 40},
-                                            }
-                                        ]
-                                        if review_body
-                                        else []
-                                    ),
-                                },
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReview(input" in query:
-                review_ids.append("implementation-review")
-                review_body = str(fields["body"])
-                return {
-                    "data": {
-                        "addPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": "implementation-review",
-                                "state": "PENDING",
-                                "body": review_body,
-                                "commit": {"oid": "a" * 40},
-                            }
-                        }
-                    }
-                }
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId:$reviewId" in query
+                assert "pullRequestReviewId" not in query
+                assert "reviewId" not in fields
                 thread_id = str(fields["threadId"])
-                review_id = str(fields["reviewId"])
-                reply_review_ids.append(review_id)
+                reply_bodies.append(str(fields["body"]))
                 comment_id = f"implementation-{thread_id}"
                 live_by_id[thread_id] = {
                     **live_by_id[thread_id],
@@ -288,25 +277,15 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": review_id,
+                            "review_id": "implementation-review",
+                            "review_state": "COMMENTED",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
                         },
                     ],
                 }
                 return {
                     "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
-                }
-            if "submitPullRequestReview" in query:
-                submitted_review_ids.append(str(fields["reviewId"]))
-                return {
-                    "data": {
-                        "submitPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": fields["reviewId"],
-                                "state": "COMMENTED",
-                                "body": fields["body"],
-                            }
-                        }
-                    }
                 }
             raise AssertionError(query)
 
@@ -324,82 +303,30 @@ class TestAllThreadReplyAndReviewerResolution:
         )
 
         assert result.replied_thread_ids == (first["id"], second["id"])
-        assert review_ids == ["implementation-review"]
-        assert reply_review_ids == ["implementation-review", "implementation-review"]
-        assert submitted_review_ids == ["implementation-review"]
+        assert len(reply_bodies) == 2
+        assert {adapter._implementation_reply_batch_nonce(body) for body in reply_bodies} == {
+            _BATCH_NONCE
+        }
 
-    def test_reply_batch_retry_reuses_pending_review_and_adds_only_missing_replies(
+    def test_reply_batch_retry_recovers_attached_replies_and_adds_only_missing_one(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A failed batch resumes the same draft review without duplicate replies."""
+        """A retry recognizes its source-attached reply before posting again."""
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
         live_by_id = {first["id"]: first, second["id"]: second}
-        review_body = ""
-        created_review_ids: list[str] = []
-        reply_calls: list[tuple[str, str]] = []
-        submit_calls: list[str] = []
+        reply_calls: list[str] = []
 
         def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            nonlocal review_body
-            if "reviews(first:100" in query:
-                nodes = (
-                    [
-                        {
-                            "id": "implementation-review",
-                            "state": "PENDING",
-                            "body": review_body,
-                            "viewerDidAuthor": True,
-                            "commit": {"oid": "a" * 40},
-                        }
-                    ]
-                    if created_review_ids
-                    else []
-                )
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": "a" * 40,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": nodes,
-                                },
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReview(input" in query:
-                assert not created_review_ids
-                created_review_ids.append("implementation-review")
-                review_body = str(fields["body"])
-                return {
-                    "data": {
-                        "addPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": "implementation-review",
-                                "state": "PENDING",
-                                "body": review_body,
-                                "commit": {"oid": "a" * 40},
-                            }
-                        }
-                    }
-                }
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId:$reviewId" in query
+                assert "pullRequestReviewId" not in query
+                assert "reviewId" not in fields
                 thread_id = str(fields["threadId"])
-                review_id = str(fields["reviewId"])
-                reply_calls.append((thread_id, review_id))
-                if (
-                    thread_id == second["id"]
-                    and [call[0] for call in reply_calls].count(thread_id) == 1
-                ):
+                reply_calls.append(thread_id)
+                if thread_id == second["id"] and reply_calls.count(thread_id) == 1:
                     raise OSError("transient GitHub reply failure")
                 comment_id = f"implementation-{thread_id}"
                 live_by_id[thread_id] = {
@@ -411,25 +338,15 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": review_id,
+                            "review_id": "implementation-review",
+                            "review_state": "COMMENTED",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
                         },
                     ],
                 }
                 return {
                     "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
-                }
-            if "submitPullRequestReview" in query:
-                submit_calls.append(str(fields["reviewId"]))
-                return {
-                    "data": {
-                        "submitPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": fields["reviewId"],
-                                "state": "COMMENTED",
-                                "body": fields["body"],
-                            }
-                        }
-                    }
                 }
             raise AssertionError(query)
 
@@ -456,88 +373,27 @@ class TestAllThreadReplyAndReviewerResolution:
         assert failed.replied_thread_ids == ()
         assert failed.retryable_thread_ids == (first["id"], second["id"])
         assert retried.replied_thread_ids == (first["id"], second["id"])
-        assert created_review_ids == ["implementation-review"]
-        assert reply_calls == [
-            (first["id"], "implementation-review"),
-            (second["id"], "implementation-review"),
-            (second["id"], "implementation-review"),
-        ]
-        assert submit_calls == ["implementation-review"]
+        assert reply_calls == [first["id"], second["id"], second["id"]]
 
-    @pytest.mark.parametrize("lost_response", ["create", "submit"])
-    def test_reply_batch_recovers_after_a_lost_create_or_submit_response(
+    def test_reply_batch_recovers_after_a_lost_thread_reply_response(
         self,
         adapter: pg.PipelineGitHub,
         monkeypatch: pytest.MonkeyPatch,
-        lost_response: str,
     ) -> None:
-        """A mutation may apply before its response is lost without replaying it."""
+        """A direct reply may apply before its response is lost without replaying it."""
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
         live_by_id = {first["id"]: first, second["id"]: second}
-        review_body = ""
-        review_state: str | None = None
-        created_review_ids: list[str] = []
-        reply_calls: list[tuple[str, str]] = []
-        submit_calls: list[str] = []
+        reply_calls: list[str] = []
 
         def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            nonlocal review_body, review_state
-            if "reviews(first:100" in query:
-                nodes = (
-                    [
-                        {
-                            "id": "implementation-review",
-                            "state": review_state,
-                            "body": review_body,
-                            "viewerDidAuthor": True,
-                            "commit": {"oid": "a" * 40},
-                        }
-                    ]
-                    if review_state is not None
-                    else []
-                )
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": "a" * 40,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": nodes,
-                                },
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReview(input" in query:
-                created_review_ids.append("implementation-review")
-                review_body = str(fields["body"])
-                review_state = "PENDING"
-                review = {
-                    "id": "implementation-review",
-                    "state": "PENDING",
-                    "body": review_body,
-                    "commit": {"oid": "a" * 40},
-                }
-                return {
-                    "data": {
-                        "addPullRequestReview": {
-                            "pullRequestReview": None if lost_response == "create" else review
-                        }
-                    }
-                }
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId:$reviewId" in query
+                assert "pullRequestReviewId" not in query
                 thread_id = str(fields["threadId"])
-                review_id = str(fields["reviewId"])
-                reply_calls.append((thread_id, review_id))
+                reply_calls.append(thread_id)
                 comment_id = f"implementation-{thread_id}"
                 live_by_id[thread_id] = {
                     **live_by_id[thread_id],
@@ -548,28 +404,14 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": review_id,
+                            "review_id": "implementation-review",
+                            "review_state": "COMMENTED",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
                         },
                     ],
                 }
-                return {
-                    "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
-                }
-            if "submitPullRequestReview" in query:
-                submit_calls.append(str(fields["reviewId"]))
-                review_state = "COMMENTED"
-                review = {
-                    "id": str(fields["reviewId"]),
-                    "state": "COMMENTED",
-                    "body": str(fields["body"]),
-                }
-                return {
-                    "data": {
-                        "submitPullRequestReview": {
-                            "pullRequestReview": None if lost_response == "submit" else review
-                        }
-                    }
-                }
+                return {"data": {"addPullRequestReviewThreadReply": None}}
             raise AssertionError(query)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
@@ -592,81 +434,28 @@ class TestAllThreadReplyAndReviewerResolution:
             replies=replies,
         )
 
-        assert first_attempt.retryable is True
+        assert first_attempt.replied_thread_ids == (first["id"], second["id"])
         assert second_attempt.replied_thread_ids == (first["id"], second["id"])
-        assert created_review_ids == ["implementation-review"]
-        assert reply_calls == [
-            (first["id"], "implementation-review"),
-            (second["id"], "implementation-review"),
-        ]
-        assert submit_calls == ["implementation-review"]
+        assert reply_calls == [first["id"], second["id"]]
 
-    def test_parallel_reply_batches_share_one_draft_review(
+    def test_parallel_reply_batches_recover_one_attached_reply_per_thread(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The PR-scoped lock prevents two local loops creating competing drafts."""
+        """The PR-scoped lock prevents two local loops duplicating thread replies."""
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
         live_by_id = {first["id"]: first, second["id"]: second}
-        review_body = ""
-        review_state: str | None = None
-        create_calls: list[str] = []
+        reply_calls: list[str] = []
 
         def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            nonlocal review_body, review_state
-            if "reviews(first:100" in query:
-                nodes = (
-                    [
-                        {
-                            "id": "implementation-review",
-                            "state": review_state,
-                            "body": review_body,
-                            "viewerDidAuthor": True,
-                            "commit": {"oid": "a" * 40},
-                        }
-                    ]
-                    if review_state is not None
-                    else []
-                )
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": "a" * 40,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": nodes,
-                                },
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReview(input" in query:
-                create_calls.append(str(fields["body"]))
-                review_body = str(fields["body"])
-                review_state = "PENDING"
-                sleep(0.05)
-                return {
-                    "data": {
-                        "addPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": "implementation-review",
-                                "state": "PENDING",
-                                "body": review_body,
-                                "commit": {"oid": "a" * 40},
-                            }
-                        }
-                    }
-                }
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId:$reviewId" in query
+                assert "pullRequestReviewId" not in query
                 thread_id = str(fields["threadId"])
+                reply_calls.append(thread_id)
+                sleep(0.05)
                 comment_id = f"implementation-{thread_id}"
                 live_by_id[thread_id] = {
                     **live_by_id[thread_id],
@@ -677,25 +466,15 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": fields["reviewId"],
+                            "review_id": "implementation-review",
+                            "review_state": "COMMENTED",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
                         },
                     ],
                 }
                 return {
                     "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
-                }
-            if "submitPullRequestReview" in query:
-                review_state = "COMMENTED"
-                return {
-                    "data": {
-                        "submitPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": fields["reviewId"],
-                                "state": "COMMENTED",
-                                "body": fields["body"],
-                            }
-                        }
-                    }
                 }
             raise AssertionError(query)
 
@@ -723,787 +502,7 @@ class TestAllThreadReplyAndReviewerResolution:
             (first["id"], second["id"]),
             (first["id"], second["id"]),
         ]
-        assert len(create_calls) == 1
-
-    def test_cross_checkout_duplicate_current_drafts_stop_without_mutation(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Independent lock roots do not retry or delete ambiguous current drafts."""
-        thread = _external_reviewer_thread()
-        reply = "Fixed the missing guard."
-        head_sha = "a" * 40
-        first_adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "one")
-        second_adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "two")
-        review_body = first_adapter._implementation_reply_review_body(
-            7,
-            head_sha,
-            {
-                thread["id"]: first_adapter._implementation_thread_reply_body(
-                    7, head_sha, thread["id"], reply
-                )
-            },
-        )
-
-        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" not in query:
-                pytest.fail(f"duplicate-draft conflict must not mutate: {query}")
-            return {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "id": "pr-7",
-                            "state": "OPEN",
-                            "headRefOid": head_sha,
-                            "autoMergeRequest": None,
-                            "reviews": {
-                                "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                "nodes": [
-                                    {
-                                        "id": "draft-one",
-                                        "state": "PENDING",
-                                        "body": review_body,
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": head_sha},
-                                    },
-                                    {
-                                        "id": "draft-two",
-                                        "state": "PENDING",
-                                        "body": review_body,
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": head_sha},
-                                    },
-                                ],
-                            },
-                        }
-                    }
-                }
-            }
-
-        for current in (first_adapter, second_adapter):
-            monkeypatch.setattr(
-                current,
-                "_review_thread_snapshot",
-                lambda _pr, _thread: _open_thread_snapshot(thread),
-            )
-            monkeypatch.setattr(current, "_graphql", graphql)
-
-        results = [
-            current.post_implementation_thread_replies(
-                7,
-                expected_head_sha=head_sha,
-                threads=[thread],
-                replies={thread["id"]: reply},
-            )
-            for current in (first_adapter, second_adapter)
-        ]
-
-        assert [result.duplicate_current_draft_ids for result in results] == [
-            ("draft-one", "draft-two"),
-            ("draft-one", "draft-two"),
-        ]
-        assert all(result.retryable is False for result in results)
-        assert all(result.blocked_thread_ids == (thread["id"],) for result in results)
-
-    def test_cross_checkout_foreign_nonce_draft_stops_without_mutation(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A different work item cannot reuse a pending draft from another checkout."""
-        thread = _external_reviewer_thread()
-        reply = "Fixed the missing guard."
-        head_sha = "a" * 40
-        adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "two")
-        foreign_body = adapter._implementation_reply_review_body(
-            7,
-            head_sha,
-            {
-                thread["id"]: adapter._implementation_thread_reply_body(
-                    7, head_sha, thread["id"], reply
-                )
-            },
-            "c" * 32,
-        )
-
-        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" not in query:
-                pytest.fail(f"foreign pending draft must not mutate: {query}")
-            return {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "id": "pr-7",
-                            "state": "OPEN",
-                            "headRefOid": head_sha,
-                            "autoMergeRequest": None,
-                            "reviews": {
-                                "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                "nodes": [
-                                    {
-                                        "id": "foreign-pending-draft",
-                                        "state": "PENDING",
-                                        "body": foreign_body,
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": head_sha},
-                                    }
-                                ],
-                            },
-                        }
-                    }
-                }
-            }
-
-        monkeypatch.setattr(
-            adapter,
-            "_review_thread_snapshot",
-            lambda _pr, _thread: _open_thread_snapshot(thread),
-        )
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        result = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha=head_sha,
-            threads=[thread],
-            replies={thread["id"]: reply},
-            batch_nonce="d" * 32,
-        )
-
-        assert result.replied_thread_ids == ()
-        assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_current_review_ids == ("foreign-pending-draft",)
-        assert result.retryable is False
-
-    def test_visible_foreign_pending_review_blocks_without_mutation(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A visible foreign pending review cannot be reused or bypassed."""
-        thread = _external_reviewer_thread()
-        mutations: list[str] = []
-
-        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" not in query:
-                mutations.append(query)
-                pytest.fail("a visible foreign pending review must stop before mutation")
-            return {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "id": "pr-7",
-                            "state": "OPEN",
-                            "headRefOid": "a" * 40,
-                            "autoMergeRequest": None,
-                            "reviews": {
-                                "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                "nodes": [
-                                    {
-                                        "id": "foreign-pending-draft",
-                                        "state": "PENDING",
-                                        "body": "Visible foreign draft.",
-                                        "viewerDidAuthor": False,
-                                        "commit": {"oid": "a" * 40},
-                                    }
-                                ],
-                            },
-                        }
-                    }
-                }
-            }
-
-        monkeypatch.setattr(
-            adapter,
-            "_review_thread_snapshot",
-            lambda _pr, _thread: _open_thread_snapshot(thread),
-        )
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        result = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha="a" * 40,
-            threads=[thread],
-            replies={thread["id"]: "Fixed the missing guard."},
-        )
-
-        assert result.replied_thread_ids == ()
-        assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_current_review_ids == ("foreign-pending-draft",)
-        assert mutations == []
-
-    def test_visible_foreign_marked_review_blocks_without_mutation(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A visible foreign submitted implementation batch cannot be bypassed."""
-        thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        foreign_body = adapter._implementation_reply_review_body(
-            7, "a" * 40, {thread["id"]: reply_body}, "d" * 32
-        )
-
-        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" not in query:
-                pytest.fail("a visible foreign batch must stop before mutation")
-            return {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "id": "pr-7",
-                            "state": "OPEN",
-                            "headRefOid": "a" * 40,
-                            "autoMergeRequest": None,
-                            "reviews": {
-                                "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                "nodes": [
-                                    {
-                                        "id": "foreign-submitted-review",
-                                        "state": "COMMENTED",
-                                        "body": foreign_body,
-                                        "viewerDidAuthor": False,
-                                        "commit": {"oid": "a" * 40},
-                                    }
-                                ],
-                            },
-                        }
-                    }
-                }
-            }
-
-        monkeypatch.setattr(
-            adapter,
-            "_review_thread_snapshot",
-            lambda _pr, _thread: _open_thread_snapshot(thread),
-        )
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        result = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha="a" * 40,
-            threads=[thread],
-            replies={thread["id"]: "Fixed the missing guard."},
-        )
-
-        assert result.replied_thread_ids == ()
-        assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_current_review_ids == ("foreign-submitted-review",)
-
-    def test_cross_checkout_submitted_batch_between_inventory_and_create_is_a_conflict(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A competing completed batch prevents this worker from adding a draft reply."""
-        thread = _external_reviewer_thread()
-        reply = "Fixed the missing guard."
-        head_sha = "a" * 40
-        adapter = PipelineGitHubForTest("org", dry_run=False, repo_root=tmp_path / "two")
-        reply_body = adapter._implementation_thread_reply_body(7, head_sha, thread["id"], reply)
-        submitted_body = adapter._implementation_reply_review_body(
-            7, head_sha, {thread["id"]: reply_body}, "c" * 32
-        )
-        reviews: list[dict[str, Any]] = []
-        added_replies: list[str] = []
-        submitted_reviews: list[str] = []
-        deleted_reviews: list[str] = []
-
-        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" in query:
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": head_sha,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": reviews,
-                                },
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReview(input" in query:
-                batch_body = str(fields["body"])
-                # Worker A submits a distinct nonce batch after worker B's
-                # inventory but before B has created its own draft.
-                reviews[:] = [
-                    {
-                        "id": "worker-a-review",
-                        "state": "COMMENTED",
-                        "body": submitted_body,
-                        "viewerDidAuthor": True,
-                        "commit": {"oid": head_sha},
-                    },
-                    {
-                        "id": "worker-b-draft",
-                        "state": "PENDING",
-                        "body": batch_body,
-                        "viewerDidAuthor": True,
-                        "commit": {"oid": head_sha},
-                    },
-                ]
-                return {
-                    "data": {
-                        "addPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": "worker-b-draft",
-                                "state": "PENDING",
-                                "body": batch_body,
-                                "commit": {"oid": head_sha},
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReviewThreadReply" in query:
-                added_replies.append(str(fields["threadId"]))
-                pytest.fail("must not add a reply after a competing submitted batch")
-            if "submitPullRequestReview" in query:
-                submitted_reviews.append(str(fields["reviewId"]))
-                pytest.fail("must not submit a competing batch")
-            if "deletePullRequestReview" in query:
-                pytest.fail("a current-review conflict must not delete any draft")
-            raise AssertionError(query)
-
-        monkeypatch.setattr(
-            adapter,
-            "_review_thread_snapshot",
-            lambda _pr, _thread: _open_thread_snapshot(thread),
-        )
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        result = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha=head_sha,
-            threads=[thread],
-            replies={thread["id"]: reply},
-        )
-
-        assert result.replied_thread_ids == ()
-        assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_current_review_ids == ("worker-a-review", "worker-b-draft")
-        assert added_replies == []
-        assert submitted_reviews == []
-        assert deleted_reviews == []
-
-    def test_resumed_pending_batch_reports_its_own_review_with_a_competitor(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A resumed draft and a competing batch are both preserved and reported."""
-        thread = _external_reviewer_thread()
-        reply = "Fixed the missing guard."
-        mutations: list[str] = []
-
-        monkeypatch.setattr(
-            adapter,
-            "_review_thread_snapshot",
-            lambda _pr, _thread: _open_thread_snapshot(thread),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_implementation_reply_review_state",
-            lambda *_args: (
-                "pr-7",
-                ("local-pending-draft", "PENDING"),
-                ("competing-current-review",),
-            ),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_add_thread_reply",
-            lambda *_args, **_kwargs: mutations.append("reply"),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_submit_implementation_reply_review",
-            lambda *_args: mutations.append("submit"),
-        )
-
-        result = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha="a" * 40,
-            threads=[thread],
-            replies={thread["id"]: reply},
-        )
-
-        assert result.replied_thread_ids == ()
-        assert result.blocked_thread_ids == (thread["id"],)
-        assert result.conflicting_current_review_ids == (
-            "competing-current-review",
-            "local-pending-draft",
-        )
-        assert mutations == []
-
-    def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A manual draft cannot make a complete exact batch retry forever."""
-        thread = _external_reviewer_thread()
-        reply = "Fixed the missing guard."
-        live = _open_thread_snapshot(_submitted_implementation_receipt(adapter, thread, reply))
-        review_body = str(live["comments"][-1]["review_body"])
-
-        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" not in query:
-                pytest.fail(f"submitted batch recovery must not mutate: {query}")
-            return {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "id": "pr-7",
-                            "state": "OPEN",
-                            "headRefOid": "a" * 40,
-                            "autoMergeRequest": None,
-                            "reviews": {
-                                "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                "nodes": [
-                                    {
-                                        "id": "implementation-review",
-                                        "state": "COMMENTED",
-                                        "body": review_body,
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": "a" * 40},
-                                    },
-                                    {
-                                        "id": "manual-draft",
-                                        "state": "PENDING",
-                                        "body": "Unrelated reviewer draft.",
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": "a" * 40},
-                                    },
-                                ],
-                            },
-                        }
-                    }
-                }
-            }
-
-        monkeypatch.setattr(adapter, "_review_thread_snapshot", lambda _pr, _id: live)
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        result = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha="a" * 40,
-            threads=[thread],
-            replies={thread["id"]: reply},
-        )
-
-        assert result.replied_thread_ids == (thread["id"],)
-        assert result.receipts[0]["implementation_reply_id"] == "implementation-comment"
-        assert result.retryable is False
-
-    def test_stale_target_preserves_a_partial_pending_batch_on_a_current_conflict(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A current-review conflict prevents cleanup of an otherwise-owned pending batch."""
-        first = _external_reviewer_thread("thread-one")
-        second = _external_reviewer_thread("thread-two")
-        live_by_id = {first["id"]: first, second["id"]: second}
-        review_body = ""
-        review_exists = False
-        manual_draft_exists = False
-        reply_calls: list[str] = []
-        deleted_review_ids: list[str] = []
-
-        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
-            return _open_thread_snapshot(live_by_id[thread_id])
-
-        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            nonlocal review_body, review_exists
-            if "reviews(first:100" in query:
-                nodes = (
-                    [
-                        {
-                            "id": "implementation-review",
-                            "state": "PENDING",
-                            "body": review_body,
-                            "viewerDidAuthor": True,
-                            "commit": {"oid": "a" * 40},
-                        }
-                    ]
-                    if review_exists
-                    else []
-                )
-                if manual_draft_exists:
-                    nodes.append(
-                        {
-                            "id": "manual-draft",
-                            "state": "PENDING",
-                            "body": "Unrelated reviewer draft.",
-                            "viewerDidAuthor": True,
-                            "commit": {"oid": "a" * 40},
-                        }
-                    )
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": "a" * 40,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": nodes,
-                                },
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReview(input" in query:
-                review_exists = True
-                review_body = str(fields["body"])
-                return {
-                    "data": {
-                        "addPullRequestReview": {
-                            "pullRequestReview": {
-                                "id": "implementation-review",
-                                "state": "PENDING",
-                                "body": review_body,
-                                "commit": {"oid": "a" * 40},
-                            }
-                        }
-                    }
-                }
-            if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId:$reviewId" in query
-                thread_id = str(fields["threadId"])
-                reply_calls.append(thread_id)
-                if thread_id == second["id"]:
-                    raise OSError("transient second reply failure")
-                live_by_id[thread_id] = {
-                    **live_by_id[thread_id],
-                    "comments": [
-                        *live_by_id[thread_id]["comments"],
-                        {
-                            "id": "implementation-first",
-                            "author": "hephaestus[bot]",
-                            "body": fields["body"],
-                            "viewer_did_author": True,
-                            "review_id": "implementation-review",
-                        },
-                    ],
-                }
-                return {
-                    "data": {
-                        "addPullRequestReviewThreadReply": {
-                            "comment": {"id": "implementation-first"}
-                        }
-                    }
-                }
-            if "deletePullRequestReview" in query:
-                pytest.fail("a current-review conflict must not delete any draft")
-            raise AssertionError(query)
-
-        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-        replies = {
-            first["id"]: "Fixed the first finding.",
-            second["id"]: "Fixed the second finding.",
-        }
-
-        first_attempt = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha="a" * 40,
-            threads=[first, second],
-            replies=replies,
-        )
-        live_by_id[second["id"]] = {
-            **live_by_id[second["id"]],
-            "comments": [
-                *live_by_id[second["id"]]["comments"],
-                {
-                    "id": "new-reviewer-comment",
-                    "author": "maintainer",
-                    "body": "Please also test it.",
-                },
-            ],
-        }
-        manual_draft_exists = True
-        second_attempt = adapter.post_implementation_thread_replies(
-            7,
-            expected_head_sha="a" * 40,
-            threads=[first, second],
-            replies=replies,
-        )
-
-        assert first_attempt.retryable is True
-        assert second_attempt.replied_thread_ids == ()
-        assert second_attempt.receipts == ()
-        assert second_attempt.blocked_thread_ids == (first["id"], second["id"])
-        assert second_attempt.conflicting_current_review_ids == (
-            "implementation-review",
-            "manual-draft",
-        )
         assert reply_calls == [first["id"], second["id"]]
-        assert deleted_review_ids == []
-
-    def test_head_drift_reports_every_preserved_stale_batch(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Stale handoff preservation reports every visible pending review without mutation."""
-        replies = {"thread-one": "Fixed the finding."}
-        old_body = adapter._implementation_reply_review_body(
-            7,
-            "a" * 40,
-            {
-                "thread-one": adapter._implementation_thread_reply_body(
-                    7, "a" * 40, "thread-one", replies["thread-one"]
-                )
-            },
-        )
-        foreign_old_body = adapter._implementation_reply_review_body(
-            7,
-            "a" * 40,
-            {
-                "thread-one": adapter._implementation_thread_reply_body(
-                    7, "a" * 40, "thread-one", replies["thread-one"]
-                )
-            },
-            "c" * 32,
-        )
-        reviews = [
-            {
-                "id": "old-automation-draft",
-                "state": "PENDING",
-                "body": old_body,
-                "viewerDidAuthor": True,
-                "commit": {"oid": "a" * 40},
-            },
-            {
-                "id": "foreign-old-draft",
-                "state": "PENDING",
-                # A valid body from another opaque operation must remain
-                # untouched even when its reply text and commit match.
-                "body": foreign_old_body,
-                "viewerDidAuthor": True,
-                "commit": {"oid": "a" * 40},
-            },
-            {
-                "id": "manual-draft",
-                "state": "PENDING",
-                # This has a valid coordinator marker but is not the exact
-                # deterministic body of the stale batch.  It is still a
-                # manual draft and must never be deleted by cleanup.
-                "body": (
-                    "Implementation responses for 1 review thread(s).\n\n"
-                    "<!-- hephaestus-implementation-review:000000000000000000000000 -->"
-                ),
-                "viewerDidAuthor": True,
-                "commit": {"oid": "a" * 40},
-            },
-        ]
-        deleted_review_ids: list[str] = []
-
-        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" in query:
-                return {
-                    "data": {
-                        "repository": {
-                            "pullRequest": {
-                                "id": "pr-7",
-                                "state": "OPEN",
-                                "headRefOid": "b" * 40,
-                                "autoMergeRequest": None,
-                                "reviews": {
-                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                    "nodes": list(reviews),
-                                },
-                            }
-                        }
-                    }
-                }
-            if "deletePullRequestReview" in query:
-                pytest.fail("stale draft preservation must not delete any review")
-            raise AssertionError(query)
-
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        assert adapter.preserve_stale_implementation_thread_reply_batch(
-            7,
-            expected_head_sha="a" * 40,
-            current_head_sha="b" * 40,
-            replies=replies,
-        ) == ("foreign-old-draft", "manual-draft", "old-automation-draft")
-        assert deleted_review_ids == []
-        assert [review["id"] for review in reviews] == [
-            "old-automation-draft",
-            "foreign-old-draft",
-            "manual-draft",
-        ]
-
-    def test_old_submitted_batch_does_not_hide_a_current_preserved_draft(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """An old completed batch is inert while current drafts remain terminally visible."""
-        replies = {"thread-one": "Fixed the finding."}
-        old_body = adapter._implementation_reply_review_body(
-            7,
-            "a" * 40,
-            {
-                "thread-one": adapter._implementation_thread_reply_body(
-                    7, "a" * 40, "thread-one", replies["thread-one"]
-                )
-            },
-        )
-
-        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
-            if "reviews(first:100" not in query:
-                pytest.fail("stale preservation must not mutate any review")
-            return {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "id": "pr-7",
-                            "state": "OPEN",
-                            "headRefOid": "b" * 40,
-                            "autoMergeRequest": None,
-                            "reviews": {
-                                "pageInfo": {"hasNextPage": False, "endCursor": None},
-                                "nodes": [
-                                    {
-                                        "id": "old-submitted-review",
-                                        "state": "COMMENTED",
-                                        "body": old_body,
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": "a" * 40},
-                                    },
-                                    {
-                                        "id": "current-pending-draft",
-                                        "state": "PENDING",
-                                        "body": "Incomplete current draft.",
-                                        "viewerDidAuthor": True,
-                                        "commit": {"oid": "b" * 40},
-                                    },
-                                ],
-                            },
-                        }
-                    }
-                }
-            }
-
-        monkeypatch.setattr(adapter, "_graphql", graphql)
-
-        assert adapter.preserve_stale_implementation_thread_reply_batch(
-            7,
-            expected_head_sha="a" * 40,
-            current_head_sha="b" * 40,
-            replies=replies,
-        ) == ("current-pending-draft",)
-
-    def test_dry_run_never_inventories_or_mutates_stale_reply_drafts(
-        self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Dry-run stale preservation must not inventory or mutate review drafts."""
-        graphql = MagicMock()
-        monkeypatch.setattr(dry_adapter, "_graphql", graphql)
-
-        assert (
-            dry_adapter.preserve_stale_implementation_thread_reply_batch(
-                7,
-                expected_head_sha="a" * 40,
-                current_head_sha="b" * 40,
-                replies={"thread-one": "Fixed the finding."},
-            )
-            == ()
-        )
-        graphql.assert_not_called()
 
     def test_external_thread_is_replied_to_then_resolved_by_fresh_reviewer(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -1528,9 +527,6 @@ class TestAllThreadReplyAndReviewerResolution:
                             "viewer_did_author": True,
                             "review_id": "implementation-review",
                             "review_state": "COMMENTED",
-                            "review_body": adapter._implementation_reply_review_body(
-                                7, "a" * 40, {thread["id"]: reply_body}
-                            ),
                             "review_commit_sha": "a" * 40,
                         },
                     ],
@@ -1564,22 +560,6 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
         monkeypatch.setattr(adapter, "_graphql", graphql)
-        monkeypatch.setattr(
-            adapter,
-            "_implementation_reply_review_state",
-            lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_find_implementation_reply_review",
-            lambda *_args: ("pr-7", ("implementation-review", "PENDING")),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_create_implementation_reply_review",
-            lambda *_args: "implementation-review",
-        )
-        monkeypatch.setattr(adapter, "_submit_implementation_reply_review", lambda *_args: True)
 
         implementation = adapter.post_implementation_thread_replies(
             7,
@@ -1641,7 +621,7 @@ class TestAllThreadReplyAndReviewerResolution:
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
             if "addPullRequestReviewThreadReply" in query:
                 calls.append(str(fields["body"]))
-                is_implementation_reply = "reviewId" in fields
+                is_implementation_reply = len(calls) == 1
                 reply_body = str(fields["body"])
                 live[0] = {
                     **live[0],
@@ -1658,13 +638,6 @@ class TestAllThreadReplyAndReviewerResolution:
                                 else "reviewer-review"
                             ),
                             "review_state": "COMMENTED" if is_implementation_reply else "",
-                            "review_body": (
-                                adapter._implementation_reply_review_body(
-                                    7, "a" * 40, {thread["id"]: reply_body}
-                                )
-                                if is_implementation_reply
-                                else ""
-                            ),
                             "review_commit_sha": "a" * 40 if is_implementation_reply else "",
                         },
                     ],
@@ -1692,22 +665,6 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
         )
         monkeypatch.setattr(adapter, "_graphql", graphql)
-        monkeypatch.setattr(
-            adapter,
-            "_implementation_reply_review_state",
-            lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_find_implementation_reply_review",
-            lambda *_args: ("pr-7", ("implementation-review", "PENDING")),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_create_implementation_reply_review",
-            lambda *_args: "implementation-review",
-        )
-        monkeypatch.setattr(adapter, "_submit_implementation_reply_review", lambda *_args: True)
         implementation = adapter.post_implementation_thread_replies(
             7,
             expected_head_sha="a" * 40,
@@ -1737,15 +694,10 @@ class TestAllThreadReplyAndReviewerResolution:
         resolving = _external_reviewer_thread("thread-resolve")
         feedback = _external_reviewer_thread("thread-feedback")
         resolving_reply = adapter._implementation_thread_reply_body(
-            7, reviewed_head_sha, resolving["id"], "Resolved the finding."
+            7, reviewed_head_sha, resolving["id"], "Resolved the finding.", _BATCH_NONCE
         )
         feedback_reply = adapter._implementation_thread_reply_body(
-            7, reviewed_head_sha, feedback["id"], "Attempted a fix."
-        )
-        batch_body = adapter._implementation_reply_review_body(
-            7,
-            reviewed_head_sha,
-            {resolving["id"]: resolving_reply, feedback["id"]: feedback_reply},
+            7, reviewed_head_sha, feedback["id"], "Attempted a fix.", _BATCH_NONCE
         )
         live_by_id = {
             resolving["id"]: {
@@ -1759,7 +711,6 @@ class TestAllThreadReplyAndReviewerResolution:
                         "viewer_did_author": True,
                         "review_id": "implementation-review",
                         "review_state": "COMMENTED",
-                        "review_body": batch_body,
                         "review_commit_sha": reviewed_head_sha,
                     },
                 ],
@@ -1775,7 +726,6 @@ class TestAllThreadReplyAndReviewerResolution:
                         "viewer_did_author": True,
                         "review_id": "implementation-review",
                         "review_state": "COMMENTED",
-                        "review_body": batch_body,
                         "review_commit_sha": reviewed_head_sha,
                     },
                 ],
@@ -1850,17 +800,14 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.blocked_thread_ids == ()
         assert calls == [("feedback", feedback["id"]), ("resolve", resolving["id"])]
 
-    def test_pending_batch_reply_is_not_a_reviewer_validation_receipt(
+    def test_noncommented_direct_reply_is_not_a_reviewer_validation_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Only a submitted, exact-head implementation batch may be resolved."""
+        """Only a COMMENTED, exact-head direct reply may be resolved."""
         thread = _external_reviewer_thread()
         head_sha = "a" * 40
         reply_body = adapter._implementation_thread_reply_body(
-            7, head_sha, thread["id"], "Fixed the missing guard."
-        )
-        batch_body = adapter._implementation_reply_review_body(
-            7, head_sha, {thread["id"]: reply_body}
+            7, head_sha, thread["id"], "Fixed the missing guard.", _BATCH_NONCE
         )
         pending = {
             **thread,
@@ -1873,7 +820,6 @@ class TestAllThreadReplyAndReviewerResolution:
                     "viewer_did_author": True,
                     "review_id": "implementation-review",
                     "review_state": "PENDING",
-                    "review_body": batch_body,
                     "review_commit_sha": head_sha,
                 },
             ],
@@ -1903,16 +849,18 @@ class TestAllThreadReplyAndReviewerResolution:
             "implementation-comment"
         ]
 
-    def test_split_submitted_reviews_cannot_become_validation_receipts(
+    def test_direct_replies_share_nonce_even_when_github_assigns_distinct_reviews(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Two singleton reviews cannot masquerade as one implementation batch."""
+        """The source-attached nonce is the batch receipt, not a review envelope."""
         head_sha = "a" * 40
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
 
         def singleton(thread: dict[str, Any], reply: str, review_id: str) -> dict[str, Any]:
-            reply_body = adapter._implementation_thread_reply_body(7, head_sha, thread["id"], reply)
+            reply_body = adapter._implementation_thread_reply_body(
+                7, head_sha, thread["id"], reply, _BATCH_NONCE
+            )
             return {
                 **thread,
                 "comments": [
@@ -1924,9 +872,6 @@ class TestAllThreadReplyAndReviewerResolution:
                         "viewer_did_author": True,
                         "review_id": review_id,
                         "review_state": "COMMENTED",
-                        "review_body": adapter._implementation_reply_review_body(
-                            7, head_sha, {thread["id"]: reply_body}
-                        ),
                         "review_commit_sha": head_sha,
                     },
                 ],
@@ -1937,26 +882,25 @@ class TestAllThreadReplyAndReviewerResolution:
             "gh_pr_state",
             lambda _pr: {"state": "OPEN", "headRefOid": head_sha, "autoMergeRequest": None},
         )
-        assert (
-            adapter.reviewer_validation_receipts(
-                7,
-                reviewed_head_sha=head_sha,
-                threads=[
-                    singleton(first, "Fixed the first finding.", "review-one"),
-                    singleton(second, "Fixed the second finding.", "review-two"),
-                ],
-            )
-            == []
+        receipts = adapter.reviewer_validation_receipts(
+            7,
+            reviewed_head_sha=head_sha,
+            threads=[
+                singleton(first, "Fixed the first finding.", "review-one"),
+                singleton(second, "Fixed the second finding.", "review-two"),
+            ],
         )
 
-    def test_noncanonical_batch_summary_cannot_become_validation_receipt(
+        assert [receipt["id"] for receipt in receipts] == [first["id"], second["id"]]
+
+    def test_validation_receipt_ignores_unanchored_review_body(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A syntactically valid but wrong batch marker cannot authorize resolution."""
+        """Only the attached direct-reply marker contributes to validation."""
         thread = _external_reviewer_thread()
         head_sha = "a" * 40
         reply_body = adapter._implementation_thread_reply_body(
-            7, head_sha, thread["id"], "Fixed the missing guard."
+            7, head_sha, thread["id"], "Fixed the missing guard.", _BATCH_NONCE
         )
         malformed = {
             **thread,
@@ -1969,10 +913,6 @@ class TestAllThreadReplyAndReviewerResolution:
                     "viewer_did_author": True,
                     "review_id": "implementation-review",
                     "review_state": "COMMENTED",
-                    "review_body": (
-                        "Implementation responses for 1 review thread(s).\n\n"
-                        "<!-- hephaestus-implementation-review:000000000000000000000000 -->"
-                    ),
                     "review_commit_sha": head_sha,
                 },
             ],
@@ -1983,10 +923,13 @@ class TestAllThreadReplyAndReviewerResolution:
             lambda _pr: {"state": "OPEN", "headRefOid": head_sha, "autoMergeRequest": None},
         )
 
-        assert (
-            adapter.reviewer_validation_receipts(7, reviewed_head_sha=head_sha, threads=[malformed])
-            == []
+        receipts = adapter.reviewer_validation_receipts(
+            7, reviewed_head_sha=head_sha, threads=[malformed]
         )
+
+        assert [receipt["implementation_reply_id"] for receipt in receipts] == [
+            "implementation-comment"
+        ]
 
     def test_malformed_reply_response_recovers_an_exact_host_read_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -1994,7 +937,7 @@ class TestAllThreadReplyAndReviewerResolution:
         """A reply mutation applied before a malformed response remains recoverable."""
         thread = _external_reviewer_thread()
         body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the guard."
+            7, "a" * 40, thread["id"], "Fixed the guard.", _BATCH_NONCE
         )
         after = {
             **thread,
@@ -2019,22 +962,6 @@ class TestAllThreadReplyAndReviewerResolution:
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
         monkeypatch.setattr(
             adapter,
-            "_implementation_reply_review_state",
-            lambda *_args: ("pr-7", ("implementation-review", "PENDING"), False),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_find_implementation_reply_review",
-            lambda *_args: ("pr-7", ("implementation-review", "PENDING")),
-        )
-        monkeypatch.setattr(
-            adapter,
-            "_create_implementation_reply_review",
-            lambda *_args: "implementation-review",
-        )
-        monkeypatch.setattr(adapter, "_submit_implementation_reply_review", lambda *_args: True)
-        monkeypatch.setattr(
-            adapter,
             "_graphql",
             lambda query, **_fields: (
                 {"data": {"addPullRequestReviewThreadReply": None}}
@@ -2054,13 +981,13 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.blocked_thread_ids == ()
         assert result.receipts[0]["implementation_reply_id"] == "implementation-comment"
 
-    def test_legacy_recovered_reply_restarts_fresh_review_without_retry_cap(
+    def test_recovered_direct_reply_is_not_reposted_after_response_loss(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A unary legacy reply blocks for fresh review instead of retrying forever."""
+        """An exact source-attached reply is recovered without another mutation."""
         thread = _external_reviewer_thread()
         body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the guard."
+            7, "a" * 40, thread["id"], "Fixed the guard.", _BATCH_NONCE
         )
         after = {
             **thread,
@@ -2078,11 +1005,6 @@ class TestAllThreadReplyAndReviewerResolution:
         monkeypatch.setattr(
             adapter, "_review_thread_snapshot", lambda _pr, _thread: _open_thread_snapshot(after)
         )
-        monkeypatch.setattr(
-            adapter,
-            "_implementation_reply_review_state",
-            lambda *_args: ("pr-7", None, False),
-        )
         graphql = MagicMock()
         monkeypatch.setattr(adapter, "_graphql", graphql)
 
@@ -2093,9 +1015,8 @@ class TestAllThreadReplyAndReviewerResolution:
             replies={thread["id"]: "Fixed the guard."},
         )
 
-        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.replied_thread_ids == (thread["id"],)
         assert result.retryable is False
-        assert result.retryable_thread_ids == ()
         graphql.assert_not_called()
 
     def test_reconciliation_rejects_a_receipt_without_the_host_read_reply(
@@ -2129,7 +1050,7 @@ class TestAllThreadReplyAndReviewerResolution:
         """Only the host viewer's final comment can carry a resolve receipt."""
         thread = _external_reviewer_thread()
         reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
+            7, "a" * 40, thread["id"], "Fixed the missing guard.", _BATCH_NONCE
         )
         foreign_reply = {
             **thread,

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -510,9 +510,9 @@ class TestAllThreadReplyAndReviewerResolution:
                 submit_calls.append(str(fields["reviewId"]))
                 review_state = "COMMENTED"
                 review = {
-                    "id": fields["reviewId"],
+                    "id": str(fields["reviewId"]),
                     "state": "COMMENTED",
-                    "body": fields["body"],
+                    "body": str(fields["body"]),
                 }
                 return {
                     "data": {
@@ -755,6 +755,64 @@ class TestAllThreadReplyAndReviewerResolution:
         assert all(result.retryable is False for result in results)
         assert all(result.blocked_thread_ids == (thread["id"],) for result in results)
 
+    def test_submitted_batch_remains_a_receipt_beside_an_unrelated_draft(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A manual draft cannot make a complete exact batch retry forever."""
+        thread = _external_reviewer_thread()
+        reply = "Fixed the missing guard."
+        live = _open_thread_snapshot(_submitted_implementation_receipt(adapter, thread, reply))
+        review_body = str(live["comments"][-1]["review_body"])
+
+        def graphql(query: str, **_fields: str | int) -> dict[str, Any]:
+            if "reviews(first:100" not in query:
+                pytest.fail(f"submitted batch recovery must not mutate: {query}")
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "id": "pr-7",
+                            "state": "OPEN",
+                            "headRefOid": "a" * 40,
+                            "autoMergeRequest": None,
+                            "reviews": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "id": "implementation-review",
+                                        "state": "COMMENTED",
+                                        "body": review_body,
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": "a" * 40},
+                                    },
+                                    {
+                                        "id": "manual-draft",
+                                        "state": "PENDING",
+                                        "body": "Unrelated reviewer draft.",
+                                        "viewerDidAuthor": True,
+                                        "commit": {"oid": "a" * 40},
+                                    },
+                                ],
+                            },
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", lambda _pr, _id: live)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: reply},
+        )
+
+        assert result.replied_thread_ids == (thread["id"],)
+        assert result.receipts[0]["implementation_reply_id"] == "implementation-comment"
+        assert result.retryable is False
+
     def test_stale_target_aborts_a_partial_pending_reply_batch(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -764,6 +822,7 @@ class TestAllThreadReplyAndReviewerResolution:
         live_by_id = {first["id"]: first, second["id"]: second}
         review_body = ""
         review_exists = False
+        manual_draft_exists = False
         reply_calls: list[str] = []
         deleted_review_ids: list[str] = []
 
@@ -786,6 +845,16 @@ class TestAllThreadReplyAndReviewerResolution:
                     if review_exists
                     else []
                 )
+                if manual_draft_exists:
+                    nodes.append(
+                        {
+                            "id": "manual-draft",
+                            "state": "PENDING",
+                            "body": "Unrelated reviewer draft.",
+                            "viewerDidAuthor": True,
+                            "commit": {"oid": "a" * 40},
+                        }
+                    )
                 return {
                     "data": {
                         "repository": {
@@ -877,6 +946,7 @@ class TestAllThreadReplyAndReviewerResolution:
                 },
             ],
         }
+        manual_draft_exists = True
         second_attempt = adapter.post_implementation_thread_replies(
             7,
             expected_head_sha="a" * 40,

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -129,6 +129,37 @@ def _open_thread_snapshot(thread: dict[str, Any], *, resolved: bool = False) -> 
     }
 
 
+def _submitted_implementation_receipt(
+    adapter: pg.PipelineGitHub,
+    thread: dict[str, Any],
+    reply: str,
+    *,
+    head_sha: str = "a" * 40,
+) -> dict[str, Any]:
+    """Return a complete host snapshot for one submitted implementation batch."""
+    reply_body = adapter._implementation_thread_reply_body(7, head_sha, thread["id"], reply)
+    review_body = adapter._implementation_reply_review_body(7, head_sha, {thread["id"]: reply_body})
+    return {
+        **thread,
+        "comments": [
+            *thread["comments"],
+            {
+                "id": "implementation-comment",
+                "author": "hephaestus[bot]",
+                "body": reply_body,
+                "viewer_did_author": True,
+                "review_id": "implementation-review",
+                "review_state": "COMMENTED",
+                "review_body": review_body,
+                "review_commit_sha": head_sha,
+            },
+        ],
+        "implementation_reply_id": "implementation-comment",
+        "implementation_reply_body": reply_body,
+        "implementation_head_sha": head_sha,
+    }
+
+
 class TestAllThreadReplyAndReviewerResolution:
     """The implementation/reviewer split applies to every open thread author."""
 
@@ -806,9 +837,15 @@ class TestAllThreadReplyAndReviewerResolution:
             {
                 "id": "manual-draft",
                 "state": "PENDING",
-                "body": "Notes for a human review",
+                # This has a valid coordinator marker but is not the exact
+                # deterministic body of the stale batch.  It is still a
+                # manual draft and must never be deleted by cleanup.
+                "body": (
+                    "Implementation responses for 1 review thread(s).\n\n"
+                    "<!-- hephaestus-implementation-review:000000000000000000000000 -->"
+                ),
                 "viewerDidAuthor": True,
-                "commit": {"oid": "b" * 40},
+                "commit": {"oid": "a" * 40},
             },
         ]
         deleted_review_ids: list[str] = []
@@ -851,6 +888,21 @@ class TestAllThreadReplyAndReviewerResolution:
         assert deleted_review_ids == ["old-automation-draft"]
         assert [review["id"] for review in reviews] == ["manual-draft"]
 
+    def test_dry_run_never_inventories_or_deletes_stale_reply_drafts(
+        self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dry-run stale cleanup must not read or mutate review drafts."""
+        graphql = MagicMock()
+        monkeypatch.setattr(dry_adapter, "_graphql", graphql)
+
+        assert dry_adapter.discard_stale_implementation_thread_reply_batch(
+            7,
+            expected_head_sha="a" * 40,
+            current_head_sha="b" * 40,
+            replies={"thread-one": "Fixed the finding."},
+        )
+        graphql.assert_not_called()
+
     def test_external_thread_is_replied_to_then_resolved_by_fresh_reviewer(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -862,6 +914,7 @@ class TestAllThreadReplyAndReviewerResolution:
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
             if "addPullRequestReviewThreadReply" in query:
                 calls.append("implementation-reply")
+                reply_body = str(fields["body"])
                 live[0] = {
                     **live[0],
                     "comments": [
@@ -869,9 +922,14 @@ class TestAllThreadReplyAndReviewerResolution:
                         {
                             "id": "implementation-comment",
                             "author": "hephaestus[bot]",
-                            "body": fields["body"],
+                            "body": reply_body,
                             "viewer_did_author": True,
                             "review_id": "implementation-review",
+                            "review_state": "COMMENTED",
+                            "review_body": adapter._implementation_reply_review_body(
+                                7, "a" * 40, {thread["id"]: reply_body}
+                            ),
+                            "review_commit_sha": "a" * 40,
                         },
                     ],
                 }
@@ -981,6 +1039,8 @@ class TestAllThreadReplyAndReviewerResolution:
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
             if "addPullRequestReviewThreadReply" in query:
                 calls.append(str(fields["body"]))
+                is_implementation_reply = "reviewId" in fields
+                reply_body = str(fields["body"])
                 live[0] = {
                     **live[0],
                     "comments": [
@@ -988,13 +1048,22 @@ class TestAllThreadReplyAndReviewerResolution:
                         {
                             "id": f"reply-{len(calls)}",
                             "author": "hephaestus[bot]",
-                            "body": fields["body"],
+                            "body": reply_body,
                             "viewer_did_author": True,
                             "review_id": (
                                 "implementation-review"
-                                if "reviewId" in fields
+                                if is_implementation_reply
                                 else "reviewer-review"
                             ),
+                            "review_state": "COMMENTED" if is_implementation_reply else "",
+                            "review_body": (
+                                adapter._implementation_reply_review_body(
+                                    7, "a" * 40, {thread["id"]: reply_body}
+                                )
+                                if is_implementation_reply
+                                else ""
+                            ),
+                            "review_commit_sha": "a" * 40 if is_implementation_reply else "",
                         },
                     ],
                 }
@@ -1065,6 +1134,17 @@ class TestAllThreadReplyAndReviewerResolution:
         reviewed_head_sha = "a" * 40
         resolving = _external_reviewer_thread("thread-resolve")
         feedback = _external_reviewer_thread("thread-feedback")
+        resolving_reply = adapter._implementation_thread_reply_body(
+            7, reviewed_head_sha, resolving["id"], "Resolved the finding."
+        )
+        feedback_reply = adapter._implementation_thread_reply_body(
+            7, reviewed_head_sha, feedback["id"], "Attempted a fix."
+        )
+        batch_body = adapter._implementation_reply_review_body(
+            7,
+            reviewed_head_sha,
+            {resolving["id"]: resolving_reply, feedback["id"]: feedback_reply},
+        )
         live_by_id = {
             resolving["id"]: {
                 **resolving,
@@ -1073,10 +1153,12 @@ class TestAllThreadReplyAndReviewerResolution:
                     {
                         "id": "implementation-resolve",
                         "author": "hephaestus[bot]",
-                        "body": adapter._implementation_thread_reply_body(
-                            7, reviewed_head_sha, resolving["id"], "Resolved the finding."
-                        ),
+                        "body": resolving_reply,
                         "viewer_did_author": True,
+                        "review_id": "implementation-review",
+                        "review_state": "COMMENTED",
+                        "review_body": batch_body,
+                        "review_commit_sha": reviewed_head_sha,
                     },
                 ],
             },
@@ -1087,10 +1169,12 @@ class TestAllThreadReplyAndReviewerResolution:
                     {
                         "id": "implementation-feedback",
                         "author": "hephaestus[bot]",
-                        "body": adapter._implementation_thread_reply_body(
-                            7, reviewed_head_sha, feedback["id"], "Attempted a fix."
-                        ),
+                        "body": feedback_reply,
                         "viewer_did_author": True,
+                        "review_id": "implementation-review",
+                        "review_state": "COMMENTED",
+                        "review_body": batch_body,
+                        "review_commit_sha": reviewed_head_sha,
                     },
                 ],
             },
@@ -1164,6 +1248,59 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.blocked_thread_ids == ()
         assert calls == [("feedback", feedback["id"]), ("resolve", resolving["id"])]
 
+    def test_pending_batch_reply_is_not_a_reviewer_validation_receipt(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only a submitted, exact-head implementation batch may be resolved."""
+        thread = _external_reviewer_thread()
+        head_sha = "a" * 40
+        reply_body = adapter._implementation_thread_reply_body(
+            7, head_sha, thread["id"], "Fixed the missing guard."
+        )
+        batch_body = adapter._implementation_reply_review_body(
+            7, head_sha, {thread["id"]: reply_body}
+        )
+        pending = {
+            **thread,
+            "comments": [
+                *thread["comments"],
+                {
+                    "id": "implementation-comment",
+                    "author": "hephaestus[bot]",
+                    "body": reply_body,
+                    "viewer_did_author": True,
+                    "review_id": "implementation-review",
+                    "review_state": "PENDING",
+                    "review_body": batch_body,
+                    "review_commit_sha": head_sha,
+                },
+            ],
+        }
+        monkeypatch.setattr(
+            adapter,
+            "gh_pr_state",
+            lambda _pr: {"state": "OPEN", "headRefOid": head_sha, "autoMergeRequest": None},
+        )
+
+        assert (
+            adapter.reviewer_validation_receipts(7, reviewed_head_sha=head_sha, threads=[pending])
+            == []
+        )
+
+        submitted = {
+            **pending,
+            "comments": [
+                *pending["comments"][:-1],
+                {**pending["comments"][-1], "review_state": "COMMENTED"},
+            ],
+        }
+        receipts = adapter.reviewer_validation_receipts(
+            7, reviewed_head_sha=head_sha, threads=[submitted]
+        )
+        assert [receipt["implementation_reply_id"] for receipt in receipts] == [
+            "implementation-comment"
+        ]
+
     def test_malformed_reply_response_recovers_an_exact_host_read_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1229,6 +1366,50 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.replied_thread_ids == (thread["id"],)
         assert result.blocked_thread_ids == ()
         assert result.receipts[0]["implementation_reply_id"] == "implementation-comment"
+
+    def test_legacy_recovered_reply_restarts_fresh_review_without_retry_cap(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A unary legacy reply blocks for fresh review instead of retrying forever."""
+        thread = _external_reviewer_thread()
+        body = adapter._implementation_thread_reply_body(
+            7, "a" * 40, thread["id"], "Fixed the guard."
+        )
+        after = {
+            **thread,
+            "comments": [
+                *thread["comments"],
+                {
+                    "id": "legacy-comment",
+                    "author": "hephaestus[bot]",
+                    "body": body,
+                    "viewer_did_author": True,
+                    "review_id": "legacy-review",
+                },
+            ],
+        }
+        monkeypatch.setattr(
+            adapter, "_review_thread_snapshot", lambda _pr, _thread: _open_thread_snapshot(after)
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_reconcile_implementation_reply_reviews",
+            lambda *_args: ("pr-7", None, False),
+        )
+        graphql = MagicMock()
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: "Fixed the guard."},
+        )
+
+        assert result.blocked_thread_ids == (thread["id"],)
+        assert result.retryable is False
+        assert result.retryable_thread_ids == ()
+        graphql.assert_not_called()
 
     def test_reconciliation_rejects_a_receipt_without_the_host_read_reply(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -1342,21 +1523,9 @@ class TestAllThreadReplyAndReviewerResolution:
         """A stale-head resolution blocks for fresh review without reopening it."""
         thread = _external_reviewer_thread()
         reply = "Fixed the missing guard."
-        reply_body = adapter._implementation_thread_reply_body(7, "a" * 40, thread["id"], reply)
-        live = [
-            {
-                **thread,
-                "comments": [
-                    *thread["comments"],
-                    {
-                        "id": "implementation-comment",
-                        "author": "hephaestus[bot]",
-                        "body": reply_body,
-                        "viewer_did_author": True,
-                    },
-                ],
-            }
-        ]
+        receipt = _submitted_implementation_receipt(adapter, thread, reply)
+        reply_body = str(receipt["implementation_reply_body"])
+        live = [receipt]
         receipts = adapter.reviewer_validation_receipts
         monkeypatch.setattr(
             adapter,
@@ -1451,24 +1620,7 @@ class TestAllThreadReplyAndReviewerResolution:
     ) -> None:
         """A reply racing resolution is never hidden by the resolved-thread list."""
         thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        receipt = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": reply_body,
-                    "viewer_did_author": True,
-                },
-            ],
-            "implementation_reply_id": "implementation-comment",
-            "implementation_reply_body": reply_body,
-            "implementation_head_sha": "a" * 40,
-        }
+        receipt = _submitted_implementation_receipt(adapter, thread, "Fixed the missing guard.")
         live = [dict(receipt)]
         calls: list[str] = []
         monkeypatch.setattr(
@@ -1535,24 +1687,7 @@ class TestAllThreadReplyAndReviewerResolution:
     ) -> None:
         """An unknown resolve outcome is blocked without an unsafe compensation write."""
         thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        receipt = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": reply_body,
-                    "viewer_did_author": True,
-                },
-            ],
-            "implementation_reply_id": "implementation-comment",
-            "implementation_reply_body": reply_body,
-            "implementation_head_sha": "a" * 40,
-        }
+        receipt = _submitted_implementation_receipt(adapter, thread, "Fixed the missing guard.")
         monkeypatch.setattr(
             adapter,
             "gh_pr_state",
@@ -1597,24 +1732,7 @@ class TestAllThreadReplyAndReviewerResolution:
     ) -> None:
         """A malformed response blocks without reopening a possibly foreign resolution."""
         thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        receipt = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": reply_body,
-                    "viewer_did_author": True,
-                },
-            ],
-            "implementation_reply_id": "implementation-comment",
-            "implementation_reply_body": reply_body,
-            "implementation_head_sha": "a" * 40,
-        }
+        receipt = _submitted_implementation_receipt(adapter, thread, "Fixed the missing guard.")
         calls: list[str] = []
         monkeypatch.setattr(
             adapter,
@@ -1666,24 +1784,7 @@ class TestAllThreadReplyAndReviewerResolution:
     ) -> None:
         """An uncertain resolve stops for re-review instead of reopening a thread."""
         thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        receipt = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": reply_body,
-                    "viewer_did_author": True,
-                },
-            ],
-            "implementation_reply_id": "implementation-comment",
-            "implementation_reply_body": reply_body,
-            "implementation_head_sha": "a" * 40,
-        }
+        receipt = _submitted_implementation_receipt(adapter, thread, "Fixed the missing guard.")
         calls: list[str] = []
         monkeypatch.setattr(
             adapter,
@@ -1728,24 +1829,7 @@ class TestAllThreadReplyAndReviewerResolution:
     ) -> None:
         """An uncertain resolve is blocked without issuing a compensating mutation."""
         thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        receipt = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": reply_body,
-                    "viewer_did_author": True,
-                },
-            ],
-            "implementation_reply_id": "implementation-comment",
-            "implementation_reply_body": reply_body,
-            "implementation_head_sha": "a" * 40,
-        }
+        receipt = _submitted_implementation_receipt(adapter, thread, "Fixed the missing guard.")
         calls: list[str] = []
         monkeypatch.setattr(
             adapter,
@@ -1790,24 +1874,7 @@ class TestAllThreadReplyAndReviewerResolution:
     ) -> None:
         """The post-resolve proof must not make a second, racy PR-state read."""
         thread = _external_reviewer_thread()
-        reply_body = adapter._implementation_thread_reply_body(
-            7, "a" * 40, thread["id"], "Fixed the missing guard."
-        )
-        receipt = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": reply_body,
-                    "viewer_did_author": True,
-                },
-            ],
-            "implementation_reply_id": "implementation-comment",
-            "implementation_reply_body": reply_body,
-            "implementation_head_sha": "a" * 40,
-        }
+        receipt = _submitted_implementation_receipt(adapter, thread, "Fixed the missing guard.")
         state_reads = 0
 
         def pr_state(_pr: int) -> dict[str, Any]:
@@ -3296,6 +3363,7 @@ class TestRepoScoping:
                 "author": {"login": "reviewer", "__typename": "User"},
                 "pullRequestReview": {
                     "id": "R1",
+                    "state": "COMMENTED",
                     "body": "review body",
                     "commit": {"oid": "a" * 40},
                 },


### PR DESCRIPTION
## Summary

- Submit all implementation responses from one address pass as one GitHub review, preserving their thread/reply association.
- Persist a CSPRNG batch nonce in the review work item and bind each pending review to that nonce.
- Re-inventory immediately after draft creation; a competing current-head implementation review blocks all reply and submission mutations.
- Preserve every visible incomplete, stale, or competing review for manual cleanup; the automation no longer calls GitHub review deletion.
- Keep an old submitted batch inert during stale preservation so it cannot hide a current pending review.
- Report every preserved review ID in one idempotent diagnostic, set implementation no-go through the existing guarded label transition, and leave every thread unresolved for a fresh pass.

## Validation

- Locked all-extras unit and integration suite passed in the pre-push gate: 6,892 tests collected
- PipelineGitHub adapter and PR-review stage suites: 358 passed
- Ruff lint and format checks passed for all changed files
- Repository-wide mypy and all pre-commit hooks passed

Closes #2523
