### PR TITLE
fix(automation): route existing PR threads to remediation

### DIFF
--- a/docs/adr/0018-reviewer-owned-thread-reconciliation.md
+++ b/docs/adr/0018-reviewer-owned-thread-reconciliation.md
@@ -21,10 +21,13 @@ prose or a stale PR snapshot.
 
 ## Decision
 
-1. Every open review thread enters implementation remediation without regard
-   to author, severity marker, or historical receipt ownership. The
-   implementation agent investigates each actionable thread, fixes it, and
-   returns a concise reply describing the change. It never resolves a thread.
+1. Every open review thread without a valid current-head implementation
+   response enters implementation remediation without regard to author,
+   severity marker, or historical receipt ownership. The implementation agent
+   investigates each actionable thread, fixes it, and returns a concise reply
+   describing the change. It never resolves a thread. A complete response set
+   enters reviewer comment validation directly; it does not trigger another
+   broad review batch before that validation.
 2. The host posts an implementation reply only after a real fix commit is
    pushed. Before and after each reply it requires a complete thread snapshot
    and an open, unarmed PR at the exact expected head. A later pass may recover

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -921,12 +921,18 @@ Architectural contract:
 PR review is the sole authority for implementation approval. Reviews and
 findings are recorded on the GitHub pull request so their history survives
 local process or agent-session loss. The implementation stage owns each PR
-branch writer, including rebase and lease-publish. PR review creates one
-detached, disposable checkout of head `H`, verifies that checkout once, submits
-one batched source-anchored review for `H`, and removes the checkout before
-handoff. A later branch push does not invalidate that posted review; only the
-final `state:implementation-go` transition requires the reviewed head to still
-be the current open, unarmed PR head.
+branch writer, including rebase and lease-publish. At entry, and again
+immediately before submitting a broad audit, PR review reads the complete
+open-thread set. Threads without a current-head implementation response go
+directly to writer remediation and do not create another broad review batch. A
+complete set of current-head responses creates a detached,
+disposable checkout for comment validation only; the reviewer resolves the
+validated threads or leaves corrective feedback. A thread-free entry creates a
+detached checkout of head `H`, verifies that checkout once, submits one batched
+source-anchored review for `H`, and removes the checkout before handoff. A
+later branch push does not invalidate that posted review; only the final
+`state:implementation-go` transition requires the reviewed head to still be
+the current open, unarmed PR head.
 
 For the registered UV performance verification, the host boundary currently
 requires macOS `sandbox-exec` plus a disposable, quota-backed disk image. On
@@ -939,11 +945,15 @@ unsandboxed fallback.
 
 ```mermaid
 flowchart LR
-    PR["PR diff and requirements"] --> Snapshot["Immutable host verification"] --> Review
+    PR["PR diff and requirements"] --> ThreadGate{"Open thread state"}
+    ThreadGate -->|"no thread"| Snapshot["Immutable host verification"] --> Review
+    ThreadGate -->|"unreplied thread"| Address["Implementation fixes and replies"]
+    ThreadGate -->|"all threads replied"| Validate["Reviewer validates reply + diff"]
     Review --> GitHub["GitHub review and inline threads"]
-    GitHub --> Gate{"Open review thread?"}
-    Gate -->|"open thread"| Address["Implementation fixes and replies"] --> Validate["Reviewer validates reply + diff"]
-    Validate -->|"resolved"| Review
+    GitHub --> Gate{"New open review thread?"}
+    Gate -->|"open thread"| Address
+    Address --> Validate
+    Validate -->|"resolved"| ThreadGate
     Validate -->|"needs work"| Address
     Gate -->|"none"| Approve["state:implementation-go"]
     Approve --> MergeWait
@@ -954,9 +964,13 @@ flowchart LR
 ```mermaid
 stateDiagram-v2
     [*] --> VerifyUnarmed
-    VerifyUnarmed --> Review: open, complete, and unarmed
+    VerifyUnarmed --> ThreadGate: open, complete, and unarmed
     VerifyUnarmed --> OperatorOwned: external arm or incomplete state
-    Review --> Checkout: GitHub snapshot H captured in detached worktree
+    ThreadGate --> Implementation: thread lacks current-head response; durable no-go
+    ThreadGate --> Checkout: no open threads; broad audit
+    ThreadGate --> Checkout: all threads have current-head responses; comment validation
+    Checkout --> Review: broad audit entry and clean snapshot matches H
+    Checkout --> Validate: comment-validation entry and clean snapshot matches H
     Checkout --> HostVerification: clean checkout matches snapshot head and fixed check is required
     HostVerification --> Review: immutable snapshot verification passed
     HostVerification --> Implementation: confirmed test failure, after durable no-go and checkout cleanup
