### PR TITLE
fix(automation): keep reviewer verification hermetic

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -271,27 +271,11 @@ class _HostVerificationSpec:
     descr: str
 
 
-_HOST_SAFE_UNIT_TEST_ARGS = (
-    "-o",
-    "addopts=",
-    "tests/unit",
-    "-q",
-    # These test the host's own mutation-capable Git/CI facilities or recurse
-    # into host verification itself. They require GitHub CLI access or Bash's
-    # global /tmp and are therefore intentionally left to normal CI, not this
-    # read-only immutable reviewer boundary.
-    "--ignore=tests/unit/ci/test_workflows.py",
-    "--deselect=tests/unit/automation/pipeline/test_worker_pool.py::TestGitOps",
-    "--deselect=tests/unit/automation/pipeline/test_worker_pool.py::"
-    "TestWorkerPoolSubmitComplete::test_immutable_build_test_runs_from_disposable_head_snapshot",
-)
-
-
 #: Python reviews run read-only by design.  The host therefore performs the
-#: complete fixed Python validation plan against an immutable snapshot before
-#: the reviewer sees it.  These commands deliberately cover the local work
-#: normally selected by ``$athena:pr-review`` without granting that agent a
-#: writable source tree, cache, or temporary directory.
+#: deterministic static validation against an immutable snapshot before the
+#: reviewer sees it.  Full test suites belong to the implementation stage and
+#: CI: a repository's unit tests can legitimately require controlled service,
+#: Git, or process fixtures that the no-network reviewer boundary must deny.
 _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
     _HostVerificationSpec(
         changed_path=None,
@@ -316,11 +300,6 @@ _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
         ),
         descr="review_python_mypy",
     ),
-    _HostVerificationSpec(
-        changed_path=None,
-        argv=("uv", "run", "pytest", *_HOST_SAFE_UNIT_TEST_ARGS),
-        descr="review_python_unit_tests",
-    ),
 )
 _PYTHON_VALIDATION_CONFIG_PATHS = frozenset(
     {
@@ -334,13 +313,6 @@ _PYTHON_VALIDATION_CONFIG_PATHS = frozenset(
         "tox.ini",
     }
 )
-_INTEGRATION_HOST_VERIFICATION_SPEC = _HostVerificationSpec(
-    changed_path=None,
-    argv=("uv", "run", "pytest", "tests/integration", "-q"),
-    descr="review_python_integration_tests",
-)
-
-
 #: Some Python regressions require additional bounded execution beyond the
 #: baseline review plan.  Their path trigger is derived only from a real Git
 #: diff header, never from reviewer or GitHub prose.
@@ -378,11 +350,6 @@ def _host_verification_specs(pr_diff: object) -> tuple[_HostVerificationSpec, ..
         return ()
     return (
         *_PYTHON_HOST_VERIFICATION_SPECS,
-        *(
-            (_INTEGRATION_HOST_VERIFICATION_SPEC,)
-            if any(path.startswith("tests/integration/") for path in changed_paths)
-            else ()
-        ),
         *(spec for spec in _PATH_HOST_VERIFICATION_SPECS if spec.changed_path in changed_paths),
     )
 

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -881,7 +881,7 @@ class TestPrReviewStageStep:
     def test_checkout_runs_registered_host_verification_before_primary_reviewer(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A changed regression receives the complete fixed host plan first."""
+        """A changed regression receives only hermetic host checks first."""
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state=REVIEW_CHECKOUT_WAIT)
@@ -918,22 +918,6 @@ class TestPrReviewStageStep:
                     "hephaestus/",
                     "scripts/",
                     "tests/",
-                ),
-            ),
-            (
-                "review_python_unit_tests",
-                (
-                    "uv",
-                    "run",
-                    "pytest",
-                    "-o",
-                    "addopts=",
-                    "tests/unit",
-                    "-q",
-                    "--ignore=tests/unit/ci/test_workflows.py",
-                    "--deselect=tests/unit/automation/pipeline/test_worker_pool.py::TestGitOps",
-                    "--deselect=tests/unit/automation/pipeline/test_worker_pool.py::"
-                    "TestWorkerPoolSubmitComplete::test_immutable_build_test_runs_from_disposable_head_snapshot",
                 ),
             ),
             (
@@ -999,7 +983,7 @@ class TestPrReviewStageStep:
     def test_python_changes_run_complete_host_validation_before_primary_reviewer(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A read-only Python review receives Ruff, mypy, and pytest receipts."""
+        """A read-only Python review receives deterministic static receipts."""
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state=REVIEW_CHECKOUT_WAIT)
@@ -1043,10 +1027,10 @@ class TestPrReviewStageStep:
         assert isinstance(result.job, BuildTestJob)
         assert result.job.descr == "review_python_ruff_check"
 
-    def test_integration_changes_add_integration_host_receipt(
+    def test_integration_changes_do_not_add_a_nonhermetic_host_suite(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """Changed integration coverage receives the matching fixed command."""
+        """Integration suites remain with CI rather than the no-network reviewer."""
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state=REVIEW_CHECKOUT_WAIT)
@@ -1060,7 +1044,7 @@ class TestPrReviewStageStep:
             }
         )
         request = stage.step(item, ctx)
-        for _ in range(4):
+        for _ in range(3):
             assert isinstance(request, JobRequest)
             item.state = request.on_done_state
             stage.on_job_done(
@@ -1078,8 +1062,8 @@ class TestPrReviewStageStep:
             request = stage.step(item, ctx)
 
         assert isinstance(request, JobRequest)
-        assert isinstance(request.job, BuildTestJob)
-        assert request.job.argv == ("uv", "run", "pytest", "tests/integration", "-q")
+        assert isinstance(request.job, AgentJob)
+        assert request.job.descr == "review"
 
     def test_actionable_host_failure_hands_remediation_to_implementation(
         self, make_ctx: Any, make_work_item: Any
@@ -1144,7 +1128,7 @@ class TestPrReviewStageStep:
         request = stage.step(item, ctx)
         assert isinstance(request, JobRequest)
         assert isinstance(request.job, BuildTestJob)
-        for _ in range(4):
+        for _ in range(3):
             item.state = request.on_done_state
             stage.on_job_done(
                 item,
@@ -1210,7 +1194,7 @@ class TestPrReviewStageStep:
         )
         request = stage.step(item, ctx)
         assert isinstance(request, JobRequest)
-        for _ in range(4):
+        for _ in range(3):
             item.state = request.on_done_state
             stage.on_job_done(
                 item,


### PR DESCRIPTION
## Summary

- remove generic unit- and integration-suite jobs from the no-network immutable reviewer verifier
- retain Ruff, format, and mypy checks before the fresh read-only reviewer runs
- preserve the explicitly bounded, path-specific performance verification and update the stage contract tests

## Root cause

The generic suites include controlled GitHub, Git, process, and service fixtures. Executing them in the strict reviewer sandbox produces capability-denied errors, preventing reviewer dispatch despite a valid PR head.

## Verification

- `uv run pytest tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_worker_pool.py -q --no-cov`
- `uv run ruff format --check hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`
- `uv run ruff check hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`
- `uv run mypy hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`
- pre-push: `uv run --all-extras --locked pytest -q` (7077 passed, 6 skipped)

Closes #2577
