### PR TITLE
fix(automation): harden direct PR review handoffs

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -582,6 +582,9 @@ def _finding_key(thread: dict[str, Any]) -> tuple[str, int, str, str] | None:
         for line_text in body.splitlines()
         if not line_text.strip().startswith("<!-- hephaestus-severity:")
     )
+    # The visible role marker distinguishes the original reviewer in GitHub's
+    # conversation but must not make an otherwise identical finding look new.
+    body = re.sub(r"^\[Review\]\s*", "", body)
     body = re.sub(r"^Reopened \(prior round, still unaddressed\):\s*", "", body).strip()
     return (path.strip(), line, side.strip().upper(), re.sub(r"\s+", " ", body).casefold())
 
@@ -2163,6 +2166,10 @@ class PrReviewStage(Stage):
         item.payload["existing_pr"] = True
         item.payload.pop("direct_pr_worktree", None)
         item.payload.pop("direct_pr_worktree_dirty", None)
+        item.payload.pop("direct_pr_rebase_attempted", None)
+        item.payload.pop("direct_pr_rebase_pending", None)
+        item.payload.pop("direct_pr_rebase_published", None)
+        item.payload.pop("direct_pr_rebase_error", None)
         item.payload["direct_pr_worktree_generation"] = generation + 1
         item.session_ids.pop(AGENT_PR_REVIEWER, None)
         item.session_ids.pop(AGENT_ADDRESS_REVIEW, None)

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1146,6 +1146,14 @@ class PrReviewStage(Stage):
         if error:
             return StageOutcome(Disposition.FINISH_FAIL, "review_checkout_unavailable")
         if not ready:
+            if item.payload.get("direct_pr_worktree"):
+                # A failed checkout barrier may have synchronized a newer
+                # remote PR head after the prior rebase. Re-run the direct
+                # rebase before reviewing that unverified replacement head.
+                item.payload.pop("direct_pr_rebase_attempted", None)
+                item.payload.pop("direct_pr_rebase_pending", None)
+                item.payload.pop("direct_pr_rebase_published", None)
+                item.payload.pop("direct_pr_rebase_error", None)
             retries = int(item.payload.get("review_checkout_retries", 0)) + 1
             item.payload["review_checkout_retries"] = retries
             if retries <= REVIEW_CHECKOUT_RETRY_CAP:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1088,9 +1088,15 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "pr_review_head_unavailable")
         base_branch = str(review_context.get("pr_base_branch") or "main")
         item.payload.update(review_context)
-        if item.payload.get("direct_pr_worktree") and not item.payload.get(
-            "direct_pr_rebase_attempted"
-        ):
+        # An adopted PR is not inherently writable: fork heads are checked out
+        # from the pull ref for read-only review, whereas a base-repository
+        # head may be safely rebased and lease-published before review.  Keep
+        # this mutation decision at the stage boundary so a detached checkout
+        # never becomes an implicit permission to push.
+        direct_pr_rewrite_allowed = bool(item.payload.get("direct_pr_worktree")) and (
+            ctx.github.pr_head_is_writable(item.pr)
+        )
+        if direct_pr_rewrite_allowed and not item.payload.get("direct_pr_rebase_attempted"):
             # A direct PR arrives as a detached, synchronized checkout. Rebase
             # it before binding any review inputs, then lease-push that exact
             # detached HEAD so the following context read reviews GitHub's
@@ -1123,6 +1129,11 @@ class PrReviewStage(Stage):
                 "expected_head_sha": expected_head,
                 "base_branch": base_branch,
                 "pr_number": item.pr,
+                # Only the pre-review rewrite flow needs to prove that its
+                # freshly rebased HEAD still contains the fetched base. Other
+                # worktrees may be reviewed read-only while their PR remains
+                # behind the current base.
+                "require_base_ancestor": direct_pr_rewrite_allowed,
             },
             descr="verify_pr_review_checkout",
         )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -204,6 +204,7 @@ def _parse_review_response(response: str) -> _ParsedReviewResponse:
 ENTER = "ENTER"
 ADOPT_WORKTREE_WAIT = "ADOPT_WORKTREE_WAIT"
 REVIEW_WAIT = "REVIEW_WAIT"
+DIRECT_REBASE_WAIT = "DIRECT_REBASE_WAIT"
 REVIEW_CHECKOUT_WAIT = "REVIEW_CHECKOUT_WAIT"
 HOST_VERIFICATION_WAIT = "HOST_VERIFICATION_WAIT"
 VALIDATE_WAIT = "VALIDATE_WAIT"
@@ -230,6 +231,7 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     ENTER: "_enter",
     ADOPT_WORKTREE_WAIT: "_adopt_worktree_wait",
     REVIEW_WAIT: "_review_wait",
+    DIRECT_REBASE_WAIT: "_direct_rebase_wait",
     REVIEW_CHECKOUT_WAIT: "_review_checkout_wait",
     HOST_VERIFICATION_WAIT: "_host_verification_wait",
     VALIDATE_WAIT: "_validate_wait",
@@ -1083,6 +1085,29 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "pr_review_head_unavailable")
         base_branch = str(review_context.get("pr_base_branch") or "main")
         item.payload.update(review_context)
+        if item.payload.get("direct_pr_worktree") and not item.payload.get(
+            "direct_pr_rebase_attempted"
+        ):
+            # A direct PR arrives as a detached, synchronized checkout. Rebase
+            # it before binding any review inputs, then lease-push that exact
+            # detached HEAD so the following context read reviews GitHub's
+            # current base-compatible head rather than a local-only rewrite.
+            item.payload["direct_pr_rebase_attempted"] = True
+            item.payload["direct_pr_rebase_pending"] = True
+            job = GitJob(
+                repo=item.repo,
+                op="rebase",
+                timeout_s=GIT_JOB_TIMEOUT_S,
+                kwargs={
+                    "cwd": _worktree_path(item, ctx),
+                    "base_branch": base_branch,
+                    "branch": item.branch,
+                    "expected_remote_sha": expected_head,
+                    "publish_detached_head": True,
+                },
+                descr="rebase_direct_pr_before_review",
+            )
+            return JobRequest(job, on_done_state=DIRECT_REBASE_WAIT)
         item.payload["review_checkout_expected_head"] = expected_head
         item.payload["review_checkout_pending"] = True
         job = GitJob(
@@ -1099,6 +1124,16 @@ class PrReviewStage(Stage):
             descr="verify_pr_review_checkout",
         )
         return JobRequest(job, on_done_state=REVIEW_CHECKOUT_WAIT)
+
+    def _direct_rebase_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Refresh context only after a direct PR rebase is durably published."""
+        del ctx
+        error = str(item.payload.pop("direct_pr_rebase_error", "") or "")
+        if error:
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_rebase_failed")
+        if not item.payload.pop("direct_pr_rebase_published", False):
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_rebase_unpublished")
+        return Continue(next_state=REVIEW_WAIT)
 
     def _review_checkout_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Submit review only after the fresh snapshot matches a clean checkout."""
