### PR TITLE
fix(automation): isolate direct issue restarts

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -49,6 +49,15 @@ class DetachedHeadPushRemoteProbeError(DetachedHeadPushError):
     """The remote branch could not be checked after a detached push failure."""
 
 
+class DirectBranchReservationCollisionError(RuntimeError):
+    """An absent-only direct branch reservation found an existing remote ref."""
+
+    def __init__(self, branch_name: str) -> None:
+        """Record the ref whose existence was confirmed by the remote probe."""
+        self.branch_name = branch_name
+        super().__init__(f"Direct-scope branch {branch_name} already exists")
+
+
 def _timeout_kw(timeout: int | None) -> dict[str, Any]:
     """Return a ``run`` kwargs fragment only when a timeout was provided."""
     return {} if timeout is None else {"timeout": timeout}
@@ -334,7 +343,41 @@ def reserve_remote_branch_if_absent(
             **_timeout_kw(timeout),
         )
     except subprocess.CalledProcessError as exc:
+        if _remote_branch_exists(branch_name, repo_root, timeout=timeout):
+            raise DirectBranchReservationCollisionError(branch_name) from exc
         raise RuntimeError(f"Failed to reserve direct-scope branch {branch_name}: {exc}") from exc
+
+
+def _remote_branch_exists(
+    branch_name: str,
+    repo_root: Path,
+    *,
+    timeout: int | None,
+) -> bool:
+    """Return whether a remote probe conclusively found ``branch_name``.
+
+    A rejected absent-only lease can mean a competing branch creator, but it
+    can also mean authentication, transport, or server trouble.  Only a
+    successful post-failure ``ls-remote`` result for the exact ref proves the
+    former; every other outcome remains a retriable infrastructure failure.
+    """
+    expected_ref = f"refs/heads/{branch_name}"
+    try:
+        probe = run(
+            ["git", "ls-remote", "--exit-code", "--heads", "origin", expected_ref],
+            cwd=repo_root,
+            check=False,
+            log_errors=False,
+            **_timeout_kw(timeout),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if probe.returncode != 0:
+        return False
+    return any(
+        line.partition("\t")[2] == expected_ref
+        for line in str(probe.stdout or "").splitlines()
+    )
 
 
 def push_branch_if_remote_matches(

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -375,8 +375,7 @@ def _remote_branch_exists(
     if probe.returncode != 0:
         return False
     return any(
-        line.partition("\t")[2] == expected_ref
-        for line in str(probe.stdout or "").splitlines()
+        line.partition("\t")[2] == expected_ref for line in str(probe.stdout or "").splitlines()
     )
 
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -134,6 +134,7 @@ from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARG
 from hephaestus.automation.pipeline.stages.repo import (
     DIRECT_SCOPE_BASE_SHA_KEY,
     DIRECT_SCOPE_BOOTSTRAP_KEY,
+    DIRECT_SCOPE_WORKTREE_NONCE_KEY,
     RepoIssueSource,
     is_full_commit_sha,
     product_to_work_item,
@@ -2714,10 +2715,11 @@ class Coordinator:
                 item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = source.base_sha
                 if item.kind is ItemKind.ISSUE and item.pr is None and item.issue is not None:
                     # A fresh direct issue is tied to one immutable checkout
-                    # snapshot.  Its branch must be unique per cursor so a
-                    # closed predecessor on the canonical name cannot stall
-                    # a restart before implementation reaches an agent.
+                    # snapshot.  Its branch and writer-worktree identity must
+                    # be unique per cursor so a preserved predecessor cannot
+                    # stall a restart before implementation reaches an agent.
                     item.branch = f"{item.issue}-auto-impl-direct-{source.run_nonce}"
+                    item.payload[DIRECT_SCOPE_WORKTREE_NONCE_KEY] = source.run_nonce
             if item.stage not in (StageName.REPO, StageName.FINISHED):
                 self._pass_work_count += 1
             if item.stage is StageName.FINISHED and item.result is None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -81,6 +81,7 @@ import queue as queue_mod
 import signal
 import threading
 import time
+import uuid
 from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import suppress
@@ -408,6 +409,7 @@ class _DirectIssueSource:
     repo: str
     issues: Iterator[int]
     base_sha: str
+    run_nonce: str
 
 
 @dataclass
@@ -2658,6 +2660,7 @@ class Coordinator:
             repo=repo,
             issues=iter(open_issues),
             base_sha=base_sha,
+            run_nonce=uuid.uuid4().hex,
         )
 
     def _begin_direct_pr_source(self, repo: str, base_sha: str) -> None:
@@ -2709,6 +2712,12 @@ class Coordinator:
             item = self._entry_to_item(entry, source.repo)
             if is_full_commit_sha(source.base_sha):
                 item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = source.base_sha
+                if item.kind is ItemKind.ISSUE and item.pr is None and item.issue is not None:
+                    # A fresh direct issue is tied to one immutable checkout
+                    # snapshot.  Its branch must be unique per cursor so a
+                    # closed predecessor on the canonical name cannot stall
+                    # a restart before implementation reaches an agent.
+                    item.branch = f"{item.issue}-auto-impl-direct-{source.run_nonce}"
             if item.stage not in (StageName.REPO, StageName.FINISHED):
                 self._pass_work_count += 1
             if item.stage is StageName.FINISHED and item.result is None:

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -121,6 +121,7 @@ from .base import (
 from .repo import (
     DIRECT_SCOPE_BASE_SHA_KEY,
     DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY,
+    DIRECT_SCOPE_RESERVATION_COLLISION_KEY,
     DIRECT_SCOPE_RESERVATION_KEY,
     is_full_commit_sha,
 )
@@ -381,6 +382,12 @@ class ImplementationStage(Stage):
                 f"branch {branch!r} already owned at {owner_path}; "
                 "redundant implementation superseded",
             )
+        if item.payload.pop(DIRECT_SCOPE_RESERVATION_COLLISION_KEY, None):
+            # A worker-side remote probe proved this direct branch already
+            # exists.  Retrying an absent-only reservation would only rerun
+            # pre-agent work and must never be interpreted as permission to
+            # overwrite the other owner.
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_scope_reservation_collision")
         if item.payload.pop("git_error", None):
             # Worktree creation failed: transient infrastructure, not an
             # implement outcome. If the retry budget remains, retry the
@@ -696,6 +703,16 @@ class ImplementationStage(Stage):
                     "branch": ownership.get("branch"),
                     "owner_path": ownership.get("owner_path"),
                 }
+                item.worktree = ""
+                return
+            collision = (
+                result.value.get("direct_scope_reservation_collision")
+                if result.error == "direct_scope_reservation_collision"
+                and isinstance(result.value, dict)
+                else None
+            )
+            if isinstance(collision, dict) and collision.get("branch") == item.branch:
+                item.payload[DIRECT_SCOPE_RESERVATION_COLLISION_KEY] = True
                 item.worktree = ""
                 return
             materialized_path = (

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -123,6 +123,8 @@ from .repo import (
     DIRECT_SCOPE_LOCAL_BRANCH_CLEANUP_KEY,
     DIRECT_SCOPE_RESERVATION_COLLISION_KEY,
     DIRECT_SCOPE_RESERVATION_KEY,
+    DIRECT_SCOPE_WORKTREE_NONCE_KEY,
+    is_direct_scope_worktree_nonce,
     is_full_commit_sha,
 )
 
@@ -332,6 +334,23 @@ class ImplementationStage(Stage):
         }
         if not adopted and direct_base_sha is not None:
             kwargs["base_sha"] = direct_base_sha
+            direct_worktree_nonce = item.payload.get(DIRECT_SCOPE_WORKTREE_NONCE_KEY)
+            direct_branch_prefix = f"{issue}-auto-impl-direct-"
+            if item.branch.startswith(direct_branch_prefix):
+                if (
+                    not is_direct_scope_worktree_nonce(direct_worktree_nonce)
+                    or item.branch != f"{direct_branch_prefix}{direct_worktree_nonce}"
+                ):
+                    return StageOutcome(
+                        Disposition.FINISH_FAIL,
+                        "direct_scope_worktree_nonce_invalid",
+                    )
+                kwargs["direct_worktree_nonce"] = direct_worktree_nonce
+            elif direct_worktree_nonce is not None:
+                return StageOutcome(
+                    Disposition.FINISH_FAIL,
+                    "direct_scope_worktree_nonce_invalid",
+                )
         if adopted:
             kwargs["sync_to_remote"] = True
             kwargs["pr_number"] = item.pr

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -60,6 +60,10 @@ logger = logging.getLogger(__name__)
 # discovery retains per-issue fresh-trunk semantics.
 DIRECT_SCOPE_BOOTSTRAP_KEY = "_direct_scope_bootstrap"
 DIRECT_SCOPE_BASE_SHA_KEY = "_direct_scope_base_sha"
+# The coordinator creates one UUID4 hex value per explicit issue cursor.  A
+# fresh direct run carries it through to its writer worktree so a preserved
+# failed checkout cannot block a later run for the same issue.
+DIRECT_SCOPE_WORKTREE_NONCE_KEY = "_direct_scope_worktree_nonce"
 # A direct-scope worker returns this receipt only after it has atomically
 # reserved the remote implementation branch.  It remains on the item until a
 # coordinator-owned push publishes a commit or the Finished stage releases the
@@ -81,6 +85,15 @@ def is_full_commit_sha(value: object) -> TypeGuard[str]:
     return bool(
         isinstance(value, str)
         and len(value) in (40, 64)
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def is_direct_scope_worktree_nonce(value: object) -> TypeGuard[str]:
+    """Return whether ``value`` is the coordinator's UUID4 hex token."""
+    return bool(
+        isinstance(value, str)
+        and len(value) == 32
         and all(character in "0123456789abcdef" for character in value)
     )
 

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -65,6 +65,11 @@ DIRECT_SCOPE_BASE_SHA_KEY = "_direct_scope_base_sha"
 # coordinator-owned push publishes a commit or the Finished stage releases the
 # still-unused reservation.
 DIRECT_SCOPE_RESERVATION_KEY = "_direct_scope_reservation"
+# Typed result retained only between the direct worktree reservation worker
+# and implementation's next step.  A confirmed remote collision is terminal
+# rather than a generic infrastructure retry: retrying cannot make a branch
+# owned by another run safe to overwrite.
+DIRECT_SCOPE_RESERVATION_COLLISION_KEY = "_direct_scope_reservation_collision"
 # The remote reservation is already released after a direct no-op.  Finished
 # uses this receipt to compare-and-delete the now-detached local branch only
 # after removing its worktree.

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2138,12 +2138,23 @@ class WorkerPool:
         pr_number = kwargs.pop("pr_number", None)
         repo_root_kwarg = kwargs.pop("repo_root", None)
         repo_root = Path(repo_root_kwarg) if repo_root_kwarg else get_repo_root()
-        direct_setup = self._prepare_direct_scope_worktree(
-            kwargs=kwargs,
-            sync_to_remote=sync_to_remote,
-            repo_root=repo_root,
-            timeout_s=job.timeout_s,
-        )
+        try:
+            direct_setup = self._prepare_direct_scope_worktree(
+                kwargs=kwargs,
+                sync_to_remote=sync_to_remote,
+                repo_root=repo_root,
+                timeout_s=job.timeout_s,
+            )
+        except git_utils.DirectBranchReservationCollisionError as exc:
+            # The post-failure remote probe proved another branch now owns
+            # this absent-only reservation.  Preserve that type across the
+            # worker boundary so Implementation terminalizes it rather than
+            # spending its generic transport retry budget (or an agent job).
+            return JobResult(
+                ok=False,
+                error="direct_scope_reservation_collision",
+                value={"direct_scope_reservation_collision": {"branch": exc.branch_name}},
+            )
         if isinstance(direct_setup, JobResult):
             return direct_setup
         base_sha, branch_name = direct_setup

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -70,6 +70,11 @@ def _is_full_commit_sha(ref: str) -> bool:
     return len(ref) in (40, 64) and all(ch in "0123456789abcdef" for ch in ref)
 
 
+def _is_direct_worktree_nonce(value: str) -> bool:
+    """Return whether ``value`` is the coordinator's UUID4 hex token."""
+    return len(value) == 32 and all(ch in "0123456789abcdef" for ch in value)
+
+
 class WorktreeDirtyError(Exception):
     """Raised when a worktree cannot be removed because it contains uncommitted changes."""
 
@@ -264,6 +269,7 @@ class WorktreeManager:
         remote_branch_reserved: bool = False,
         isolated: bool = False,
         isolated_generation: int = 0,
+        direct_worktree_nonce: str | None = None,
         timeout: int | None = None,
     ) -> Path:
         """Create a new worktree for an issue.
@@ -291,6 +297,9 @@ class WorktreeManager:
                 A nonzero value creates a distinct path so a changed PR head
                 is reviewed from a fresh checkout without replacing the
                 preserved failed checkout.
+            direct_worktree_nonce: Trusted per-run UUID4 hex token for a
+                direct issue writer.  It creates a new direct path while
+                preserving an interrupted predecessor's checkout.
             timeout: Optional timeout in seconds for each git command.
 
         Returns:
@@ -306,15 +315,21 @@ class WorktreeManager:
             remote_branch_reserved=remote_branch_reserved,
             isolated=isolated,
             isolated_generation=isolated_generation,
+            direct_worktree_nonce=direct_worktree_nonce,
         )
         with self.lock:
             isolated_key = f"review-pr-{issue_number}"
             if isolated_generation:
                 isolated_key = f"{isolated_key}-{isolated_generation}"
-            worktree_key: int | str = isolated_key if isolated else issue_number
+            direct_key = (
+                f"{issue_number}-direct-{direct_worktree_nonce}"
+                if direct_worktree_nonce is not None
+                else issue_number
+            )
+            worktree_key: int | str = isolated_key if isolated else direct_key
             if branch_name is None:
                 branch_name = f"{issue_number}-auto"
-            worktree_path = self.base_dir / (isolated_key if isolated else f"issue-{issue_number}")
+            worktree_path = self.base_dir / (isolated_key if isolated else f"issue-{direct_key}")
             if base_sha is not None and (
                 refresh_base
                 or isolated
@@ -389,6 +404,7 @@ class WorktreeManager:
         remote_branch_reserved: bool,
         isolated: bool,
         isolated_generation: int,
+        direct_worktree_nonce: str | None,
     ) -> None:
         """Validate non-I/O worktree request invariants before acquiring locks."""
         if (
@@ -399,6 +415,10 @@ class WorktreeManager:
             raise RuntimeError("isolated worktree generation is invalid")
         if isolated_generation and not isolated:
             raise RuntimeError("isolated worktree generation requires isolation")
+        if direct_worktree_nonce is not None and (
+            base_sha is None or isolated or not _is_direct_worktree_nonce(direct_worktree_nonce)
+        ):
+            raise RuntimeError("direct scope worktree nonce is invalid")
         if base_sha is not None and (
             refresh_base
             or isolated

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1002,9 +1002,7 @@ class TestWorktreeAndAdvise:
                 ok=False,
                 error="direct_scope_reservation_collision",
                 value={
-                    "direct_scope_reservation_collision": {
-                        "branch": "1-auto-impl-direct-abc123"
-                    }
+                    "direct_scope_reservation_collision": {"branch": "1-auto-impl-direct-abc123"}
                 },
             ),
             ctx,

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -899,6 +899,28 @@ class TestWorktreeAndAdvise:
             "base_sha": "a" * 40,
         }
 
+    def test_direct_scope_worktree_forwards_the_coordinator_run_nonce(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A restart-specific branch also receives a restart-specific worktree path."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        run_nonce = "d" * 32
+        item.branch = f"1-auto-impl-direct-{run_nonce}"
+        item.payload.update(
+            {
+                "_direct_scope_base_sha": "a" * 40,
+                "_direct_scope_worktree_nonce": run_nonce,
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs["direct_worktree_nonce"] == run_nonce
+
     def test_worktree_result_stores_path_and_dirty_state(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -175,6 +175,21 @@ class TestGate:
         assert result.next_state == "WORKTREE_WAIT"
         assert item.branch == "7-auto-impl"
 
+    def test_gate_preserves_preallocated_direct_restart_branch(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Direct-source branch allocation must survive the implementation gate unchanged."""
+        stage = ImplementationStage()
+        ctx = make_ctx(github=FakeStageGitHub(labels=["state:plan-go"]))
+        item = make_work_item(issue=7, state="GATE")
+        item.branch = "7-auto-impl-direct-abc123"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "WORKTREE_WAIT"
+        assert item.branch == "7-auto-impl-direct-abc123"
+
     def test_gate_live_label_failure_cannot_authorize_from_cached_go(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -970,6 +985,39 @@ class TestWorktreeAndAdvise:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.RETRY
         assert item.attempts["implement"] == 0  # transient: no budget burned
+
+    def test_confirmed_direct_reservation_collision_finishes_without_retry(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A confirmed branch collision stops before an agent or generic retry can run."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl-direct-abc123"
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error="direct_scope_reservation_collision",
+                value={
+                    "direct_scope_reservation_collision": {
+                        "branch": "1-auto-impl-direct-abc123"
+                    }
+                },
+            ),
+            ctx,
+        )
+        item.state = "DIRTY_DECISION_WAIT"
+        outcome = stage.step(item, ctx)
+
+        assert outcome == StageOutcome(
+            Disposition.FINISH_FAIL,
+            "direct_scope_reservation_collision",
+        )
+        assert item.attempts["implement"] == 0
+        assert "git_error_retries" not in item.payload
 
     def test_worktree_rollback_failure_preserves_direct_reservation_receipt(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -190,6 +190,8 @@ class TestQuiescence:
         assert second_item.branch == f"617-auto-impl-direct-{nonce_two.hex}"
         assert first_item.branch != second_item.branch
         assert first_item.payload["_direct_scope_base_sha"] == base_sha
+        assert first_item.payload["_direct_scope_worktree_nonce"] == nonce_one.hex
+        assert second_item.payload["_direct_scope_worktree_nonce"] == nonce_two.hex
 
     def test_direct_issue_with_open_replacement_pr_does_not_allocate_a_fresh_branch(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -132,6 +133,93 @@ def _issue_item(
 
 class TestQuiescence:
     """Full-run tests driving seeded items to the finished ledger."""
+
+    def test_fresh_direct_issue_uses_a_unique_branch_per_source_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A closed predecessor cannot reserve a later direct run's branch name."""
+        base_sha = "a" * 40
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[617],
+            loops=1,
+            projects_dir=tmp_path,
+        )
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
+        nonce_one = uuid.UUID(int=1)
+        nonce_two = uuid.UUID(int=2)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator.uuid.uuid4",
+            lambda: nonce_one,
+        )
+        first = Coordinator(
+            config,
+            github=FakeStageGitHub(labels=["state:plan-go"]),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        first._begin_direct_issue_source("repo-a", base_sha)
+        first_source = first._direct_issue_source
+        assert first_source is not None
+        assert first._drain_direct_issue_source() == 1
+        first_item = first.queues[StageName.IMPLEMENTATION].snapshot()[0]
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator.uuid.uuid4",
+            lambda: nonce_two,
+        )
+        second = Coordinator(
+            config,
+            github=FakeStageGitHub(labels=["state:plan-go"]),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        second._begin_direct_issue_source("repo-a", base_sha)
+        second_source = second._direct_issue_source
+        assert second_source is not None
+        assert second._drain_direct_issue_source() == 1
+        second_item = second.queues[StageName.IMPLEMENTATION].snapshot()[0]
+
+        assert first_source.run_nonce == nonce_one.hex
+        assert second_source.run_nonce == nonce_two.hex
+        assert first_item.branch == f"617-auto-impl-direct-{nonce_one.hex}"
+        assert second_item.branch == f"617-auto-impl-direct-{nonce_two.hex}"
+        assert first_item.branch != second_item.branch
+        assert first_item.payload["_direct_scope_base_sha"] == base_sha
+
+    def test_direct_issue_with_open_replacement_pr_does_not_allocate_a_fresh_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact ``Closes #N`` rediscovery path remains an adopted PR path."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[617],
+            loops=1,
+            projects_dir=tmp_path,
+        )
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(labels=["state:plan-go"], open_pr=812),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._begin_direct_issue_source("repo-a", "a" * 40)
+
+        assert coordinator._drain_direct_issue_source() == 1
+        item = coordinator.queues[StageName.PR_REVIEW].snapshot()[0]
+
+        assert item.pr == 812
+        assert item.branch == ""
+        assert item.payload["existing_pr"] is True
 
     def test_metrics_server_starts_for_run_and_stops_on_teardown(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1633,7 +1633,7 @@ class TestGitOps:
         completion_q: CompletionQueue,
         tmp_path: Path,
     ) -> None:
-        """A concurrent remote branch owner fails the worktree job closed."""
+        """A confirmed remote branch owner yields a typed terminal result."""
         pinned_sha = "a" * 40
         job = GitJob(
             repo="test/repo",
@@ -1657,14 +1657,52 @@ class TestGitOps:
             ),
             patch(
                 f"{_WP}.git_utils.reserve_remote_branch_if_absent",
-                side_effect=RuntimeError("remote branch already exists"),
+                side_effect=git_utils.DirectBranchReservationCollisionError("7-auto"),
             ),
         ):
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert "remote branch already exists" in (result.error or "")
+        assert result.error == "direct_scope_reservation_collision"
+        assert result.value == {"direct_scope_reservation_collision": {"branch": "7-auto"}}
+
+    def test_direct_pinned_worktree_keeps_unproven_reservation_failure_retryable(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A transport failure is not mislabeled as another run's branch collision."""
+        pinned_sha = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+                "refresh_base": False,
+                "base_sha": pinned_sha,
+            },
+        )
+        with (
+            patch(
+                f"{_WP}.git_utils.run",
+                return_value=subprocess.CompletedProcess([], 0, stdout=pinned_sha + "\n"),
+            ),
+            patch(
+                f"{_WP}.git_utils.reserve_remote_branch_if_absent",
+                side_effect=RuntimeError("network unavailable"),
+            ),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "RuntimeError: network unavailable"
+        assert result.value is None
 
     def test_create_worktree_syncs_adopted_clean_branch(
         self,

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -15,6 +15,7 @@ from hephaestus.automation.git_utils import (
     DetachedHeadPushRemoteHeadChangedError,
     DetachedHeadPushRemoteHeadUnchangedError,
     DetachedHeadPushRemoteProbeError,
+    DirectBranchReservationCollisionError,
     _commit_policy_rebase_command,
     _remove_untracked_files_tracked_by_ref,
     clear_repo_caches,
@@ -418,6 +419,48 @@ class TestDirectScopeBranchReservation:
             cwd=tmp_path,
             timeout=42,
         )
+
+    def test_reserve_reports_a_typed_collision_only_after_exact_remote_probe(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """A failed absent-only lease is a collision only when the ref is proven live."""
+        pin = "a" * 40
+        branch = "2452-auto-impl-direct-abc123"
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(1, ["git", "push"]),
+            Mock(returncode=0, stdout=f"{pin}\trefs/heads/{branch}\n"),
+        ]
+
+        with pytest.raises(DirectBranchReservationCollisionError, match=branch):
+            reserve_remote_branch_if_absent(branch, pin, tmp_path, timeout=42)
+
+        assert git_utils_mocks.run.call_args_list[1].args[0] == [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{branch}",
+        ]
+        assert git_utils_mocks.run.call_args_list[1].kwargs == {
+            "cwd": tmp_path,
+            "check": False,
+            "log_errors": False,
+            "timeout": 42,
+        }
+
+    def test_reserve_keeps_an_unproven_rejection_as_a_generic_error(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """Transport/auth failures must retain the implementation retry path."""
+        pin = "a" * 40
+        git_utils_mocks.run.side_effect = [
+            subprocess.CalledProcessError(1, ["git", "push"]),
+            Mock(returncode=2, stdout=""),
+        ]
+
+        with pytest.raises(RuntimeError, match="Failed to reserve direct-scope branch"):
+            reserve_remote_branch_if_absent("2452-auto-impl", pin, tmp_path, timeout=42)
 
     def test_strict_publish_requires_expected_remote_sha(
         self, git_utils_mocks: Any, tmp_path: Path

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -199,6 +199,32 @@ class TestWorktreeManager:
             pin,
         ]
 
+    def test_direct_scope_run_nonce_uses_a_fresh_path_without_reusing_a_stale_one(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A restarted direct run preserves the prior issue worktree."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        stale_path = manager.base_dir / "issue-2460"
+        stale_path.mkdir(parents=True)
+        run_nonce = "d" * 32
+
+        with (
+            patch.object(manager, "_worktree_holding_branch", return_value=None),
+            patch.object(manager, "_direct_scope_local_branch_exists", return_value=False),
+        ):
+            result = manager.create_worktree(
+                2460,
+                "2460-auto-impl-direct-" + run_nonce,
+                base_sha="a" * 40,
+                remote_branch_reserved=True,
+                direct_worktree_nonce=run_nonce,
+            )
+
+        assert stale_path.exists()
+        assert result == manager.base_dir / f"issue-2460-direct-{run_nonce}"
+        assert manager.worktrees[f"2460-direct-{run_nonce}"] == result
+
     def test_direct_scope_rejects_refresh_before_any_git_mutation(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:


### PR DESCRIPTION
Summary:

- Isolate direct issue restarts so direct restarts do not reuse an incorrect branch.

Testing:

- Full locked pytest suite runs in the pre-push hook.

Closes #2549