### PR TITLE
fix(automation): retry implementation reply handoffs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1007,6 +1007,18 @@ Architectural contract:
 - The implementation agent replies to every fixed open thread but never resolves it.
 - The implementation stage rebases and lease-publishes the writer branch before
   review; a rebase is never performed by a reviewer checkout.
+- A post-push implementation-reply handoff is an exact, bounded host-only
+  retry of one immutable response batch. A failed or partial PR-state read,
+  including a per-thread read that temporarily lags the just-pushed head,
+  preserves that batch for retry; a complete host read is required before it
+  can instead prove the batch stale. The scratchpad copy is intentionally not
+  a restart journal: before the first replay, the implementation stage writes
+  the exact response map, source-snapshot fingerprint, head, and batch nonce
+  to an immutable actor-owned GitHub journal record, retrying only that append
+  on a transient host failure. A restarted loop can recover only that exact
+  record when its immutable source-comment snapshots still match; the journal
+  is a machine recovery artifact, not an implementation response, so the only
+  human-facing `[Response]` remains anchored to the source review thread.
 - The reviewer validates each implementation reply against the current diff;
   it resolves validated threads or posts corrective feedback and leaves them open.
 - Validation stores an immutable fingerprint of every implementation reply

--- a/hephaestus/automation/pipeline/reply_handoff.py
+++ b/hephaestus/automation/pipeline/reply_handoff.py
@@ -1,0 +1,461 @@
+"""Durable, commit-gated implementation reply handoffs.
+
+The implementation and PR-review stages can each hold a validated response
+batch after the writer pushes a fix.  This module is the single owner of the
+replay contract: preserve the exact thread snapshots and response prose, wait
+briefly for GitHub to expose the pushed head, then retry only that batch.  A
+head or conversation that actually changed is never replayed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Sequence
+from copy import deepcopy
+from hashlib import sha256
+from typing import Any, Literal
+
+from hephaestus.automation.address_review_core import parse_addressed_replies
+from hephaestus.automation.review_journal import IssueComment
+
+IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP = 2
+IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP = 2
+IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP = 2
+PENDING_IMPLEMENTATION_REPLY_HANDOFF = "pending_implementation_reply_handoff"
+PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES = "pending_implementation_reply_handoff_retries"
+PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
+    "pending_implementation_reply_handoff_visibility_retries"
+)
+PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL = "pending_implementation_reply_handoff_journal"
+PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES = (
+    "pending_implementation_reply_handoff_journal_retries"
+)
+
+_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
+_FULL_COMMIT_SHA_RE = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?")
+_HANDOFF_JOURNAL_RE = re.compile(
+    r"^<!-- hephaestus-implementation-reply-handoff:"
+    r"pr=(?P<pr>\d+):head=(?P<head>[0-9a-f]{40}(?:[0-9a-f]{24})?):"
+    r"batch=(?P<batch>[0-9a-f]{32}) -->$"
+)
+
+
+def pr_is_current_open_head(state: object, expected_head_sha: object) -> bool:
+    """Return whether a fresh PR state proves one exact open, unarmed head."""
+    return bool(
+        isinstance(expected_head_sha, str)
+        and _FULL_COMMIT_SHA_RE.fullmatch(expected_head_sha)
+        and isinstance(state, dict)
+        and state.get("state") == "OPEN"
+        and state.get("autoMergeRequest") is None
+        and state.get("headRefOid") == expected_head_sha
+    )
+
+
+def _has_complete_pr_state(state: object) -> bool:
+    """Return whether a PR-state response contains all stale-proof fields."""
+    return bool(
+        isinstance(state, dict)
+        and isinstance(state.get("state"), str)
+        and "autoMergeRequest" in state
+        and isinstance(state.get("headRefOid"), str)
+        and _FULL_COMMIT_SHA_RE.fullmatch(state["headRefOid"])
+    )
+
+
+def implementation_reply_handoff(
+    head_sha: object,
+    threads: object,
+    replies: object,
+    batch_nonce: object,
+) -> dict[str, Any] | None:
+    """Return a replay-safe outstanding implementation-reply handoff.
+
+    The persisted value is an exact host snapshot plus the model's already
+    validated reply mapping.  It grants no authority itself: the GitHub
+    adapter rechecks the current PR and thread state before every retry.
+    """
+    if (
+        not isinstance(head_sha, str)
+        or _FULL_COMMIT_SHA_RE.fullmatch(head_sha) is None
+        or not isinstance(threads, list)
+        or not isinstance(replies, dict)
+        or not isinstance(batch_nonce, str)
+        or _BATCH_NONCE_RE.fullmatch(batch_nonce) is None
+    ):
+        return None
+    snapshots = [dict(thread) for thread in threads if isinstance(thread, dict)]
+    if len(snapshots) != len(threads):
+        return None
+    normalized_replies = parse_addressed_replies(
+        {"addressed": list(replies), "replies": replies}, snapshots
+    )
+    if normalized_replies is None:
+        return None
+    ids = {str(snapshot.get("id") or "") for snapshot in snapshots}
+    if "" in ids or ids != set(normalized_replies) or len(ids) != len(snapshots):
+        return None
+    return {
+        "head_sha": head_sha,
+        "threads": deepcopy(snapshots),
+        "replies": dict(normalized_replies),
+        "batch_nonce": batch_nonce,
+    }
+
+
+def _thread_snapshot_fingerprint(threads: object) -> str | None:
+    """Return the immutable source-conversation fingerprint for live threads.
+
+    A writer push naturally changes a thread's live PR head and can move its
+    diff anchor.  Those fields are deliberately excluded: the adapter checks
+    the live head immediately before every mutation.  The recovery journal is
+    instead bound to the complete sequence of existing source-comment ids and
+    bodies, matching the adapter's per-thread concurrency guard.
+    """
+    if not isinstance(threads, list):
+        return None
+    source_threads: list[tuple[str, tuple[tuple[str, str], ...]]] = []
+    seen_thread_ids: set[str] = set()
+    for thread in threads:
+        if not isinstance(thread, dict):
+            return None
+        thread_id = thread.get("id")
+        comments = thread.get("comments")
+        if (
+            not isinstance(thread_id, str)
+            or not thread_id.strip()
+            or thread_id in seen_thread_ids
+            or not isinstance(comments, list)
+            or not comments
+        ):
+            return None
+        seen_thread_ids.add(thread_id)
+        source_comments: list[tuple[str, str]] = []
+        seen_comment_ids: set[str] = set()
+        for comment in comments:
+            if not isinstance(comment, dict):
+                return None
+            comment_id = comment.get("id")
+            body = comment.get("body")
+            if (
+                not isinstance(comment_id, str)
+                or not comment_id.strip()
+                or comment_id in seen_comment_ids
+                or not isinstance(body, str)
+            ):
+                return None
+            seen_comment_ids.add(comment_id)
+            source_comments.append((comment_id, body))
+        source_threads.append((thread_id, tuple(source_comments)))
+    try:
+        encoded = json.dumps(sorted(source_threads), sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    except (TypeError, ValueError):
+        return None
+    return sha256(encoded).hexdigest()
+
+
+def implementation_reply_handoff_journal_entry(
+    pr_number: object,
+    handoff: object,
+) -> tuple[str, str] | None:
+    """Render the immutable GitHub journal record for one exact reply batch.
+
+    This is an internal recovery artifact, not an implementation response: the
+    only human-facing ``[Response]`` prose is later posted on its source
+    review thread. Its sole purpose is to let a restarted coordinator replay
+    the already-pushed writer's exact, validated batch without asking a fresh
+    no-op implementer to make an unprovable claim.
+    """
+    if isinstance(pr_number, bool) or not isinstance(pr_number, int) or pr_number <= 0:
+        return None
+    normalized = implementation_reply_handoff(
+        handoff.get("head_sha") if isinstance(handoff, dict) else None,
+        handoff.get("threads") if isinstance(handoff, dict) else None,
+        handoff.get("replies") if isinstance(handoff, dict) else None,
+        handoff.get("batch_nonce") if isinstance(handoff, dict) else None,
+    )
+    if normalized is None:
+        return None
+    marker = (
+        "<!-- hephaestus-implementation-reply-handoff:"
+        f"pr={pr_number}:head={normalized['head_sha']}:batch={normalized['batch_nonce']} -->"
+    )
+    thread_snapshot_sha256 = _thread_snapshot_fingerprint(normalized["threads"])
+    if thread_snapshot_sha256 is None:
+        return None
+    payload = json.dumps(
+        {
+            "format": 1,
+            "pr_number": pr_number,
+            "head_sha": normalized["head_sha"],
+            "batch_nonce": normalized["batch_nonce"],
+            "thread_snapshot_sha256": thread_snapshot_sha256,
+            "replies": normalized["replies"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    # Keep the machine journal invisible in the issue timeline. The actual
+    # implementation prose is only rendered as its source-attached response.
+    body = f"{marker}\n<!-- {payload} -->"
+    return marker, body
+
+
+def _journal_handoff_from_comment(
+    comment: IssueComment,
+    *,
+    pr_number: int,
+    threads: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Parse one actor-owned journal comment when it targets these source threads."""
+    marker, separator, payload = comment.body.lstrip().partition("\n")
+    match = _HANDOFF_JOURNAL_RE.fullmatch(marker)
+    if match is None or int(match.group("pr")) != pr_number:
+        return None
+    if not (separator and payload.startswith("<!-- ") and payload.endswith(" -->")):
+        raise ValueError("implementation reply handoff journal is malformed")
+    try:
+        raw = json.loads(payload.removeprefix("<!-- ").removesuffix(" -->"))
+    except json.JSONDecodeError as error:
+        raise ValueError("implementation reply handoff journal is malformed") from error
+    if not isinstance(raw, dict) or raw.get("format") != 1 or raw.get("pr_number") != pr_number:
+        raise ValueError("implementation reply handoff journal identity is invalid")
+    if raw.get("thread_snapshot_sha256") != _thread_snapshot_fingerprint(threads):
+        return None
+    handoff = implementation_reply_handoff(
+        raw.get("head_sha"),
+        threads,
+        raw.get("replies"),
+        raw.get("batch_nonce"),
+    )
+    if (
+        handoff is None
+        or not isinstance(raw.get("head_sha"), str)
+        or not isinstance(raw.get("batch_nonce"), str)
+        or handoff["head_sha"] != match.group("head")
+        or handoff["batch_nonce"] != match.group("batch")
+    ):
+        raise ValueError("implementation reply handoff journal payload is invalid")
+    return handoff
+
+
+def journaled_implementation_reply_handoff(
+    comments: Sequence[IssueComment],
+    *,
+    pr_number: object,
+    threads: object,
+) -> dict[str, Any] | None:
+    """Recover the latest exact actor-owned reply batch for current source threads.
+
+    A journal record is eligible only if GitHub identifies it as written by
+    the current actor and its immutable source-snapshot fingerprint exactly
+    matches the live remediation snapshot read for this pass. The host adapter
+    still validates the current open head and every source thread before any
+    reply mutation occurs.
+    """
+    if isinstance(pr_number, bool) or not isinstance(pr_number, int) or pr_number <= 0:
+        return None
+    if not isinstance(threads, list) or not all(isinstance(thread, dict) for thread in threads):
+        return None
+    recovered: dict[str, Any] | None = None
+    for comment in comments:
+        if (
+            comment.viewer_did_author
+            and (
+                handoff := _journal_handoff_from_comment(
+                    comment,
+                    pr_number=pr_number,
+                    threads=threads,
+                )
+            )
+            is not None
+        ):
+            recovered = handoff
+    return recovered
+
+
+def _take_visibility_retry(
+    payload: dict[str, Any],
+    *,
+    issue_number: int | None,
+    logger: logging.Logger,
+) -> bool:
+    """Record one bounded backoff while GitHub converges on a pushed head."""
+    visibility_retries = payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, 0)
+    if (
+        not isinstance(visibility_retries, int)
+        or isinstance(visibility_retries, bool)
+        or visibility_retries < 0
+        or visibility_retries >= IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP
+    ):
+        return False
+    visibility_retries += 1
+    payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES] = visibility_retries
+    payload["retry_delay_s"] = float(2 ** (visibility_retries - 1))
+    logger.info(
+        "reply_handoff:%s: waiting for pushed implementation head visibility before replying "
+        "to review threads (%d/%d)",
+        issue_number,
+        visibility_retries,
+        IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP,
+    )
+    return True
+
+
+def _classify_handoff_pr_state(
+    state: object,
+    *,
+    head_sha: str,
+    payload: dict[str, Any],
+    issue_number: int | None,
+    logger: logging.Logger,
+) -> Literal["current", "visibility_wait", "stale", "retry"]:
+    """Classify one host state read without confusing incompleteness with drift."""
+    if not isinstance(state, dict) or not _has_complete_pr_state(state):
+        return "retry"
+    if pr_is_current_open_head(state, head_sha):
+        return "current"
+    if (
+        state.get("state") == "OPEN"
+        and state.get("autoMergeRequest") is None
+        and _take_visibility_retry(payload, issue_number=issue_number, logger=logger)
+    ):
+        return "visibility_wait"
+    return "stale"
+
+
+def _consume_reply_post_result(
+    payload: dict[str, Any],
+    *,
+    result: object,
+    head_sha: str,
+    threads: list[dict[str, Any]],
+    replies: dict[str, str],
+    batch_nonce: str,
+    issue_number: int | None,
+    logger: logging.Logger,
+) -> Literal["completed", "visibility_wait", "stale", "invalid", "retry"]:
+    """Classify one reply mutation result and retain only proven retry work."""
+    expected_ids = set(replies)
+    replied = set(getattr(result, "replied_thread_ids", ()))
+    receipts = list(getattr(result, "receipts", ()))
+    if replied == expected_ids and len(receipts) == len(replied):
+        payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+        payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+        return "completed"
+    if bool(getattr(result, "visibility_lag", False)):
+        if replied or receipts:
+            return "invalid"
+        if _take_visibility_retry(
+            payload,
+            issue_number=issue_number,
+            logger=logger,
+        ):
+            return "visibility_wait"
+        return "stale"
+    remaining_ids = expected_ids - replied
+    retryable = bool(getattr(result, "retryable", False))
+    result_retryable_ids = set(getattr(result, "retryable_thread_ids", ()))
+    retryable_ids = (
+        result_retryable_ids
+        if result_retryable_ids and result_retryable_ids.issubset(remaining_ids)
+        else remaining_ids
+        if retryable and not result_retryable_ids
+        else set()
+    )
+    if not retryable_ids:
+        payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+        payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+        return "stale"
+    if not replied.issubset(expected_ids) or len(receipts) != len(replied):
+        return "invalid"
+    replacement = implementation_reply_handoff(
+        head_sha,
+        [snapshot for snapshot in threads if str(snapshot.get("id") or "") in retryable_ids],
+        {thread_id: reply for thread_id, reply in replies.items() if thread_id in retryable_ids},
+        batch_nonce,
+    )
+    if replacement is None:
+        return "invalid"
+    payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = replacement
+    return "retry"
+
+
+def retry_pending_implementation_reply_handoff(
+    payload: dict[str, Any],
+    *,
+    pr_number: int | None,
+    issue_number: int | None,
+    github: Any,
+    logger: logging.Logger,
+) -> Literal["none", "completed", "visibility_wait", "stale", "invalid", "retry"]:
+    """Retry one exact post-push reply batch without invoking an agent.
+
+    Returns ``none`` when no handoff exists, ``completed`` when every reply
+    has a host receipt, ``visibility_wait`` while GitHub is briefly catching
+    up with the pushed head, ``stale`` when the exact pushed head can no
+    longer safely receive the saved response, ``invalid`` for malformed
+    persisted state, and ``retry`` for a bounded transient/incomplete host
+    operation.  No outcome authorizes review or merge decisions.
+    """
+    raw_handoff = payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF)
+    if raw_handoff is None:
+        return "none"
+    handoff = implementation_reply_handoff(
+        raw_handoff.get("head_sha") if isinstance(raw_handoff, dict) else None,
+        raw_handoff.get("threads") if isinstance(raw_handoff, dict) else None,
+        raw_handoff.get("replies") if isinstance(raw_handoff, dict) else None,
+        raw_handoff.get("batch_nonce") if isinstance(raw_handoff, dict) else None,
+    )
+    if handoff is None or pr_number is None:
+        return "invalid"
+    head_sha = handoff["head_sha"]
+    threads = handoff["threads"]
+    replies = handoff["replies"]
+    batch_nonce = handoff["batch_nonce"]
+    try:
+        state = github.gh_pr_state(pr_number)
+        pr_state_outcome = _classify_handoff_pr_state(
+            state,
+            head_sha=head_sha,
+            payload=payload,
+            issue_number=issue_number,
+            logger=logger,
+        )
+        if pr_state_outcome != "current":
+            if pr_state_outcome != "stale":
+                return pr_state_outcome
+            payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+            payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+            payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
+            return "stale"
+        payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
+        result = github.post_implementation_thread_replies(
+            pr_number,
+            expected_head_sha=head_sha,
+            threads=threads,
+            replies=replies,
+            batch_nonce=batch_nonce,
+        )
+    except Exception as error:
+        logger.warning(
+            "reply_handoff:%s: implementation reply handoff retry failed (%s)",
+            issue_number,
+            type(error).__name__,
+        )
+        return "retry"
+
+    return _consume_reply_post_result(
+        payload,
+        result=result,
+        head_sha=head_sha,
+        threads=threads,
+        replies=replies,
+        batch_nonce=batch_nonce,
+        issue_number=issue_number,
+        logger=logger,
+    )

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -135,9 +135,11 @@ class ImplementationThreadReplyResult:
     GitHub object. ``retryable_thread_ids`` identifies only replies whose host
     outcome is transport/read-ambiguous. An ordinary ``blocked_thread_ids``
     result means the saved snapshot is stale and must return through a fresh