@@ -1480,6 +1515,8 @@ class PrReviewStage(Stage):
         """
         if self._consume_direct_worktree_result(item, result):
             return
+        if self._consume_direct_pr_rebase_result(item, result):
+            return
         if self._consume_review_checkout_result(item, result):
             return
         if item.state == HOST_VERIFICATION_WAIT:
@@ -1653,6 +1690,21 @@ class PrReviewStage(Stage):
         if not item.payload.pop("direct_pr_worktree_pending", None):
             return False
         PrReviewStage._on_direct_pr_worktree_done(item, result)
+        return True
+
+    @staticmethod
+    def _consume_direct_pr_rebase_result(item: WorkItem, result: JobResult) -> bool:
+        """Store the single direct-PR rebase/publish result before state changes."""
+        if not item.payload.pop("direct_pr_rebase_pending", None):
+            return False
+        if not result.ok:
+            item.payload["direct_pr_rebase_error"] = result.error or "rebase job failed"
+            return True
+        value = result.value
+        if not isinstance(value, dict) or not value.get("published"):
+            item.payload["direct_pr_rebase_error"] = "rebase job did not publish a detached head"
+            return True
+        item.payload["direct_pr_rebase_published"] = True
         return True
 
     @staticmethod

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2417,8 +2417,10 @@ class WorkerPool:
             check=False,
             timeout=job.timeout_s,
         )
-        if base_is_ancestor.returncode != 0:
+        if base_is_ancestor.returncode == 1:
             return JobResult(ok=True, value={"ready": False, "reason": "base_drift"})
+        if base_is_ancestor.returncode != 0:
+            return JobResult(ok=False, error="review checkout base ancestry check failed")
         diff = git_utils.run(
             ["git", "diff", "--no-ext-diff", "--binary", f"{base}...{head}"],
             cwd=worktree,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2407,20 +2407,23 @@ class WorkerPool:
         ).stdout.strip()
         if not base:
             return JobResult(ok=False, error="review checkout base ref unavailable")
-        # The base can advance after the direct rebase publishes but before
-        # this barrier fetches it.  A matching PR head alone is not enough:
-        # require that it still contains the freshly fetched base, otherwise
-        # let the stage clear its rebase receipt and retry from the new base.
-        base_is_ancestor = git_utils.run(
-            ["git", "merge-base", "--is-ancestor", base, head],
-            cwd=worktree,
-            check=False,
-            timeout=job.timeout_s,
-        )
-        if base_is_ancestor.returncode == 1:
-            return JobResult(ok=True, value={"ready": False, "reason": "base_drift"})
-        if base_is_ancestor.returncode != 0:
-            return JobResult(ok=False, error="review checkout base ancestry check failed")
+        if job.kwargs.get("require_base_ancestor") is True:
+            # A direct, writable PR was just rebased and lease-published.  If
+            # the base advanced before this checkout barrier, retry that
+            # rewrite rather than reviewing a now-stale replacement head.
+            # Read-only fork heads and normal pipeline worktrees do not take
+            # this mutation path, so base movement must not strand them in a
+            # retry loop.
+            base_is_ancestor = git_utils.run(
+                ["git", "merge-base", "--is-ancestor", base, head],
+                cwd=worktree,
+                check=False,
+                timeout=job.timeout_s,
+            )
+            if base_is_ancestor.returncode == 1:
+                return JobResult(ok=True, value={"ready": False, "reason": "base_drift"})
+            if base_is_ancestor.returncode != 0:
+                return JobResult(ok=False, error="review checkout base ancestry check failed")
         diff = git_utils.run(
             ["git", "diff", "--no-ext-diff", "--binary", f"{base}...{head}"],
             cwd=worktree,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1774,8 +1774,7 @@ class WorkerPool:
             return self._git_remove_worktree(job)
 
         elif job.op == "rebase":
-            result = git_utils.rebase_worktree_onto(**job.kwargs, timeout=job.timeout_s)
-            return JobResult(ok=result, value=result)
+            return self._git_rebase(job)
 
         elif job.op == "push":
             git_utils.push_current_branch_with_lease_on_divergence(
@@ -1828,6 +1827,37 @@ class WorkerPool:
         else:
             # Should be impossible due to GitJob.__post_init__ validation
             return JobResult(ok=False, error=f"unknown op {job.op!r}")
+
+    def _git_rebase(self, job: GitJob) -> JobResult:
+        """Rebase a checkout and optionally lease-publish a detached PR head."""
+        kwargs = dict(job.kwargs)
+        publish_detached_head = bool(kwargs.pop("publish_detached_head", False))
+        branch = str(kwargs.pop("branch", "") or "")
+        expected_remote_sha = kwargs.pop("expected_remote_sha", None)
+        result = git_utils.rebase_worktree_onto(**kwargs, timeout=job.timeout_s)
+        if not result:
+            if not publish_detached_head:
+                return JobResult(ok=False, value=False)
+            return JobResult(ok=False, value={"rebased": False}, error="rebase conflicted")
+        if not publish_detached_head:
+            return JobResult(ok=True, value=True)
+        cwd = Path(str(kwargs.get("cwd") or ""))
+        if not branch or not _is_full_commit_sha(expected_remote_sha) or not cwd.is_dir():
+            return JobResult(ok=False, error="direct rebase publish arguments invalid")
+        source_sha = self._read_detached_push_head(cwd, timeout=job.timeout_s)
+        if isinstance(source_sha, JobResult):
+            return source_sha
+        git_utils.push_head_to_branch(
+            branch,
+            expected_remote_sha,
+            cwd,
+            source_sha=source_sha,
+            timeout=job.timeout_s,
+        )
+        return JobResult(
+            ok=True,
+            value={"rebased": True, "published": True, "head_sha": source_sha},
+        )
 
     def _git_sync_checkout(self, job: GitJob) -> JobResult:
         """Validate and fast-forward a reusable checkout without discarding local work."""

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2407,6 +2407,18 @@ class WorkerPool:
         ).stdout.strip()
         if not base:
             return JobResult(ok=False, error="review checkout base ref unavailable")
+        # The base can advance after the direct rebase publishes but before
+        # this barrier fetches it.  A matching PR head alone is not enough:
+        # require that it still contains the freshly fetched base, otherwise
+        # let the stage clear its rebase receipt and retry from the new base.
+        base_is_ancestor = git_utils.run(
+            ["git", "merge-base", "--is-ancestor", base, head],
+            cwd=worktree,
+            check=False,
+            timeout=job.timeout_s,
+        )
+        if base_is_ancestor.returncode != 0:
+            return JobResult(ok=True, value={"ready": False, "reason": "base_drift"})
         diff = git_utils.run(
             ["git", "diff", "--no-ext-diff", "--binary", f"{base}...{head}"],
             cwd=worktree,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1030,7 +1030,7 @@ class PipelineGitHub:
         shared CSPRNG batch nonce binds the complete implementation pass without
         publishing an unanchored review-level summary.
         """
-        candidates: list[tuple[dict[str, Any], str, str, str]] = []
+        candidates: list[tuple[dict[str, Any], str, str, str, str]] = []
         seen_thread_ids: set[str] = set()
         for thread in threads:
             if not isinstance(thread, dict):
@@ -1053,16 +1053,22 @@ class PipelineGitHub:
                 return []
             reply_id, reply_body = implementation_reply
             batch_nonce = self._implementation_reply_batch_nonce(reply_body)
-            if batch_nonce is None:
+            review_id = comments[-1].get("review_id")
+            if batch_nonce is None or not isinstance(review_id, str) or not review_id:
                 return []
             seen_thread_ids.add(thread_id)
-            candidates.append((thread, reply_id, reply_body, batch_nonce))
+            candidates.append((thread, reply_id, reply_body, batch_nonce, review_id))
         if not candidates:
             return []
         batch_nonces = {candidate[3] for candidate in candidates}
         if len(batch_nonces) != 1:
             return []
-        return [(thread, reply_id, reply_body) for thread, reply_id, reply_body, _ in candidates]
+        # Multiple implementation responses from one pass must share one
+        # submitted GitHub review, not merely a common local nonce. Otherwise
+        # legacy one-review-per-comment replies could be resolved as a batch.
+        if len(candidates) > 1 and len({candidate[4] for candidate in candidates}) != 1:
+            return []
+        return [(thread, reply_id, reply_body) for thread, reply_id, reply_body, _, _ in candidates]
 
     def reviewer_validation_receipts(
         self,
@@ -1593,6 +1599,7 @@ class PipelineGitHub:
         reply_bodies: dict[str, str] = {}
         pull_request_ids: set[str] = set()
         pending_review_ids: set[str] = set()
+        commented_review_ids: set[str] = set()
         has_commented_recovery = False
         try:
             for thread_id in candidate_ids:
@@ -1641,6 +1648,7 @@ class PipelineGitHub:
                         pending_review_ids.add(review_id)
                     elif review_state == "COMMENTED":
                         has_commented_recovery = True
+                        commented_review_ids.add(review_id)
                     else:
                         blocked.append(thread_id)
                     continue
@@ -1660,7 +1668,6 @@ class PipelineGitHub:
                 )
             pull_request_id = next(iter(pull_request_ids))
             pending_review_id = next(iter(pending_review_ids), None)
-            needs_envelope = len(candidate_ids) > 1 or pending_review_id is not None
             if has_commented_recovery and (prepared or pending_review_id is not None):
                 # A submitted review cannot safely be extended. A mixed
                 # recovery means another actor changed the batch boundary.
@@ -1668,14 +1675,30 @@ class PipelineGitHub:
                     retryable_thread_ids=candidate_ids,
                     retryable=True,
                 )
+            if has_commented_recovery and len(candidate_ids) > 1 and len(commented_review_ids) != 1:
+                # Never let legacy one-review-per-comment recovery masquerade
+                # as a complete implementation pass.
+                return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
+            if has_commented_recovery:
+                # The submit mutation may have succeeded even when its
+                # response was lost. Every reply is already bound to the
+                # submitted review, so a retry must not create an empty one.
+                return ImplementationThreadReplyResult(
+                    replied_thread_ids=candidate_ids,
+                    receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
+                )
+            needs_envelope = len(candidate_ids) > 1 or pending_review_id is not None
             if needs_envelope and pending_review_id is None:
                 pending_review_id = self._create_pending_implementation_review(
                     pull_request_id, expected_head_sha, batch_nonce
                 )
                 if pending_review_id is None:
+                    # GitHub may have accepted the create mutation while its
+                    # response was lost. There is no source-attached receipt
+                    # yet from which to identify that pending review safely;
+                    # fail closed rather than creating a duplicate envelope.
                     return ImplementationThreadReplyResult(
-                        retryable_thread_ids=candidate_ids,
-                        retryable=True,
+                        blocked_thread_ids=candidate_ids,
                     )
             for thread_id, snapshot, body in prepared:
                 comment_id = self._add_thread_reply(

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -170,7 +170,7 @@ def rate_budget_ok(now_epoch: float | None = None) -> tuple[bool, float]:
 
 
 def _with_severity_marker(comment: dict[str, Any]) -> str:
-    """Prepend the ``<!-- hephaestus-severity: X -->`` marker line (#1856).
+    """Publish a visible reviewer prefix and durable severity marker (#1856).
 
     An absent/unknown severity is written as ``major`` (blocking) so an
     unclassifiable thread never silently unblocks a GO, and so the pre-#1856
@@ -187,12 +187,13 @@ def _with_severity_marker(comment: dict[str, Any]) -> str:
         and not line.strip().startswith(SCOPE_RETRACTION_MARKER_PREFIX)
         and not _STANDALONE_VERDICT_LINE_RE.match(line)
     )
+    if body.startswith("[Review] "):
+        body = body.removeprefix("[Review] ")
     paths = normalize_scope_retraction_paths(comment.get("scope_retraction_paths"))
     markers = [f"{SEVERITY_MARKER_PREFIX} {sev} -->"]
     if paths:
         markers.append(scope_retraction_marker(paths))
-    markers.append(body)
-    return "\n".join(markers)
+    return "\n".join([f"[Review] {body}", *markers])
 
 
 def _has_no_explicit_pull_request_bypasses(protection: dict[str, Any]) -> bool:
@@ -948,12 +949,20 @@ class PipelineGitHub:
             raise ValueError(
                 "implementation reply batch nonce must be 32 lowercase hexadecimal chars"
             )
+        response = reply.removeprefix("[Response] ")
         seed = ":".join(
-            [self._repo_slug or self.org, str(pr_number), thread_id, head_sha, reply, batch_nonce]
+            [
+                self._repo_slug or self.org,
+                str(pr_number),
+                thread_id,
+                head_sha,
+                response,
+                batch_nonce,
+            ]
         )
         marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
         return (
-            f"{reply}\n\n"
+            f"[Response] {response}\n\n"
             f"<!-- hephaestus-implementation-reply:{marker} -->\n"
             f"<!-- hephaestus-implementation-batch:{batch_nonce} -->"
         )
@@ -995,7 +1004,10 @@ class PipelineGitHub:
         marker_match = _IMPLEMENTATION_REPLY_BODY_RE.fullmatch(reply_body)
         if marker_match is None:
             return None
-        reply = self._safe_thread_reply(marker_match.group(1))
+        visible_reply = marker_match.group(1)
+        if not visible_reply.startswith("[Response] "):
+            return None
+        reply = self._safe_thread_reply(visible_reply.removeprefix("[Response] "))
         batch_nonce = marker_match.group(2)
         if reply is None or batch_nonce is None:
             return None
@@ -1104,27 +1116,39 @@ class PipelineGitHub:
         )
         marker = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
         return (
-            f"Reviewer validation found this still unresolved: {feedback}\n\n"
+            f"[Review] Reviewer validation found this still unresolved: {feedback}\n\n"
             f"<!-- hephaestus-reviewer-validation:{marker} -->"
         )
 
