### PR TITLE
fix(automation): seal external verifier runtimes

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -119,7 +119,7 @@ _TRUSTED_GIT_CANDIDATES = (
     Path("/usr/bin/git"),
 )
 _HOST_RUNTIME_CACHE_DIRNAME = "hephaestus-host-validation-runtime"
-_HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v3-rewritten-launchers"
+_HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v4-all-worker-environments"
 
 # The host verification handles code from an untrusted pull request.  Bound
 # the Git archive before extraction and bound every child output/write path.
@@ -272,19 +272,17 @@ def _is_sealed_runtime_cache(target: Path) -> bool:
 def _verifier_owned_runtime_environment(checkout: Path) -> Path:
     """Return a read-only runtime outside the mutable review checkout.
 
-    ``uv run`` commonly executes the worker from ``<checkout>/.venv``.  That
-    ignored tree is not Git-bound, so it cannot be reused as verification
-    evidence. Snapshot the already-running host interpreter environment once
-    into the user-private temp area, seal it, and use only that external copy
-    for immutable host validation.
+    The worker environment can be inside or outside the checkout.  In either
+    case, snapshot it once into the user-private temp area, seal it, and use
+    only that external copy for immutable host validation.  This prevents the
+    sandboxed command from resolving a live worker ``.venv`` path and ensures
+    the verifier has one consistent read-only runtime contract.
     """
     runtime = Path(sys.prefix).resolve()
     try:
-        inside_checkout = runtime.is_relative_to(checkout.resolve())
+        checkout.resolve()
     except OSError as exc:
         raise _HostVerificationBoundaryError("host_verification_runtime_unavailable") from exc
-    if not inside_checkout:
-        return runtime
 
     cache_root = Path(tempfile.gettempdir()) / _HOST_RUNTIME_CACHE_DIRNAME
     if cache_root.is_symlink():

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -936,6 +936,28 @@ class TestWorkerPoolSubmitComplete:
         ):
             _verifier_owned_runtime_environment(checkout)
 
+    def test_verifier_runtime_snapshots_external_worker_environment(self, tmp_path: Path) -> None:
+        """The verifier never exposes a live worker environment to the sandbox."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        runtime = tmp_path / "worker-runtime"
+        launcher = runtime / "bin" / "python"
+        launcher.parent.mkdir(parents=True)
+        launcher.write_text("host interpreter\n", encoding="utf-8")
+        (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+        cache_temp = tmp_path / "cache-temp"
+
+        with (
+            patch(f"{_WP}.sys.prefix", str(runtime)),
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+        ):
+            sealed = _verifier_owned_runtime_environment(checkout)
+
+        assert sealed != runtime
+        assert sealed.is_relative_to(cache_temp / "hephaestus-host-validation-runtime")
+        assert (sealed / "bin" / "python").read_text(encoding="utf-8") == "host interpreter\n"
+        assert not ((sealed / "bin" / "python").stat().st_mode & 0o222)
+
     def test_verifier_runtime_dereferences_the_python_launcher(self, tmp_path: Path) -> None:
         """The sealed copy does not retain a launcher back into its source runtime."""
         checkout = tmp_path / "checkout"


### PR DESCRIPTION
Summary:

- seal the immutable verifier runtime for external worker environments too
- cover the repository-level worker virtual-environment topology

Closes #2540