@@ -985,8 +999,11 @@ Architectural contract:
 - Actionable findings use durable inline threads. Severity describes newly
   posted findings only; it never makes an existing unresolved thread advisory.
 - Prior rounds remain visible in the PR timeline.
-- Any open review thread produces `state:implementation-no-go`; only a fresh
-  review with no open threads produces `state:implementation-go`.
+- Any open review thread without a current-head implementation response
+  produces `state:implementation-no-go` and is handed to implementation
+  before another broad review. A fresh broad audit of a thread-free PR, or a
+  fresh comment-validation pass that resolves every current thread, may produce
+  `state:implementation-go`.
 - The implementation agent replies to every fixed open thread but never resolves it.
 - The implementation stage rebases and lease-publishes the writer branch before
   review; a rebase is never performed by a reviewer checkout.
@@ -1002,16 +1019,18 @@ Architectural contract:
 - The review decision proof is a fresh GitHub snapshot plus a clean checkout
   at that snapshot's head. A GitHub marker can recover only a candidate reply
   after restart; it is never a substitute for that fresh proof.
-- Review agents stay read-only. For an applicable Python change, the host runs
-  its complete fixed, repository-owned `uv` validation plan (Ruff check and
-  format, mypy, unit pytest, applicable integration pytest, plus any registered
-  regression) against the checkout-proven head and supplies bounded receipts to
-  the fresh reviewer and validator. Tool/dependency configuration changes also
-  select that plan. If the running `uv` environment is inside the review
-  checkout, the host first seals a verifier-owned copy outside every worktree;
-  the untracked local environment is never accepted as evidence. The receipts
-  are evidence only: they are cleared on a new head and cannot grant
-  `state:implementation-go` without the ordinary audit and GitHub checks.
+- Review agents stay read-only. For an applicable Python change, the original
+  broad audit receives the host's fixed, repository-owned `uv` validation
+  receipts from the checkout-proven head. Comment validation instead evaluates
+  the complete current-head implementation-response receipts, thread history,
+  and checkout-bound diff; it does not create a second broad audit or demand
+  an independent rerun of an implementation claim. Tool/dependency
+  configuration changes also select the host validation plan. If the running
+  `uv` environment is inside the review checkout, the host first seals a
+  verifier-owned copy outside every worktree; the untracked local environment
+  is never accepted as evidence. The receipts are evidence only: they are
+  cleared on a new head and cannot grant `state:implementation-go` without the
+  relevant fresh audit or comment-validation and GitHub checks.
 - No queue stage arms, disables, adopts, or polls auto-merge.
 
 ### 5.6 Merge wait

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -725,7 +725,15 @@ class ImplementationStage(Stage):
             "agent_model": stage_model(ctx, "implementer", implementer_model, provider=agent),
         }
         direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
-        if direct_base_sha is not None:
+        # A direct cursor's bootstrap pin reserves a newly created writer
+        # branch.  Once an existing PR is adopted, its remote branch is the
+        # writer authority; carrying the cursor pin forward must neither
+        # require a new receipt nor lease-push against the unrelated trunk
+        # SHA.
+        requires_fresh_direct_reservation = (
+            not bool(item.payload.get("existing_pr")) and direct_base_sha is not None
+        )
+        if requires_fresh_direct_reservation:
             if not is_full_commit_sha(direct_base_sha):
                 return StageOutcome(Disposition.FINISH_FAIL, "direct_scope_base_pin_invalid")
             kwargs["expected_remote_sha"] = direct_base_sha