-    def _add_thread_reply(self, thread_id: str, body: str) -> str | None:
+    def _add_thread_reply(
+        self, thread_id: str, body: str, *, pull_request_review_id: str | None = None
+    ) -> str | None:
         """Post one response on an existing review thread.
 
-        Both implementation receipts and fresh reviewer feedback use this one
-        mutation.  It intentionally cannot attach a reply to a review-level
-        envelope: every response is anchored by ``pullRequestReviewThreadId``.
+        Every response remains anchored by ``pullRequestReviewThreadId``. An
+        implementation pass may additionally bind its replies to one pending
+        review envelope so GitHub renders the complete pass as one review.
         """
-        query = (
-            "mutation($threadId:ID!,$body:String!,$clientMutationId:String!){"
-            "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body,"
-            "clientMutationId:$clientMutationId}){comment{id}}}"
-        )
+        if pull_request_review_id is None:
+            query = (
+                "mutation($threadId:ID!,$body:String!,$clientMutationId:String!){"
+                "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body,"
+                "clientMutationId:$clientMutationId}){comment{id}}}"
+            )
+        else:
+            query = (
+                "mutation($threadId:ID!,$reviewId:ID!,$body:String!,$clientMutationId:String!){"
+                "addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,"
+                "pullRequestReviewId:$reviewId,body:$body,clientMutationId:$clientMutationId})"
+                "{comment{id}}}"
+            )
         mutation_fields: dict[str, str] = {
             "threadId": thread_id,
             "body": body,
             "clientMutationId": hashlib.sha256(f"{thread_id}:{body}".encode()).hexdigest(),
         }
+        if pull_request_review_id is not None:
+            mutation_fields["reviewId"] = pull_request_review_id
         data = self._graphql(
             query,
             **mutation_fields,
@@ -1139,6 +1163,59 @@ class PipelineGitHub:
         if not isinstance(comment, dict) or not isinstance(comment.get("id"), str):
             return None
         return str(comment["id"])
+
+    def _create_pending_implementation_review(
+        self, pull_request_id: str, head_sha: str, batch_nonce: str
+    ) -> str | None:
+        """Create one pending review envelope for an implementation reply batch."""
+        query = (
+            "mutation($pullRequestId:ID!,$commitOID:GitObjectID!,$clientMutationId:String!){"
+            "addPullRequestReview(input:{pullRequestId:$pullRequestId,commitOID:$commitOID,"
+            "clientMutationId:$clientMutationId}){pullRequestReview{id}}}"
+        )
+        data = self._graphql(
+            query,
+            pullRequestId=pull_request_id,
+            commitOID=head_sha,
+            clientMutationId=hashlib.sha256(
+                f"{pull_request_id}:{head_sha}:{batch_nonce}:implementation-review".encode()
+            ).hexdigest(),
+        )
+        response_data = data.get("data") if isinstance(data, dict) else None
+        mutation = (
+            response_data.get("addPullRequestReview") if isinstance(response_data, dict) else None
+        )
+        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
+        review_id = review.get("id") if isinstance(review, dict) else None
+        return review_id if isinstance(review_id, str) and review_id else None
+
+    def _submit_implementation_review(self, pull_request_id: str, review_id: str) -> bool:
+        """Submit a complete pending implementation reply review as a comment."""
+        query = (
+            "mutation($pullRequestId:ID!,$reviewId:ID!,$clientMutationId:String!){"
+            "submitPullRequestReview(input:{pullRequestId:$pullRequestId,pullRequestReviewId:$reviewId,"
+            "event:COMMENT,clientMutationId:$clientMutationId}){pullRequestReview{id state}}}"
+        )
+        data = self._graphql(
+            query,
+            pullRequestId=pull_request_id,
+            reviewId=review_id,
+            clientMutationId=hashlib.sha256(
+                f"{pull_request_id}:{review_id}:implementation-submit".encode()
+            ).hexdigest(),
+        )
+        response_data = data.get("data") if isinstance(data, dict) else None
+        mutation = (
+            response_data.get("submitPullRequestReview")
+            if isinstance(response_data, dict)
+            else None
+        )
+        review = mutation.get("pullRequestReview") if isinstance(mutation, dict) else None
+        return bool(
+            isinstance(review, dict)
+            and review.get("id") == review_id
+            and review.get("state") == "COMMENTED"
+        )
 
     def _review_thread_snapshot(  # noqa: C901 - GraphQL response validation is fail-closed
         self, pr_number: int, thread_id: str
@@ -1333,6 +1410,7 @@ class PipelineGitHub:
                             "line": expected_thread_fields[2],
                             "side": expected_thread_fields[3],
                             "comments": comments,
+                            "pr_node_id": expected_pr_id,
                             "pr_state": expected_pr_state,
                         },
                         page_count > 1,
@@ -1512,9 +1590,15 @@ class PipelineGitHub:
 
         prepared: list[tuple[str, dict[str, Any], str]] = []
         recovered: dict[str, dict[str, Any]] = {}
+        reply_bodies: dict[str, str] = {}
+        pull_request_ids: set[str] = set()
+        pending_review_ids: set[str] = set()
+        has_commented_recovery = False
         try:
             for thread_id in candidate_ids:
                 reply = self._safe_thread_reply(replies.get(thread_id))
+                if reply is not None:
+                    reply = self._safe_thread_reply(reply.removeprefix("[Response] "))
                 snapshot = snapshots[thread_id]
                 if reply is None:
                     blocked.append(thread_id)
@@ -1530,12 +1614,35 @@ class PipelineGitHub:
                 ):
                     blocked.append(thread_id)
                     continue
+                pull_request_id = live.get("pr_node_id")
+                if not isinstance(pull_request_id, str) or not pull_request_id:
+                    blocked.append(thread_id)
+                    continue
+                pull_request_ids.add(pull_request_id)
+                reply_bodies[thread_id] = body
                 # A prior transport failure may have applied this exact reply.
                 # Recover its host proof before treating the saved snapshot as
                 # stale or attempting a duplicate mutation.
                 recovered_id = self._host_reply_receipt(snapshot, live, body)
                 if recovered_id is not None:
                     recovered[thread_id] = receipt(live, recovered_id, body)
+                    final_comment = live.get("comments", [])[-1]
+                    review_id = (
+                        final_comment.get("review_id") if isinstance(final_comment, dict) else None
+                    )
+                    review_state = (
+                        final_comment.get("review_state")
+                        if isinstance(final_comment, dict)
+                        else None
+                    )
+                    if not isinstance(review_id, str) or not review_id:
+                        blocked.append(thread_id)
+                    elif review_state == "PENDING":
+                        pending_review_ids.add(review_id)
+                    elif review_state == "COMMENTED":
+                        has_commented_recovery = True
+                    else:
+                        blocked.append(thread_id)
                     continue
                 if not self._same_thread_snapshot(snapshot, live):
                     blocked.append(thread_id)
@@ -1546,8 +1653,34 @@ class PipelineGitHub:
                 return ImplementationThreadReplyResult(
                     blocked_thread_ids=tuple(sorted(blocked)),
                 )
+            if len(pull_request_ids) != 1 or len(pending_review_ids) > 1:
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            pull_request_id = next(iter(pull_request_ids))
+            pending_review_id = next(iter(pending_review_ids), None)
+            needs_envelope = len(candidate_ids) > 1 or pending_review_id is not None
+            if has_commented_recovery and (prepared or pending_review_id is not None):
+                # A submitted review cannot safely be extended. A mixed
+                # recovery means another actor changed the batch boundary.
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            if needs_envelope and pending_review_id is None:
+                pending_review_id = self._create_pending_implementation_review(
+                    pull_request_id, expected_head_sha, batch_nonce
+                )
+                if pending_review_id is None:
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                    )
             for thread_id, snapshot, body in prepared:
-                comment_id = self._add_thread_reply(thread_id, body)
+                comment_id = self._add_thread_reply(
+                    thread_id, body, pull_request_review_id=pending_review_id
+                )
                 replied_live = self._review_thread_snapshot(pr_number, thread_id)
                 if (
                     not isinstance(replied_live, dict)
@@ -1572,6 +1705,37 @@ class PipelineGitHub:
                         retryable=True,
                     )
                 recovered[thread_id] = receipt(replied_live, proved_comment_id, body)
+            if pending_review_id is not None and not self._submit_implementation_review(
+                pull_request_id, pending_review_id
+            ):
+                return ImplementationThreadReplyResult(
+                    retryable_thread_ids=candidate_ids,
+                    retryable=True,
+                )
+            if pending_review_id is not None:
+                for thread_id in candidate_ids:
+                    body = reply_bodies[thread_id]
+                    submitted_live = self._review_thread_snapshot(pr_number, thread_id)
+                    if (
+                        not isinstance(submitted_live, dict)
+                        or submitted_live.get("isResolved") is not False
+                        or not self._pr_is_current_open_head(
+                            submitted_live.get("pr_state"), expected_head_sha
+                        )
+                    ):
+                        return ImplementationThreadReplyResult(
+                            retryable_thread_ids=candidate_ids,
+                            retryable=True,
+                        )
+                    submitted_id = self._validated_implementation_reply(
+                        pr_number, expected_head_sha, submitted_live
+                    )
+                    if submitted_id is None or submitted_id[1] != body:
+                        return ImplementationThreadReplyResult(
+                            retryable_thread_ids=candidate_ids,
+                            retryable=True,
+                        )
+                    recovered[thread_id] = receipt(submitted_live, submitted_id[0], body)
         except (
             AttributeError,
             OSError,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1687,8 +1687,10 @@ class PipelineGitHub:
                     replied_thread_ids=candidate_ids,
                     receipts=tuple(recovered[thread_id] for thread_id in candidate_ids),
                 )