-    reviewer pass rather than replay. Direct thread replies never create a
-    review-level envelope, so there is no review ownership conflict state to
-    recover or preserve.
+    reviewer pass rather than replay. ``visibility_lag`` distinguishes a
+    second GitHub thread read that has not yet observed the just-pushed head;
+    the caller consumes its separate bounded backoff rather than transport
+    retries. Implementation replies are submitted through one review-level
+    envelope so every response from a pass remains batched.
     """
 
     replied_thread_ids: tuple[str, ...] = ()
@@ -145,6 +147,7 @@ class ImplementationThreadReplyResult:
     receipts: tuple[dict[str, Any], ...] = ()
     retryable_thread_ids: tuple[str, ...] = ()
     retryable: bool = False
+    visibility_lag: bool = False
 
 
 @dataclass(frozen=True)

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -103,6 +103,18 @@ from hephaestus.automation.worktree_manager import BRANCH_WORKTREE_OWNED
 from hephaestus.prompts import PromptCatalog
 
 from ..jobs import WORKTREE_MATERIALIZED_KEY
+from ..reply_handoff import (
+    IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP,
+    IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES,
+    implementation_reply_handoff,
+    implementation_reply_handoff_journal_entry,
+    journaled_implementation_reply_handoff,
+    retry_pending_implementation_reply_handoff,
+)
 from ..scope_retraction import is_safe_scope_retraction_path, scope_retraction_paths_for_threads
 from .base import (
     GIT_JOB_TIMEOUT_S,
@@ -602,6 +614,33 @@ class ImplementationStage(Stage):
                 item.payload["scope_retraction_paths"] = scope_retraction_paths
             else:
                 item.payload.pop("scope_retraction_paths", None)
+            snapshots = item.payload.get("remediation_thread_snapshots")
+            if isinstance(snapshots, list):
+                try:
+                    recovered_handoff = journaled_implementation_reply_handoff(
+                        ctx.github.issue_comments(issue),
+                        pr_number=item.pr,
+                        threads=snapshots,
+                    )
+                except (OSError, RuntimeError, ValueError) as error:
+                    logger.warning(
+                        "implementation:%d: could not recover implementation reply handoff "
+                        "journal (%s)",
+                        issue,
+                        type(error).__name__,
+                    )
+                    return StageOutcome(
+                        Disposition.RETRY,
+                        "implementation_reply_handoff_journal_read",
+                    )
+                if recovered_handoff is not None:
+                    item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = recovered_handoff
+                    item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+                    logger.info(
+                        "implementation:%d: recovered exact GitHub-journaled review reply handoff",
+                        issue,
+                    )
+                    return Continue(next_state=PR_CREATE)
             job = AgentJob(
                 repo=item.repo,
                 issue=issue,
@@ -847,17 +886,25 @@ class ImplementationStage(Stage):
     def _post_remediation_replies_after_push(
         item: WorkItem, result: JobResult, ctx: StageContext
     ) -> None:
-        """Post implementation responses only after the writer pushed a real commit."""
+        """Prepare one commit-gated reply handoff after the writer runs.
+
+        GitHub can briefly expose the previous PR head immediately after a
+        successful push.  The PR_CREATE state owns the bounded host-only
+        replay, so the exact agent responses survive that visibility lag
+        without another implementation turn or commit. Before that retry can
+        begin, this method records the exact batch in GitHub's immutable
+        journal, allowing an interrupted loop to recover the original writer
+        response without a fresh no-op implementation claim.
+        """
         if not item.payload.get("implementation_remediation"):
             return
         receipt = result.value if isinstance(result.value, dict) else {}
         head_sha = receipt.get("head_sha")
         snapshots = item.payload.get("remediation_thread_snapshots")
-        if (
-            not receipt.get("pushed")
-            or not is_full_commit_sha(head_sha)
-            or not isinstance(snapshots, list)
-        ):
+        if not isinstance(snapshots, list):
+            item.payload["remediation_reply_error"] = True
+            return
+        if not receipt.get("pushed") or not is_full_commit_sha(head_sha):
             item.payload["remediation_reply_error"] = True
             return
         replies = parse_addressed_replies(
@@ -867,28 +914,147 @@ class ImplementationStage(Stage):
         if replies is None or item.pr is None:
             item.payload["remediation_reply_error"] = True
             return
-        try:
-            reply_result = ctx.github.post_implementation_thread_replies(
-                item.pr,
-                expected_head_sha=head_sha,
-                threads=snapshots,
-                replies=replies,
-                batch_nonce=secrets.token_hex(16),
+        handoff = implementation_reply_handoff(
+            head_sha,
+            snapshots,
+            replies,
+            secrets.token_hex(16),
+        )
+        if handoff is None:
+            item.payload["remediation_reply_error"] = True
+            return
+        journal_entry = implementation_reply_handoff_journal_entry(item.pr, handoff)
+        if journal_entry is None or item.issue is None:
+            item.payload["remediation_reply_error"] = True
+            return
+        marker, body = journal_entry
+        # Persist the deterministic batch locally before the GitHub append.
+        # A transient append failure must retry this host-only write, never
+        # rerun the writer or create a second remediation commit.
+        item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = handoff
+        item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL] = {
+            "marker": marker,
+            "body": body,
+        }
+        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, None)
+        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+        if ImplementationStage._persist_remediation_reply_handoff_journal(item, ctx) is not None:
+            return
+
+    @staticmethod
+    def _persist_remediation_reply_handoff_journal(
+        item: WorkItem, ctx: StageContext
+    ) -> StageOutcome | None:
+        """Durably append a prepared recovery journal with bounded host-only retries."""
+        pending = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL)
+        if pending is None:
+            return None
+        handoff = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF)
+        if item.issue is None or item.pr is None or not isinstance(pending, dict):
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_invalid"
             )
+        expected_entry = implementation_reply_handoff_journal_entry(item.pr, handoff)
+        marker = pending.get("marker")
+        body = pending.get("body")
+        if (
+            expected_entry is None
+            or not isinstance(marker, str)
+            or not isinstance(body, str)
+            or (marker, body) != expected_entry
+        ):
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_invalid"
+            )
+        try:
+            ctx.github.append_issue_comment(item.issue, marker, body)
         except Exception as error:
+            retries = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, 0)
+            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
+                return StageOutcome(
+                    Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_invalid"
+                )
+            retries += 1
+            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES] = retries
             logger.warning(
-                "implementation:%s: failed to post review-thread responses (%s)",
+                "implementation:%d: could not persist implementation reply handoff journal; "
+                "retrying host-only append %d/%d (%s)",
                 item.issue,
+                retries,
+                IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP,
                 type(error).__name__,
             )
-            item.payload["remediation_reply_error"] = True
-            return
-        replied = set(getattr(reply_result, "replied_thread_ids", ()))
-        if replied != set(replies) or len(getattr(reply_result, "receipts", ())) != len(replied):
-            item.payload["remediation_reply_error"] = True
-            return
+            if retries <= IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP:
+                return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_journal_retry")
+            return StageOutcome(
+                Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_failed"
+            )
+        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL, None)
+        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, None)
+        return None
+
+    @staticmethod
+    def _complete_remediation_reply_handoff(
+        item: WorkItem, ctx: StageContext
+    ) -> StageOutcome | None:
+        """Advance, retry, or fail one persisted host-only response handoff."""
+        handoff_status = retry_pending_implementation_reply_handoff(
+            item.payload,
+            pr_number=item.pr,
+            issue_number=item.issue,
+            github=ctx.github,
+            logger=logger,
+        )
+        if handoff_status in {"none", "completed"}:
+            if handoff_status == "completed":
+                item.payload.pop("implementation_remediation", None)
+                item.payload.pop("remediation_output", None)
+            return None
+        if handoff_status == "visibility_wait":
+            return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
+        if handoff_status == "invalid":
+            logger.error(
+                "implementation:%d: refusing to replay malformed implementation reply handoff",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        if handoff_status == "retry":
+            retries = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, 0)
+            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
+                return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+            retries += 1
+            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES] = retries
+            if retries <= IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP:
+                logger.warning(
+                    "implementation:%d: retrying exact implementation reply handoff %d/%d",
+                    item.issue,
+                    retries,
+                    IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP,
+                )
+                return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_retry")
+            logger.error(
+                "implementation:%d: implementation reply handoff retry cap reached",
+                item.issue,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_failed")
+
+        # The shared handoff has proved that the pushed head or one of its
+        # source threads changed.  Do not replay the old response; return the
+        # existing PR to a fresh review entry instead.
         item.payload.pop("implementation_remediation", None)
         item.payload.pop("remediation_output", None)
+        if item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        logger.info(
+            "implementation:%d: reply handoff became stale; returning PR #%d for a fresh "
+            "review snapshot",
+            item.issue,
+            item.pr,
+        )
+        return StageOutcome(
+            Disposition.ADVANCE,
+            f"PR #{item.pr} ready for fresh review after stale reply handoff",
+        )
 
     @staticmethod
     def _on_implement_done(item: WorkItem, result: JobResult) -> None:
@@ -1294,6 +1460,14 @@ class ImplementationStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         if item.payload.pop("remediation_reply_error", None):
             return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_failed")
+
+        journal_outcome = self._persist_remediation_reply_handoff_journal(item, ctx)
+        if journal_outcome is not None:
+            return journal_outcome
+
+        handoff_outcome = self._complete_remediation_reply_handoff(item, ctx)
+        if handoff_outcome is not None:
+            return handoff_outcome
 
         if item.payload.get("no_commits"):
             # An item can retain a PR after an interrupted or re-entered

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -96,7 +96,6 @@ import logging
 import re
 import secrets
 from collections.abc import Callable
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -127,6 +126,14 @@ from hephaestus.automation.session_naming import (
 )
 from hephaestus.automation.state_labels import STATE_SKIP
 
+from ..reply_handoff import (
+    IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF as _PENDING_IMPLEMENTATION_REPLY_HANDOFF,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES as _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES,
+    implementation_reply_handoff,
+    pr_is_current_open_head,
+    retry_pending_implementation_reply_handoff,
+)
 from ..scope_retraction import scope_retraction_paths_for_threads
 from ..work_item import ItemKind
 from .base import (
@@ -153,6 +160,11 @@ from .base import (
 from .repo import is_full_commit_sha
 
 logger = logging.getLogger(__name__)
+
+# Compatibility aliases for callers that used the former stage-local helpers.
+# The shared reply-handoff module is the sole implementation.
+_implementation_reply_handoff = implementation_reply_handoff
+_pr_is_current_open_head = pr_is_current_open_head
 
 _JSON_RESPONSE_BLOCK_RE = re.compile(
     r"^[ \t]*```json[ \t]*\r?\n(.*?)\r?\n^[ \t]*```[ \t]*$",
@@ -227,17 +239,6 @@ def _issue_number(item: WorkItem) -> int:
     return item.issue
 
 
-def _pr_is_current_open_head(state: object, expected_head_sha: object) -> bool:
-    """Return whether a fresh PR state proves one exact open, unarmed head."""
-    return bool(
-        is_full_commit_sha(expected_head_sha)
-        and isinstance(state, dict)
-        and state.get("state") == "OPEN"
-        and state.get("autoMergeRequest") is None
-        and state.get("headRefOid") == expected_head_sha
-    )
-
-
 def _review_context_kind(item: WorkItem) -> str:
     """Return the prompt-facing numeric context kind for this review item."""
     return "PR" if item.payload.get("review_context_kind") == "PR" else "issue"
@@ -251,18 +252,6 @@ def _review_context_kind(item: WorkItem) -> str:
 REVIEW_ERROR_RETRY_CAP = 2
 REVIEW_CHECKOUT_RETRY_CAP = 2
 
-#: A pushed implementation fix must receive its review-thread explanation
-#: without requiring a second code change.  This bounded retry is host-only:
-#: it replays the exact saved thread snapshots and agent prose, never asks an
-#: implementation model to invent a new response.
-IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP = 2
-IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP = 2
-_PENDING_IMPLEMENTATION_REPLY_HANDOFF = "pending_implementation_reply_handoff"
-_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES = "pending_implementation_reply_handoff_retries"
-_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES = (
-    "pending_implementation_reply_handoff_visibility_retries"
-)
-_IMPLEMENTATION_REPLY_BATCH_NONCE_RE = re.compile(r"[0-9a-f]{32}")
 _HOST_VERIFICATION_PENDING = "host_verification_pending"
 _COMMENT_VALIDATION_ONLY = "reviewer_comment_validation_only"
 
@@ -612,46 +601,6 @@ def _address_replies(address_result: Any, threads: list[dict[str, Any]]) -> dict
     returned prose is posted by the host only after its fix commit is pushed.
     """
     return parse_addressed_replies(address_result, threads)
