### PR TITLE
ci(test): run high-cost tests nightly

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,7 @@
 | auto-label-severity.yml | Reconciles `severity:*` labels from issue form content. | issues opened/edited |
 | auto-tag.yml | Manually computes and pushes the next signed release tag. | workflow_dispatch |
 | merge-queue-smoke.yml | Single fast `merge-queue-smoke` job for merge-queue entries (lockfile, workflow-schema, and symlink validation). | merge_group |
+| nightly-tests.yml | Runs the high-cost functional tests excluded from pull-request checks. | schedule, workflow_dispatch |
 | performance.yml | Runs bounded worker-pool capacity, latency, and sustained-concurrency tests and retains the JSON report. | schedule, workflow_dispatch |
 | release.yml | Builds, tests, publishes, and creates releases for tags. | push tags `v*`, workflow_dispatch |
 | security.yml | Runs scheduled/manual security scans and PR-time security checks for dependency-sensitive changes. | pull_request paths, schedule, workflow_dispatch |

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -538,7 +538,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers \
+          uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers -m "not nightly" \
             --cov=hephaestus --cov-report=term-missing --cov-report=xml
 
       - name: Check unit test structure
@@ -578,7 +578,7 @@ jobs:
         # the CLI entry-point checks must never skip here (#2173).
         env:
           HEPHAESTUS_REQUIRE_CLI: "1"
-        run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers
+        run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"
 
   installed-cli-tests:
     # Installed-artifact lane (#2173): build the wheel, install it into a

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,33 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - name: Install locked project environment
+        run: uv sync --all-groups --all-extras --locked
+      - name: Run nightly tests
+        run: >
+          uv run pytest tests/unit tests/integration
+          --override-ini="addopts=" -v --strict-markers -m "nightly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
         # entry-point checks must never skip here (#2173).
         env:
           HEPHAESTUS_REQUIRE_CLI: "1"
-        run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers
+        run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"
 
   type-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run unit tests
         if: matrix.test-type == 'unit'
-        run: uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers
+        run: uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers -m "not nightly"
 
       - name: Check unit test structure
         if: matrix.test-type == 'unit'
@@ -110,4 +110,4 @@ jobs:
         env:
           HEPHAESTUS_REQUIRE_CLI: "1"
         run: |
-          uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers
+          uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,7 @@ addopts = [
     "-v",
     "--strict-markers",
     "-m",
-    "not performance",
+    "not performance and not nightly",
     "--cov=hephaestus",
     "--cov-report=term-missing",
 ]
@@ -236,6 +236,7 @@ markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "unit: marks tests as unit tests",
     "performance: bounded capacity, latency, and sustained-concurrency tests",
+    "nightly: high-cost functional tests run by the scheduled nightly workflow",
     "requires_posix: requires POSIX coreutils (echo, false, ls) and/or git on PATH; skipped on win32",
 ]
 

--- a/tests/integration/test_generic_secret_hook.py
+++ b/tests/integration/test_generic_secret_hook.py
@@ -55,6 +55,7 @@ def test_gitleaks_hook_is_mandatory_and_matches_ci_version() -> None:
 
 
 @pytest.mark.requires_posix
+@pytest.mark.nightly
 def test_gitleaks_blocks_staged_secret_without_private_denylist(tmp_path: Path) -> None:
     """Gitleaks must reject staged credentials without an operator denylist."""
     repo = tmp_path / "repo"

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1349,6 +1349,7 @@ class TestImplementationAdmission:
 
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [retrying, deferred]
 
+    @pytest.mark.nightly
     def test_duplicate_issue_numbers_collapse_to_first_queued(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1395,6 +1396,7 @@ class TestImplementationAdmission:
         # Repo-scoped reason string (#2057).
         assert duplicate.result.reason == "repo-a#21 superseded by queued duplicate"
 
+    @pytest.mark.nightly
     def test_cross_repo_same_issue_number_both_dispatch(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1429,6 +1431,7 @@ class TestImplementationAdmission:
         assert b71.result is None or "superseded" not in (b71.result.reason or "")
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
 
+    @pytest.mark.nightly
     def test_three_duplicates_collapse_to_first(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -207,6 +207,7 @@ class TestInterruptSemantics:
         assert item.result.reason == "resumable at pr_review"
         assert coordinator.ledger == []
 
+    @pytest.mark.nightly
     def test_second_signal_immediate_teardown_synthesizes_interrupted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -39,6 +39,7 @@ RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
 TEST_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
 PERFORMANCE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "performance.yml"
+NIGHTLY_TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly-tests.yml"
 PERFORMANCE_DOC = REPO_ROOT / "docs" / "performance-testing.md"
 SETUP_PI_ACTION = REPO_ROOT / ".github" / "actions" / "setup-pi-cli" / "action.yml"
 
@@ -279,7 +280,44 @@ class TestPerformanceWorkflow:
         config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         addopts = config["tool"]["pytest"]["ini_options"]["addopts"]
         assert "-m" in addopts
-        assert "not performance" in addopts
+        assert any("not performance" in option for option in addopts)
+
+
+class TestNightlyTestsWorkflow:
+    """Contracts for the scheduled high-cost functional-test lane."""
+
+    def _load(self) -> dict[str, Any]:
+        workflow: dict[str, Any] = yaml.load(
+            NIGHTLY_TESTS_WORKFLOW.read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        return workflow
+
+    def test_lane_is_scheduled_manual_and_selects_only_nightly_tests(self) -> None:
+        """High-cost tests must be isolated from pull-request workflows."""
+        workflow = self._load()
+        assert set(workflow["on"]) == {"schedule", "workflow_dispatch"}
+
+        run_steps = [
+            str(step["run"])
+            for step in workflow["jobs"]["nightly-tests"]["steps"]
+            if step.get("name") == "Run nightly tests"
+        ]
+        assert len(run_steps) == 1
+        assert "uv run pytest tests/unit tests/integration" in run_steps[0]
+        assert '-m "nightly"' in run_steps[0]
+        assert '--override-ini="addopts="' in run_steps[0]
+
+    def test_default_pytest_options_deselect_nightly_tests(self) -> None:
+        """Developer and required-CI defaults must exclude the nightly marker."""
+        config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        addopts = config["tool"]["pytest"]["ini_options"]["addopts"]
+        assert any("not nightly" in option for option in addopts)
+
+    def test_pull_request_test_commands_deselect_nightly_tests(self) -> None:
+        """Commands that override pytest defaults retain the nightly exclusion."""
+        for workflow_path in (REQUIRED_WORKFLOW, TEST_WORKFLOW):
+            assert '-m "not nightly"' in workflow_path.read_text(encoding="utf-8")
 
 
 class TestIsCheckoutStep:


### PR DESCRIPTION
## Summary
- isolate the five measured high-cost functional tests behind the nightly marker
- exclude them from pull-request and release test commands
- add a scheduled/manual nightly workflow with regression coverage

## Validation
- pre-push suite: 6936 passed, 6 skipped, 5 deselected; coverage 85.44 percent
- nightly lane: 5 passed

Closes #2536