### PR TITLE
fix(automation): classify pytest short summaries

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -806,13 +806,15 @@ def _confirmed_pytest_failure(returncode: int, stdout: str, stderr: str) -> bool
     """Return whether the fixed pytest command, not its runner, failed.
 
     ``sandbox-exec``/UV/bootstrap errors also surface as nonzero exits.  Only
-    pytest's normal test-failure exit code plus its terminal summary is safe to
-    send to the implementation agent as a code-remediation task.
+    pytest's normal test-failure exit code plus either supported terminal
+    summary format is safe to send to the implementation agent as a
+    code-remediation task.
     """
     transcript = f"{stdout}\n{stderr}"
     return returncode == 1 and bool(
         re.search(
-            r"(?m)^=+ .*?\b[1-9]\d* failed\b.*?\bin [0-9.]+s =+$",
+            r"(?m)^(?:=+ .*?\b[1-9]\d* failed\b.*?\bin [0-9.]+s =+|"
+            r"[1-9]\d* failed(?:, [^\n]*)? in [0-9.]+s)$",
             transcript,
         )
     )

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -620,6 +620,13 @@ class TestWorkerPoolSubmitComplete:
             "========================= 1 failed, 5 passed in 0.42s =========================\n",
             "",
         )
+        assert _confirmed_pytest_failure(
+            1,
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/unit/test_example.py::test_example - assert False\n"
+            "1 failed, 6199 passed, 26 skipped in 121.30s\n",
+            "",
+        )
         assert not _confirmed_pytest_failure(
             1,
             "uv bootstrap error: 1 failed to prepare environment",


### PR DESCRIPTION
Summary:

- recognize pytest short-summary test failures as validation work
- retain strict rejection of bootstrap diagnostics

Closes #2542