-
-
-def _implementation_reply_handoff(
-    head_sha: object,
-    threads: object,
-    replies: object,
-    batch_nonce: object,
-) -> dict[str, Any] | None:
-    """Return a replay-safe outstanding implementation-reply handoff.
-
-    The persisted value is intentionally an exact host snapshot plus the
-    model's already validated reply mapping.  It is neither a review receipt
-    nor an authority to mutate: the adapter rechecks the live PR and thread
-    state before each retry.
-    """
-    if (
-        not is_full_commit_sha(head_sha)
-        or not isinstance(threads, list)
-        or not isinstance(replies, dict)
-        or not isinstance(batch_nonce, str)
-        or _IMPLEMENTATION_REPLY_BATCH_NONCE_RE.fullmatch(batch_nonce) is None
-    ):
-        return None
-    snapshots = [dict(thread) for thread in threads if isinstance(thread, dict)]
-    if len(snapshots) != len(threads):
-        return None
-    normalized_replies = _address_replies(
-        {"addressed": list(replies), "replies": replies}, snapshots
-    )
-    if normalized_replies is None:
-        return None
-    ids = {str(snapshot.get("id") or "") for snapshot in snapshots}
-    if "" in ids or ids != set(normalized_replies) or len(ids) != len(snapshots):
-        return None
-    return {
-        "head_sha": head_sha,
-        "threads": deepcopy(snapshots),
-        "replies": dict(normalized_replies),
-        "batch_nonce": batch_nonce,
-    }
 
 
 def _validation_thread_snapshots(
@@ -2231,118 +2180,14 @@ class PrReviewStage(Stage):
 
     @staticmethod
     def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
-        """Retry one exact post-push reply batch without invoking an agent.
-
-        Returns ``none`` when no handoff exists, ``completed`` when every
-        reply has a host receipt, ``visibility_wait`` while GitHub is briefly
-        catching up with the pushed head, ``stale`` when the exact pushed head
-        can no longer safely receive the saved response, ``invalid`` for
-        malformed persisted state, and ``retry`` for a bounded
-        transient/incomplete host operation.  No outcome grants reviewer
-        authority; normal fresh review still validates and resolves the replies.
-        """
-        raw_handoff = item.payload.get(_PENDING_IMPLEMENTATION_REPLY_HANDOFF)
-        if raw_handoff is None:
-            return "none"
-        handoff = _implementation_reply_handoff(
-            raw_handoff.get("head_sha") if isinstance(raw_handoff, dict) else None,
-            raw_handoff.get("threads") if isinstance(raw_handoff, dict) else None,
-            raw_handoff.get("replies") if isinstance(raw_handoff, dict) else None,
-            raw_handoff.get("batch_nonce") if isinstance(raw_handoff, dict) else None,
+        """Delegate recovery to the common host-only reply handoff contract."""
+        return retry_pending_implementation_reply_handoff(
+            item.payload,
+            pr_number=item.pr,
+            issue_number=item.issue,
+            github=ctx.github,
+            logger=logger,
         )
-        if handoff is None or item.pr is None:
-            return "invalid"
-        head_sha = handoff["head_sha"]
-        threads = handoff["threads"]
-        replies = handoff["replies"]
-        batch_nonce = handoff["batch_nonce"]
-        try:
-            state = ctx.github.gh_pr_state(item.pr)
-            if not _pr_is_current_open_head(state, head_sha):
-                if (
-                    isinstance(state, dict)
-                    and state.get("state") == "OPEN"
-                    and state.get("autoMergeRequest") is None
-                ):
-                    visibility_retries = item.payload.get(
-                        _PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, 0
-                    )
-                    if (
-                        isinstance(visibility_retries, int)
-                        and not isinstance(visibility_retries, bool)
-                        and visibility_retries >= 0
-                        and visibility_retries < IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP
-                    ):
-                        visibility_retries += 1
-                        item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES] = (
-                            visibility_retries
-                        )
-                        item.payload["retry_delay_s"] = float(2 ** (visibility_retries - 1))
-                        logger.info(
-                            "pr_review:%s: waiting for pushed implementation head visibility "
-                            "before replying to review threads (%d/%d)",
-                            item.issue,
-                            visibility_retries,
-                            IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRY_CAP,
-                        )
-                        return "visibility_wait"
-                item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-                item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-                item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
-                return "stale"
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
-            result = ctx.github.post_implementation_thread_replies(
-                item.pr,
-                expected_head_sha=head_sha,
-                threads=threads,
-                replies=replies,
-                batch_nonce=batch_nonce,
-            )
-        except Exception as error:
-            logger.warning(
-                "pr_review:%s: implementation reply handoff retry failed (%s)",
-                item.issue,
-                type(error).__name__,
-            )
-            return "retry"
-
-        expected_ids = set(replies)
-        replied = set(getattr(result, "replied_thread_ids", ()))
-        receipts = list(getattr(result, "receipts", ()))
-        if replied == expected_ids and len(receipts) == len(replied):
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-            return "completed"
-        remaining_ids = expected_ids - replied
-        retryable = bool(getattr(result, "retryable", False))
-        result_retryable_ids = set(getattr(result, "retryable_thread_ids", ()))
-        retryable_ids = (
-            result_retryable_ids
-            if result_retryable_ids and result_retryable_ids.issubset(remaining_ids)
-            else remaining_ids
-            if retryable and not result_retryable_ids
-            else set()
-        )
-        if not retryable_ids:
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-            return "stale"
-        if not replied.issubset(expected_ids) or len(receipts) != len(replied):
-            return "invalid"
-        replacement = _implementation_reply_handoff(
-            head_sha,
-            [snapshot for snapshot in threads if str(snapshot.get("id") or "") in retryable_ids],
-            {
-                thread_id: reply
-                for thread_id, reply in replies.items()
-                if thread_id in retryable_ids
-            },
-            batch_nonce,
-        )
-        if replacement is None:
-            return "invalid"
-        item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF] = replacement
-        return "retry"
 
     def _eval(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901 - state-machine gate
         """EVAL [M]: apply the structural-audit gate and review budget.

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -93,6 +93,7 @@ _IMPLEMENTATION_REPLY_BODY_RE = re.compile(
     r"(?s)\A(.*)\n\n<!-- hephaestus-implementation-reply:[0-9a-f]{24} -->\n"
     r"<!-- hephaestus-implementation-batch:([0-9a-f]{32}) -->\Z"
 )
+_FULL_COMMIT_SHA_RE = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?")
 
 
 def _parse_included_http_response(
@@ -827,7 +828,7 @@ class PipelineGitHub:
         """Return whether a fresh PR state is open, unarmed, and on the reviewed head."""
         return bool(
             isinstance(expected_head_sha, str)
-            and re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
+            and _FULL_COMMIT_SHA_RE.fullmatch(expected_head_sha)
             and isinstance(state, dict)
             and str(state.get("state") or "").upper() == "OPEN"
             and state.get("autoMergeRequest") is None
@@ -1570,7 +1571,7 @@ class PipelineGitHub:
         candidate_ids = tuple(sorted(str(thread_id) for thread_id in replies))
         if (
             not candidate_ids
-            or not re.fullmatch(r"[0-9a-f]{40}", expected_head_sha)
+            or _FULL_COMMIT_SHA_RE.fullmatch(expected_head_sha) is None
             or re.fullmatch(r"[0-9a-f]{32}", batch_nonce) is None
         ):
             return ImplementationThreadReplyResult(blocked_thread_ids=candidate_ids)
@@ -1614,13 +1615,20 @@ class PipelineGitHub:
                     pr_number, expected_head_sha, thread_id, reply, batch_nonce
                 )
                 live = self._review_thread_snapshot(pr_number, thread_id)
-                if (
-                    not isinstance(live, dict)
-                    or live.get("isResolved") is not False
-                    or not self._pr_is_current_open_head(live.get("pr_state"), expected_head_sha)
-                ):
+                if not isinstance(live, dict) or live.get("isResolved") is not False:
                     blocked.append(thread_id)
                     continue
+                if not self._pr_is_current_open_head(live.get("pr_state"), expected_head_sha):
+                    # The shared handoff has just observed the exact pushed
+                    # head. A later per-thread GraphQL read can still lag that
+                    # fact briefly. Treat it as a retryable host-visibility
+                    # race; the outer retry rereads PR state and classifies a
+                    # real head move as stale before posting anything.
+                    return ImplementationThreadReplyResult(
+                        retryable_thread_ids=candidate_ids,
+                        retryable=True,
+                        visibility_lag=True,
+                    )
                 pull_request_id = live.get("pr_node_id")
                 if not isinstance(pull_request_id, str) or not pull_request_id:
                     blocked.append(thread_id)
@@ -1796,7 +1804,7 @@ class PipelineGitHub:
             or "" in expected_ids
             or set(resolved_thread_ids) & set(feedback)
             or expected_ids != set(resolved_thread_ids) | set(feedback)
-            or not re.fullmatch(r"[0-9a-f]{40}", reviewed_head_sha)
+            or _FULL_COMMIT_SHA_RE.fullmatch(reviewed_head_sha) is None
             or self._skip(
                 f"reconcile {len(candidate_ids)} reviewer-validated threads on PR #{pr_number}"
             )

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -13,6 +14,7 @@ from hephaestus.automation.pipeline.jobs import AgentJob, BuildTestJob, GitJob, 
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import (
     Continue,
+    ImplementationThreadReplyResult,
     JobRequest,
     StageOutcome,
     implementation as implementation_module,
@@ -1591,14 +1593,22 @@ class TestCommitPushAndPrCreate:
     ) -> None:
         """The writer posts one [Response] reply per addressed review thread."""
         stage = ImplementationStage()
-        github = FakeStageGitHub()
+        github = FakeStageGitHub(
+            pr_state={"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None}
+        )
         ctx = make_ctx(github=github)
         item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
         item.payload.update(
             {
                 "implementation_remediation": True,
                 "remediation_thread_snapshots": [
-                    {"id": "thread-1", "path": "a.py", "line": 3, "body": "fix it"}
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "body": "fix it",
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
                 ],
                 "remediation_output": {
                     "addressed": ["thread-1"],
@@ -1613,8 +1623,447 @@ class TestCommitPushAndPrCreate:
             ctx,
         )
 
+        item.state = "PR_CREATE"
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
         assert ("post_implementation_thread_replies", (1001, ("thread-1",))) in github.mutation_log
         assert "implementation_remediation" not in item.payload
+
+    def test_remediation_reply_handoff_waits_for_github_head_visibility(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A post-push visibility lag retries the exact response batch without another commit."""
+
+        class HeadVisibilityLagGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self._states = deque(
+                    [
+                        {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
+                        {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None},
+                    ]
+                )
+
+            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+                del pr_number
+                return self._states.popleft() if self._states else None
+
+        stage = ImplementationStage()
+        github = HeadVisibilityLagGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_thread_snapshots": [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "fix it",
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
+                ],
+                "remediation_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "[Response] Fixed the missing guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "b" * 40}),
+            ctx,
+        )
+
+        assert "pending_implementation_reply_handoff" in item.payload
+        assert "remediation_reply_error" not in item.payload
+        assert not any(
+            name == "post_implementation_thread_replies" for name, _ in github.mutation_log
+        )
+
+        item.state = "PR_CREATE"
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
+        )
+        assert item.payload["retry_delay_s"] == 1.0
+        assert not any(
+            name == "post_implementation_thread_replies" for name, _ in github.mutation_log
+        )
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
+        assert ("post_implementation_thread_replies", (1001, ("thread-1",))) in github.mutation_log
+        assert "pending_implementation_reply_handoff" not in item.payload
+        assert "implementation_remediation" not in item.payload
+
+    def test_remediation_reply_handoff_retries_a_transient_pr_state_read(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed PR-state read preserves the exact batch for one host-only retry."""
+
+        class TransientReadGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self._states = deque(
+                    [
+                        None,
+                        {
+                            "state": "OPEN",
+                            "headRefOid": "b" * 40,
+                            "autoMergeRequest": None,
+                        },
+                    ]
+                )
+
+            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+                del pr_number
+                return self._states.popleft() if self._states else None
+
+        stage = ImplementationStage()
+        github = TransientReadGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_thread_snapshots": [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "fix it",
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
+                ],
+                "remediation_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "[Response] Fixed the missing guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "b" * 40}),
+            ctx,
+        )
+        item.state = "PR_CREATE"
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_retry"
+        )
+        assert "pending_implementation_reply_handoff" in item.payload
+        assert not any(
+            name == "post_implementation_thread_replies" for name, _ in github.mutation_log
+        )
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
+        assert (
+            github.mutation_log.count(("post_implementation_thread_replies", (1001, ("thread-1",))))
+            == 1
+        )
+
+    def test_remediation_reply_handoff_backoffs_for_a_lagging_thread_snapshot(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Adapter-side head lag uses the visibility delay rather than transport retries."""
+
+        class ThreadSnapshotLagGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(
+                    pr_state={
+                        "state": "OPEN",
+                        "headRefOid": "b" * 40,
+                        "autoMergeRequest": None,
+                    }
+                )
+                self._reply_results = deque(
+                    [
+                        ImplementationThreadReplyResult(
+                            retryable_thread_ids=("thread-1",),
+                            retryable=True,
+                            visibility_lag=True,
+                        )
+                    ]
+                )
+
+            def post_implementation_thread_replies(
+                self,
+                pr_number: int,
+                *,
+                expected_head_sha: str,
+                threads: list[dict[str, Any]],
+                replies: dict[str, str],
+                batch_nonce: str,
+            ) -> ImplementationThreadReplyResult:
+                if self._reply_results:
+                    return self._reply_results.popleft()
+                return super().post_implementation_thread_replies(
+                    pr_number,
+                    expected_head_sha=expected_head_sha,
+                    threads=threads,
+                    replies=replies,
+                    batch_nonce=batch_nonce,
+                )
+
+        stage = ImplementationStage()
+        github = ThreadSnapshotLagGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_thread_snapshots": [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "fix it",
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
+                ],
+                "remediation_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "[Response] Fixed the missing guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "b" * 40}),
+            ctx,
+        )
+        item.state = "PR_CREATE"
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
+        )
+        assert item.payload["retry_delay_s"] == 1.0
+        assert "pending_implementation_reply_handoff_retries" not in item.payload
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
+        assert (
+            github.mutation_log.count(("post_implementation_thread_replies", (1001, ("thread-1",))))
+            == 1
+        )
+
+    def test_remediation_reply_handoff_reconstructs_after_restart_without_new_commit(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A restart replays its exact GitHub-journaled batch without another agent or commit."""
+
+        class TransientReadGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self._states = deque(
+                    [
+                        None,
+                        {
+                            "state": "OPEN",
+                            "headRefOid": "b" * 40,
+                            "autoMergeRequest": None,
+                        },
+                    ]
+                )
+
+            def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+                del pr_number
+                return self._states.popleft() if self._states else None
+
+        stage = ImplementationStage()
+        github = TransientReadGitHub()
+        ctx = make_ctx(github=github)
+        publisher = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        publisher.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_thread_snapshots": [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "fix it",
+                        "review_commit_sha": "a" * 40,
+                        "pr_state": {
+                            "state": "OPEN",
+                            "headRefOid": "a" * 40,
+                            "autoMergeRequest": None,
+                        },
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
+                ],
+                "remediation_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "[Response] Verified the already-pushed guard."},
+                },
+            }
+        )
+
+        # The original writer records its exact, already-validated response
+        # before the process is interrupted after its push.
+        stage.on_job_done(
+            publisher,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "b" * 40}),
+            ctx,
+        )
+
+        resumed = make_work_item(issue=1, pr=1001, state="IMPLEMENT_WAIT")
+        # The normal restarted read sees the writer's new head and may see a
+        # relocated diff anchor.  These mutable fields must not invalidate an
+        # otherwise identical source-review conversation.
+        post_push_snapshots = [
+            {
+                **publisher.payload["remediation_thread_snapshots"][0],
+                "path": "renamed.py",
+                "line": 97,
+                "body": "fix it at its new location",
+                "pr_state": {
+                    "state": "OPEN",
+                    "headRefOid": "b" * 40,
+                    "autoMergeRequest": None,
+                },
+            }
+        ]
+        resumed.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_threads": post_push_snapshots,
+                "remediation_thread_snapshots": post_push_snapshots,
+            }
+        )
+
+        assert stage.step(resumed, ctx) == Continue(next_state="PR_CREATE")
+        assert "pending_implementation_reply_handoff" in resumed.payload
+        assert "remediation_output" not in resumed.payload
+
+        resumed.state = "PR_CREATE"
+        assert stage.step(resumed, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_retry"
+        )
+        assert stage.step(resumed, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
+        assert (
+            github.mutation_log.count(("post_implementation_thread_replies", (1001, ("thread-1",))))
+            == 1
+        )
+
+    def test_remediation_reply_handoff_retries_a_transient_journal_write_without_a_new_commit(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An immutable-journal write failure retries only the prepared batch."""
+
+        class TransientJournalGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(
+                    pr_state={
+                        "state": "OPEN",
+                        "headRefOid": "b" * 40,
+                        "autoMergeRequest": None,
+                    }
+                )
+                self.journal_calls = 0
+
+            def append_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
+                self.journal_calls += 1
+                if self.journal_calls == 1:
+                    raise OSError("temporary GitHub outage")
+                super().append_issue_comment(issue_number, marker, body)
+
+        stage = ImplementationStage()
+        github = TransientJournalGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_thread_snapshots": [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "fix it",
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
+                ],
+                "remediation_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "[Response] Fixed the missing guard."},
+                },
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": True, "head_sha": "b" * 40}),
+            ctx,
+        )
+
+        assert github.journal_calls == 1
+        assert "pending_implementation_reply_handoff" in item.payload
+        assert "pending_implementation_reply_handoff_journal" in item.payload
+        assert item.attempts.get("implement", 0) == 0
+
+        item.state = "PR_CREATE"
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
+        assert github.journal_calls == 2
+        assert "pending_implementation_reply_handoff_journal" not in item.payload
+        assert (
+            github.mutation_log.count(("post_implementation_thread_replies", (1001, ("thread-1",))))
+            == 1
+        )
+
+    def test_remediation_reply_handoff_rejects_no_commit_on_the_source_review_head(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A no-op run may not answer a thread against unchanged reviewed code."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(
+            pr_state={"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None}
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="COMMIT_PUSH_WAIT")
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_thread_snapshots": [
+                    {
+                        "id": "thread-1",
+                        "path": "a.py",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "fix it",
+                        "review_commit_sha": "a" * 40,
+                        "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
+                    }
+                ],
+                "remediation_output": {
+                    "addressed": ["thread-1"],
+                    "replies": {"thread-1": "[Response] This must not be posted."},
+                },
+            }
+        )
+
+        stage.on_job_done(item, JobResult(ok=True, value=False), ctx)
+
+        assert item.payload["remediation_reply_error"] is True
+        assert "pending_implementation_reply_handoff" not in item.payload
 
     def test_commit_push_requests_git_job(self, make_ctx: Any, make_work_item: Any) -> None:
         """COMMIT_PUSH_WAIT submits the commit_push GitJob."""

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -17,6 +17,10 @@ from hephaestus.automation.pipeline.jobs import (
     GitJob,
     JobResult,
 )