-            needs_envelope = len(candidate_ids) > 1 or pending_review_id is not None
-            if needs_envelope and pending_review_id is None:
+            # Every implementation pass, including a singleton reply, must be
+            # submitted as one GitHub review. The later comment-review handoff
+            # accepts only replies bound to that submitted review.
+            if pending_review_id is None:
                 pending_review_id = self._create_pending_implementation_review(
                     pull_request_id, expected_head_sha, batch_nonce
                 )

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -107,10 +107,11 @@ def get_review_validation_prompt(
 ) -> str:
     """Get the prompt that validates whether prior review comments were addressed.
 
-    Used by the pipeline PR-review stage to re-check, with a fresh review of
-    the current change, prior review, and implementation reply, that the
-    implementer's supplied patch and evidence adequately address the previous
-    iteration's review comments. It keeps an unaddressed
+    Used by the pipeline PR-review stage for a fresh comment-review of the
+    current change, prior review, and implementation reply. It verifies that
+    the implementer responded to each thread with coherent, diff-consistent
+    evidence; the original implementation review remains the thorough
+    correctness review. It keeps an incomplete
     original thread open and supplies a concrete reviewer reply describing
     what remains; it never creates a replacement inline thread.
 

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -109,8 +109,8 @@ def get_review_validation_prompt(
 
     Used by the pipeline PR-review stage to re-check, with a fresh review of
     the current change, prior review, and implementation reply, that the
-    implementer's fixes actually resolved the previous iteration's review
-    comments. It keeps an unaddressed
+    implementer's supplied patch and evidence adequately address the previous
+    iteration's review comments. It keeps an unaddressed
     original thread open and supplies a concrete reviewer reply describing
     what remains; it never creates a replacement inline thread.
 

--- a/hephaestus/prompts/templates/default/pr_review/validation.j2
+++ b/hephaestus/prompts/templates/default/pr_review/validation.j2
@@ -45,6 +45,14 @@ sandbox. If every receipt has `ok: true` and the current reviewed head matches
 each `head_sha`, treat them as independent local execution evidence; if any
 receipt is missing or failed, do not claim the plan passed.
 
+Evidence-provenance rule: validate whether the implementation reply supplies
+concrete, internally coherent evidence (for example, the exact command and
+result, an added regression test, or a linked artifact) that supports its
+claimed fix. Do not independently reproduce, rerun, or require host/CI
+execution of that evidence. A sandbox access failure or the absence of an
+independent execution is not a reason to leave a thread unresolved when the
+current diff and the supplied implementation evidence adequately address it.
+
 ---
 
 For EACH prior comment with `implementation_reply_submitted: true`, judge

--- a/hephaestus/prompts/templates/default/pr_review/validation.j2
+++ b/hephaestus/prompts/templates/default/pr_review/validation.j2
@@ -1,15 +1,19 @@
 
-You are VALIDATING whether prior review comments on PR #{{ pr_number }}
-({{ review_context_kind }} #{{ issue_number }}) were actually addressed by the current diff.
+You are VALIDATING the implementation agent's handling of prior review
+comments on PR #{{ pr_number }} ({{ review_context_kind }} #{{ issue_number }}).
 
 Perform a fresh validation review of EVERY open review thread below using the
 current diff, the prior review conversation, and the implementation reply. Do
 not create replacement threads or expand the task beyond those existing
-threads. For each thread with `implementation_reply_submitted: true`, decide
-whether the CURRENT diff AND that implementation reply actually resolve it.
-Your result authorizes the coordinator to resolve only those replied-to
-threads. For a replied-to thread that remains open, your `detail` is posted as
-the reviewer response explaining what is still wrong.
+threads. This is the comment-review pass, not the original implementation
+review. Do not independently adjudicate the original code-level concern or
+perform a new thorough correctness review. For each thread with
+`implementation_reply_submitted: true`, decide only whether the implementation
+agent has responded to that thread with concrete, internally coherent evidence
+that is consistent with the current diff. Your result authorizes the
+coordinator to resolve only those replied-to threads. For a replied-to thread
+that remains open, your `detail` is posted as the reviewer response explaining
+which response or evidence requirement is still missing.
 
 Threads with `implementation_reply_submitted: false` are still open work for
 the implementation agent. Read them, but do NOT include them in either JSON
@@ -48,21 +52,24 @@ receipt is missing or failed, do not claim the plan passed.
 Evidence-provenance rule: validate whether the implementation reply supplies
 concrete, internally coherent evidence (for example, the exact command and
 result, an added regression test, or a linked artifact) that supports its
-claimed fix. Do not independently reproduce, rerun, or require host/CI
-execution of that evidence. A sandbox access failure or the absence of an
-independent execution is not a reason to leave a thread unresolved when the
-current diff and the supplied implementation evidence adequately address it.
+claimed handling. Do not independently reproduce, rerun, or require host/CI
+execution of that evidence. Do not independently adjudicate the original
+code-level concern. A sandbox access failure, the absence of an independent
+execution, or a new opinion about the implementation is not a reason to leave
+a thread unresolved when the response and its evidence are internally coherent
+and consistent with the current diff.
 
 ---
 
-For EACH prior comment with `implementation_reply_submitted: true`, judge
-against the current diff into exactly ONE of two buckets:
-- ADDRESSED — the diff changes the cited code in a way that resolves the
-  comment's concern and the implementation reply accurately explains it. When
-in doubt that both do so, treat it as NOT addressed (false "addressed" is
-worse than a redundant open thread).
-- NOT ADDRESSED — the cited code is unchanged, or the change does not actually
-  resolve the concern the comment raised.
+For EACH prior comment with `implementation_reply_submitted: true`, judge the
+implementation handoff into exactly ONE of two buckets:
+- ADDRESSED — the implementation reply directly responds to the prior comment,
+  identifies what was changed or deliberately not changed, and supplies
+  concrete, internally coherent evidence consistent with the current diff.
+- NOT ADDRESSED — the implementation reply is missing, does not address the
+  prior comment, or its claimed change/evidence is materially inconsistent
+  with the current diff. Do not use this bucket merely because you would make
+  a different technical judgment about the fix.
 
 **Output format:**
 Write your reasoning in prose. At the very end, emit a single fenced JSON block
@@ -76,15 +83,15 @@ with an explicit decision for EVERY eligible thread:
 ```
 
 Rules:
-- `resolved`: an array of the thread IDs whose current diff AND
-  implementation reply resolve the concern. Echo each `thread_id` VERBATIM.
-- `unaddressed`: array of the prior comments the diff and implementation reply
-  do NOT resolve. Echo the
+- `resolved`: an array of the thread IDs whose implementation reply and
+  evidence satisfy this comment-review handoff. Echo each `thread_id` VERBATIM.
+- `unaddressed`: array of the prior comments whose implementation handoff is
+  incomplete or inconsistent. Echo the
   comment's `thread_id` VERBATIM (this is how the thread is matched — it must be
   exact); include the original `path`/`line`; `original_body` is the original
   comment text (verbatim or trimmed); `detail` states concretely what is still
-  missing. A deliberate design is still NOT ADDRESSED unless the implementation
-  response explains a change that resolves the reviewer concern; never use a
+  missing from the response or evidence. A deliberate design may be ADDRESSED
+  when the response clearly explains it with coherent evidence; never use a
   separate dismissal bucket.
 - Every eligible thread ID appears in EXACTLY ONE bucket. A missing, duplicate,
   or extra ID makes the validation unusable.

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -295,6 +295,7 @@ class TestPrReviewStageStep:
         assert result.job.op == "verify_pr_review_checkout"
         assert result.job.kwargs["expected_head_sha"] == "a" * 40
         assert result.job.kwargs["base_branch"] == "main"
+        assert result.job.kwargs["require_base_ancestor"] is False
         assert result.on_done_state == REVIEW_CHECKOUT_WAIT
         assert "reviewed_pr_head_sha" not in item.payload
 
@@ -348,6 +349,50 @@ class TestPrReviewStageStep:
         assert isinstance(barrier, JobRequest)
         assert isinstance(barrier.job, GitJob)
         assert barrier.job.op == "verify_pr_review_checkout"
+        assert barrier.job.kwargs["require_base_ancestor"] is True
+
+    def test_read_only_direct_pr_does_not_rebase_or_publish_before_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A fork head is reviewed from its immutable PR ref without a write attempt."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_head_writable=False,
+            pr_review_context={
+                "pr_diff": "diff --git a/a.py b/a.py\n+new\n",
+                "pr_description": "Closes #1",
+                "pr_head_sha": "a" * 40,
+                "pr_base_branch": "main",
+            },
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, kind=ItemKind.PR, state="REVIEW_WAIT")
+        item.worktree = "/tmp/repo/review-worktree"
+        item.branch = "fork-review-branch"
+        item.payload["direct_pr_worktree"] = item.worktree
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "verify_pr_review_checkout"
+        assert result.job.kwargs["require_base_ancestor"] is False
+        assert "direct_pr_rebase_attempted" not in item.payload
+
+    def test_direct_pr_rebase_failure_finishes_without_reviewing_stale_head(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed detached rebase is terminal and cannot reach the reviewer."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state=DIRECT_REBASE_WAIT)
+        item.payload["direct_pr_rebase_pending"] = True
+
+        stage.on_job_done(item, JobResult(ok=False, error="rebase conflicted"), ctx)
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "direct_pr_rebase_failed"
+        )
 
     def test_direct_pr_checkout_head_drift_retries_the_rebase(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -349,6 +349,50 @@ class TestPrReviewStageStep:
         assert isinstance(barrier.job, GitJob)
         assert barrier.job.op == "verify_pr_review_checkout"
 
+    def test_direct_pr_checkout_head_drift_retries_the_rebase(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A changed direct head cannot bypass the rebase on checkout retry."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_review_context={
+                "pr_diff": "diff --git a/a.py b/a.py\n+new\n",
+                "pr_description": "Closes #1",
+                "pr_head_sha": "b" * 40,
+                "pr_base_branch": "main",
+            }
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(
+            issue=1,
+            pr=1001,
+            kind=ItemKind.PR,
+            state=REVIEW_CHECKOUT_WAIT,
+        )
+        item.worktree = "/tmp/repo/review-worktree"
+        item.branch = "review-branch"
+        item.payload.update(
+            {
+                "direct_pr_worktree": item.worktree,
+                "direct_pr_rebase_attempted": True,
+                "direct_pr_rebase_published": True,
+                "review_checkout_expected_head": "a" * 40,
+                "review_checkout_ready": False,
+            }
+        )
+
+        retry = stage.step(item, ctx)
+
+        assert retry == Continue(next_state="REVIEW_WAIT")
+        assert "direct_pr_rebase_attempted" not in item.payload
+        assert "direct_pr_rebase_published" not in item.payload
+
+        item.state = retry.next_state
+        rebased = stage.step(item, ctx)
+        assert isinstance(rebased, JobRequest)
+        assert isinstance(rebased.job, GitJob)
+        assert rebased.job.op == "rebase"
+
     def test_checkout_barrier_renews_the_proof_for_an_unchanged_head(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -41,6 +41,7 @@ from hephaestus.automation.pipeline.stages.pr_review import (
     _reviewer_thread_decisions,
     _validation_receipt_fingerprints,
     _validation_thread_snapshots,
+    _without_duplicate_live_findings,
 )
 from hephaestus.automation.pipeline.work_item import ItemKind
 from hephaestus.automation.prompts.address_review import get_address_review_prompt
@@ -2004,6 +2005,26 @@ class TestReviewThreadLifecycle:
         assert not _is_postable_finding({**valid, "severity": "informational"})
         assert not _is_postable_finding({**valid, "body": "<!-- hephaestus-severity: major -->"})
 
+    def test_visible_reviewer_prefix_does_not_repost_a_live_finding(self) -> None:
+        """The human-readable role prefix is not part of finding identity."""
+        finding = {
+            "path": "hephaestus/example.py",
+            "line": 3,
+            "side": "RIGHT",
+            "body": "Handle the null value before reading it.",
+        }
+        live = {
+            "thread-1": {
+                **finding,
+                "body": (
+                    "[Review] Handle the null value before reading it.\n"
+                    "<!-- hephaestus-severity: major -->"
+                ),
+            }
+        }
+
+        assert _without_duplicate_live_findings([finding], live) == []
+
     def test_reviewer_feedback_is_preserved_for_the_next_implementer(self) -> None:
         """A rejection reply is present in the next remediation prompt payload."""
         thread = self._thread("thread-1", 3, "fix this")
@@ -3429,6 +3450,53 @@ class TestEvalVerdicts:
         assert isinstance(retry, JobRequest)
         assert isinstance(retry.job, GitJob)
         assert retry.job.kwargs["isolated_generation"] == 1
+
+    def test_direct_pr_drift_restart_rebases_the_recreated_checkout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A fresh direct checkout must not inherit an old rebase attempt."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_review_context={
+                "pr_diff": "diff --git a/a.py b/a.py\n+new\n",
+                "pr_description": "Closes #1",
+                "pr_head_sha": "a" * 40,
+                "pr_base_branch": "main",
+            }
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, kind=ItemKind.PR, state="PUSH_WAIT")
+        item.worktree = "/tmp/review-pr-1001"
+        item.branch = "review-branch"
+        item.payload.update(
+            {
+                "direct_pr_rebase_attempted": True,
+                "direct_pr_rebase_pending": True,
+                "direct_pr_rebase_published": True,
+                "direct_pr_rebase_error": "old error",
+            }
+        )
+
+        assert PrReviewStage._restart_direct_pr_review(item) is None
+        assert (
+            not {
+                "direct_pr_rebase_attempted",
+                "direct_pr_rebase_pending",
+                "direct_pr_rebase_published",
+                "direct_pr_rebase_error",
+            }
+            & item.payload.keys()
+        )
+
+        item.worktree = "/tmp/review-pr-1001-1"
+        item.payload["direct_pr_worktree"] = item.worktree
+        item.state = "REVIEW_WAIT"
+        restart = stage.step(item, ctx)
+
+        assert isinstance(restart, JobRequest)
+        assert isinstance(restart.job, GitJob)
+        assert restart.job.op == "rebase"
+        assert restart.on_done_state == DIRECT_REBASE_WAIT
 
     def test_detached_push_without_a_durable_recovery_receipt_preserves_the_checkout(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -28,6 +28,7 @@ from hephaestus.automation.pipeline.stages.pr_review import (
     ADOPT_WORKTREE_WAIT,
     DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP,
     DIRECT_PUSH_RETRY_CAP,
+    DIRECT_REBASE_WAIT,
     REVIEW_CHECKOUT_WAIT,
     REVIEW_ERROR_RETRY_CAP,
     PrReviewStage,
@@ -295,6 +296,57 @@ class TestPrReviewStageStep:
         assert result.job.kwargs["base_branch"] == "main"
         assert result.on_done_state == REVIEW_CHECKOUT_WAIT
         assert "reviewed_pr_head_sha" not in item.payload
+
+    def test_direct_pr_rebases_and_lease_pushes_before_binding_review_checkout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A direct PR is refreshed onto its base before a reviewer sees its diff."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_review_context={
+                "pr_diff": "diff --git a/a.py b/a.py\n+new\n",
+                "pr_description": "Closes #1",
+                "pr_head_sha": "a" * 40,
+                "pr_base_branch": "main",
+            }
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, kind=ItemKind.PR, state="REVIEW_WAIT")
+        item.worktree = "/tmp/repo/review-worktree"
+        item.branch = "review-branch"
+        item.payload["direct_pr_worktree"] = item.worktree
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "rebase"
+        assert result.job.kwargs == {
+            "cwd": result.job.kwargs["cwd"],
+            "base_branch": "main",
+            "branch": "review-branch",
+            "expected_remote_sha": "a" * 40,
+            "publish_detached_head": True,
+        }
+        assert result.on_done_state == DIRECT_REBASE_WAIT
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=True,
+                value={"rebased": True, "published": True, "head_sha": "b" * 40},
+            ),
+            ctx,
+        )
+        item.state = result.on_done_state
+        transition = stage.step(item, ctx)
+        assert transition == Continue(next_state="REVIEW_WAIT")
+        item.state = transition.next_state
+
+        barrier = stage.step(item, ctx)
+        assert isinstance(barrier, JobRequest)
+        assert isinstance(barrier.job, GitJob)
+        assert barrier.job.op == "verify_pr_review_checkout"
 
     def test_checkout_barrier_renews_the_proof_for_an_unchanged_head(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2167,6 +2167,44 @@ class TestGitOps:
         assert result.ok is rebase_clean
         assert result.value is rebase_clean
 
+    def test_direct_rebase_dispatch_lease_pushes_the_detached_head(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A direct-review rebase publishes only against its captured PR head."""
+        job = GitJob(
+            repo="test/repo",
+            op="rebase",
+            timeout_s=60,
+            kwargs={
+                "cwd": tmp_path,
+                "base_branch": "main",
+                "branch": "70-existing",
+                "expected_remote_sha": "a" * 40,
+                "publish_detached_head": True,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.rebase_worktree_onto", return_value=True) as mock_rebase,
+            patch.object(pool, "_read_detached_push_head", return_value="b" * 40),
+            patch(f"{_WP}.git_utils.push_head_to_branch") as mock_push,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        mock_rebase.assert_called_once_with(cwd=tmp_path, base_branch="main", timeout=60)
+        mock_push.assert_called_once_with(
+            "70-existing",
+            "a" * 40,
+            tmp_path,
+            source_sha="b" * 40,
+            timeout=60,
+        )
+        assert result.ok is True
+        assert result.value == {"rebased": True, "published": True, "head_sha": "b" * 40}
+
     def test_push_dispatch(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1919,7 +1919,6 @@ class TestGitOps:
                     MagicMock(stdout="a" * 40 + "\n"),
                     MagicMock(stdout=""),
                     MagicMock(stdout="b" * 40 + "\n"),
-                    MagicMock(returncode=0),
                     MagicMock(stdout="checkout diff for A"),
                 ],
             ) as mock_run,
@@ -1935,7 +1934,7 @@ class TestGitOps:
             "diff": "checkout diff for A",
         }
         mock_sync.assert_called_once_with(tmp_path, "70-existing", pr_number=70, timeout=60)
