### PR TITLE
[Fix] Classify pytest elapsed summaries

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -814,7 +814,8 @@ def _confirmed_pytest_failure(returncode: int, stdout: str, stderr: str) -> bool
     return returncode == 1 and bool(
         re.search(
             r"(?m)^(?:=+ .*?\b[1-9]\d* failed\b.*?\bin [0-9.]+s =+|"
-            r"[1-9]\d* failed(?:, [^\n]*)? in [0-9.]+s)$",
+            r"[1-9]\d* failed(?:, [^\n]*)? in [0-9.]+s"
+            r"(?: \(\d+:\d{2}(?::\d{2})?\))?)$",
             transcript,
         )
     )

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -627,6 +627,14 @@ class TestWorkerPoolSubmitComplete:
             "1 failed, 6199 passed, 26 skipped in 121.30s\n",
             "",
         )
+        assert _confirmed_pytest_failure(
+            1,
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/unit/test_example.py::test_example - assert False\n"
+            "1 failed, 6199 passed, 26 skipped, 64 deselected, 83 warnings in 100.48s "
+            "(0:01:40)\n",
+            "",
+        )
         assert not _confirmed_pytest_failure(
             1,
             "uv bootstrap error: 1 failed to prepare environment",


### PR DESCRIPTION
Summary: accepts pytest terminal failure summaries that include its optional parenthesized elapsed-time clock, so a real PR test failure reaches implementation remediation instead of ending as a runner failure.

Validation:
- Focused classifier regression
- Worker-pool suite: 163 passed
- Full local unit suite: 6,648 selected, 84.87% coverage
- Pre-commit suite
- Locked pre-push suite

Closes #2544