### PR TITLE
fix(automation): reclaim direct PR writer worktrees

### DIFF
--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -353,20 +353,35 @@ class ImplementationStage(Stage):
             "refresh_base": not adopted and direct_base_sha is None,
             "repo_root": str(ctx.paths.repo_root),
         }
-        if not adopted and direct_base_sha is not None:
+        direct_worktree_nonce = item.payload.get(DIRECT_SCOPE_WORKTREE_NONCE_KEY)
+        direct_branch_prefix = f"{issue}-auto-impl-direct-"
+        direct_branch_nonce = (
+            item.branch.removeprefix(direct_branch_prefix)
+            if item.branch.startswith(direct_branch_prefix)
+            else None
+        )
+        if direct_branch_nonce is not None and not is_direct_scope_worktree_nonce(
+            direct_branch_nonce
+        ):
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "direct_scope_worktree_nonce_invalid",
+            )
+        if adopted and direct_branch_nonce is not None:
+            # A direct source receives a new cursor nonce on every invocation,
+            # but an already-open PR retains the nonce that identifies its
+            # original managed writer. Recover that writer by the immutable
+            # branch identity, not by the new source cursor.
+            kwargs["direct_worktree_nonce"] = direct_branch_nonce
+        elif not adopted and direct_base_sha is not None:
             kwargs["base_sha"] = direct_base_sha
-            direct_worktree_nonce = item.payload.get(DIRECT_SCOPE_WORKTREE_NONCE_KEY)
-            direct_branch_prefix = f"{issue}-auto-impl-direct-"
-            if item.branch.startswith(direct_branch_prefix):
-                if (
-                    not is_direct_scope_worktree_nonce(direct_worktree_nonce)
-                    or item.branch != f"{direct_branch_prefix}{direct_worktree_nonce}"
-                ):
+            if direct_branch_nonce is not None:
+                if direct_worktree_nonce != direct_branch_nonce:
                     return StageOutcome(
                         Disposition.FINISH_FAIL,
                         "direct_scope_worktree_nonce_invalid",
                     )
-                kwargs["direct_worktree_nonce"] = direct_worktree_nonce
+                kwargs["direct_worktree_nonce"] = direct_branch_nonce
             elif direct_worktree_nonce is not None:
                 return StageOutcome(
                     Disposition.FINISH_FAIL,

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -362,6 +362,7 @@ class WorktreeManager:
                             worktree_path=worktree_path,
                             branch_name=branch_name,
                             refresh_base=refresh_base,
+                            require_exact_registered_branch=direct_worktree_nonce is not None,
                             timeout=timeout,
                         )
                     ):
@@ -517,6 +518,7 @@ class WorktreeManager:
         worktree_path: Path,
         branch_name: str,
         refresh_base: bool,
+        require_exact_registered_branch: bool,
         timeout: int | None,
     ) -> Path | None:
         """Reuse normal worktrees or clear a known-clean path before creation."""
@@ -529,6 +531,17 @@ class WorktreeManager:
                 self.worktrees[worktree_key] = existing
                 return existing
             raise BranchWorktreeOwnedError(branch_name, existing)
+        registered = (
+            self._registered_worktree_at_path(worktree_path, timeout=timeout)
+            if require_exact_registered_branch
+            else None
+        )
+        if registered is not None and registered.get("branch") != f"refs/heads/{branch_name}":
+            # The issue/nonce-derived path is only an identity when Git also
+            # proves that the path has the requested branch checked out.  A
+            # different registered branch here must never be reused when
+            # dirty or force-removed when clean.
+            raise BranchWorktreeOwnedError(branch_name, worktree_path)
         if self._reuse_existing_dirty_worktree(
             issue_number,
             worktree_key,
@@ -961,12 +974,21 @@ class WorktreeManager:
         timeout: int | None = None,
     ) -> bool:
         """Return True when ``worktree_path`` appears in git's worktree list."""
+        return self._registered_worktree_at_path(worktree_path, timeout=timeout) is not None
+
+    def _registered_worktree_at_path(
+        self,
+        worktree_path: Path,
+        *,
+        timeout: int | None = None,
+    ) -> dict[str, str] | None:
+        """Return Git's worktree record for ``worktree_path``, if registered."""
         target = worktree_path.resolve()
         for wt in self.list_worktrees(raise_on_error=True, timeout=timeout):
             path = wt.get("path")
             if path and Path(path).resolve() == target:
