### PR TITLE
feat(github): harden portable PR review helpers

### DIFF
--- a/hephaestus/github/skill_pr_review.py
+++ b/hephaestus/github/skill_pr_review.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
@@ -20,7 +21,9 @@ from hephaestus.cli.utils import (
 from hephaestus.github.client import gh_call
 from hephaestus.github.git_ops import run_git
 
-_PR_URL = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/[1-9][0-9]*/?")
+_PR_URL = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/[1-9][0-9]*")
+_COMMIT_OID = re.compile(r"[0-9a-f]{40}\Z")
+_GITHUB_REPOSITORY = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+\Z")
 _RESOLVE_FIELDS = "number,url,state,headRefName,baseRefName,headRefOid,baseRefOid"
 _EVIDENCE_FIELDS = (
     "number,title,body,state,isDraft,author,baseRefName,headRefName,"
@@ -28,11 +31,46 @@ _EVIDENCE_FIELDS = (
 )
 
 
+@dataclass(frozen=True)
+class RepositoryTarget:
+    """An explicit GitHub target that never relies on checkout inference."""
+
+    host: str
+    repository: str
+
+    def repository_argument(self) -> str:
+        """Return the fully qualified repository argument accepted by ``gh``."""
+        return f"{self.host}/{self.repository}"
+
+
 def validate_pr_identifier(value: str) -> None:
     """Require a positive PR number or canonical GitHub pull-request URL."""
     if (value.isascii() and value.isdigit() and int(value) > 0) or _PR_URL.fullmatch(value):
         return
     raise RuntimeError(f"invalid pull-request identifier: {value!r}")
+
+
+def _pull_request_number(value: str) -> int:
+    validate_pr_identifier(value)
+    if value.isdigit():
+        return int(value)
+    return int(urlparse(value).path.rsplit("/", maxsplit=1)[-1])
+
+
+def _require_commit_oid(value: object, label: str) -> str:
+    if not isinstance(value, str) or _COMMIT_OID.fullmatch(value) is None:
+        raise RuntimeError(f"{label} must be a lowercase 40-hex Git commit OID")
+    return value
+
+
+def _require_repository(value: object, label: str) -> str:
+    if not isinstance(value, str) or _GITHUB_REPOSITORY.fullmatch(value) is None:
+        raise RuntimeError(f"{label} must be a canonical GitHub owner/repository")
+    return value
+
+
+def _canonical_pull_request_url(repository: str, number: int) -> str:
+    return f"https://github.com/{_require_repository(repository, 'repository')}/pull/{number}"
 
 
 def repository_from_pr_url(url: str, number: int) -> str:
@@ -46,7 +84,10 @@ def repository_from_pr_url(url: str, number: int) -> str:
         or path_parts[3] != str(number)
     ):
         raise RuntimeError(f"GitHub returned invalid pull-request URL: {url}")
-    return "/".join(path_parts[:2])
+    repository = "/".join(path_parts[:2])
+    if url != _canonical_pull_request_url(repository, number):
+        raise RuntimeError(f"GitHub returned invalid pull-request URL: {url}")
+    return repository
 
 
 def _command_error(result: subprocess.CompletedProcess[str], command: str) -> RuntimeError:
@@ -69,6 +110,20 @@ def _git_output(*arguments: str) -> str:
     return result.stdout
 
 
+def _require_complete_git_history() -> None:
+    """Reject shallow repositories, which cannot provide a complete diff lens."""
+    if _git_output("rev-parse", "--is-shallow-repository").strip() != "false":
+        raise RuntimeError("repository history is shallow; immutable diff evidence is incomplete")
+
+
+def _unambiguous_merge_base(base_oid: str, head_oid: str) -> str:
+    """Return the only merge base shared by the two immutable revisions."""
+    merge_bases = _git_output("merge-base", "--all", base_oid, head_oid).splitlines()
+    if len(merge_bases) != 1:
+        raise RuntimeError("immutable diff lenses require exactly one merge base")
+    return _require_commit_oid(merge_bases[0], "merge base")
+
+
 def _load_object(output: str) -> dict[str, Any]:
     """Decode one GitHub JSON object or reject malformed results."""
     value: Any = json.loads(output)
@@ -77,37 +132,101 @@ def _load_object(output: str) -> dict[str, Any]:
     return value
 
 
-def _resolve_open_pr(identifier: str) -> dict[str, Any]:
+def _target_from_arguments(
+    parser: Any,
+    identifier: str | None,
+    host: str | None,
+    repository: str | None,
+) -> RepositoryTarget:
+    """Bind an explicit target, or derive it only from a direct canonical URL."""
+    if (host is None) != (repository is None):
+        parser.error("--target-host and --target-repository must be supplied together")
+    if host is not None and repository is not None:
+        if host != "github.com":
+            parser.error("--target-host must be github.com")
+        try:
+            target = RepositoryTarget(
+                host=host,
+                repository=_require_repository(repository, "--target-repository"),
+            )
+        except RuntimeError as error:
+            parser.error(str(error))
+        if identifier is not None and identifier.startswith("https://"):
+            try:
+                supplied = repository_from_pr_url(identifier, _pull_request_number(identifier))
+            except RuntimeError as error:
+                parser.error(str(error))
+            if supplied.casefold() != target.repository.casefold():
+                parser.error("pull-request URL does not match --target-repository")
+        return target
+    if identifier is not None and identifier.startswith("https://"):
+        try:
+            return RepositoryTarget(
+                host="github.com",
+                repository=repository_from_pr_url(identifier, _pull_request_number(identifier)),
+            )
+        except RuntimeError as error:
+            parser.error(str(error))
+    parser.error(
+        "numeric pull requests and branch discovery require --target-host and --target-repository"
+    )
+    raise AssertionError("argument parser returned after a target error")
+
+
+def _resolve_open_pr(identifier: str, target: RepositoryTarget) -> dict[str, Any]:
     """Return metadata for one explicitly identified open PR."""
-    validate_pr_identifier(identifier)
-    pull_request = _load_object(_gh_output("pr", "view", identifier, "--json", _RESOLVE_FIELDS))
+    number = _pull_request_number(identifier)
+    if identifier.startswith("https://"):
+        supplied = repository_from_pr_url(identifier, number)
+        if supplied.casefold() != target.repository.casefold():
+            raise RuntimeError("pull-request URL does not match the retained target")
+    pull_request = _load_object(
+        _gh_output(
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            target.repository_argument(),
+            "--json",
+            _RESOLVE_FIELDS,
+        )
+    )
     metadata_problem = resolve_metadata_error(pull_request)
     if metadata_problem:
         raise RuntimeError(metadata_problem)
     if pull_request.get("state") != "OPEN":
         raise RuntimeError(f"pull request {identifier} is not open")
+    if pull_request.get("number") != number:
+        raise RuntimeError("GitHub returned a pull request different from the request")
+    for field in ("baseRefOid", "headRefOid"):
+        _require_commit_oid(pull_request.get(field), f"GitHub immutable PR revision {field}")
     return pull_request
 
 
-def _validate_repository_identity(pull_request: dict[str, Any]) -> None:
-    """Reject a PR URL that belongs to a different repository than the checkout."""
+def _validate_repository_identity(pull_request: dict[str, Any], target: RepositoryTarget) -> None:
+    """Reject a PR URL that differs from the retained explicit forge target."""
     number = pull_request.get("number")
     url = pull_request.get("url")
     if not isinstance(number, int) or not isinstance(url, str):
         raise RuntimeError("GitHub returned incomplete pull-request identity")
-    repository = _load_object(_gh_output("repo", "view", "--json", "nameWithOwner"))
-    current = repository.get("nameWithOwner")
-    if not isinstance(current, str) or not current:
-        raise RuntimeError("GitHub returned incomplete repository identity")
     pull_repository = repository_from_pr_url(url, number)
-    if pull_repository.casefold() != current.casefold():
-        raise RuntimeError(f"pull request {url} does not belong to current repository {current}")
+    if pull_repository.casefold() != target.repository.casefold():
+        raise RuntimeError(
+            f"pull request {url} does not belong to target repository {target.repository}"
+        )
+    pull_request["review_target"] = {
+        "host": target.host,
+        "kind": "github",
+        "number": number,
+        "repository": target.repository,
+        "url": url,
+    }
 
 
-def resolve_pull_request(explicit: str | None) -> dict[str, Any]:
+def resolve_pull_request(explicit: str | None, target: RepositoryTarget) -> dict[str, Any]:
     """Resolve an explicit PR or the sole open PR associated with this branch."""
     if explicit:
-        return _resolve_open_pr(explicit)
+        return _resolve_open_pr(explicit, target)
 
     branch = _git_output("branch", "--show-current").strip()
     if not branch:
@@ -116,6 +235,8 @@ def resolve_pull_request(explicit: str | None) -> dict[str, Any]:
         _gh_output(
             "pr",
             "list",
+            "--repo",
+            target.repository_argument(),
             "--state",
             "open",
             "--head",
@@ -133,7 +254,7 @@ def resolve_pull_request(explicit: str | None) -> dict[str, Any]:
         number = candidates[0].get("number")
         if not isinstance(number, int) or number < 1:
             raise RuntimeError("GitHub returned an invalid pull-request candidate")
-        return _resolve_open_pr(str(number))
+        return _resolve_open_pr(str(number), target)
     if not candidates:
         raise LookupError(f"no open pull request found for branch {branch!r}")
     rendered = "\n".join(
@@ -154,14 +275,19 @@ def _print_error(exit_code: int, error: Exception, json_output: bool) -> int:
 def resolve_pr_main(argv: Sequence[str] | None = None) -> int:
     """Resolve an explicit PR or the sole open PR for the current branch."""
     parser = create_parser("hephaestus-resolve-pr", description=__doc__)
+    parser.add_argument("--target-host", metavar="HOST")
+    parser.add_argument("--target-repository", metavar="OWNER/REPOSITORY")
     parser.add_argument("pull_request", nargs="?", metavar="PR_NUMBER_OR_URL")
     add_github_throttle_args(parser)
     add_json_arg(parser)
     arguments = parser.parse_args(argv)
     configure_github_throttle_from_args(arguments)
+    target = _target_from_arguments(
+        parser, arguments.pull_request, arguments.target_host, arguments.target_repository
+    )
     try:
-        pull_request = resolve_pull_request(arguments.pull_request)
-        _validate_repository_identity(pull_request)
+        pull_request = resolve_pull_request(arguments.pull_request, target)
+        _validate_repository_identity(pull_request, target)
     except json.JSONDecodeError as error:
         return _print_error(1, error, arguments.json)
     except LookupError as error:
@@ -347,12 +473,12 @@ def pr_diff_context_main(argv: Sequence[str] | None = None) -> int:
     arguments = parser.parse_args(argv)
     base_ref, head_ref = arguments.base_ref, arguments.head_ref
     try:
-        for label, value in (("base ref", base_ref), ("head ref", head_ref)):
-            if value.startswith("-"):
-                raise RuntimeError(f"{label} must not begin with '-': {value!r}")
+        base_ref = _require_commit_oid(base_ref, "base OID")
+        head_ref = _require_commit_oid(head_ref, "head OID")
+        _require_complete_git_history()
         _git_output("rev-parse", "--verify", f"{base_ref}^{{commit}}")
         _git_output("rev-parse", "--verify", f"{head_ref}^{{commit}}")
-        merge_base = _git_output("merge-base", base_ref, head_ref).strip()
+        merge_base = _unambiguous_merge_base(base_ref, head_ref)
         behind_count = int(_git_output("rev-list", "--count", f"{head_ref}..{base_ref}").strip())
     except (FileNotFoundError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
         return _print_error(1, error, arguments.json)

--- a/hephaestus/github/skill_pr_review.py
+++ b/hephaestus/github/skill_pr_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -29,6 +30,7 @@ _EVIDENCE_FIELDS = (
     "number,title,body,state,isDraft,author,baseRefName,headRefName,"
     "reviews,statusCheckRollup,closingIssuesReferences,url"
 )
+_GIT_READ_ARGUMENTS = ("-c", "core.commitGraph=false", "--no-replace-objects")
 
 
 @dataclass(frozen=True)
@@ -103,11 +105,35 @@ def _gh_output(*arguments: str, accepted_codes: tuple[int, ...] = (0,)) -> str:
 
 
 def _git_output(*arguments: str) -> str:
-    """Run Git through the shared adapter and return stdout."""
-    result = run_git(list(arguments), check=False, log_on_error=False)
+    """Run an immutable Git read through the shared adapter and return stdout."""
+    result = run_git(
+        [*_GIT_READ_ARGUMENTS, *arguments],
+        check=False,
+        env=_git_read_environment(),
+        log_on_error=False,
+    )
     if result.returncode != 0:
         raise _command_error(result, f"git {' '.join(arguments)}")
     return result.stdout
+
+
+def _git_read_environment() -> dict[str, str]:
+    """Return a hermetic environment for non-interactive immutable Git reads."""
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update(
+        {
+            "GIT_ATTR_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_GRAFT_FILE": os.devnull,
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    return environment
 
 
 def _require_complete_git_history() -> None:

--- a/tests/unit/github/test_skill_pr_review.py
+++ b/tests/unit/github/test_skill_pr_review.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import hephaestus.github.skill_pr_review as skill_pr_review
 from hephaestus.github.skill_pr_review import (
+    _git_read_environment,
     collect_pr_evidence_main,
     pr_diff_context_main,
     repository_from_pr_url,
@@ -64,7 +64,7 @@ def test_git_read_environment_rejects_inherited_git_overrides(monkeypatch) -> No
     for key, value in hostile_environment.items():
         monkeypatch.setenv(key, value)
 
-    environment = skill_pr_review._git_read_environment()
+    environment = _git_read_environment()
 
     for key, value in hostile_environment.items():
         assert environment.get(key) != value

--- a/tests/unit/github/test_skill_pr_review.py
+++ b/tests/unit/github/test_skill_pr_review.py
@@ -6,6 +6,8 @@ import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hephaestus.github.skill_pr_review import (
     collect_pr_evidence_main,
     pr_diff_context_main,
@@ -50,24 +52,36 @@ def test_repository_from_pr_url_rejects_an_unexpected_number() -> None:
 def test_resolve_pr_emits_open_pr_metadata_after_repository_identity_check(
     mock_gh_call: MagicMock, _mock_throttle: MagicMock, capsys
 ) -> None:
-    """Explicit resolution validates both the state and the current repository."""
+    """Explicit resolution validates the supplied target and immutable revisions."""
     pull_request = {
         "number": 42,
         "url": "https://github.com/owner/repository/pull/42",
         "state": "OPEN",
         "headRefName": "feature",
         "baseRefName": "main",
-        "headRefOid": "head",
-        "baseRefOid": "base",
+        "headRefOid": "a" * 40,
+        "baseRefOid": "b" * 40,
     }
     mock_gh_call.side_effect = [
         _completed(stdout=json.dumps(pull_request)),
-        _completed(stdout=json.dumps({"nameWithOwner": "owner/repository"})),
     ]
 
-    assert resolve_pr_main(["42"]) == 0
+    assert (
+        resolve_pr_main(
+            ["--target-host", "github.com", "--target-repository", "owner/repository", "42"]
+        )
+        == 0
+    )
 
-    assert json.loads(capsys.readouterr().out) == pull_request
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["review_target"] == {
+        "host": "github.com",
+        "kind": "github",
+        "number": 42,
+        "repository": "owner/repository",
+        "url": "https://github.com/owner/repository/pull/42",
+    }
+    assert {key: value for key, value in payload.items() if key != "review_target"} == pull_request
     assert mock_gh_call.call_args_list[0].args[0][:3] == ["pr", "view", "42"]
 
 
@@ -86,17 +100,68 @@ def test_resolve_pr_reports_foreign_pr_as_an_operational_error(
                     "state": "OPEN",
                     "headRefName": "feature",
                     "baseRefName": "main",
-                    "headRefOid": "head",
-                    "baseRefOid": "base",
+                    "headRefOid": "a" * 40,
+                    "baseRefOid": "b" * 40,
                 }
             )
         ),
-        _completed(stdout=json.dumps({"nameWithOwner": "owner/repository"})),
     ]
 
-    assert resolve_pr_main(["42"]) == 1
+    assert (
+        resolve_pr_main(
+            ["--target-host", "github.com", "--target-repository", "owner/repository", "42"]
+        )
+        == 1
+    )
 
-    assert "does not belong to current repository" in capsys.readouterr().err
+    assert "does not belong to target repository" in capsys.readouterr().err
+
+
+@patch("hephaestus.github.skill_pr_review.configure_github_throttle_from_args")
+def test_resolve_pr_rejects_numeric_identifier_without_explicit_target(
+    _mock_throttle: MagicMock, capsys
+) -> None:
+    """A numeric PR never inherits repository identity from the checkout."""
+    with pytest.raises(SystemExit, match="2"):
+        resolve_pr_main(["42"])
+
+    assert "require --target-host and --target-repository" in capsys.readouterr().err
+
+
+@patch("hephaestus.github.skill_pr_review.configure_github_throttle_from_args")
+@patch("hephaestus.github.skill_pr_review.gh_call")
+def test_resolve_pr_rejects_non_immutable_provider_revisions(
+    mock_gh_call: MagicMock, _mock_throttle: MagicMock, capsys
+) -> None:
+    """The retained review target includes immutable commit OIDs only."""
+    mock_gh_call.return_value = _completed(
+        stdout=json.dumps(
+            {
+                "number": 42,
+                "url": "https://github.com/owner/repository/pull/42",
+                "state": "OPEN",
+                "headRefName": "feature",
+                "baseRefName": "main",
+                "headRefOid": "main",
+                "baseRefOid": "base",
+            }
+        )
+    )
+
+    assert (
+        resolve_pr_main(
+            [
+                "--target-host",
+                "github.com",
+                "--target-repository",
+                "owner/repository",
+                "42",
+            ]
+        )
+        == 1
+    )
+
+    assert "lowercase 40-hex Git commit OID" in capsys.readouterr().err
 
 
 @patch("hephaestus.github.skill_pr_review.configure_github_throttle_from_args")
@@ -229,24 +294,28 @@ def test_diff_context_uses_the_supplied_base_for_both_lenses(
     mock_run_git: MagicMock, capsys
 ) -> None:
     """The current-base and author-intent ranges share the verified inputs."""
+    base = "a" * 40
+    head = "b" * 40
+    merge_base = "c" * 40
     mock_run_git.side_effect = [
+        _completed(stdout="false\n"),
         _completed(),
         _completed(),
-        _completed(stdout="merge-base\n"),
+        _completed(stdout=f"{merge_base}\n"),
         _completed(stdout="3\n"),
     ]
 
-    assert pr_diff_context_main(["base", "head"]) == 0
+    assert pr_diff_context_main([base, head]) == 0
 
     assert json.loads(capsys.readouterr().out) == {
-        "base_ref": "base",
-        "head_ref": "head",
-        "merge_base": "merge-base",
+        "base_ref": base,
+        "head_ref": head,
+        "merge_base": merge_base,
         "behind_count": 3,
-        "author_intent_range": "merge-base...head",
-        "current_base_range": "base..head",
+        "author_intent_range": f"{merge_base}...{head}",
+        "current_base_range": f"{base}..{head}",
     }
-    assert mock_run_git.call_args_list[0].args[0] == ["rev-parse", "--verify", "base^{commit}"]
+    assert mock_run_git.call_args_list[0].args[0] == ["rev-parse", "--is-shallow-repository"]
 
 
 @patch("hephaestus.github.skill_pr_review.run_git")
@@ -254,7 +323,7 @@ def test_diff_context_reports_invalid_refs_as_json(mock_run_git: MagicMock, caps
     """Diff context keeps invalid Git references machine-readable."""
     mock_run_git.return_value = _completed(stderr="unknown revision", returncode=128)
 
-    assert pr_diff_context_main(["missing", "head", "--json"]) == 1
+    assert pr_diff_context_main(["a" * 40, "b" * 40, "--json"]) == 1
 
     assert json.loads(capsys.readouterr().out) == {
         "exit_code": 1,
@@ -266,7 +335,19 @@ def test_diff_context_reports_invalid_refs_as_json(mock_run_git: MagicMock, caps
 @patch("hephaestus.github.skill_pr_review.configure_github_throttle_from_args")
 def test_resolve_pr_json_error_is_machine_readable(_mock_throttle: MagicMock, capsys) -> None:
     """The standard --json error contract is available for orchestrators."""
-    assert resolve_pr_main(["invalid", "--json"]) == 1
+    assert (
+        resolve_pr_main(
+            [
+                "--target-host",
+                "github.com",
+                "--target-repository",
+                "owner/repository",
+                "invalid",
+                "--json",
+            ]
+        )
+        == 1
+    )
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "error"
@@ -288,10 +369,21 @@ def test_resolve_pr_rejects_missing_immutable_refs_as_json(
     }
     mock_gh_call.side_effect = [
         _completed(stdout=json.dumps(pull_request)),
-        _completed(stdout=json.dumps({"nameWithOwner": "owner/repository"})),
     ]
 
-    assert resolve_pr_main(["42", "--json"]) == 1
+    assert (
+        resolve_pr_main(
+            [
+                "--target-host",
+                "github.com",
+                "--target-repository",
+                "owner/repository",
+                "42",
+                "--json",
+            ]
+        )
+        == 1
+    )
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "error"

--- a/tests/unit/github/test_skill_pr_review.py
+++ b/tests/unit/github/test_skill_pr_review.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import hephaestus.github.skill_pr_review as skill_pr_review
 from hephaestus.github.skill_pr_review import (
     collect_pr_evidence_main,
     pr_diff_context_main,
@@ -45,6 +47,30 @@ def test_repository_from_pr_url_rejects_an_unexpected_number() -> None:
         assert "invalid pull-request URL" in str(error)
     else:  # pragma: no cover - defensive assertion for an invalid URL accepted
         raise AssertionError("mismatched PR URL was accepted")
+
+
+def test_git_read_environment_rejects_inherited_git_overrides(monkeypatch) -> None:
+    """Immutable review reads cannot inherit a caller-controlled Git graph."""
+    hostile_environment = {
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES": "/attacker/objects",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.commitGraph",
+        "GIT_CONFIG_VALUE_0": "true",
+        "GIT_DIR": "/attacker/.git",
+        "GIT_GRAFT_FILE": "/attacker/grafts",
+        "GIT_REPLACE_REF_BASE": "/attacker/replace",
+        "GIT_WORK_TREE": "/attacker/worktree",
+    }
+    for key, value in hostile_environment.items():
+        monkeypatch.setenv(key, value)
+
+    environment = skill_pr_review._git_read_environment()
+
+    for key, value in hostile_environment.items():
+        assert environment.get(key) != value
+    assert environment["GIT_GRAFT_FILE"] == os.devnull
+    assert environment["GIT_NO_LAZY_FETCH"] == "1"
+    assert environment["GIT_NO_REPLACE_OBJECTS"] == "1"
 
 
 @patch("hephaestus.github.skill_pr_review.configure_github_throttle_from_args")
@@ -315,7 +341,15 @@ def test_diff_context_uses_the_supplied_base_for_both_lenses(
         "author_intent_range": f"{merge_base}...{head}",
         "current_base_range": f"{base}..{head}",
     }
-    assert mock_run_git.call_args_list[0].args[0] == ["rev-parse", "--is-shallow-repository"]
+    first_call = mock_run_git.call_args_list[0]
+    assert first_call.args[0] == [
+        "-c",
+        "core.commitGraph=false",
+        "--no-replace-objects",
+        "rev-parse",
+        "--is-shallow-repository",
+    ]
+    assert first_call.kwargs["env"]["GIT_NO_REPLACE_OBJECTS"] == "1"
 
 
 @patch("hephaestus.github.skill_pr_review.run_git")


### PR DESCRIPTION
## Summary

- require an explicit GitHub target for portable PR resolution
- bind canonical URLs and immutable base/head commit OIDs
- require complete history and one merge base for portable diff context

Closes #2539

## Validation

- just check test
- required locked pre-push suite (6,947 tests)