@@ -950,13 +958,17 @@ class ImplementationStage(Stage):
             else:
                 item.worktree = ""
             direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+            requires_fresh_direct_reservation = (
+                not bool(item.payload.get("existing_pr")) and direct_base_sha is not None
+            )
             reservation = (
                 result.value.get("direct_scope_reservation")
                 if isinstance(result.value, dict)
                 else None
             )
             if (
-                is_full_commit_sha(direct_base_sha)
+                requires_fresh_direct_reservation
+                and is_full_commit_sha(direct_base_sha)
                 and isinstance(reservation, dict)
                 and reservation.get("branch") == item.branch
                 and reservation.get("base_sha") == direct_base_sha
@@ -984,7 +996,10 @@ class ImplementationStage(Stage):
             item.payload["worktree_status"] = str(value.get("status", ""))
             item.payload["worktree_diff"] = str(value.get("diff", ""))
             direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
-            if direct_base_sha is not None:
+            requires_fresh_direct_reservation = (
+                not bool(item.payload.get("existing_pr")) and direct_base_sha is not None
+            )
+            if requires_fresh_direct_reservation:
                 reservation = value.get("direct_scope_reservation")
                 if (
                     not is_full_commit_sha(direct_base_sha)

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -3,11 +3,14 @@
 The queue stage is the sole live implementation of the review/validate/address
 state machine (docs/architecture.md §5.5 "pr_review" is the binding contract):
 
-- Normal path: ENTER creates a detached review checkout, REVIEW_WAIT binds it
+- Normal path: ENTER first reads every open thread. Any thread without a
+  current-head implementation response writes NO-GO and fails directly back
+  to ``implementation``; it never triggers another broad review. Fully
+  replied threads create a detached checkout for comment validation only.
+  A thread-free entry creates a detached review checkout, REVIEW_WAIT binds it
   once to PR head ``H``, then REVIEW_WAIT -> VALIDATE_WAIT -> POST -> EVAL.
   A clean audit writes GO and removes the checkout before advancing to
-  ``merge_wait``. Any open thread writes NO-GO, removes the checkout, and
-  fails back to ``implementation`` for the branch-writer remediation pass.
+  ``merge_wait``.
   Recovery-only mini-states for interrupted older items preserve their
   original routing but cannot grant the review stage writer capability.
 - Budgets: ``pr_review_iter`` = 3 (soft cap), ``pr_review_hard`` = 6 (hard
@@ -38,9 +41,9 @@ state machine (docs/architecture.md §5.5 "pr_review" is the binding contract):
   author—is implementation work. The implementation agent investigates and
   fixes each thread, then returns a concise reply. The host posts that reply
   only after the fix commit is pushed and never resolves the thread. The
-  reviewer then performs a fresh review of the current change, prior review,
-  implementation reply, and every open thread. The reviewer is the sole actor
-  that can resolve a valid
+  reviewer then performs a fresh comment validation of the current change,
+  prior review, implementation reply, and every open thread. The reviewer is
+  the sole actor that can resolve a valid
   thread or post precise rejection feedback while leaving it open. Any open
   thread -> no-go label, review-checkout cleanup, and implementation handoff. A clean audit ->
   ``_write_go`` performs one final complete-thread live-read, requires a
@@ -261,6 +264,7 @@ _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
 )
 _IMPLEMENTATION_REPLY_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
 _HOST_VERIFICATION_PENDING = "host_verification_pending"
+_COMMENT_VALIDATION_ONLY = "reviewer_comment_validation_only"
 
 
 @dataclass(frozen=True)
@@ -825,8 +829,9 @@ class PrReviewStage(Stage):
 
     State machine (doc section "5. pr_review"):
 
-    - ENTER: retain any implementation writer and create a detached review
-      checkout of the PR head.
+    - ENTER: route live review threads before retaining any implementation
+      writer and creating a detached review checkout of the PR head. The
+      stage repeats that thread gate immediately before a broad audit.
     - REVIEW_WAIT: clear stale round payload, submit the inline-review job
       (verdict parsed in-worker; review text is the verdict's ``raw``).
     - VALIDATE_WAIT: submit the prior-comment validation job (skipped
@@ -868,6 +873,10 @@ class PrReviewStage(Stage):
             arm_outcome = self._require_confirmed_unarmed(item.pr, ctx)
             if arm_outcome is not None:
                 return arm_outcome
+            if item.state == ENTER:
+                thread_outcome = self._route_existing_threads_before_audit(item, ctx)
+                if thread_outcome is not None:
+                    return thread_outcome
             # The implementation worktree is a branch writer. Never review
             # from it: preserve it for a possible remediation pass and create
             # a detached, disposable checkout below.
@@ -885,6 +894,120 @@ class PrReviewStage(Stage):
             # consumed at the GATE, bounds the total number of cycles).
             item.payload.pop("review_error_retries", None)
         return None
+
+    @staticmethod
+    def _route_existing_threads_before_audit(
+        item: WorkItem, ctx: StageContext
+    ) -> StageOutcome | None:
+        """Route inherited threads to their responsible role before a new audit.
+
+        An unresolved thread lacking a current-head implementation response is
+        writer work, not input for another broad review.  Conversely, a
+        complete current-head response set enters the detached checkout only
+        for reviewer comment validation, where the reviewer may resolve the
+        threads or explain why they remain open.
+        """
+        if item.pr is None:  # guarded by on_enter; keeps type narrowing local
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        entry = PrReviewStage._read_existing_thread_entry(item, ctx)
+        if entry is None:
+            return None
+        if isinstance(entry, StageOutcome):
+            return entry
+        live_threads, remediation_threads, snapshots = entry
+
+        branch = item.branch or ctx.github.get_pr_head_branch(item.pr)
+        if not branch:
+            return StageOutcome(Disposition.FINISH_FAIL, "direct_pr_no_head_branch")
+        item.branch = branch
+        item.payload["existing_pr"] = True
+
+        if all(bool(snapshot.get("implementation_reply_submitted")) for snapshot in snapshots):
+            item.payload[_COMMENT_VALIDATION_ONLY] = True
+            return None
+
+        # Scope-retraction remediation needs a base proof that only the
+        # detached checkout can derive.  Preserve the safe established path
+        # for this exceptional directive instead of sending an unprovable
+        # retraction to a writer.
+        scope_retraction_paths = _scope_retraction_paths(remediation_threads)
+        if scope_retraction_paths is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_path_invalid")
+        if scope_retraction_paths:
+            item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+            item.payload.pop("reviewed_pr_head_sha", None)
+            return None
+
+        item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+        item.payload["unresolved_threads"] = [dict(thread) for thread in live_threads]
+        item.payload["remediation_threads"] = remediation_threads
+        item.payload["remediation_thread_snapshots"] = [dict(thread) for thread in live_threads]
+        item.payload["unresolved_threads_before_address"] = len(remediation_threads)
+        no_go_outcome = PrReviewStage._write_no_go(item, ctx)
+        if no_go_outcome is not None:
+            if isinstance(no_go_outcome, StageOutcome):
+                return no_go_outcome
+            return StageOutcome(Disposition.FINISH_FAIL, "reviewed_head_drift")
+        item.payload["implementation_remediation"] = True
+        return StageOutcome(Disposition.FAIL_BACK, "implementation_remediation")
+
+    @staticmethod
+    def _read_existing_thread_entry(
+        item: WorkItem, ctx: StageContext
+    ) -> (
+        tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]
+        | StageOutcome
+        | None
+    ):
+        """Return a current-head complete thread snapshot for entry routing."""
+        if item.pr is None:  # guarded by on_enter; keeps type narrowing local
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        try:
+            initial_threads = ctx.github.list_unresolved_review_threads(item.pr)
+        except Exception as error:
+            logger.warning(
+                "pr_review:%s: could not read existing review threads at entry (%s)",
+                item.issue,
+                type(error).__name__,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "review_threads_unavailable")
+        if not initial_threads:
+            item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+            return None
+        bind_outcome = PrReviewStage._bind_current_head_for_negative(item, ctx)
+        if bind_outcome is not None:
+            return bind_outcome
+        reviewed_head = str(item.payload.get("reviewed_pr_head_sha") or "")
+        try:
+            live_threads = ctx.github.list_unresolved_review_threads(item.pr)
+            receipts = ctx.github.reviewer_validation_receipts(
+                item.pr,
+                reviewed_head_sha=reviewed_head,
+                threads=live_threads,
+            )
+        except Exception as error:
+            logger.warning(
+                "pr_review:%s: could not read existing thread responses at entry (%s)",
+                item.issue,
+                type(error).__name__,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "review_thread_receipts_unavailable")
+        if not live_threads:
+            # The thread set changed while its negative transition was being
+            # bound.  The normal checkout path obtains the only valid clean
+            # review proof; do not reuse this negative-only head binding.
+            item.payload.pop("reviewed_pr_head_sha", None)
+            item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+            return None
+        snapshots = _validation_thread_snapshots(live_threads, receipts)
+        remediation_threads = _normalize_remediation_threads(live_threads)
+        if (
+            snapshots is None
+            or _validation_receipt_fingerprints(receipts) is None
+            or len(remediation_threads) != len(live_threads)
+        ):
+            return StageOutcome(Disposition.FINISH_FAIL, "review_thread_receipts_invalid")
+        return (live_threads, remediation_threads, snapshots)
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Execute the next PR-review action for the item's current state.
@@ -1052,6 +1175,11 @@ class PrReviewStage(Stage):
         if isinstance(prior_generation, bool) or not isinstance(prior_generation, int):
             prior_generation = 0
         item.payload["reviewed_pr_proof_generation"] = prior_generation + 1
+        if item.payload.get(_COMMENT_VALIDATION_ONLY):
+            # The original audit already left these threads.  At this point
+            # the reviewer only validates the implementation's current-head
+            # replies, so do not create a second broad review batch.
+            return Continue(next_state=VALIDATE_WAIT)
         verifications = _host_verification_specs(item.payload.get("pr_diff"))
         if verifications:
             logger.info(
@@ -1061,7 +1189,7 @@ class PrReviewStage(Stage):
             )
             item.payload["host_verification_receipts"] = []
             return self._submit_host_verification(item, ctx, verifications[0])
-        return self._submit_review_job(item, ctx)
+        return self._route_threads_before_broad_review(item, ctx)
 
     @staticmethod
     def _submit_host_verification(
@@ -1138,6 +1266,67 @@ class PrReviewStage(Stage):
         )
         item.payload["review_job_pending"] = True
         return JobRequest(job, on_done_state=VALIDATE_WAIT)
+
+    def _route_threads_before_broad_review(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Recheck threads immediately before dispatching a broad audit.
+
+        ``on_enter`` owns the first routing decision, but a reviewer checkout
+        and its fixed host verification can take long enough for a new thread
+        to appear.  Never schedule a second broad audit for that new work:
+        give unreplied threads to implementation, or send a complete response
+        set to comment validation on the already-proven detached checkout.
+        """
+        if item.pr is None:
+            return self._cleanup_review_worktree_then(
+                item,
+                StageOutcome(Disposition.FINISH_FAIL, "no_pr"),
+            )
+        reviewed_head = str(item.payload.get("reviewed_pr_head_sha") or "")
+        if not is_full_commit_sha(reviewed_head):
+            return self._cleanup_review_worktree_then(
+                item,
+                StageOutcome(Disposition.FINISH_FAIL, "reviewed_head_unavailable"),
+            )
+        try:
+            live_threads = ctx.github.list_unresolved_review_threads(item.pr)
+            receipts = ctx.github.reviewer_validation_receipts(
+                item.pr,
+                reviewed_head_sha=reviewed_head,
+                threads=live_threads,
+            )
+        except Exception as error:
+            logger.warning(
+                "pr_review:%s: could not reread threads before broad review (%s)",
+                item.issue,
+                type(error).__name__,
+            )
+            return self._cleanup_review_worktree_then(
+                item,
+                StageOutcome(Disposition.FINISH_FAIL, "review_thread_receipts_unavailable"),
+            )
+        if not live_threads:
+            return self._submit_review_job(item, ctx)
+        snapshots = _validation_thread_snapshots(live_threads, receipts)
+        remediation_threads = _normalize_remediation_threads(live_threads)
+        if (
+            snapshots is None
+            or _validation_receipt_fingerprints(receipts) is None
+            or len(remediation_threads) != len(live_threads)
+            or _scope_retraction_paths(remediation_threads) is None
+        ):
+            return self._cleanup_review_worktree_then(
+                item,
+                StageOutcome(Disposition.FINISH_FAIL, "review_thread_receipts_invalid"),
+            )
+        if all(bool(snapshot.get("implementation_reply_submitted")) for snapshot in snapshots):
+            item.payload[_COMMENT_VALIDATION_ONLY] = True
+            return Continue(next_state=VALIDATE_WAIT)
+        item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+        item.payload["unresolved_threads"] = [dict(thread) for thread in live_threads]
+        item.payload["remediation_threads"] = remediation_threads
+        item.payload["remediation_thread_snapshots"] = [dict(thread) for thread in live_threads]
+        item.payload["unresolved_threads_before_address"] = len(remediation_threads)
+        return Continue(next_state=ADDRESS_WAIT)
 
     def _validate_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Perform a fresh review of implementation replies before resolution."""
@@ -1243,7 +1432,7 @@ class PrReviewStage(Stage):
                 None,
                 "host_verification_receipt_invalid",
             )
-        return self._submit_review_job(item, ctx)
+        return self._route_threads_before_broad_review(item, ctx)
 
     def _handle_host_verification_failure(
         self,
@@ -1803,11 +1992,14 @@ class PrReviewStage(Stage):
         """
         if item.pr is None:  # guarded by step(); kept for restart safety
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        validation_only = bool(item.payload.get(_COMMENT_VALIDATION_ONLY))
         audit = item.payload.get("review_audit")
-        if not isinstance(audit, ReviewAudit) or not audit.valid:
+        if not validation_only and (not isinstance(audit, ReviewAudit) or not audit.valid):
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
-        raw_threads = [dict(t) for t in item.payload.get("review_threads") or []]
+        raw_threads = (
+            [] if validation_only else [dict(t) for t in item.payload.get("review_threads") or []]
+        )
         # Validation controls only the reviewer-owned reconciliation of
         # implementation replies. Fresh audit findings are independently
         # deduplicated against live threads below; a validator must never
@@ -1976,6 +2168,19 @@ class PrReviewStage(Stage):
         item.payload["remediation_threads"] = remediation_threads
         item.payload["remediation_thread_snapshots"] = [dict(thread) for thread in live_threads]
         item.payload["unresolved_threads_before_address"] = len(remediation_threads)
+        if validation_only:
+            # The validator has made the exhaustive current-head decisions
+            # for the original review's threads.  It is now the fresh review
+            # evidence for this comment-validation-only pass; no new broad
+            # audit findings are invented or posted.
+            item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+            item.payload["review_audit"] = ReviewAudit(
+                grade="A",
+                summary="Reviewer validated the implementation responses to all open threads.",
+                findings=(),
+                raw_feedback="",
+                valid=True,
+            )
         if not remediation_threads:
             return Continue(next_state=EVAL)
         # The original review has already been submitted as one batch. Do not

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1067,7 +1067,7 @@ class TestWorktreeAndAdvise:
     def test_direct_worktree_rejects_missing_remote_reservation_receipt(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A protocol drift cannot let a direct agent run without its lease receipt."""
+        """A fresh direct agent cannot run without its creation lease receipt."""
         stage = ImplementationStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, state="WORKTREE_WAIT")
@@ -1078,6 +1078,39 @@ class TestWorktreeAndAdvise:
 
         assert item.worktree == ""
         assert item.payload["git_error"] is True
+
+    def test_adopted_direct_worktree_does_not_require_a_fresh_reservation_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An existing direct PR reuses its writer without creating a new lease."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl-direct-" + "b" * 32
+        item.payload["existing_pr"] = True
+        # The new direct cursor's bootstrap pin is still present, but it does
+        # not authorize or require a replacement reservation for this PR.
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=True,
+                value={
+                    "path": "/tmp/wt",
+                    "dirty": False,
+                    "status": "",
+                    "diff": "",
+                },
+            ),
+            ctx,
+        )
+
+        assert item.worktree == "/tmp/wt"
+        assert "git_error" not in item.payload
+        assert "_direct_scope_reservation" not in item.payload
+        item.state = "DIRTY_DECISION_WAIT"
+        assert stage.step(item, ctx) == Continue(next_state="REBASE_WAIT")
 
     def test_worktree_string_result_stores_path(self, make_ctx: Any, make_work_item: Any) -> None:
         """A plain string worktree result is the worktree path."""
@@ -1643,6 +1676,24 @@ class TestCommitPushAndPrCreate:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob)
         assert result.job.kwargs["expected_remote_sha"] == "a" * 40