-        assert mock_run.call_args_list[4].args[0] == [
+        assert mock_run.call_args_list[3].args[0] == [
             "git",
             "diff",
             "--no-ext-diff",
@@ -1960,6 +1959,7 @@ class TestGitOps:
                 "expected_head_sha": "a" * 40,
                 "base_branch": "main",
                 "pr_number": 70,
+                "require_base_ancestor": True,
             },
         )
         with (
@@ -2006,6 +2006,7 @@ class TestGitOps:
                 "expected_head_sha": "a" * 40,
                 "base_branch": "main",
                 "pr_number": 70,
+                "require_base_ancestor": True,
             },
         )
         with (

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1919,6 +1919,7 @@ class TestGitOps:
                     MagicMock(stdout="a" * 40 + "\n"),
                     MagicMock(stdout=""),
                     MagicMock(stdout="b" * 40 + "\n"),
+                    MagicMock(returncode=0),
                     MagicMock(stdout="checkout diff for A"),
                 ],
             ) as mock_run,
@@ -1934,13 +1935,59 @@ class TestGitOps:
             "diff": "checkout diff for A",
         }
         mock_sync.assert_called_once_with(tmp_path, "70-existing", pr_number=70, timeout=60)
-        assert mock_run.call_args_list[3].args[0] == [
+        assert mock_run.call_args_list[4].args[0] == [
             "git",
             "diff",
             "--no-ext-diff",
             "--binary",
             f"{'b' * 40}...{'a' * 40}",
         ]
+
+    def test_verify_pr_review_checkout_retries_when_base_drifted(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A head behind the freshly fetched base cannot be reviewed."""
+        job = GitJob(
+            repo="test/repo",
+            op="verify_pr_review_checkout",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path),
+                "branch": "70-existing",
+                "expected_head_sha": "a" * 40,
+                "base_branch": "main",
+                "pr_number": 70,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
+            patch(f"{_WP}.git_utils.sync_worktree_to_remote_branch"),
+            patch(
+                f"{_WP}.git_utils.run",
+                side_effect=[
+                    MagicMock(stdout="a" * 40 + "\n"),
+                    MagicMock(stdout=""),
+                    MagicMock(stdout="b" * 40 + "\n"),
+                    MagicMock(returncode=1),
+                ],
+            ) as mock_run,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {"ready": False, "reason": "base_drift"}
+        assert mock_run.call_args_list[3].args[0] == [
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            "b" * 40,
+            "a" * 40,
+        ]
+        assert mock_run.call_args_list[3].kwargs["check"] is False
 
     def test_verify_pr_review_checkout_reports_sync_failure(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1989,6 +1989,44 @@ class TestGitOps:
         ]
         assert mock_run.call_args_list[3].kwargs["check"] is False
 
+    def test_verify_pr_review_checkout_fails_when_base_ancestry_check_errors(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """An ancestry-check operational error must not trigger a rebase retry."""
+        job = GitJob(
+            repo="test/repo",
+            op="verify_pr_review_checkout",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path),
+                "branch": "70-existing",
+                "expected_head_sha": "a" * 40,
+                "base_branch": "main",
+                "pr_number": 70,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
+            patch(f"{_WP}.git_utils.sync_worktree_to_remote_branch"),
+            patch(
+                f"{_WP}.git_utils.run",
+                side_effect=[
+                    MagicMock(stdout="a" * 40 + "\n"),
+                    MagicMock(stdout=""),
+                    MagicMock(stdout="b" * 40 + "\n"),
+                    MagicMock(returncode=128),
+                ],
+            ),
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "review checkout base ancestry check failed"
+
     def test_verify_pr_review_checkout_reports_sync_failure(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -294,41 +294,67 @@ class TestAllThreadReplyAndReviewerResolution:
         assert attached_review_ids == ["review-1", "review-1"]
         assert submitted_review_ids == ["review-1"]
 
-    def test_implementation_responses_use_only_thread_reply_mutations(
+    def test_singleton_implementation_response_uses_one_submitted_review(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Implementation output has no general PullRequestReview body."""
+        """A one-thread pass retains the same submitted-review handoff contract."""
         thread = _external_reviewer_thread("thread-one")
         live = thread
-        queries: list[str] = []
+        created_reviews: list[dict[str, str | int]] = []
+        attached_review_ids: list[str] = []
+        submitted_review_ids: list[str] = []
 
         def snapshot(_pr: int, _thread_id: str) -> dict[str, Any]:
             return _open_thread_snapshot(live)
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
             nonlocal live
-            queries.append(query)
-            if "addPullRequestReviewThreadReply" not in query:
-                raise AssertionError(f"unexpected review-envelope mutation: {query}")
-            assert "pullRequestReviewId" not in query
-            body = str(fields["body"])
-            live = {
-                **live,
-                "comments": [
-                    *live["comments"],
-                    {
-                        "id": "implementation-comment",
-                        "author": "hephaestus[bot]",
-                        "body": body,
-                        "viewer_did_author": True,
-                    },
-                ],
-            }
-            return {
-                "data": {
-                    "addPullRequestReviewThreadReply": {"comment": {"id": "implementation-comment"}}
+            if "addPullRequestReview(input:" in query:
+                created_reviews.append(fields)
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
+            if "addPullRequestReviewThreadReply" in query:
+                attached_review_ids.append(str(fields["reviewId"]))
+                body = str(fields["body"])
+                live = {
+                    **live,
+                    "comments": [
+                        *live["comments"],
+                        {
+                            "id": "implementation-comment",
+                            "author": "hephaestus[bot]",
+                            "body": body,
+                            "viewer_did_author": True,
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
+                        },
+                    ],
                 }
-            }
+                return {
+                    "data": {
+                        "addPullRequestReviewThreadReply": {
+                            "comment": {"id": "implementation-comment"}
+                        }
+                    }
+                }
+            if "submitPullRequestReview" in query:
+                submitted_review_ids.append(str(fields["reviewId"]))
+                live = {
+                    **live,
+                    "comments": [
+                        *live["comments"][:-1],
+                        {**live["comments"][-1], "review_state": "COMMENTED"},
+                    ],
+                }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
+                }
+            raise AssertionError(query)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
         monkeypatch.setattr(adapter, "_graphql", graphql)
@@ -343,7 +369,9 @@ class TestAllThreadReplyAndReviewerResolution:
 
         assert result.replied_thread_ids == (thread["id"],)
         assert len(result.receipts) == 1
-        assert len(queries) == 1
+        assert len(created_reviews) == 1
+        assert attached_review_ids == ["review-1"]
+        assert submitted_review_ids == ["review-1"]
 
     def test_implementation_replies_share_one_source_attached_batch(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -677,7 +705,7 @@ class TestAllThreadReplyAndReviewerResolution:
     def test_linked_worktrees_share_one_reply_lock(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Separate worktree roots serialize direct replies through common Git metadata."""
+        """Separate worktree roots serialize implementation reviews through common Git metadata."""
         common_git_dir = tmp_path / "repository" / ".git"
         first_root = tmp_path / "worktree-first"
         second_root = tmp_path / "worktree-second"
@@ -705,26 +733,52 @@ class TestAllThreadReplyAndReviewerResolution:
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
             nonlocal live
-            assert "addPullRequestReviewThreadReply" in query
-            reply_calls.append(str(fields["body"]))
-            sleep(0.05)
-            live = {
-                **live,
-                "comments": [
-                    *live["comments"],
-                    {
-                        "id": "implementation-comment",
-                        "author": "hephaestus[bot]",
-                        "body": fields["body"],
-                        "viewer_did_author": True,
-                    },
-                ],
-            }
-            return {
-                "data": {
-                    "addPullRequestReviewThreadReply": {"comment": {"id": "implementation-comment"}}
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
+            if "addPullRequestReviewThreadReply" in query:
+                assert fields["reviewId"] == "review-1"
+                reply_calls.append(str(fields["body"]))
+                sleep(0.05)
+                live = {
+                    **live,
+                    "comments": [
+                        *live["comments"],
+                        {
+                            "id": "implementation-comment",
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
+                        },
+                    ],
                 }
-            }
+                return {
+                    "data": {
+                        "addPullRequestReviewThreadReply": {
+                            "comment": {"id": "implementation-comment"}
+                        }
+                    }
+                }
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                live = {
+                    **live,
+                    "comments": [
+                        *live["comments"][:-1],
+                        {**live["comments"][-1], "review_state": "COMMENTED"},
+                    ],
+                }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
+                }
+            raise AssertionError(query)
 
         for candidate in (first_adapter, second_adapter):
             monkeypatch.setattr(candidate, "_review_thread_snapshot", snapshot)
@@ -829,8 +883,12 @@ class TestAllThreadReplyAndReviewerResolution:
         calls: list[str] = []
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                calls.append("create-implementation-review")
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
             if "addPullRequestReviewThreadReply" in query:
                 calls.append("implementation-reply")
+                assert fields["reviewId"] == "review-1"
                 reply_body = str(fields["body"])
                 live[0] = {
                     **live[0],
@@ -841,8 +899,8 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": reply_body,
                             "viewer_did_author": True,
-                            "review_id": "implementation-review",
-                            "review_state": "COMMENTED",
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
                             "review_commit_sha": "a" * 40,
                         },
                     ],
@@ -851,6 +909,23 @@ class TestAllThreadReplyAndReviewerResolution:
                     "data": {
                         "addPullRequestReviewThreadReply": {
                             "comment": {"id": "implementation-comment"}
+                        }
+                    }
+                }
+            if "submitPullRequestReview" in query:
+                calls.append("submit-implementation-review")
+                assert fields["reviewId"] == "review-1"
+                live[0] = {
+                    **live[0],
+                    "comments": [
+                        *live[0]["comments"][:-1],
+                        {**live[0]["comments"][-1], "review_state": "COMMENTED"},
+                    ],
+                }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
                         }
                     }
                 }
@@ -924,7 +999,12 @@ class TestAllThreadReplyAndReviewerResolution:
         assert reviewer.resolved_thread_ids == (thread["id"],)
         assert reviewer.feedback_thread_ids == ()
         assert reviewer.blocked_thread_ids == ()
-        assert calls == ["implementation-reply", "resolve"]
+        assert calls == [
+            "create-implementation-review",
+            "implementation-reply",
+            "submit-implementation-review",
+            "resolve",
+        ]
 
     def test_reviewer_rejection_posts_explanation_and_keeps_thread_open(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -935,9 +1015,13 @@ class TestAllThreadReplyAndReviewerResolution:
         calls: list[str] = []
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
             if "addPullRequestReviewThreadReply" in query:
                 calls.append(str(fields["body"]))
-                is_implementation_reply = len(calls) == 1
+                is_implementation_reply = "reviewId" in fields
+                if is_implementation_reply:
+                    assert fields["reviewId"] == "review-1"
                 reply_body = str(fields["body"])
                 live[0] = {
                     **live[0],
@@ -949,11 +1033,9 @@ class TestAllThreadReplyAndReviewerResolution:
                             "body": reply_body,
                             "viewer_did_author": True,
                             "review_id": (
-                                "implementation-review"
-                                if is_implementation_reply
-                                else "reviewer-review"
+                                "review-1" if is_implementation_reply else "reviewer-review"
                             ),
-                            "review_state": "COMMENTED" if is_implementation_reply else "",
+                            "review_state": "PENDING" if is_implementation_reply else "",
                             "review_commit_sha": "a" * 40 if is_implementation_reply else "",
                         },
                     ],
@@ -962,6 +1044,22 @@ class TestAllThreadReplyAndReviewerResolution:
                     "data": {
                         "addPullRequestReviewThreadReply": {
                             "comment": {"id": f"reply-{len(calls)}"}
+                        }
+                    }
+                }
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                live[0] = {
+                    **live[0],
+                    "comments": [
+                        *live[0]["comments"][:-1],
+                        {**live[0]["comments"][-1], "review_state": "COMMENTED"},
+                    ],
+                }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
                         }
                     }
                 }
@@ -1209,13 +1307,22 @@ class TestAllThreadReplyAndReviewerResolution:
 
         assert receipts == []
 
+    @pytest.mark.parametrize(
+        "thread_ids",
+        [
+            ("thread-one",),
+            ("thread-one", "thread-two"),
+        ],
+    )
     def test_reply_batch_recovers_after_a_lost_submit_response_without_empty_review(
-        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+        self,
+        adapter: pg.PipelineGitHub,
+        monkeypatch: pytest.MonkeyPatch,
+        thread_ids: tuple[str, ...],
     ) -> None:
-        """A remotely submitted batch is recovered without a second empty review."""
-        first = _external_reviewer_thread("thread-one")
-        second = _external_reviewer_thread("thread-two")
-        live_by_id = {first["id"]: first, second["id"]: second}
+        """A submitted singleton or batch is recovered without an empty review."""
+        threads = [_external_reviewer_thread(thread_id) for thread_id in thread_ids]
+        live_by_id = {str(thread["id"]): thread for thread in threads}
         created = 0
         submitted = 0
 
@@ -1267,20 +1374,17 @@ class TestAllThreadReplyAndReviewerResolution:
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
         monkeypatch.setattr(adapter, "_graphql", graphql)
-        replies = {
-            first["id"]: "Fixed the first finding.",
-            second["id"]: "Fixed the second finding.",
-        }
+        replies = {str(thread["id"]): "Fixed the finding." for thread in threads}
 
         failed = adapter.post_implementation_thread_replies(
-            7, expected_head_sha="a" * 40, threads=[first, second], replies=replies
+            7, expected_head_sha="a" * 40, threads=threads, replies=replies
         )
         recovered = adapter.post_implementation_thread_replies(
-            7, expected_head_sha="a" * 40, threads=[first, second], replies=replies
+            7, expected_head_sha="a" * 40, threads=threads, replies=replies
         )
 
         assert failed.retryable is True
-        assert recovered.replied_thread_ids == (first["id"], second["id"])
+        assert recovered.replied_thread_ids == tuple(sorted(thread_ids))
         assert created == 1
         assert submitted == 1
 
@@ -1405,41 +1509,60 @@ class TestAllThreadReplyAndReviewerResolution:
     def test_malformed_reply_response_recovers_an_exact_host_read_receipt(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A reply mutation applied before a malformed response remains recoverable."""
+        """A singleton reply mutation applied before a malformed response remains recoverable."""
         thread = _external_reviewer_thread()
         body = adapter._implementation_thread_reply_body(
             7, "a" * 40, thread["id"], "Fixed the guard.", _BATCH_NONCE
         )
-        after = {
-            **thread,
-            "comments": [
-                *thread["comments"],
-                {
-                    "id": "implementation-comment",
-                    "author": "hephaestus[bot]",
-                    "body": body,
-                    "viewer_did_author": True,
-                    "review_id": "implementation-review",
-                },
-            ],
-        }
-        snapshot_reads = 0
+        live = thread
 
         def snapshot(_pr: int, _thread: str) -> dict[str, Any]:
-            nonlocal snapshot_reads
-            snapshot_reads += 1
-            return _open_thread_snapshot(thread if snapshot_reads == 1 else after)
+            return _open_thread_snapshot(live)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
-        monkeypatch.setattr(
-            adapter,
-            "_graphql",
-            lambda query, **_fields: (
-                {"data": {"addPullRequestReviewThreadReply": None}}
-                if "addPullRequestReviewThreadReply" in query
-                else pytest.fail(query)
-            ),
-        )
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal live
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
+            if "addPullRequestReviewThreadReply" in query:
+                assert fields["reviewId"] == "review-1"
+                live = {
+                    **live,
+                    "comments": [
+                        *live["comments"],
+                        {
+                            "id": "implementation-comment",
+                            "author": "hephaestus[bot]",
+                            "body": body,
+                            "viewer_did_author": True,
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
+                        },
+                    ],
+                }
+                return {"data": {"addPullRequestReviewThreadReply": None}}
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                live = {
+                    **live,
+                    "comments": [
+                        *live["comments"][:-1],
+                        {**live["comments"][-1], "review_state": "COMMENTED"},
+                    ],
+                }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_graphql", graphql)
 
         result = adapter.post_implementation_thread_replies(
             7,

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -156,6 +156,7 @@ def _open_thread_snapshot(thread: dict[str, Any], *, resolved: bool = False) -> 
     return {
         **thread,
         "isResolved": resolved,
+        "pr_node_id": "pull-request",
         "pr_state": {
             "state": "OPEN",
             "headRefOid": "a" * 40,
@@ -197,6 +198,101 @@ def _submitted_implementation_receipt(
 
 class TestAllThreadReplyAndReviewerResolution:
     """The implementation/reviewer split applies to every open thread author."""
+
+    def test_published_review_and_response_bodies_have_visible_role_prefixes(
+        self, adapter: pg.PipelineGitHub
+    ) -> None:
+        """The GitHub-visible role is unambiguous without inspecting markers."""
+        implementation = adapter._implementation_thread_reply_body(
+            7, "a" * 40, "thread-one", "Fixed the missing guard.", _BATCH_NONCE
+        )
+        feedback = adapter._reviewer_thread_feedback_body(
+            7, "a" * 40, "thread-one", "The null case remains uncovered."
+        )
+
+        assert implementation.startswith("[Response] Fixed the missing guard.")
+        assert feedback.startswith("[Review] Reviewer validation found this still unresolved:")
+
+    def test_implementation_batch_uses_one_pending_review_then_submits_once(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All replies from one implementation pass share one submitted review."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        created_reviews: list[dict[str, str | int]] = []
+        attached_review_ids: list[str] = []
+        submitted_review_ids: list[str] = []
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                created_reviews.append(fields)
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
+            if "addPullRequestReviewThreadReply" in query:
+                thread_id = str(fields["threadId"])
+                attached_review_ids.append(str(fields["reviewId"]))
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": f"implementation-{thread_id}",
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
+                        },
+                    ],
+                }
+                return {
+                    "data": {
+                        "addPullRequestReviewThreadReply": {
+                            "comment": {"id": f"implementation-{thread_id}"}
+                        }
+                    }
+                }
+            if "submitPullRequestReview" in query:
+                submitted_review_ids.append(str(fields["reviewId"]))
+                for thread_id, live in live_by_id.items():
+                    live_by_id[thread_id] = {
+                        **live,
+                        "comments": [
+                            *live["comments"][:-1],
+                            {**live["comments"][-1], "review_state": "COMMENTED"},
+                        ],
+                    }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
+                }
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies={
+                first["id"]: "Fixed the first finding.",
+                second["id"]: "Fixed the second finding.",
+            },
+        )
+
+        assert result.replied_thread_ids == (first["id"], second["id"])
+        assert len(created_reviews) == 1
+        assert attached_review_ids == ["review-1", "review-1"]
+        assert submitted_review_ids == ["review-1"]
 
     def test_implementation_responses_use_only_thread_reply_mutations(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
@@ -262,9 +358,10 @@ class TestAllThreadReplyAndReviewerResolution:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId" not in query
-                assert "reviewId" not in fields
+                assert fields["reviewId"] == "review-1"
                 thread_id = str(fields["threadId"])
                 reply_bodies.append(str(fields["body"]))
                 comment_id = f"implementation-{thread_id}"
@@ -277,8 +374,8 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": "implementation-review",
-                            "review_state": "COMMENTED",
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
                             "review_body": "",
                             "review_commit_sha": "a" * 40,
                         },
@@ -286,6 +383,23 @@ class TestAllThreadReplyAndReviewerResolution:
                 }
                 return {
                     "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                for thread_id, live in live_by_id.items():
+                    live_by_id[thread_id] = {
+                        **live,
+                        "comments": [
+                            *live["comments"][:-1],
+                            {**live["comments"][-1], "review_state": "COMMENTED"},
+                        ],
+                    }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
                 }
             raise AssertionError(query)
 
@@ -321,9 +435,10 @@ class TestAllThreadReplyAndReviewerResolution:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId" not in query
-                assert "reviewId" not in fields
+                assert fields["reviewId"] == "review-1"
                 thread_id = str(fields["threadId"])
                 reply_calls.append(thread_id)
                 if thread_id == second["id"] and reply_calls.count(thread_id) == 1:
@@ -338,8 +453,8 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": "implementation-review",
-                            "review_state": "COMMENTED",
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
                             "review_body": "",
                             "review_commit_sha": "a" * 40,
                         },
@@ -347,6 +462,23 @@ class TestAllThreadReplyAndReviewerResolution:
                 }
                 return {
                     "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                for thread_id, live in live_by_id.items():
+                    live_by_id[thread_id] = {
+                        **live,
+                        "comments": [
+                            *live["comments"][:-1],
+                            {**live["comments"][-1], "review_state": "COMMENTED"},
+                        ],
+                    }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
                 }
             raise AssertionError(query)
 
@@ -390,8 +522,10 @@ class TestAllThreadReplyAndReviewerResolution:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId" not in query
+                assert fields["reviewId"] == "review-1"
                 thread_id = str(fields["threadId"])
                 reply_calls.append(thread_id)
                 comment_id = f"implementation-{thread_id}"
@@ -404,14 +538,31 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": "implementation-review",
-                            "review_state": "COMMENTED",
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
                             "review_body": "",
                             "review_commit_sha": "a" * 40,
                         },
                     ],
                 }
                 return {"data": {"addPullRequestReviewThreadReply": None}}
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                for thread_id, live in live_by_id.items():
+                    live_by_id[thread_id] = {
+                        **live,
+                        "comments": [
+                            *live["comments"][:-1],
+                            {**live["comments"][-1], "review_state": "COMMENTED"},
+                        ],
+                    }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
+                }
             raise AssertionError(query)
 
         monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