+from hephaestus.automation.pipeline.reply_handoff import (
+    implementation_reply_handoff_journal_entry,
+    journaled_implementation_reply_handoff,
+)
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import (
     Continue,
@@ -47,6 +51,7 @@ from hephaestus.automation.pipeline.stages.pr_review import (
 )
 from hephaestus.automation.pipeline.work_item import ItemKind
 from hephaestus.automation.review_audit import ReviewAudit, parse_review_audit
+from hephaestus.automation.review_journal import IssueComment
 from hephaestus.automation.state_labels import STATE_SKIP
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
@@ -1950,6 +1955,15 @@ class TestReviewThreadLifecycle:
             "replies": {"thread-1": "Fixed the first concern."},
             "batch_nonce": "b" * 32,
         }
+        assert (
+            _implementation_reply_handoff(
+                "c" * 64,
+                [self._thread("thread-2", 4, "second")],
+                {"thread-2": "Fixed the second concern."},
+                "d" * 32,
+            )
+            is not None
+        )
         thread["body"] = "mutated after the handoff"
         assert handoff["threads"][0]["body"] != thread["body"]
         assert (
@@ -1961,6 +1975,68 @@ class TestReviewThreadLifecycle:
         assert _implementation_reply_handoff("a" * 40, ["not-a-thread"], {}, "b" * 32) is None
         assert (
             _implementation_reply_handoff("a" * 40, [{"id": ""}], {"": "fixed"}, "b" * 32) is None
+        )
+
+    def test_implementation_reply_handoff_journal_requires_actor_and_exact_source_comments(
+        self,
+    ) -> None:
+        """Recovery binds to our immutable source comments, not mutable anchors."""
+        thread = self._thread("thread-1", 3, "first")
+        handoff = _implementation_reply_handoff(
+            "a" * 40,
+            [thread],
+            {"thread-1": "Fixed the first concern."},
+            "b" * 32,
+        )
+        assert handoff is not None
+        entry = implementation_reply_handoff_journal_entry(1001, handoff)
+        assert entry is not None
+        _marker, body = entry
+        assert body.splitlines()[1].startswith("<!-- ")
+
+        assert (
+            journaled_implementation_reply_handoff(
+                [IssueComment(body=body, viewer_did_author=False)],
+                pr_number=1001,
+                threads=[thread],
+            )
+            is None
+        )
+        moved_thread = {
+            **thread,
+            "path": "renamed.py",
+            "line": 999,
+            "body": "a refreshed derived summary",
+            "pr_state": {
+                "state": "OPEN",
+                "headRefOid": "c" * 40,
+                "autoMergeRequest": None,
+            },
+        }
+        recovered = journaled_implementation_reply_handoff(
+            [IssueComment(body=body, viewer_did_author=True)],
+            pr_number=1001,
+            threads=[moved_thread],
+        )
+        assert recovered is not None
+        assert recovered["replies"] == handoff["replies"]
+        assert (
+            journaled_implementation_reply_handoff(
+                [IssueComment(body=body, viewer_did_author=True)],
+                pr_number=1001,
+                threads=[
+                    {
+                        **moved_thread,
+                        "comments": [
+                            {
+                                **moved_thread["comments"][0],
+                                "body": "an externally changed source comment",
+                            }
+                        ],
+                    }
+                ],
+            )
+            is None
         )
 
     def test_validation_receipts_require_one_complete_immutable_thread_snapshot(self) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -373,6 +373,69 @@ class TestAllThreadReplyAndReviewerResolution:
         assert attached_review_ids == ["review-1"]
         assert submitted_review_ids == ["review-1"]
 
+    def test_reply_batch_retries_when_thread_snapshot_lags_the_current_pr_head(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second GitHub read seeing the old head is visibility lag, not thread drift."""
+        thread = _external_reviewer_thread("thread-one")
+        stale_live = {
+            **_open_thread_snapshot(thread),
+            "pr_state": {
+                "state": "OPEN",
+                "headRefOid": "b" * 40,
+                "autoMergeRequest": None,
+            },
+        }
+        graphql = MagicMock()
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", lambda _pr, _thread: stale_live)
+        monkeypatch.setattr(adapter, "_graphql", graphql)
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha="a" * 40,
+            threads=[thread],
+            replies={thread["id"]: "Fixed the missing guard."},
+        )
+
+        assert result.replied_thread_ids == ()
+        assert result.retryable is True
+        assert result.visibility_lag is True
+        assert result.retryable_thread_ids == (thread["id"],)
+        assert result.blocked_thread_ids == ()
+        graphql.assert_not_called()
+
+    def test_reply_batch_accepts_a_full_sha256_head(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reply adapter preserves the pipeline's 40-or-64 OID contract."""
+        head_sha = "a" * 64
+        thread = _external_reviewer_thread("thread-one")
+        live = {
+            **_open_thread_snapshot(thread),
+            "pr_state": {
+                "state": "OPEN",
+                "headRefOid": head_sha,
+                "autoMergeRequest": None,
+            },
+        }
+        create_calls: list[tuple[str, str]] = []
+        monkeypatch.setattr(adapter, "_review_thread_snapshot", lambda _pr, _thread: live)
+        monkeypatch.setattr(
+            adapter,
+            "_create_pending_implementation_review",
+            lambda _pr_node, actual_head, _nonce: create_calls.append((actual_head, _nonce)),
+        )
+
+        result = adapter.post_implementation_thread_replies(
+            7,
+            expected_head_sha=head_sha,
+            threads=[thread],
+            replies={thread["id"]: "Fixed the missing guard."},
+        )
+
+        assert create_calls == [(head_sha, _BATCH_NONCE)]
+        assert result.blocked_thread_ids == (thread["id"],)
+
     def test_implementation_replies_share_one_source_attached_batch(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Summary:

- Persist exact post-push implementation response batches before GitHub mutation.
- Share bounded visibility and transport recovery across implementation and PR-review stages.
- Recover fresh review safely when a head or thread snapshot genuinely changes.

Testing:

- `uv run --all-extras --locked pytest -q`
- `uv run mypy hephaestus/ scripts/ tests/`
- `uv run ruff check hephaestus/ tests/`

Closes #2586
