### PR TITLE
[Fix] Invalidate stale verifier runtimes

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -118,7 +118,7 @@ _TRUSTED_GIT_CANDIDATES = (
     Path("/usr/bin/git"),
 )
 _HOST_RUNTIME_CACHE_DIRNAME = "hephaestus-host-validation-runtime"
-_HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v4-all-worker-environments"
+_HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v5-dependency-manifest"
 
 # The host verification handles code from an untrusted pull request.  Bound
 # the Git archive before extraction and bound every child output/write path.
@@ -210,6 +210,18 @@ def _host_runtime_fingerprint(runtime: Path) -> str:
         hasher.update((runtime / "pyvenv.cfg").read_bytes())
     except OSError:
         hasher.update(str(runtime).encode())
+    manifests = sorted(
+        (
+            *runtime.rglob("*.dist-info/RECORD"),
+            *runtime.rglob("*.egg-info/PKG-INFO"),
+        ),
+        key=lambda path: path.as_posix(),
+    )
+    for manifest in manifests:
+        hasher.update(manifest.relative_to(runtime).as_posix().encode())
+        hasher.update(b"\0")
+        hasher.update(manifest.read_bytes())
+        hasher.update(b"\0")
     return hasher.hexdigest()
 
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -972,6 +972,43 @@ class TestWorkerPoolSubmitComplete:
         assert (sealed / "bin" / "python").read_text(encoding="utf-8") == "host interpreter\n"
         assert not ((sealed / "bin" / "python").stat().st_mode & 0o222)
 
+    def test_verifier_runtime_does_not_reuse_a_different_dependency_set(
+        self, tmp_path: Path
+    ) -> None:
+        """A changed installed package set receives a fresh sealed runtime."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        cache_temp = tmp_path / "cache-temp"
+
+        def make_runtime(name: str, record: str) -> Path:
+            runtime = tmp_path / name
+            (runtime / "bin").mkdir(parents=True)
+            (runtime / "bin" / "python").write_text("host interpreter\n", encoding="utf-8")
+            (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+            dist_info = runtime / "lib" / "python3.13" / "site-packages" / "demo-1.0.dist-info"
+            dist_info.mkdir(parents=True)
+            (dist_info / "RECORD").write_text(record, encoding="utf-8")
+            return runtime
+
+        first_runtime = make_runtime("runtime-first", "demo.py,sha256=first,1\n")
+        second_runtime = make_runtime("runtime-second", "demo.py,sha256=second,2\n")
+
+        with (
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+            patch(f"{_WP}.sys.prefix", str(first_runtime)),
+        ):
+            first = _verifier_owned_runtime_environment(checkout)
+        with (
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+            patch(f"{_WP}.sys.prefix", str(second_runtime)),
+        ):
+            second = _verifier_owned_runtime_environment(checkout)
+
+        assert second != first
+        assert (
+            second / "lib" / "python3.13" / "site-packages" / "demo-1.0.dist-info" / "RECORD"
+        ).read_text(encoding="utf-8") == "demo.py,sha256=second,2\n"
+
     def test_verifier_runtime_dereferences_the_python_launcher(self, tmp_path: Path) -> None:
         """The sealed copy does not retain a launcher back into its source runtime."""
         checkout = tmp_path / "checkout"


### PR DESCRIPTION
## Summary

- version the sealed host-verifier runtime cache and bind it to installed distribution manifests;
- prevent an older UV dependency set from suppressing PR-review dispatch on a later one;
- add a regression test covering distinct dependency metadata with identical `pyvenv.cfg` content.

## Verification

- `uv run pytest tests/unit/automation/pipeline/test_worker_pool.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py -q --no-cov` — 357 passed.
- `uv run ruff check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py`
- `uv run ruff format --check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py`
- `uv run mypy hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py`
- Pre-push `uv run --all-extras --locked pytest -q` — 7,077 passed; coverage 84.79%.
- Exact immutable `review_python_mypy` verification against PR #2570's head now passes.

Closes #2575