@@ -451,8 +602,10 @@ class TestAllThreadReplyAndReviewerResolution:
             return _open_thread_snapshot(live_by_id[thread_id])
 
         def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            if "addPullRequestReview(input:" in query:
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
             if "addPullRequestReviewThreadReply" in query:
-                assert "pullRequestReviewId" not in query
+                assert fields["reviewId"] == "review-1"
                 thread_id = str(fields["threadId"])
                 reply_calls.append(thread_id)
                 sleep(0.05)
@@ -466,8 +619,8 @@ class TestAllThreadReplyAndReviewerResolution:
                             "author": "hephaestus[bot]",
                             "body": fields["body"],
                             "viewer_did_author": True,
-                            "review_id": "implementation-review",
-                            "review_state": "COMMENTED",
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
                             "review_body": "",
                             "review_commit_sha": "a" * 40,
                         },
@@ -475,6 +628,23 @@ class TestAllThreadReplyAndReviewerResolution:
                 }
                 return {
                     "data": {"addPullRequestReviewThreadReply": {"comment": {"id": comment_id}}}
+                }
+            if "submitPullRequestReview" in query:
+                assert fields["reviewId"] == "review-1"
+                for thread_id, live in live_by_id.items():
+                    live_by_id[thread_id] = {
+                        **live,
+                        "comments": [
+                            *live["comments"][:-1],
+                            {**live["comments"][-1], "review_state": "COMMENTED"},
+                        ],
+                    }
+                return {
+                    "data": {
+                        "submitPullRequestReview": {
+                            "pullRequestReview": {"id": "review-1", "state": "COMMENTED"}
+                        }
+                    }
                 }
             raise AssertionError(query)
 
