### PR TITLE
fix(automation): resolve pipeline repository identity

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -45,7 +45,7 @@ from hephaestus.cli.utils import (
 from hephaestus.config.paths import resolve_projects_dir
 
 from ._review_utils import build_automation_parser
-from .git_utils import get_repo_slug
+from .git_utils import get_repo_info
 from .pipeline.routing import PipelineScope, StageName
 
 logger = logging.getLogger(__name__)
@@ -188,13 +188,10 @@ def _resolve_repo() -> tuple[str, str]:
     """Resolve ``(org, repo)`` for the current checkout.
 
     Returns:
-        The GitHub ``owner`` and ``repo`` name derived from the local repo
-        slug (``owner/repo``).
+        The GitHub ``owner`` and ``repo`` name derived from the local remote.
 
     """
-    slug = get_repo_slug()
-    org, _, repo = slug.partition("/")
-    return org, repo
+    return get_repo_info()
 
 
 def main() -> int:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -62,6 +62,7 @@ from .dependency_resolver import CyclicDependencyError, DependencyResolver
 # that constructs an IssueImplementer.  Explicit ``as`` alias satisfies mypy
 # ``implicit_reexport=false`` and makes the re-export intentional.
 from .git_utils import (
+    get_repo_info,
     get_repo_root as get_repo_root,
     run,
 )
@@ -430,15 +431,10 @@ def _resolve_repo() -> tuple[str, str]:
     """Resolve ``(org, repo)`` for the current checkout.
 
     Returns:
-        The GitHub ``owner`` and ``repo`` name derived from the local repo
-        slug (``owner/repo``).
+        The GitHub ``owner`` and ``repo`` name derived from the local remote.
 
     """
-    from .git_utils import get_repo_slug
-
-    slug = get_repo_slug()
-    org, _, repo = slug.partition("/")
-    return org, repo
+    return get_repo_info()
 
 
 def main() -> int:

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -36,7 +36,7 @@ from hephaestus.cli.utils import (
 from hephaestus.config.paths import resolve_projects_dir
 
 from ._review_utils import build_automation_parser
-from .git_utils import get_repo_slug
+from .git_utils import get_repo_info
 from .github_api import (
     GitHubRateLimitError,
     gh_list_open_issues,
@@ -142,13 +142,10 @@ def _resolve_repo() -> tuple[str, str]:
     """Resolve ``(org, repo)`` for the current checkout.
 
     Returns:
-        The GitHub ``owner`` and ``repo`` name derived from the local repo
-        slug (``owner/repo``).
+        The GitHub ``owner`` and ``repo`` name derived from the local remote.
 
     """
-    slug = get_repo_slug()
-    org, _, repo = slug.partition("/")
-    return org, repo
+    return get_repo_info()
 
 
 def main() -> int:

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -37,7 +37,7 @@ from hephaestus.cli.utils import (
 from hephaestus.config.paths import resolve_projects_dir
 
 from ._review_utils import build_review_parser
-from .git_utils import get_repo_slug
+from .git_utils import get_repo_info
 from .pipeline.routing import PipelineScope, StageName
 
 logger = logging.getLogger(__name__)
@@ -118,13 +118,10 @@ def _resolve_repo() -> tuple[str, str]:
     """Resolve ``(org, repo)`` for the current checkout.
 
     Returns:
-        The GitHub ``owner`` and ``repo`` name derived from the local repo
-        slug (``owner/repo``).
+        The GitHub ``owner`` and ``repo`` name derived from the local remote.
 
     """
-    slug = get_repo_slug()
-    org, _, repo = slug.partition("/")
-    return org, repo
+    return get_repo_info()
 
 
 def main() -> int:

--- a/tests/unit/automation/test_wrapper_repo_identity.py
+++ b/tests/unit/automation/test_wrapper_repo_identity.py
@@ -1,0 +1,36 @@
+"""Regression coverage for queue-pipeline wrapper repository identity."""
+
+from __future__ import annotations
+
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.automation import ci_driver, implementer, planner, pr_reviewer
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        pytest.param(planner, id="planner"),
+        pytest.param(implementer, id="implementer"),
+        pytest.param(pr_reviewer, id="pr_reviewer"),
+        pytest.param(ci_driver, id="ci_driver"),
+    ],
+)
+def test_pipeline_wrappers_use_full_repository_identity(wrapper: ModuleType) -> None:
+    """Pipeline scopes use ``get_repo_info``, not the short logging slug."""
+    with (
+        patch.object(wrapper, "get_repo_slug", return_value="Hephaestus", create=True) as get_slug,
+        patch.object(
+            wrapper,
+            "get_repo_info",
+            return_value=("HomericIntelligence", "Hephaestus"),
+            create=True,
+        ) as get_repo_info,
+    ):
+        assert wrapper._resolve_repo() == ("HomericIntelligence", "Hephaestus")
+
+    get_repo_info.assert_called_once_with()
+    get_slug.assert_not_called()


### PR DESCRIPTION
Summary:
- resolve direct pipeline wrapper scopes from the configured remote owner/repository identity
- preserve `get_repo_slug()` as the short display/logging identifier
- cover planner, implementer, PR-review, and drive-green wrappers with a regression test

Closes #2552
