### PR TITLE
Fix automation loop direct issue planning context

### DIFF
--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -65,8 +65,6 @@ from hephaestus.automation.protocol import (
 from hephaestus.automation.review_journal import (
     IssueComment,
     blocked_audit_recovery_body,
-    is_plan_comment,
-    is_plan_review_comment,
 )
 from hephaestus.automation.state_labels import (
     ALL_IMPLEMENTATION_STATE_LABELS,
@@ -383,9 +381,10 @@ class PipelineGitHub:
             if not isinstance(body, str):
                 continue
             stripped = body.lstrip()
-            if is_plan_review_comment(stripped):
+            first_line = stripped.splitlines()[0] if stripped else ""
+            if first_line in {PLAN_REVIEW_CANONICAL_MARKER, PLAN_REVIEW_PREFIX}:
                 continue
-            if is_plan_comment(stripped):
+            if first_line in {PLAN_CANONICAL_MARKER, PLAN_COMMENT_MARKER}:
                 return True
         return False
 

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -2900,6 +2900,38 @@ class TestRepoScoping:
 
         assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            f"{PLAN_COMMENT_MARKER} appendix\n\nNot canonical.",
+            f"{PLAN_CANONICAL_MARKER} appendix\n{PLAN_COMMENT_MARKER}\nNot canonical.",
+        ],
+    )
+    def test_repo_scoped_has_existing_plan_rejects_marker_prefixes(
+        self,
+        body: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Only an exact first-line marker identifies a canonical plan."""
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            if argv[:2] == ["issue", "view"]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        {
+                            "comments": [
+                                {"body": body, "viewerDidAuthor": True},
+                            ],
+                        }
+                    )
+                )
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        assert not pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
+
     def test_repo_scoped_has_existing_plan_ignores_foreign_plan_marker(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
Implemented exact first-line canonical plan detection, rejecting marker-prefixed spoof comments while preserving valid markers:

- [pipeline_github.py:384](/Users/mvillmow/Projects/ProjectHephaestus/build/loop-validation-1950-live/Hephaestus/hephaestus/automation/pipeline_github.py:384)
- Added regression tests at [test_pipeline_github.py:2910](/Users/mvillmow/Projects/ProjectHephaestus/build/loop-validation-1950-live/Hephaestus/tests/unit/automation/test_pipeline_github.py:2910)

Verification passed:

- 7,082 tests passed; coverage 84.57%
- mypy, Ruff lint/format, and all pre-commit hooks passed

Changes remain uncommitted as required.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests -q --tb=short

## Closes
Closes #1950

Generated by Hephaestus automation
