### PR TITLE
Propagate per-PR merge failures to the merge command exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,14 @@ sync (#993).
 | `hephaestus-pr-diff-context` | Compute author-intent and current-base pull-request diff ranges |
 | `hephaestus-repository-evidence` | Collect bounded Git history and source-pattern evidence |
 
+`hephaestus-merge-prs` exits `0` only when every discovered PR was merged,
+successfully queued, or intentionally skipped by `--dry-run`. It exits `1`
+when any requested PR is blocked, fails, or is unexpectedly left unprocessed,
+and exits `130` when interrupted. With `--json`, every outcome—including
+failure or interruption before PR discovery—contains `results`, `totals`,
+`requested`, and `processed`; pre-discovery outcomes use an empty result list,
+zero totals, and zero requested/processed counts.
+
 ### System & Data
 
 | Command | Description |

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -691,6 +691,9 @@ def main() -> int:
         prs = _list_open_prs_for_cli(repo_name)
         if prs is None:
             return _emit_pr_merge_error(args.json, "pull-request listing failed")
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        logger.error("PR merge setup failed: %s", exc)
+        return _emit_pr_merge_error(args.json)
     except KeyboardInterrupt:
         logger.warning("PR merge interrupted before batch discovery completed")
         return _emit_merge_summary(

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -21,6 +21,8 @@ import json
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from hephaestus.cli.utils import (
@@ -35,6 +37,43 @@ from hephaestus.github.git_ops import git_branch_exists, git_push, git_remote_ur
 from hephaestus.logging.utils import get_logger
 
 logger = get_logger(__name__)
+
+
+class _MergeStatus(str, Enum):
+    """Terminal state for one requested pull request."""
+
+    MERGED = "merged"
+    QUEUED = "queued"
+    SKIPPED = "skipped"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+def _escape_summary_detail(value: object) -> str:
+    """Return printable single-line text for logs and structured output."""
+    return ascii(str(value))[1:-1]
+
+
+@dataclass(frozen=True)
+class _PrMergeOutcome:
+    """Describe the terminal result of processing one pull request."""
+
+    pr_number: int | None
+    status: _MergeStatus
+    detail: str
+
+    def __post_init__(self) -> None:
+        """Normalize untrusted provider text before output."""
+        object.__setattr__(self, "detail", _escape_summary_detail(self.detail))
+
+    def as_dict(self) -> dict[str, int | str | None]:
+        """Return a JSON-serializable representation of this outcome."""
+        return {
+            "pr_number": self.pr_number,
+            "status": self.status.value,
+            "detail": self.detail,
+        }
 
 
 def detect_repo_from_remote() -> str | None:
@@ -179,13 +218,16 @@ def try_push_head_branch(head_branch: str, dry_run: bool) -> None:
         )
 
 
-def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
-    """Handle and log the result of a PR merge.
+def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> _PrMergeOutcome:
+    """Classify the result of a PR merge.
 
     Args:
         result: Merge result dict from gh api, or a legacy object-style result
         pr_number: PR number
         base_branch: Base branch name
+
+    Returns:
+        The terminal provider outcome for the pull request.
 
     """
     queued = False
@@ -200,20 +242,27 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
             message = getattr(result, "message", None)
             sha = getattr(result, "sha", None)
         except AttributeError:
-            # Fallback for unexpected types. `sha` is intentionally not set here:
-            # it is only read in the `if merged:` branch below, and this path
-            # forces merged=False.
             merged = False
             message = str(result)
+            sha = None
 
     if merged:
-        logger.info("  PR #%d merged into %s via squash. sha=%s", pr_number, base_branch, sha)
-    elif queued:
-        # A merge-queue repo does not merge synchronously: the PR is enqueued and
-        # the queue merges it server-side. This is success, not a failure.
-        logger.info("  PR #%d enqueued in the %s merge queue. %s", pr_number, base_branch, message)
-    else:
-        logger.error("  Failed to merge PR #%d. API message: %s", pr_number, message)
+        return _PrMergeOutcome(
+            pr_number,
+            _MergeStatus.MERGED,
+            f"merged into {base_branch} via squash; sha={sha}",
+        )
+    if queued:
+        return _PrMergeOutcome(
+            pr_number,
+            _MergeStatus.QUEUED,
+            f"enqueued in the {base_branch} merge queue; {message}",
+        )
+    return _PrMergeOutcome(
+        pr_number,
+        _MergeStatus.FAILED,
+        f"merge API did not merge PR: {message}",
+    )
 
 
 def _gh_json(args: list[str]) -> Any:
@@ -414,10 +463,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _emit_pr_merge_error(json_output: bool) -> int:
-    if json_output:
-        emit_json_status(1)
-    return 1
+def _emit_pr_merge_error(json_output: bool, message: str = "setup failed") -> int:
+    return _emit_merge_summary(
+        [],
+        requested=0,
+        json_output=json_output,
+        forced_exit_code=1,
+        message=message,
+    )
 
 
 def _resolve_repo_name(repo_arg: str | None) -> str | None:
@@ -461,26 +514,35 @@ def _attempt_pr_merge(
     head_sha: str,
     base_branch: str,
     dry_run: bool,
-) -> None:
+) -> _PrMergeOutcome:
     if dry_run:
         logger.info("[DRY-RUN] Would merge PR #%d via squash", pr_number)
-        return
+        return _PrMergeOutcome(
+            pr_number,
+            _MergeStatus.SKIPPED,
+            "dry-run suppressed merge",
+        )
 
-    try:
-        result = _merge_pr(repo_name, pr_number, head_sha)
-        handle_merge_result(result, pr_number, base_branch)
-    except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as exc:
-        logger.error("  Error merging PR #%d: %s", pr_number, exc)
+    result = _merge_pr(repo_name, pr_number, head_sha)
+    return handle_merge_result(result, pr_number, base_branch)
 
 
-def _process_pr(repo_name: str, pr: dict[str, Any], push_all: bool, dry_run: bool) -> None:
+def _process_pr(
+    repo_name: str,
+    pr: dict[str, Any],
+    push_all: bool,
+    dry_run: bool,
+) -> _PrMergeOutcome:
     pr_number = int(pr["number"])
     head_branch = str(pr.get("headRefName") or "")
     head_sha = str(pr.get("headRefOid") or "")
     base_branch = str(pr.get("baseRefName") or "main")
     if not head_sha:
-        logger.error("  Unable to retrieve head commit for PR #%d", pr_number)
-        return
+        return _PrMergeOutcome(
+            pr_number,
+            _MergeStatus.FAILED,
+            "head commit is missing",
+        )
 
     logger.info("\nChecking PR #%d: %s -> %s", pr_number, head_branch, base_branch)
     success = _checks_pass_or_legacy(repo_name, pr_number, head_sha)
@@ -490,14 +552,25 @@ def _process_pr(repo_name: str, pr: dict[str, Any], push_all: bool, dry_run: boo
         try_push_head_branch(head_branch, dry_run)
 
     if not success:
-        logger.warning("  CI/CD checks not successful for PR #%d. Skipping merge.", pr_number)
-        return
+        return _PrMergeOutcome(
+            pr_number,
+            _MergeStatus.BLOCKED,
+            "CI/CD checks are not successful",
+        )
 
     logger.info("  CI/CD checks passed for PR #%d. Attempting merge...", pr_number)
     if not push_all and not dry_run:
         try_push_head_branch(head_branch, dry_run)
 
-    _attempt_pr_merge(repo_name, pr_number, head_sha, base_branch, dry_run)
+    return _attempt_pr_merge(repo_name, pr_number, head_sha, base_branch, dry_run)
+
+
+def _pr_number_or_none(pr: dict[str, Any]) -> int | None:
+    """Return the PR number when the listing row contains a valid integer."""
+    try:
+        return int(pr["number"])
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def _process_open_prs(
@@ -505,35 +578,141 @@ def _process_open_prs(
     prs: list[dict[str, Any]],
     push_all: bool,
     dry_run: bool,
-) -> None:
+) -> list[_PrMergeOutcome]:
+    outcomes: list[_PrMergeOutcome] = []
     for pr in prs:
-        _process_pr(repo_name, pr, push_all=push_all, dry_run=dry_run)
+        try:
+            outcomes.append(_process_pr(repo_name, pr, push_all=push_all, dry_run=dry_run))
+        except KeyboardInterrupt:
+            outcomes.append(
+                _PrMergeOutcome(
+                    _pr_number_or_none(pr),
+                    _MergeStatus.INTERRUPTED,
+                    "processing interrupted",
+                )
+            )
+            break
+        except Exception as exc:
+            outcomes.append(
+                _PrMergeOutcome(
+                    _pr_number_or_none(pr),
+                    _MergeStatus.FAILED,
+                    f"{type(exc).__name__}: {exc}",
+                )
+            )
+    return outcomes
+
+
+def _merge_totals(outcomes: list[_PrMergeOutcome]) -> dict[str, int]:
+    """Count outcomes by every supported terminal status."""
+    totals = {status.value: 0 for status in _MergeStatus}
+    for outcome in outcomes:
+        totals[outcome.status.value] += 1
+    return totals
+
+
+def _merge_exit_code(
+    outcomes: list[_PrMergeOutcome],
+    requested: int,
+    *,
+    interrupted: bool = False,
+) -> int:
+    """Return the command exit status for a completed or interrupted batch."""
+    statuses = {outcome.status for outcome in outcomes}
+    if interrupted or _MergeStatus.INTERRUPTED in statuses:
+        return 130
+    if len(outcomes) != requested:
+        return 1
+    if statuses & {_MergeStatus.BLOCKED, _MergeStatus.FAILED}:
+        return 1
+    return 0
+
+
+def _emit_merge_summary(
+    outcomes: list[_PrMergeOutcome],
+    requested: int,
+    *,
+    json_output: bool,
+    interrupted: bool = False,
+    forced_exit_code: int | None = None,
+    message: str | None = None,
+) -> int:
+    """Log and optionally serialize the complete merge-batch summary."""
+    totals = _merge_totals(outcomes)
+    exit_code = (
+        forced_exit_code
+        if forced_exit_code is not None
+        else _merge_exit_code(outcomes, requested, interrupted=interrupted)
+    )
+
+    for outcome in outcomes:
+        logger.info(
+            "pr_merge_result pr=%s status=%s detail=%s",
+            outcome.pr_number,
+            outcome.status.value,
+            outcome.detail,
+        )
+    logger.info(
+        "pr_merge_summary requested=%d processed=%d totals=%s exit_code=%d",
+        requested,
+        len(outcomes),
+        totals,
+        exit_code,
+    )
+
+    if json_output:
+        emit_json_status(
+            exit_code,
+            message,
+            results=[outcome.as_dict() for outcome in outcomes],
+            totals=totals,
+            requested=requested,
+            processed=len(outcomes),
+        )
+    return exit_code
 
 
 def main() -> int:
     """Serve as the main entry point for PR merge automation."""
     parser = _build_arg_parser()
     args = parser.parse_args()
-    configure_github_throttle_from_args(args)
 
-    repo_name = _resolve_repo_name(args.repo)
-    if not repo_name:
-        return _emit_pr_merge_error(args.json)
+    try:
+        configure_github_throttle_from_args(args)
+        repo_name = _resolve_repo_name(args.repo)
+        if not repo_name:
+            return _emit_pr_merge_error(args.json, "repository could not be resolved")
 
-    logger.info("Working with repository: %s", repo_name)
-    if not _verify_repo_access(repo_name):
-        return _emit_pr_merge_error(args.json)
+        logger.info("Working with repository: %s", repo_name)
+        if not _verify_repo_access(repo_name):
+            return _emit_pr_merge_error(args.json, "repository access failed")
 
-    _update_main_branch(args.dry_run)
-    prs = _list_open_prs_for_cli(repo_name)
-    if prs is None:
-        return _emit_pr_merge_error(args.json)
+        _update_main_branch(args.dry_run)
+        prs = _list_open_prs_for_cli(repo_name)
+        if prs is None:
+            return _emit_pr_merge_error(args.json, "pull-request listing failed")
+    except KeyboardInterrupt:
+        logger.warning("PR merge interrupted before batch discovery completed")
+        return _emit_merge_summary(
+            [],
+            requested=0,
+            json_output=args.json,
+            interrupted=True,
+            message="interrupted before PR batch discovery completed",
+        )
 
-    _process_open_prs(repo_name, prs, push_all=args.push_all, dry_run=args.dry_run)
-    logger.info("\nDone processing all open PRs.")
-    if args.json:
-        emit_json_status(0)
-    return 0
+    outcomes = _process_open_prs(
+        repo_name,
+        prs,
+        push_all=args.push_all,
+        dry_run=args.dry_run,
+    )
+    return _emit_merge_summary(
+        outcomes,
+        requested=len(prs),
+        json_output=args.json,
+        message="PR merge batch complete",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/github/test_github_utils.py
+++ b/tests/unit/github/test_github_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.github import pr_merge as pr_merge_module
 from hephaestus.github.pr_merge import (
     checks_success_and_log,
     detect_repo_from_remote,
@@ -190,16 +191,18 @@ class TestHandleMergeResult:
     """Tests for handle_merge_result."""
 
     def test_successful_merge_logged(self):
-        """Successful merge is logged."""
+        """Successful merge is classified."""
         result = MagicMock(merged=True, sha="abc123", message="Merged")
-        # Should not raise
-        handle_merge_result(result, pr_number=42, base_branch="main")
+        outcome = handle_merge_result(result, pr_number=42, base_branch="main")
+
+        assert outcome.status is pr_merge_module._MergeStatus.MERGED
 
     def test_failed_merge_logged(self):
-        """Failed merge is logged as error."""
+        """Failed merge is classified."""
         result = MagicMock(merged=False, sha=None, message="Merge conflict")
-        # Should not raise
-        handle_merge_result(result, pr_number=42, base_branch="main")
+        outcome = handle_merge_result(result, pr_number=42, base_branch="main")
+
+        assert outcome.status is pr_merge_module._MergeStatus.FAILED
 
     def test_exception_during_result_parsing(self):
         """Handles exception during result attribute access."""
@@ -209,8 +212,9 @@ class TestHandleMergeResult:
             def merged(self):
                 raise AttributeError("no merged attr")
 
-        # Should not raise
-        handle_merge_result(BadResult(), pr_number=1, base_branch="main")
+        outcome = handle_merge_result(BadResult(), pr_number=1, base_branch="main")
+
+        assert outcome.status is pr_merge_module._MergeStatus.FAILED
 
 
 class TestTryPushHeadBranch:

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -811,6 +811,49 @@ class TestMainJson:
         assert payload["requested"] == payload["processed"] == 0
 
     @pytest.mark.parametrize(
+        "git_side_effect",
+        [
+            [subprocess.CalledProcessError(1, ["git", "checkout", "main"])],
+            [None, subprocess.CalledProcessError(1, ["git", "pull", "origin", "main"])],
+        ],
+        ids=["checkout", "pull"],
+    )
+    def test_main_update_failure_json_emits_complete_empty_summary(
+        self,
+        monkeypatch,
+        capsys,
+        git_side_effect: list[subprocess.CalledProcessError | None],
+    ) -> None:
+        """A failed checkout or pull emits the documented setup error envelope."""
+        run_git = MagicMock(side_effect=git_side_effect)
+        list_prs = MagicMock(return_value=[])
+        monkeypatch.setattr("sys.argv", ["prog", "--repo", "owner/repo", "--json"])
+        monkeypatch.setattr(pr_merge_module, "_verify_repo_access", lambda _repo: True)
+        monkeypatch.setattr(pr_merge_module, "run_git_cmd", run_git)
+        monkeypatch.setattr(pr_merge_module, "_list_open_prs_for_cli", list_prs)
+
+        assert pr_merge_module.main() == 1
+        payload = json.loads(capsys.readouterr().out)
+
+        assert payload == {
+            "status": "error",
+            "exit_code": 1,
+            "message": "setup failed",
+            "results": [],
+            "totals": {
+                "merged": 0,
+                "queued": 0,
+                "skipped": 0,
+                "blocked": 0,
+                "failed": 0,
+                "interrupted": 0,
+            },
+            "requested": 0,
+            "processed": 0,
+        }
+        list_prs.assert_not_called()
+
+    @pytest.mark.parametrize(
         "interrupt_target",
         ["_update_main_branch", "_list_open_prs_for_cli"],
     )

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hephaestus.github import pr_merge as pr_merge_module
 from hephaestus.github.pr_merge import (
     _enqueue_pr,
@@ -299,21 +301,25 @@ class TestHandleMergeResult:
     """Tests for handle_merge_result."""
 
     def test_logs_success_when_merged(self) -> None:
-        """Does not raise when merge result indicates success."""
+        """Returns a merged outcome when the provider confirms success."""
         result = MagicMock()
         result.merged = True
         result.message = "Merged"
         result.sha = "abc123"
-        # Should not raise
-        handle_merge_result(result, pr_number=42, base_branch="main")
+        outcome = handle_merge_result(result, pr_number=42, base_branch="main")
+
+        assert outcome.status is pr_merge_module._MergeStatus.MERGED
+        assert outcome.pr_number == 42
 
     def test_logs_error_when_not_merged(self) -> None:
-        """Does not raise when merge result indicates failure."""
+        """Returns a failed outcome when the provider rejects the merge."""
         result = MagicMock()
         result.merged = False
         result.message = "Merge conflict"
         result.sha = None
-        handle_merge_result(result, pr_number=42, base_branch="main")
+        outcome = handle_merge_result(result, pr_number=42, base_branch="main")
+
+        assert outcome.status is pr_merge_module._MergeStatus.FAILED
 
 
 class TestProcessPr:
@@ -330,15 +336,17 @@ class TestProcessPr:
             "try_push_head_branch",
             lambda branch, dry_run: pushes.append((branch, dry_run)),
         )
-        monkeypatch.setattr(
-            pr_merge_module,
-            "_attempt_pr_merge",
-            lambda repo, number, sha, base, dry_run: merges.append(
-                (repo, number, sha, base, dry_run)
-            ),
-        )
+        expected = pr_merge_module._PrMergeOutcome(1, pr_merge_module._MergeStatus.MERGED, "merged")
 
-        pr_merge_module._process_pr(
+        def attempt_merge(
+            repo: str, number: int, sha: str, base: str, dry_run: bool
+        ) -> pr_merge_module._PrMergeOutcome:
+            merges.append((repo, number, sha, base, dry_run))
+            return expected
+
+        monkeypatch.setattr(pr_merge_module, "_attempt_pr_merge", attempt_merge)
+
+        outcome = pr_merge_module._process_pr(
             "owner/repo",
             {
                 "number": 1,
@@ -352,6 +360,7 @@ class TestProcessPr:
 
         assert pushes == [("feature", False)]
         assert merges == [("owner/repo", 1, "abc123", "main", False)]
+        assert outcome is expected
 
     def test_process_pr_missing_head_sha_skips_checks_and_merge(self, monkeypatch) -> None:
         """PRs without a head SHA skip check and merge work."""
@@ -360,7 +369,7 @@ class TestProcessPr:
         monkeypatch.setattr(pr_merge_module, "_checks_pass_or_legacy", check)
         monkeypatch.setattr(pr_merge_module, "_attempt_pr_merge", merge)
 
-        pr_merge_module._process_pr(
+        outcome = pr_merge_module._process_pr(
             "owner/repo",
             {"number": 1, "headRefName": "feature", "baseRefName": "main"},
             push_all=False,
@@ -369,6 +378,141 @@ class TestProcessPr:
 
         check.assert_not_called()
         merge.assert_not_called()
+        assert outcome.status is pr_merge_module._MergeStatus.FAILED
+
+    @pytest.mark.parametrize(
+        ("checks_pass", "expected_events", "expected_status"),
+        [
+            (False, ["checks", "push"], pr_merge_module._MergeStatus.BLOCKED),
+            (True, ["checks", "push", "merge"], pr_merge_module._MergeStatus.MERGED),
+        ],
+    )
+    def test_push_all_preserves_check_push_merge_sequence(
+        self,
+        monkeypatch,
+        checks_pass: bool,
+        expected_events: list[str],
+        expected_status: pr_merge_module._MergeStatus,
+    ) -> None:
+        """Push-all pushes once after checks, including when checks block merging."""
+        events: list[str] = []
+
+        def checks(*_args: object) -> bool:
+            events.append("checks")
+            return checks_pass
+
+        def push(_branch: str, _dry_run: bool) -> None:
+            events.append("push")
+
+        def merge(*_args: object) -> pr_merge_module._PrMergeOutcome:
+            events.append("merge")
+            return pr_merge_module._PrMergeOutcome(1, pr_merge_module._MergeStatus.MERGED, "merged")
+
+        monkeypatch.setattr(pr_merge_module, "_checks_pass_or_legacy", checks)
+        monkeypatch.setattr(pr_merge_module, "try_push_head_branch", push)
+        monkeypatch.setattr(pr_merge_module, "_attempt_pr_merge", merge)
+
+        outcome = pr_merge_module._process_pr(
+            "owner/repo",
+            {
+                "number": 1,
+                "headRefName": "feature",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+            },
+            push_all=True,
+            dry_run=False,
+        )
+
+        assert events == expected_events
+        assert outcome.status is expected_status
+
+
+class TestMergeBatchOutcomes:
+    """Tests for batch outcome collection and exit-status selection."""
+
+    def test_all_success_returns_zero_with_merged_results(self) -> None:
+        outcomes = [
+            pr_merge_module._PrMergeOutcome(1, pr_merge_module._MergeStatus.MERGED, "merged"),
+            pr_merge_module._PrMergeOutcome(2, pr_merge_module._MergeStatus.QUEUED, "queued"),
+        ]
+
+        assert pr_merge_module._merge_exit_code(outcomes, requested=2) == 0
+
+    def test_partial_failure_continues_and_returns_one(self, monkeypatch) -> None:
+        process = MagicMock(
+            side_effect=[
+                RuntimeError("merge failed"),
+                pr_merge_module._PrMergeOutcome(2, pr_merge_module._MergeStatus.MERGED, "merged"),
+            ]
+        )
+        monkeypatch.setattr(pr_merge_module, "_process_pr", process)
+
+        outcomes = pr_merge_module._process_open_prs(
+            "owner/repo",
+            [{"number": 1}, {"number": 2}],
+            push_all=False,
+            dry_run=False,
+        )
+
+        assert [outcome.status for outcome in outcomes] == [
+            pr_merge_module._MergeStatus.FAILED,
+            pr_merge_module._MergeStatus.MERGED,
+        ]
+        assert process.call_count == 2
+        assert pr_merge_module._merge_exit_code(outcomes, requested=2) == 1
+
+    def test_all_eligible_prs_in_dry_run_are_skipped_and_exit_zero(self, monkeypatch) -> None:
+        monkeypatch.setattr(pr_merge_module, "_checks_pass_or_legacy", lambda *_args: True)
+        merge = MagicMock()
+        monkeypatch.setattr(pr_merge_module, "_merge_pr", merge)
+
+        outcomes = pr_merge_module._process_open_prs(
+            "owner/repo",
+            [
+                {
+                    "number": 1,
+                    "headRefName": "one",
+                    "headRefOid": "sha-one",
+                    "baseRefName": "main",
+                },
+                {
+                    "number": 2,
+                    "headRefName": "two",
+                    "headRefOid": "sha-two",
+                    "baseRefName": "main",
+                },
+            ],
+            push_all=False,
+            dry_run=True,
+        )
+
+        assert [outcome.status for outcome in outcomes] == [
+            pr_merge_module._MergeStatus.SKIPPED,
+            pr_merge_module._MergeStatus.SKIPPED,
+        ]
+        assert pr_merge_module._merge_exit_code(outcomes, requested=2) == 0
+        merge.assert_not_called()
+
+    def test_interruption_records_current_pr_stops_batch_and_returns_130(self, monkeypatch) -> None:
+        process = MagicMock(side_effect=KeyboardInterrupt)
+        monkeypatch.setattr(pr_merge_module, "_process_pr", process)
+
+        outcomes = pr_merge_module._process_open_prs(
+            "owner/repo",
+            [{"number": 1}, {"number": 2}],
+            push_all=False,
+            dry_run=False,
+        )
+
+        assert [outcome.status for outcome in outcomes] == [
+            pr_merge_module._MergeStatus.INTERRUPTED
+        ]
+        assert pr_merge_module._merge_exit_code(outcomes, requested=2) == 130
+        assert process.call_count == 1
+
+    def test_incomplete_batch_returns_one(self) -> None:
+        assert pr_merge_module._merge_exit_code([], requested=1) == 1
 
 
 class TestMain:
@@ -434,13 +578,13 @@ class TestMain:
     @patch("hephaestus.github.pr_merge.run_git_cmd")
     @patch("hephaestus.github.pr_merge.gh_call")
     def test_skips_pr_when_checks_fail(self, mock_gh_call, _mock_git, mock_push) -> None:
-        """main() skips merge when CI checks fail."""
+        """main() returns failure when CI checks block a requested merge."""
         mock_gh_call.side_effect = self._make_pr(bucket="fail")
         with patch("hephaestus.github.pr_merge.detect_repo_from_remote", return_value="owner/repo"):
             with patch("sys.argv", ["prog"]):
                 from hephaestus.github.pr_merge import main
 
-                assert main() == 0
+                assert main() == 1
 
         assert len(mock_gh_call.call_args_list) == 3
         mock_push.assert_not_called()
@@ -510,7 +654,7 @@ class TestMain:
             with patch("sys.argv", ["prog", "--push-all"]):
                 from hephaestus.github.pr_merge import main
 
-                assert main() == 0
+                assert main() == 1
 
         mock_push.assert_called_once_with("feature", False)
 
@@ -539,7 +683,7 @@ class TestMain:
             with patch("sys.argv", ["prog"]):
                 from hephaestus.github.pr_merge import main
 
-                assert main() == 0
+                assert main() == 1
         mock_push.assert_called_once_with("good", False)
 
     @patch("hephaestus.github.pr_merge.try_push_head_branch")
@@ -574,7 +718,7 @@ class TestMain:
             with patch("sys.argv", ["prog"]):
                 from hephaestus.github.pr_merge import main
 
-                assert main() == 0
+                assert main() == 1
 
         merge_paths = [
             call.args[0][3]
@@ -599,7 +743,22 @@ class TestMainJson:
             with patch("sys.argv", ["prog", "--json"]):
                 assert main() == 1
         payload = json.loads(capsys.readouterr().out)
-        assert payload["status"] == "error"
+        assert payload == {
+            "status": "error",
+            "exit_code": 1,
+            "message": "repository could not be resolved",
+            "results": [],
+            "totals": {
+                "merged": 0,
+                "queued": 0,
+                "skipped": 0,
+                "blocked": 0,
+                "failed": 0,
+                "interrupted": 0,
+            },
+            "requested": 0,
+            "processed": 0,
+        }
 
     @patch("hephaestus.github.pr_merge.gh_call")
     @patch("hephaestus.github.pr_merge.try_push_head_branch")
@@ -616,8 +775,22 @@ class TestMainJson:
 
                 assert main() == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["status"] == "ok"
-        assert payload["exit_code"] == 0
+        assert payload == {
+            "status": "ok",
+            "exit_code": 0,
+            "message": "PR merge batch complete",
+            "results": [],
+            "totals": {
+                "merged": 0,
+                "queued": 0,
+                "skipped": 0,
+                "blocked": 0,
+                "failed": 0,
+                "interrupted": 0,
+            },
+            "requested": 0,
+            "processed": 0,
+        }
 
     @patch("hephaestus.github.pr_merge.gh_call")
     @patch("hephaestus.github.pr_merge.run_git_cmd")
@@ -634,6 +807,96 @@ class TestMainJson:
                 assert main() == 1
         payload = json.loads(capsys.readouterr().out)
         assert payload["status"] == "error"
+        assert payload["results"] == []
+        assert payload["requested"] == payload["processed"] == 0
+
+    @pytest.mark.parametrize(
+        "interrupt_target",
+        ["_update_main_branch", "_list_open_prs_for_cli"],
+    )
+    def test_setup_interrupt_json_emits_complete_empty_summary(
+        self,
+        monkeypatch,
+        capsys,
+        interrupt_target: str,
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["prog", "--repo", "owner/repo", "--json"])
+        monkeypatch.setattr(pr_merge_module, "_verify_repo_access", lambda _repo: True)
+        monkeypatch.setattr(pr_merge_module, "_update_main_branch", MagicMock())
+        monkeypatch.setattr(
+            pr_merge_module,
+            "_list_open_prs_for_cli",
+            MagicMock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            pr_merge_module,
+            interrupt_target,
+            MagicMock(side_effect=KeyboardInterrupt),
+        )
+
+        assert pr_merge_module.main() == 130
+        payload = json.loads(capsys.readouterr().out)
+
+        assert payload == {
+            "status": "error",
+            "exit_code": 130,
+            "message": "interrupted before PR batch discovery completed",
+            "results": [],
+            "totals": {
+                "merged": 0,
+                "queued": 0,
+                "skipped": 0,
+                "blocked": 0,
+                "failed": 0,
+                "interrupted": 0,
+            },
+            "requested": 0,
+            "processed": 0,
+        }
+
+    def test_json_summary_contains_per_pr_results_and_totals(self, capsys) -> None:
+        outcomes = [
+            pr_merge_module._PrMergeOutcome(
+                7,
+                pr_merge_module._MergeStatus.FAILED,
+                "line one\nline two",
+            )
+        ]
+
+        assert (
+            pr_merge_module._emit_merge_summary(
+                outcomes,
+                requested=1,
+                json_output=True,
+            )
+            == 1
+        )
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"] == [
+            {
+                "pr_number": 7,
+                "status": "failed",
+                "detail": r"line one\nline two",
+            }
+        ]
+        assert payload["totals"]["failed"] == 1
+        assert payload["requested"] == 1
+        assert payload["processed"] == 1
+
+    def test_multiline_exception_is_escaped_in_one_summary_record(self, monkeypatch) -> None:
+        process = MagicMock(side_effect=RuntimeError("line one\nline two"))
+        monkeypatch.setattr(pr_merge_module, "_process_pr", process)
+
+        outcomes = pr_merge_module._process_open_prs(
+            "owner/repo",
+            [{"number": 7}],
+            push_all=False,
+            dry_run=False,
+        )
+
+        assert outcomes[0].detail == r"RuntimeError: line one\nline two"
+        assert "\n" not in outcomes[0].detail
 
 
 class TestSquashOnlyInvariant:
@@ -763,15 +1026,14 @@ class TestMergeQueueHandling:
         ]
 
     def test_handle_merge_result_logs_queued_as_success(self) -> None:
-        """A queued result must not be logged as a failure."""
-        with patch.object(pr_merge_module, "logger") as mock_logger:
-            handle_merge_result(
-                {"queued": True, "message": "enqueued in merge queue"},
-                pr_number=7,
-                base_branch="main",
-            )
-        mock_logger.error.assert_not_called()
-        mock_logger.info.assert_called_once()
+        """A queued result is explicitly classified as provider success."""
+        outcome = handle_merge_result(
+            {"queued": True, "message": "enqueued in merge queue"},
+            pr_number=7,
+            base_branch="main",
+        )
+
+        assert outcome.status is pr_merge_module._MergeStatus.QUEUED
 
 
 class TestCanonicalGitOps:


### PR DESCRIPTION
## Summary
- Added typed per-PR outcomes, deterministic exit codes, interruption handling, and structured summaries in `hephaestus/github/pr_merge.py:42-707`.
- Documented the CLI exit/JSON contract in `README.md:386`.
- Added coverage for success, partial failure, blocked PRs, dry-run, merge queues, incomplete batches, and interruptions in `tests/unit/github/test_pr_merge.py:301-1036`.

Verification:

- Full suite: 7,082 passed, 24 skipped, 18 deselected; coverage 84.94%.
- Ruff formatting/lint and mypy passed.
- `git diff --check` passed.
- PR-review publication deferred because the orchestrator has not created the PR yet.
- Working tree contains only the four intended modified files; no commit or GitHub mutations performed.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests -q --tb=short

## Closes
Closes #2385

Generated by Hephaestus automation