+
+    def test_adopted_direct_commit_push_uses_its_pr_branch_without_a_fresh_pin(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An adopted PR must not lease-push against its cursor's trunk SHA."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        item.branch = "1-auto-impl-direct-" + "b" * 32
+        item.worktree = "/tmp/wt"
+        item.payload["existing_pr"] = True
+        item.payload["_direct_scope_base_sha"] = "a" * 40
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert "expected_remote_sha" not in result.job.kwargs
 
     def test_commit_push_no_commit_sets_skip_payload(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -23,12 +23,14 @@ from hephaestus.automation.pipeline.stages import (
     ImplementationThreadReplyResult,
     JobRequest,
     StageOutcome,
+    pr_review as stage_module,
 )
 from hephaestus.automation.pipeline.stages.pr_review import (
     ADOPT_WORKTREE_WAIT,
     CLEANUP_REVIEW_WORKTREE_WAIT,
     DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP,
     DIRECT_PUSH_RETRY_CAP,
+    HOST_VERIFICATION_WAIT,
     REVIEW_CHECKOUT_WAIT,
     REVIEW_ERROR_RETRY_CAP,
     PrReviewStage,
@@ -268,6 +270,217 @@ class TestPrReviewStageOnEnter:
         assert isinstance(request.job, GitJob)
         assert request.job.op == "create_worktree"
         assert request.job.kwargs["isolated"] is True
+
+    def test_on_enter_routes_unreplied_threads_to_implementation_before_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Existing threads without current-head responses never trigger a new audit."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            unresolved=[(1, 0)], pr_head_branch="1-auto-impl-direct-" + "b" * 32
+        )
+        item = make_work_item(issue=1, pr=1001, kind=ItemKind.PR, state="ENTER")
+
+        outcome = stage.on_enter(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(Disposition.FAIL_BACK, "implementation_remediation")
+        assert item.branch == "1-auto-impl-direct-" + "b" * 32
+        assert item.payload["existing_pr"] is True
+        assert item.payload["implementation_remediation"] is True
+        assert item.payload["remediation_threads"] == [
+            {
+                "thread_id": "live-thread-1001-0",
+                "path": "a.py",
+                "line": 1,
+                "body": "<!-- hephaestus-severity: major -->\nfinding",
+            }
+        ]
+        assert item.payload["remediation_thread_snapshots"][0]["id"] == "live-thread-1001-0"
+        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+
+    def test_on_enter_routes_fully_replied_threads_to_comment_validation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A current-head implementation reply proceeds to reviewer validation only."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            unresolved=[(1, 0)], pr_head_branch="1-auto-impl-direct-" + "b" * 32
+        )
+        github._thread_replies["live-thread-1001-0"] = [
+            {
+                "id": "implementation-reply-live-thread-1001-0",
+                "author": "hephaestus[bot]",
+                "body": "[Response] Fixed and tested.",
+            }
+        ]
+        item = make_work_item(issue=1, pr=1001, kind=ItemKind.PR, state="ENTER")
+        ctx = make_ctx(github=github)
+
+        assert stage.on_enter(item, ctx) is None
+        assert item.payload["existing_pr"] is True
+        assert item.payload["reviewer_comment_validation_only"] is True
+
+        item.state = REVIEW_CHECKOUT_WAIT
+        item.payload["review_checkout_ready"] = True
+        item.payload["review_checkout_expected_head"] = "a" * 40
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="VALIDATE_WAIT")
+        assert "review_audit" not in item.payload
+
+    def test_on_enter_fails_closed_when_existing_thread_read_fails(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed thread read cannot be bypassed by starting a new review."""
+
+        class ThreadReadFailsGitHub(FakeStageGitHub):
+            def list_unresolved_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+                del pr_number
+                raise RuntimeError("GitHub unavailable")
+
+        stage = PrReviewStage()
+        item = make_work_item(issue=1, pr=1001, kind=ItemKind.PR, state="ENTER")
+
+        assert stage.on_enter(item, make_ctx(github=ThreadReadFailsGitHub())) == StageOutcome(
+            Disposition.FINISH_FAIL, "review_threads_unavailable"
+        )
+
+    def test_checkout_rechecks_new_unreplied_thread_before_submitting_a_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A thread appearing after entry goes to implementation, not a broad audit."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(1, 0)])
+        item = make_work_item(issue=1, pr=1001, state=REVIEW_CHECKOUT_WAIT)
+        item.worktree = "/tmp/detached-review"
+        item.payload.update(
+            {
+                "review_checkout_ready": True,
+                "review_checkout_expected_head": "a" * 40,
+                "pr_diff": "",
+            }
+        )
+
+        result = stage.step(item, make_ctx(github=github))
+
+        assert result == Continue(next_state="ADDRESS_WAIT")
+        assert item.payload["remediation_threads"][0]["thread_id"] == "live-thread-1001-0"
+
+    def test_host_verification_rechecks_new_unreplied_thread_before_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A thread appearing during host checks cannot lead to a broad review batch."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(1, 0)])
+        item = make_work_item(issue=1, pr=1001, state=HOST_VERIFICATION_WAIT)
+        item.worktree = "/tmp/detached-review"
+        item.payload.update(
+            {
+                "reviewed_pr_head_sha": "a" * 40,
+                "pr_diff": "diff --git a/example.py b/example.py\n+new line\n",
+            }
+        )
+        specs = stage_module._host_verification_specs(item.payload["pr_diff"])
+        item.payload["host_verification_receipts"] = [
+            {
+                "head_sha": "a" * 40,
+                "argv": list(spec.argv),
+                "immutable_source": True,
+                "ok": True,
+                "stdout_tail": "",
+                "stderr_tail": "",
+            }
+            for spec in specs
+        ]
+
+        result = stage.step(item, make_ctx(github=github))
+
+        assert result == Continue(next_state="ADDRESS_WAIT")
+        assert item.payload["remediation_threads"][0]["thread_id"] == "live-thread-1001-0"
+
+    def test_comment_validation_resolves_threads_without_posting_a_second_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Comment validation reconciles the original thread instead of publishing findings."""
+
+        class ResolvingGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self.live = [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "[Review] Fix the guard.",
+                        "comments": [
+                            {
+                                "id": "review-comment-1",
+                                "author": "reviewer",
+                                "body": "[Review] Fix the guard.",
+                            },
+                            {
+                                "id": "implementation-reply-thread-1",
+                                "author": "hephaestus[bot]",
+                                "body": "[Response] Added the guard and tests.",
+                            },
+                        ],
+                    }
+                ]
+
+            def list_unresolved_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+                del pr_number
+                return [dict(thread) for thread in self.live]
+
+            def reviewer_validation_receipts(
+                self,
+                pr_number: int,
+                *,
+                reviewed_head_sha: str,
+                threads: list[dict[str, Any]],
+            ) -> list[dict[str, Any]]:
+                del pr_number
+                return [
+                    {
+                        **thread,
+                        "implementation_reply_id": "implementation-reply-thread-1",
+                        "implementation_reply_body": "[Response] Added the guard and tests.",
+                        "implementation_head_sha": reviewed_head_sha,
+                    }
+                    for thread in threads
+                ]
+
+            def reconcile_reviewer_validated_threads(self, *args: Any, **kwargs: Any) -> Any:
+                del args, kwargs
+                self.live = []
+                return SimpleNamespace(
+                    resolved_thread_ids=("thread-1",),
+                    feedback_thread_ids=(),
+                    blocked_thread_ids=(),
+                )
+
+        github = ResolvingGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="POST")
+        item.payload.update(
+            {
+                "reviewer_comment_validation_only": True,
+                "reviewed_pr_head_sha": "a" * 40,
+                "validation_result": '{"resolved":["thread-1"],"unaddressed":[]}',
+            }
+        )
+
+        result = PrReviewStage().step(item, ctx)
+
+        assert result == Continue(next_state="EVAL")
+        assert 1001 not in github.reviews
+        assert item.payload["review_audit"] == ReviewAudit(
+            grade="A",
+            summary="Reviewer validated the implementation responses to all open threads.",
+            findings=(),
+            raw_feedback="",
+            valid=True,
+        )
 
     def test_on_enter_double_call_rechecks_unarmed_state_without_mutation(
         self, make_ctx: Any, make_work_item: Any
@@ -793,7 +1006,7 @@ class TestPrReviewStageStep:
         """Structured comments survive the worker boundary and are actionable."""
         events: list[Any] = []
         stage = PrReviewStage()
-        github = FakeStageGitHub(unresolved=[(1, 0)], by_severity=[(1, 0, 0)])
+        github = FakeStageGitHub(by_severity=[(0, 0, 0), (1, 0, 0)])
         ctx = make_ctx(github=github, event_fn=events.append)
         item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
         item.worktree = "/tmp/wt"
@@ -4027,11 +4240,10 @@ class TestFullWalks:
     """Full pool-driven walks of the whole stage (canonical FakeWorkerPool)."""
 
     def test_nogo_round_then_clean_go_walk(self, make_ctx: Any, make_work_item: Any) -> None:
-        """A non-GO review exits to the implementation-owned remediation pass."""
+        """An existing open thread exits directly to implementation remediation."""
         stage = PrReviewStage()
-        # Each fresh review snapshot consumes one scripted thread shape.
-        # The first review finds blocking threads and transfers them directly
-        # to implementation after one batched review submission.
+        # Existing open threads must be handled by the writer before any new
+        # broad review batch is scheduled.
         github = FakeStageGitHub(
             by_severity=[
                 (2, 0, 0),
@@ -4050,21 +4262,11 @@ class TestFullWalks:
         item.worktree = "/tmp/wt21"
 
         pool = FakeWorkerPool()
-        pool.script(
-            JobResult(ok=True, value=_valid_audit()),  # review round 1
-            JobResult(ok=True, value='{"resolved": [], "unaddressed": []}'),  # validate round 1
-            JobResult(ok=True, value=True),  # remove detached review worktree
-        )
-
         outcome = _drive(stage, item, ctx, pool)
 
         assert isinstance(outcome, StageOutcome)
         assert outcome == StageOutcome(Disposition.FAIL_BACK, "implementation_remediation")
-        assert [h.job.descr for h in pool.submitted] == [
-            "review",
-            "validate",
-            "remove_read_only_review_worktree",
-        ]
+        assert pool.submitted == []
         assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
 
     def test_unresolved_thread_walk_exhausts_without_terminal_handoff(


### PR DESCRIPTION
## Summary

- distinguish a fresh direct-branch reservation from an adopted PR writer, preventing stale cursor pins from rejecting a synced worktree or lease-pushing against `main`
- hand unresolved review threads without current-head implementation responses directly to the implementer before any broad audit
- validate fully replied threads in a detached read-only checkout without posting a duplicate broad review batch
- document the two-role lifecycle and add regression coverage

## Verification

- `uv run pytest --no-cov tests/unit/automation/pipeline -q`
- `uv run mypy hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`
- `uv run ruff check hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py`

Closes #2584