@@ -1127,10 +1297,10 @@ class TestAllThreadReplyAndReviewerResolution:
         assert result.blocked_thread_ids == ()
         assert result.receipts[0]["implementation_reply_id"] == "implementation-comment"
 
-    def test_recovered_direct_reply_is_not_reposted_after_response_loss(
+    def test_reply_without_submitted_review_metadata_is_not_recovered(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An exact source-attached reply is recovered without another mutation."""
+        """A legacy reply without a submitted-review receipt cannot authorize recovery."""
         thread = _external_reviewer_thread()
         body = adapter._implementation_thread_reply_body(
             7, "a" * 40, thread["id"], "Fixed the guard.", _BATCH_NONCE
@@ -1161,8 +1331,8 @@ class TestAllThreadReplyAndReviewerResolution:
             replies={thread["id"]: "Fixed the guard."},
         )
 
-        assert result.replied_thread_ids == (thread["id"],)
-        assert result.retryable is False
+        assert result.replied_thread_ids == ()
+        assert result.blocked_thread_ids == (thread["id"],)
         graphql.assert_not_called()
 
     def test_reconciliation_rejects_a_receipt_without_the_host_read_reply(
@@ -3309,7 +3479,7 @@ class TestRepoScoping:
                         "path": "a.py",
                         "line": 1,
                         "side": "RIGHT",
-                        "body": "<!-- hephaestus-severity: major -->\nfinding",
+                        "body": "[Review] finding\n<!-- hephaestus-severity: major -->",
                     }
                 ],
             }
@@ -4211,8 +4381,15 @@ class TestSeverityMarker:
             "body": "Fix this",
         }
         result = pg._with_severity_marker(comment)
-        assert result.startswith("<!-- hephaestus-severity: minor -->")
+        assert result.startswith("[Review] Fix this")
+        assert "<!-- hephaestus-severity: minor -->" in result
         assert "Fix this" in result
+
+    def test_with_severity_marker_starts_with_visible_reviewer_prefix(self) -> None:
+        """Published original findings visibly identify the reviewer role."""
+        result = pg._with_severity_marker({"severity": "major", "body": "Fix this"})
+
+        assert result.startswith("[Review] Fix this")
 
     def test_with_severity_marker_defaults_absent_to_major(self) -> None:
         """_with_severity_marker defaults absent severity to major (fail-safe)."""
@@ -4220,7 +4397,8 @@ class TestSeverityMarker:
             "body": "Fix this",
         }
         result = pg._with_severity_marker(comment)
-        assert result.startswith("<!-- hephaestus-severity: major -->")
+        assert result.startswith("[Review] Fix this")
+        assert "<!-- hephaestus-severity: major -->" in result
 
     def test_with_severity_marker_persists_valid_scope_retraction_manifest(self) -> None:
         """Validated complete scope paths survive the GitHub review round trip."""
@@ -4241,7 +4419,8 @@ class TestSeverityMarker:
             "severity": "critical",
         }
         result = pg._with_severity_marker(comment)
-        assert result.startswith("<!-- hephaestus-severity: critical -->")
+        assert result.startswith("[Review] Critical finding")
+        assert "<!-- hephaestus-severity: critical -->" in result
         assert "<!-- hephaestus-severity: nitpick -->" not in result
         assert "Verdict: GO" not in result
         assert result.count("<!-- hephaestus-severity:") == 1

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -1165,10 +1165,10 @@ class TestAllThreadReplyAndReviewerResolution:
             "implementation-comment"
         ]
 
-    def test_direct_replies_share_nonce_even_when_github_assigns_distinct_reviews(
+    def test_direct_replies_with_split_reviews_are_not_validation_receipts(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The source-attached nonce is the batch receipt, not a review envelope."""
+        """One implementation pass must remain one submitted GitHub review."""
         head_sha = "a" * 40
         first = _external_reviewer_thread("thread-one")
         second = _external_reviewer_thread("thread-two")
@@ -1207,7 +1207,162 @@ class TestAllThreadReplyAndReviewerResolution:
             ],
         )
 
