### PR TITLE
fix(automation): preserve PR review completion ownership

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -260,6 +260,7 @@ _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
     "pending_implementation_reply_handoff_visibility_retries"
 )
 _IMPLEMENTATION_REPLY_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
+_HOST_VERIFICATION_PENDING = "host_verification_pending"
 
 
 @dataclass(frozen=True)
@@ -414,6 +415,7 @@ _ROUND_PAYLOAD_KEYS = (
     "reviewed_pr_base_sha",
     "host_verification_receipts",
     "host_verification_failure",
+    _HOST_VERIFICATION_PENDING,
 )
 
 
@@ -1066,6 +1068,11 @@ class PrReviewStage(Stage):
         item: WorkItem, ctx: StageContext, verification: _HostVerificationSpec
     ) -> JobRequest:
         """Submit one fixed host command from the immutable review plan."""
+        # Completion callbacks run before the coordinator installs
+        # ``on_done_state``.  Keep an explicit ownership marker instead of
+        # inferring this job's type from the current mini-state, which can
+        # also be the state that submits the primary review job.
+        item.payload[_HOST_VERIFICATION_PENDING] = verification.descr
         return JobRequest(
             BuildTestJob(
                 repo=item.repo,
@@ -1418,7 +1425,16 @@ class PrReviewStage(Stage):
             disposition = Disposition(str(outcome_value))
         except ValueError:
             return StageOutcome(Disposition.FINISH_FAIL, "review_worktree_cleanup_outcome_invalid")
-        self._restore_writer_worktree(item)
+        if disposition is Disposition.RETRY:
+            # A retry requires a new detached snapshot.  Do not requeue the
+            # already-consumed cleanup state, and do not temporarily expose a
+            # retained implementation checkout as reviewer input.
+            item.worktree = ""
+            if item.payload.get("writer_worktree"):
+                item.payload["reviewer_checkout_needed"] = True
+            item.state = ENTER
+        else:
+            self._restore_writer_worktree(item)
         item.payload.pop("review_worktree", None)
         item.payload.pop("direct_pr_worktree", None)
         item.payload.pop("direct_pr_worktree_dirty", None)
@@ -1442,7 +1458,7 @@ class PrReviewStage(Stage):
             return
         if self._consume_review_checkout_result(item, result):
             return
-        if item.state == HOST_VERIFICATION_WAIT:
+        if self._consume_host_verification_result(item, result):
             self._store_host_verification_result(item, result)
             return
 
@@ -1645,6 +1661,12 @@ class PrReviewStage(Stage):
                 item.payload["reviewed_pr_base_sha"] = review_base
         item.payload["review_checkout_ready"] = ready
         return True
+
+    @staticmethod
+    def _consume_host_verification_result(item: WorkItem, result: JobResult) -> bool:
+        """Claim one fixed host-check completion independent of mini-state."""
+        del result
+        return item.payload.pop(_HOST_VERIFICATION_PENDING, None) is not None
 
     @staticmethod
     def _store_host_verification_result(item: WorkItem, result: JobResult) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -459,6 +459,46 @@ class TestPrReviewStageStep:
         )
         assert item.worktree == ""
 
+    def test_review_cleanup_retry_restarts_from_a_fresh_snapshot(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A retry never re-enters cleanup after removing its old snapshot."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(
+            issue=1,
+            pr=1001,
+            kind=ItemKind.PR,
+            state=CLEANUP_REVIEW_WORKTREE_WAIT,
+        )
+        item.worktree = "/tmp/detached-review"
+        item.branch = "review-branch"
+        item.payload.update(
+            {
+                "existing_pr": True,
+                "writer_worktree": "/tmp/implementation-writer",
+                "review_worktree": item.worktree,
+                "review_worktree_cleanup_done": "pending",
+                "review_worktree_cleanup_outcome": Disposition.RETRY.value,
+                "review_worktree_cleanup_note": "review audit format failure",
+            }
+        )
+
+        removal = stage.step(item, ctx)
+        assert isinstance(removal, JobRequest)
+        stage.on_job_done(item, JobResult(ok=True), ctx)
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.RETRY, "review audit format failure"
+        )
+        assert item.state == "ENTER"
+        assert item.worktree == ""
+        assert item.payload["writer_worktree"] == "/tmp/implementation-writer"
+
+        fresh_snapshot = stage.step(item, ctx)
+        assert isinstance(fresh_snapshot, JobRequest)
+        assert fresh_snapshot.job.descr == "direct_pr_review_worktree"
+
     def test_checkout_barrier_renews_the_proof_for_an_unchanged_head(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -954,7 +994,6 @@ class TestPrReviewStageStep:
                 "stdout_tail": f"{index + 1} passed in 0.32s",
             }
             receipts.append(receipt)
-            item.state = request.on_done_state
             stage.on_job_done(
                 item,
                 JobResult(
@@ -968,6 +1007,7 @@ class TestPrReviewStageStep:
                 ),
                 ctx,
             )
+            item.state = request.on_done_state
             request = stage.step(item, ctx)
 
         review = request
@@ -979,6 +1019,15 @@ class TestPrReviewStageStep:
         assert review.job.prompt_kwargs["host_verifications_json"] == json.dumps(
             receipts, sort_keys=True
         )
+
+        # The coordinator calls on_job_done before installing the next state.
+        # A reviewer sent from HOST_VERIFICATION_WAIT must retain its audit
+        # rather than being consumed as an additional host receipt.
+        audit = _valid_audit()
+        stage.on_job_done(item, JobResult(ok=True, value=audit), ctx)
+
+        assert item.payload["review_audit"] == audit
+        assert item.payload["host_verification_receipts"] == receipts
 
     def test_python_changes_run_complete_host_validation_before_primary_reviewer(
         self, make_ctx: Any, make_work_item: Any


### PR DESCRIPTION
## Summary

- assign explicit ownership markers to host-check completions
- retain a valid reviewer audit when it is dispatched from the host-check state
- restart retry cleanup from a new detached review snapshot without exposing a writer worktree

## Validation

- `uv run --all-extras --locked pytest -q`
- `uv run ruff format --check hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`
- `uv run ruff check hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`
- `uv run mypy --cache-dir=/dev/null hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`

Closes #2579