-                return True
-        return False
+                return wt
+        return None
 
     def _path_has_contents(self, path: Path) -> bool:
         """Return True if a path exists and contains any directory entries."""

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -309,7 +309,11 @@ class WorktreeManager:
             RuntimeError: If worktree creation fails
 
         """
+        if branch_name is None:
+            branch_name = f"{issue_number}-auto"
         self._validate_create_worktree_request(
+            issue_number=issue_number,
+            branch_name=branch_name,
             refresh_base=refresh_base,
             base_sha=base_sha,
             remote_branch_reserved=remote_branch_reserved,
@@ -327,8 +331,6 @@ class WorktreeManager:
                 else issue_number
             )
             worktree_key: int | str = isolated_key if isolated else direct_key
-            if branch_name is None:
-                branch_name = f"{issue_number}-auto"
             worktree_path = self.base_dir / (isolated_key if isolated else f"issue-{direct_key}")
             if base_sha is not None and (
                 refresh_base
@@ -399,6 +401,8 @@ class WorktreeManager:
     @staticmethod
     def _validate_create_worktree_request(
         *,
+        issue_number: int,
+        branch_name: str,
         refresh_base: bool,
         base_sha: str | None,
         remote_branch_reserved: bool,
@@ -416,7 +420,9 @@ class WorktreeManager:
         if isolated_generation and not isolated:
             raise RuntimeError("isolated worktree generation requires isolation")
         if direct_worktree_nonce is not None and (
-            base_sha is None or isolated or not _is_direct_worktree_nonce(direct_worktree_nonce)
+            isolated
+            or not _is_direct_worktree_nonce(direct_worktree_nonce)
+            or branch_name != f"{issue_number}-auto-impl-direct-{direct_worktree_nonce}"
         ):
             raise RuntimeError("direct scope worktree nonce is invalid")
         if base_sha is not None and (

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -972,6 +972,52 @@ class TestWorktreeAndAdvise:
         assert isinstance(result.job, GitJob)
         assert result.job.kwargs["direct_worktree_nonce"] == run_nonce
 
+    def test_adopted_direct_pr_reuses_the_nonce_encoded_in_its_branch(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An existing direct PR returns to its original managed writer path."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="WORKTREE_WAIT")
+        run_nonce = "d" * 32
+        item.branch = f"1-auto-impl-direct-{run_nonce}"
+        item.payload.update(
+            {
+                "existing_pr": True,
+                # A new direct cursor has a different nonce, so recovery must
+                # derive the writer identity from the adopted PR branch.
+                "_direct_scope_worktree_nonce": "e" * 32,
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs == {
+            "issue_number": 1,
+            "branch_name": f"1-auto-impl-direct-{run_nonce}",
+            "refresh_base": False,
+            "repo_root": "/tmp/repo",
+            "direct_worktree_nonce": run_nonce,
+            "sync_to_remote": True,
+            "pr_number": 1001,
+        }
+
+    def test_adopted_direct_pr_rejects_a_malformed_writer_identity(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An external lookalike branch cannot claim a managed direct path."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=1, pr=1001, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl-direct-not-a-trusted-nonce"
+        item.payload["existing_pr"] = True
+
+        assert stage.step(item, make_ctx()) == StageOutcome(
+            Disposition.FINISH_FAIL,
+            "direct_scope_worktree_nonce_invalid",
+        )
+
     def test_worktree_result_stores_path_and_dirty_state(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -225,6 +225,26 @@ class TestWorktreeManager:
         assert result == manager.base_dir / f"issue-2460-direct-{run_nonce}"
         assert manager.worktrees[f"2460-direct-{run_nonce}"] == result
 
+    def test_adopted_direct_pr_reuses_its_matching_nonce_writer(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """A later adopted-PR pass can reclaim its managed direct writer."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        run_nonce = "d" * 32
+        branch = f"2460-auto-impl-direct-{run_nonce}"
+        expected = manager.base_dir / f"issue-2460-direct-{run_nonce}"
+
+        with patch.object(manager, "_worktree_holding_branch", return_value=expected):
+            result = manager.create_worktree(
+                2460,
+                branch,
+                direct_worktree_nonce=run_nonce,
+            )
+
+        assert result == expected
+        assert manager.worktrees[f"2460-direct-{run_nonce}"] == expected
+
     def test_direct_scope_rejects_refresh_before_any_git_mutation(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -245,6 +245,46 @@ class TestWorktreeManager:
         assert result == expected
         assert manager.worktrees[f"2460-direct-{run_nonce}"] == expected
 
+    @pytest.mark.parametrize("writer_state", ["clean", "dirty"])
+    def test_adopted_direct_pr_refuses_a_different_branch_at_its_writer_path(
+        self, worktree_mocks: Any, tmp_path: Any, writer_state: str
+    ) -> None:
+        """A direct recovery never repurposes a registered writer for another branch."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        run_nonce = "d" * 32
+        branch = f"2460-auto-impl-direct-{run_nonce}"
+        expected = manager.base_dir / f"issue-2460-direct-{run_nonce}"
+        expected.mkdir(parents=True)
+
+        with (
+            patch.object(manager, "_worktree_holding_branch", return_value=None),
+            patch.object(
+                manager,
+                "_registered_worktree_at_path",
+                return_value={
+                    "path": str(expected),
+                    "branch": "refs/heads/unrelated-writer",
+                },
+            ),
+            patch(
+                "hephaestus.automation.worktree_manager.is_clean_working_tree",
+                return_value=writer_state == "clean",
+            ) as clean,
+            pytest.raises(BranchWorktreeOwnedError) as raised,
+        ):
+            manager.create_worktree(
+                2460,
+                branch,
+                direct_worktree_nonce=run_nonce,
+            )
+
+        assert raised.value.branch == branch
+        assert raised.value.owner_path == expected
+        assert manager.worktrees == {}
+        clean.assert_not_called()
+        worktree_mocks.run.assert_not_called()
+
     def test_direct_scope_rejects_refresh_before_any_git_mutation(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:


### PR DESCRIPTION
## Summary

- recover the original direct writer worktree when an existing direct PR is adopted after a process restart
- constrain reuse to the exact nonce encoded in the managed PR branch and preserve fail-closed validation
- cover recovery and malformed-identity behavior

## Verification

- uv run --all-extras --locked pytest -q
- uv run ruff format --check hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/worktree_manager.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/test_worktree_manager.py
- uv run ruff check hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/worktree_manager.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/test_worktree_manager.py
- uv run mypy --cache-dir=/dev/null hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/worktree_manager.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/test_worktree_manager.py

Closes #2582