-        assert [receipt["id"] for receipt in receipts] == [first["id"], second["id"]]
+        assert receipts == []
+
+    def test_reply_batch_recovers_after_a_lost_submit_response_without_empty_review(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A remotely submitted batch is recovered without a second empty review."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        created = 0
+        submitted = 0
+
+        def snapshot(_pr: int, thread_id: str) -> dict[str, Any]:
+            return _open_thread_snapshot(live_by_id[thread_id])
+
+        def graphql(query: str, **fields: str | int) -> dict[str, Any]:
+            nonlocal created, submitted
+            if "addPullRequestReview(input:" in query:
+                created += 1
+                return {"data": {"addPullRequestReview": {"pullRequestReview": {"id": "review-1"}}}}
+            if "addPullRequestReviewThreadReply" in query:
+                thread_id = str(fields["threadId"])
+                live_by_id[thread_id] = {
+                    **live_by_id[thread_id],
+                    "comments": [
+                        *live_by_id[thread_id]["comments"],
+                        {
+                            "id": f"implementation-{thread_id}",
+                            "author": "hephaestus[bot]",
+                            "body": fields["body"],
+                            "viewer_did_author": True,
+                            "review_id": "review-1",
+                            "review_state": "PENDING",
+                            "review_body": "",
+                            "review_commit_sha": "a" * 40,
+                        },
+                    ],
+                }
+                return {
+                    "data": {
+                        "addPullRequestReviewThreadReply": {
+                            "comment": {"id": f"implementation-{thread_id}"}
+                        }
+                    }
+                }
+            if "submitPullRequestReview" in query:
+                submitted += 1
+                for thread_id, live in live_by_id.items():
+                    live_by_id[thread_id] = {
+                        **live,
+                        "comments": [
+                            *live["comments"][:-1],
+                            {**live["comments"][-1], "review_state": "COMMENTED"},
+                        ],
+                    }
+                return {"data": {"submitPullRequestReview": None}}
+            raise AssertionError(query)
+
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", snapshot)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+        replies = {
+            first["id"]: "Fixed the first finding.",
+            second["id"]: "Fixed the second finding.",
+        }
+
+        failed = adapter.post_implementation_thread_replies(
+            7, expected_head_sha="a" * 40, threads=[first, second], replies=replies
+        )
+        recovered = adapter.post_implementation_thread_replies(
+            7, expected_head_sha="a" * 40, threads=[first, second], replies=replies
+        )
+
+        assert failed.retryable is True
+        assert recovered.replied_thread_ids == (first["id"], second["id"])
+        assert created == 1
+        assert submitted == 1
+
+    def test_reply_batch_fails_closed_when_review_creation_is_ambiguous(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A lost create response never schedules a duplicate empty review."""
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+        live_by_id = {first["id"]: first, second["id"]: second}
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, thread_id: _open_thread_snapshot(live_by_id[thread_id]),
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_graphql",
+            lambda query, **_fields: (
+                {"data": {"addPullRequestReview": None}}
+                if "addPullRequestReview(input:" in query
+                else pytest.fail(query)
+            ),
+        )
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[first, second],
+            replies={first["id"]: "Fixed first.", second["id"]: "Fixed second."},
+        )
+
+        assert result.blocked_thread_ids == (first["id"], second["id"])
+        assert result.retryable is False
+
+    def test_reply_batch_fails_closed_for_recovered_split_reviews(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Recovered legacy replies cannot bypass the one-review contract."""
+        head_sha = "a" * 40
+        first = _external_reviewer_thread("thread-one")
+        second = _external_reviewer_thread("thread-two")
+
+        def replied(thread: dict[str, Any], review_id: str) -> dict[str, Any]:
+            body = adapter._implementation_thread_reply_body(
+                7, head_sha, thread["id"], "Fixed the finding.", _BATCH_NONCE
+            )
+            return {
+                **thread,
+                "comments": [
+                    *thread["comments"],
+                    {
+                        "id": f"implementation-{thread['id']}",
+                        "author": "hephaestus[bot]",
+                        "body": body,
+                        "viewer_did_author": True,
+                        "review_id": review_id,
+                        "review_state": "COMMENTED",
+                        "review_body": "",
+                        "review_commit_sha": head_sha,
+                    },
+                ],
+            }
+
+        live_by_id = {
+            first["id"]: replied(first, "review-one"),
+            second["id"]: replied(second, "review-two"),
+        }
+        monkeypatch.setattr(
+            adapter,
+            "_review_thread_snapshot",
+            lambda _pr, thread_id: _open_thread_snapshot(live_by_id[thread_id]),
+        )
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha=head_sha,
+            threads=[first, second],
+            replies={first["id"]: "Fixed the finding.", second["id"]: "Fixed the finding."},
+        )
+
+        assert result.blocked_thread_ids == (first["id"], second["id"])
 
     def test_validation_receipt_ignores_unanchored_review_body(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1136,6 +1136,13 @@ class TestReviewValidationPrompt:
         assert "fresh validation review" in out
         assert "current diff, the prior review conversation, and the implementation reply" in out
 
+    def test_validation_checks_the_implementers_evidence_without_rerunning_it(self) -> None:
+        """Thread validation evaluates supplied evidence, not a new local execution."""
+        out = self._build()
+
+        assert "Do not independently reproduce, rerun" in out
+        assert "sandbox access failure" in out
+
     def test_requires_explicit_two_way_validation_contract(self) -> None:
         out = self._build()
         assert '"resolved"' in out

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1142,6 +1142,7 @@ class TestReviewValidationPrompt:
 
         assert "Do not independently reproduce, rerun" in out
         assert "sandbox access failure" in out
+        assert "Do not independently adjudicate the original code-level concern" in out
 
     def test_requires_explicit_two_way_validation_contract(self) -> None:
         out = self._build()


### PR DESCRIPTION
## Summary

- Rebase and lease-push direct PR review checkouts before binding reviewer inputs.
- Publish each implementation reply pass as one submitted, source-attached review envelope.
- Make reviewer and implementation roles visible in review-thread bodies.
- Validate that an implementation response supplies adequate evidence, without independently rerunning it.

## Validation

- `uv run pytest tests/unit -q` — 6648 passed, 6 skipped
- Pre-push `uv run --all-extras --locked pytest -q` — passed
- Focused stage, worker, GitHub-publishing, and prompt suites — 609 passed
- `uv run ruff check ...` and `uv run mypy ...` — passed

Closes #2546