### PR TITLE
fix(automation): converge reopened issue remediation

### DIFF
--- a/docs/adr/0018-reviewer-owned-thread-reconciliation.md
+++ b/docs/adr/0018-reviewer-owned-thread-reconciliation.md
@@ -28,8 +28,12 @@ prose or a stale PR snapshot.
    describing the change. It never resolves a thread. A complete response set
    enters reviewer comment validation directly; it does not trigger another
    broad review batch before that validation.
-2. The host posts an implementation reply only after a real fix commit is
-   pushed. Before and after each reply it requires a complete thread snapshot
+2. The host posts an implementation reply after a real fix commit is pushed,
+   or after a successful no-commit remediation response with the explicit
+   suffix ``[auto-msg] reply has no corresponding commit, review thoroughly``.
+   The latter is evidence for the reviewer, never proof that the concern is
+   resolved: the reviewer must analyze the response and current code. Before
+   and after each reply the host requires a complete thread snapshot
    and an open, unarmed PR at the exact expected head. A later pass may recover
    a candidate reply from the final, viewer-owned thread comment on GitHub only
    when its marker recomputes for that exact thread and head; fresh GitHub
@@ -72,5 +76,8 @@ prose or a stale PR snapshot.
   implementation loop; only the host may replay its exact saved reply batch.
   It retries only the thread IDs with ambiguous host outcomes; a changed thread
   is deliberately rereviewed rather than retried.
+- A no-commit response is not rejected based on its source. Its warning is
+  length-bounded with deterministic truncation when needed, and the independent
+  reviewer retains sole responsibility for accepting or rejecting it.
 - The queue can apply implementation approval only after the fresh open-thread
   read is empty; review prose and CI remain non-authoritative for that label.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1198,7 +1198,7 @@ globally bounded.
 
 [`seeding.py`](../hephaestus/automation/pipeline/seeding.py) is the pure
 classifier the coordinator consults on every restart. It maps
-`(labels, PR existence/state)` to a single entry stage using **ordered
+`(issue state, labels, PR existence/state)` to a single entry stage using **ordered
 label rank**:
 
 ```
@@ -1228,7 +1228,8 @@ PR-probe failure cannot misclassify toward IMPLEMENTATION).
 | GitHub state | Entry stage |
 |-------------------------------------------------------|----------------------------------|
 | `state:skip`/`epic` | excluded (`stage = None`) |
-| Direct PR already merged | `FINISHED` (pass, idempotent) |
+| Closed issue with a merged PR carrying exact `Closes #N` | `FINISHED` (pass, idempotent) |
+| Open/reopened issue with a historic merged PR | Treat as no open PR; route by current state label |
 | Direct PR already closed | excluded |
 | Open PR carries PR-level `state:implementation-go` | `MERGE_WAIT` |
 | Any other open PR, including one carrying only issue-level `state:implementation-go` | `PR_REVIEW` |

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -869,15 +869,9 @@ def find_merged_closing_pr(issue_number: int) -> int | None:
 def find_merged_pr_for_issue(issue_number: int) -> int | None:
     """Find the MERGED PR for a single issue (tri-state fetch layer, epic #1809).
 
-    Mirrors :func:`find_pr_for_issue`'s strategies with ``--state merged``:
-
-    1. Branch name lookup (``{issue}-auto-impl``, merged PRs).
-    2. Exact ``Closes #N`` body search via :func:`find_merged_closing_pr`.
-
-    Used by pipeline seeding so the "PR merged → finished" classification row
-    is reachable: when the open-PR lookup misses, this lookup distinguishes
-    merged work (finished, idempotent) from closed/abandoned PRs (invisible —
-    normalized to "no PR") and from genuinely PR-less issues.
+    Only an exact ``Closes #N`` body line establishes the relationship. A
+    branch name is not completion evidence: branches may be reused and a
+    merged PR without the required closing line must not terminalize an issue.
 
     Args:
         issue_number: GitHub issue number.
@@ -886,33 +880,6 @@ def find_merged_pr_for_issue(issue_number: int) -> int | None:
         The merged PR number if found, ``None`` otherwise.
 
     """
-    branch_name = issue_auto_impl_branch_name(issue_number)
-    try:
-        result = _gh_call(
-            [
-                "pr",
-                "list",
-                "--head",
-                branch_name,
-                "--state",
-                "merged",
-                "--json",
-                "number",
-                "--limit",
-                "1",
-            ],
-            check=False,
-        )
-        pr_data = json.loads(result.stdout or "[]")
-        if pr_data:
-            pr_number = int(pr_data[0]["number"])
-            logger.info(
-                "Found merged PR #%d for issue #%d via branch name", pr_number, issue_number
-            )
-            return pr_number
-    except Exception as e:
-        logger.debug("Merged branch-name lookup failed for issue #%d: %s", issue_number, e)
-
     return find_merged_closing_pr(issue_number)
 
 

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -81,6 +81,15 @@ _REVIEW_PARSE_FAILED = {
 }
 
 
+def has_exact_closing_line(body: str, issue_number: int) -> bool:
+    """Return whether ``body`` contains the canonical ``Closes #N`` policy line.
+
+    The optional carriage return admits CRLF bodies while rejecting grouped and
+    suffixed issue references that GitHub's text search can otherwise return.
+    """
+    return re.search(rf"^Closes #{issue_number}\r?$", body, re.MULTILINE) is not None
+
+
 @overload
 def load_state_file[StateModelT: BaseModel](
     state_dir: Path,
@@ -796,10 +805,9 @@ def find_pr_for_issue(
         # line boundaries (re.MULTILINE) so ``Closes #1234`` cannot match a
         # query for #12, and grouped ``Closes #12, #18`` cannot match either
         # — only PRs that follow ``pr-policy``'s exact-line format match.
-        closes_pattern = re.compile(rf"^Closes #{issue_number}\r?$", re.MULTILINE)
         for candidate in pr_data:
             body = candidate.get("body") or ""
-            if closes_pattern.search(body):
+            if has_exact_closing_line(body, issue_number):
                 pr_number = int(candidate["number"])
                 logger.info("Found PR #%d for issue #%d via body search", pr_number, issue_number)
                 return pr_number
@@ -849,10 +857,9 @@ def find_merged_closing_pr(issue_number: int) -> int | None:
             check=False,
         )
         pr_data = json.loads(result.stdout or "[]")
-        closes_pattern = re.compile(rf"^Closes #{issue_number}\r?$", re.MULTILINE)
         for candidate in pr_data:
             body = candidate.get("body") or ""
-            if closes_pattern.search(body):
+            if has_exact_closing_line(body, issue_number):
                 pr_number = int(candidate["number"])
                 logger.info(
                     "Found merged PR #%d closing issue #%d via body search",

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -796,7 +796,7 @@ def find_pr_for_issue(
         # line boundaries (re.MULTILINE) so ``Closes #1234`` cannot match a
         # query for #12, and grouped ``Closes #12, #18`` cannot match either
         # — only PRs that follow ``pr-policy``'s exact-line format match.
-        closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
+        closes_pattern = re.compile(rf"^Closes #{issue_number}\r?$", re.MULTILINE)
         for candidate in pr_data:
             body = candidate.get("body") or ""
             if closes_pattern.search(body):
@@ -849,7 +849,7 @@ def find_merged_closing_pr(issue_number: int) -> int | None:
             check=False,
         )
         pr_data = json.loads(result.stdout or "[]")
-        closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
+        closes_pattern = re.compile(rf"^Closes #{issue_number}\r?$", re.MULTILINE)
         for candidate in pr_data:
             body = candidate.get("body") or ""
             if closes_pattern.search(body):

--- a/hephaestus/automation/address_review_core.py
+++ b/hephaestus/automation/address_review_core.py
@@ -7,6 +7,7 @@ from typing import Any
 from ._review_utils import parse_json_block
 
 _ADDRESS_PARSE_DEFAULT: dict[str, Any] = {"addressed": [], "replies": {}}
+MAX_ADDRESS_REPLY_CHARS = 4_000
 
 
 def _parse_addressed_block(text: str) -> dict[str, Any]:
@@ -53,7 +54,7 @@ def parse_addressed_replies(
     normalized: dict[str, str] = {}
     for thread_id in known_ids:
         reply = replies.get(thread_id)
-        if not isinstance(reply, str) or not 0 < len(reply.strip()) <= 4_000:
+        if not isinstance(reply, str) or not 0 < len(reply.strip()) <= MAX_ADDRESS_REPLY_CHARS:
             return None
         normalized[thread_id] = reply.strip()
     return normalized

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -180,6 +180,9 @@ _IMPLEMENTATION_FILE_CLAIMS_PAYLOAD = "_implementation_file_claims"
 #: WorkItem payload key holding consecutive file-overlap deferrals.
 _FILE_OVERLAP_DEFERRALS_KEY = "file_overlap_deferrals"
 
+#: Host-owned snapshot of the active claims that last blocked a queued item.
+_FILE_OVERLAP_BLOCKED_CLAIMS_KEY = "_file_overlap_blocked_claims"
+
 #: Deferral counts strictly above this value are logged as warnings.
 _FILE_OVERLAP_WARNING_THRESHOLD = 10
 
@@ -1771,6 +1774,7 @@ class Coordinator:
             if (claims := submission_claims.get(id(item))) is not None:
                 item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(claims)
             item.payload.pop(_FILE_OVERLAP_DEFERRALS_KEY, None)
+            item.payload.pop(_FILE_OVERLAP_BLOCKED_CLAIMS_KEY, None)
             self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
             self._run_item(item)
 
@@ -1892,16 +1896,26 @@ class Coordinator:
         for item, identity in candidates:
             if item.issue is None:  # defensive: candidate construction excludes this case
                 continue
+            blocked_claims = item.payload.get(_FILE_OVERLAP_BLOCKED_CLAIMS_KEY)
+            if blocked_claims is not None and set(blocked_claims) == claimed:
+                # The same active reservation still blocks this item. Polling
+                # must remain quiet until that reservation changes.
+                continue
             repo = (self.config.org, item.repo)
             payload_claims = item.payload.get(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD)
             if payload_claims is None:
                 planned = _admission._fetch_planned_files(item.issue, repo=repo)
                 item_claims = {(repo, path) for path in planned} if planned else set()
+                # Freeze the plan on first admission attempt, including while
+                # blocked, so coordinator polling never repeats GitHub reads.
+                item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(item_claims)
             else:
                 item_claims = set(payload_claims)
             if item_claims and (item_claims & claimed):
                 self._record_file_overlap_deferral(item, identity)
+                item.payload[_FILE_OVERLAP_BLOCKED_CLAIMS_KEY] = set(claimed)
                 continue
+            item.payload.pop(_FILE_OVERLAP_BLOCKED_CLAIMS_KEY, None)
             claimed.update(item_claims)
             # Preserve an empty snapshot too: unknown plans fail open, but
             # must not be fetched again after being admitted.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -408,9 +408,10 @@ class _DirectIssueSource:
     """
 
     repo: str
-    issues: Iterator[int]
+    issues: deque[int]
     base_sha: str
     run_nonce: str
+    overlap_blocked_claims: frozenset[_admission.PlanFileClaim] | None = None
 
 
 @dataclass
@@ -1892,8 +1893,12 @@ class Coordinator:
             if item.issue is None:  # defensive: candidate construction excludes this case
                 continue
             repo = (self.config.org, item.repo)
-            planned = _admission._fetch_planned_files(item.issue, repo=repo)
-            item_claims = {(repo, path) for path in planned} if planned else set()
+            payload_claims = item.payload.get(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD)
+            if payload_claims is None:
+                planned = _admission._fetch_planned_files(item.issue, repo=repo)
+                item_claims = {(repo, path) for path in planned} if planned else set()
+            else:
+                item_claims = set(payload_claims)
             if item_claims and (item_claims & claimed):
                 self._record_file_overlap_deferral(item, identity)
                 continue
@@ -2659,7 +2664,7 @@ class Coordinator:
         open_issues = _admission._filter_open_issues(repo, self.config.issues)
         self._direct_issue_source = _DirectIssueSource(
             repo=repo,
-            issues=iter(open_issues),
+            issues=deque(open_issues),
             base_sha=base_sha,
             run_nonce=uuid.uuid4().hex,
         )
@@ -2680,54 +2685,86 @@ class Coordinator:
             self.queues[stage].can_offer() for stage in _DIRECT_ISSUE_ENTRY_STAGES
         )
 
+    def _prepare_direct_issue_item(
+        self,
+        source: _DirectIssueSource,
+        issue: int,
+        active_claims: frozenset[_admission.PlanFileClaim],
+        *,
+        overlap_enabled: bool,
+    ) -> tuple[WorkItem | None, bool]:
+        """Classify one source issue and snapshot its overlap reservation."""
+        entry = self._seed_direct_issue_entry(source.repo, issue)
+        if entry.stage is None:
+            if entry.skip_tag_obligation is not None:
+                self.github.skip_epics({entry.skip_tag_obligation.issue: []})
+            logger.info("seed excluded: %s", entry.reason)
+            return None, False
+
+        item = self._entry_to_item(entry, source.repo)
+        if overlap_enabled and item.stage is StageName.IMPLEMENTATION:
+            repo = (self.config.org, item.repo)
+            planned = _admission._fetch_planned_files(issue, repo=repo)
+            item_claims = {(repo, path) for path in planned} if planned else set()
+            if item_claims and item_claims.intersection(active_claims):
+                return None, True
+            item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(item_claims)
+
+        if is_full_commit_sha(source.base_sha):
+            item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = source.base_sha
+            if item.kind is ItemKind.ISSUE and item.pr is None and item.issue is not None:
+                item.branch = f"{item.issue}-auto-impl-direct-{source.run_nonce}"
+                item.payload[DIRECT_SCOPE_WORKTREE_NONCE_KEY] = source.run_nonce
+        if item.stage not in (StageName.REPO, StageName.FINISHED):
+            self._pass_work_count += 1
+        if item.stage is StageName.FINISHED and item.result is None:
+            item.result = ItemResult(
+                passed=entry.passed,
+                reason=entry.reason,
+                final_stage=StageName.FINISHED,
+            )
+        return item, False
+
     def _drain_direct_issue_source(self) -> int:
         """Pull explicit issues directly into queues without a seed spill buffer.
 
         An issue is classified only after its eventual destination is
-        guaranteed to have capacity.  The loop fills immediately available
-        capacity, then leaves the remaining caller-owned iterator live until
-        normal queue draining creates another safe admission point.
+        guaranteed to have capacity. With parallel overlap serialization, a
+        bounded deque lets one full source pass rotate conflicting issues and
+        admit the first independent candidate. A fully blocked pass is cached
+        against the immutable active-claim set, preventing hot-loop GitHub
+        plan fetches until implementation ownership changes.
         """
         source = self._direct_issue_source
         if source is None:
             return 0
 
+        active_claims = frozenset(self._active_implementation_file_claims())
+        overlap_enabled = self._overlap_serialization_enabled()
+        if overlap_enabled and source.overlap_blocked_claims == active_claims:
+            return 0
+        source.overlap_blocked_claims = None
+
         pushed = 0
-        while self._direct_issue_queues_can_accept():
-            try:
-                issue = next(source.issues)
-            except StopIteration:
-                self._direct_issue_source = None
-                break
+        scanned = 0
+        scan_limit = len(source.issues)
+        blocked_by_overlap = False
+        while self._direct_issue_queues_can_accept() and source.issues and scanned < scan_limit:
+            issue = source.issues.popleft()
+            scanned += 1
 
-            entry = self._seed_direct_issue_entry(source.repo, issue)
-            if entry.stage is None:
-                # Epic tagging is the one sanctioned seeding write.  Complete
-                # it before honoring the source exclusion, exactly as the
-                # ordinary seed path does.
-                if entry.skip_tag_obligation is not None:
-                    self.github.skip_epics({entry.skip_tag_obligation.issue: []})
-                logger.info("seed excluded: %s", entry.reason)
+            item, overlaps = self._prepare_direct_issue_item(
+                source,
+                issue,
+                active_claims,
+                overlap_enabled=overlap_enabled,
+            )
+            if overlaps:
+                source.issues.append(issue)
+                blocked_by_overlap = True
                 continue
-
-            item = self._entry_to_item(entry, source.repo)
-            if is_full_commit_sha(source.base_sha):
-                item.payload[DIRECT_SCOPE_BASE_SHA_KEY] = source.base_sha
-                if item.kind is ItemKind.ISSUE and item.pr is None and item.issue is not None:
-                    # A fresh direct issue is tied to one immutable checkout
-                    # snapshot.  Its branch and writer-worktree identity must
-                    # be unique per cursor so a preserved predecessor cannot
-                    # stall a restart before implementation reaches an agent.
-                    item.branch = f"{item.issue}-auto-impl-direct-{source.run_nonce}"
-                    item.payload[DIRECT_SCOPE_WORKTREE_NONCE_KEY] = source.run_nonce
-            if item.stage not in (StageName.REPO, StageName.FINISHED):
-                self._pass_work_count += 1
-            if item.stage is StageName.FINISHED and item.result is None:
-                item.result = ItemResult(
-                    passed=entry.passed,
-                    reason=entry.reason,
-                    final_stage=StageName.FINISHED,
-                )
+            if item is None:
+                continue
             # ``_direct_issue_queues_can_accept`` covers every possible
             # classifier result and the coordinator-wide permit budget. This
             # source owns the coordinator thread, so a failed lifecycle push
@@ -2735,6 +2772,19 @@ class Coordinator:
             # saturation or a completion/shutdown fault.
             if self._push_item(item, item.stage, enter=True):
                 pushed += 1
+                # Let the implementation drain establish ownership before a
+                # later source item is considered, otherwise two overlapping
+                # plans can be queued in the same bootstrap tick.
+                if overlap_enabled and item.stage is StageName.IMPLEMENTATION:
+                    break
+        if not source.issues:
+            self._direct_issue_source = None
+        elif pushed == 0 and blocked_by_overlap and scanned == scan_limit:
+            source.overlap_blocked_claims = active_claims
+            logger.info(
+                "direct issue source blocked by active file claims; candidates=%d",
+                scan_limit,
+            )
         return pushed
 
     def _drain_direct_pr_source(self) -> int:

--- a/hephaestus/automation/pipeline/reply_handoff.py
+++ b/hephaestus/automation/pipeline/reply_handoff.py
@@ -1,10 +1,10 @@
-"""Durable, commit-gated implementation reply handoffs.
+"""Durable, head-gated implementation reply handoffs.
 
 The implementation and PR-review stages can each hold a validated response
-batch after the writer pushes a fix.  This module is the single owner of the
-replay contract: preserve the exact thread snapshots and response prose, wait
-briefly for GitHub to expose the pushed head, then retry only that batch.  A
-head or conversation that actually changed is never replayed.
+batch after the writer runs. This module is the single owner of the replay
+contract: preserve the exact thread snapshots and response prose, bind them to
+the pushed or unchanged reviewed head, then retry only that batch. A head or
+conversation that actually changed is never replayed.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -393,19 +393,28 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
 
     """
     issue_data = github.gh_issue_json(issue_number)
-    raw_labels = issue_data.get("labels", []) if isinstance(issue_data, dict) else []
-    labels = {
-        str(label.get("name", ""))
+    if not isinstance(issue_data, dict):
+        raise TypeError("issue snapshot must be a JSON object")
+    if issue_data.get("number") != issue_number:
+        raise ValueError("issue snapshot number does not match the requested issue")
+    state = issue_data.get("state")
+    if not isinstance(state, str) or state.upper() not in {
+        IssueState.OPEN.value,
+        IssueState.CLOSED.value,
+    }:
+        raise ValueError("issue snapshot state must be exactly OPEN or CLOSED")
+    raw_labels = issue_data.get("labels")
+    if not isinstance(raw_labels, list):
+        raise ValueError("issue snapshot labels must be a list")
+    if any(
+        not isinstance(label, dict) or not isinstance(label.get("name"), str)
         for label in raw_labels
-        if isinstance(label, dict) and label.get("name")
-    }
-    title = str(issue_data.get("title") or "") if isinstance(issue_data, dict) else ""
-    body = str(issue_data.get("body") or "") if isinstance(issue_data, dict) else ""
-    issue_is_closed = (
-        str(issue_data.get("state") or "").upper() == IssueState.CLOSED.value
-        if isinstance(issue_data, dict)
-        else False
-    )
+    ):
+        raise ValueError("issue snapshot labels must contain string names")
+    labels = {label["name"] for label in raw_labels if label["name"]}
+    title = str(issue_data.get("title") or "")
+    body = str(issue_data.get("body") or "")
+    issue_is_closed = state.upper() == IssueState.CLOSED.value
     epic = is_epic(sorted(labels), title)
     pr_is_open = False
     pr_is_merged = False

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -11,7 +11,8 @@ Entry routing (the binding contract is the classification table in
 ``docs/architecture.md`` §7 "Seeding and restart reconstruction"):
 
 - ``state:skip`` or epic → excluded (stage ``None``, logged)
-- PR merged → finished (pass, idempotent)
+- Closed issue + merged PR carrying an exact ``Closes #N`` line → finished
+  (pass, idempotent)
 - Open PR + PR-level ``state:implementation-go`` → merge_wait
 - Any other open PR → pr_review (including an issue-level implementation-GO)
 - No PR, at-or-past ``state:plan-go`` → implementation
@@ -43,6 +44,7 @@ from hephaestus.automation.github_api import (
     gh_pr_label_names,
     gh_pr_state,
 )
+from hephaestus.automation.models import IssueState
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
@@ -89,6 +91,7 @@ class IssueFacts:
             merged), None otherwise.
         pr_is_open: True iff PR exists and is open.
         pr_is_merged: True iff PR exists and is merged.
+        issue_is_closed: True iff GitHub currently reports the issue closed.
         pr_has_implementation_go: True iff the open PR carries
             ``state:implementation-go``.
         pr_has_implementation_no_go: True iff the open PR carries
@@ -111,6 +114,7 @@ class IssueFacts:
     pr_number: int | None
     pr_is_open: bool
     pr_is_merged: bool
+    issue_is_closed: bool = False
     pr_has_implementation_go: bool = False
     pr_has_implementation_no_go: bool = False
     body: str = ""
@@ -259,8 +263,10 @@ def classify_issue(facts: IssueFacts) -> Classification:
         LOG.warning("issue excluded: %s", reason)
         return None, reason
 
-    # Terminal state: merged PR
-    if facts.pr_is_merged:
+    # Completion requires the current issue state as well as a merged PR that
+    # carries the exact closing reference. A reopened issue may retain the
+    # historical PR relationship, but it is actionable again.
+    if facts.issue_is_closed and facts.pr_is_merged:
         return StageName.FINISHED, f"#{facts.number} PR merged (idempotent)"
 
     # Extract the active state label
@@ -353,6 +359,7 @@ def seed_issue(issue_number: int) -> IssueFacts:
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
+        issue_is_closed=issue_info.state == IssueState.CLOSED,
         pr_has_implementation_go=pr_has_implementation_go,
         pr_has_implementation_no_go=pr_has_implementation_no_go,
     )
@@ -394,6 +401,11 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
     }
     title = str(issue_data.get("title") or "") if isinstance(issue_data, dict) else ""
     body = str(issue_data.get("body") or "") if isinstance(issue_data, dict) else ""
+    issue_is_closed = (
+        str(issue_data.get("state") or "").upper() == IssueState.CLOSED.value
+        if isinstance(issue_data, dict)
+        else False
+    )
     epic = is_epic(sorted(labels), title)
     pr_is_open = False
     pr_is_merged = False
@@ -419,6 +431,7 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
+        issue_is_closed=issue_is_closed,
         pr_has_implementation_go=pr_has_implementation_go,
         pr_has_implementation_no_go=pr_has_implementation_no_go,
     )
@@ -470,7 +483,7 @@ def seed_from_cli(
     - ``repos`` → one :attr:`StageName.REPO` entry each (discovery seeds).
     - ``issues`` → :func:`seed_issue` + :func:`classify_issue` per issue.
     - ``prs`` → tri-state classification mirroring ``classify_issue``'s
-      open-PR routing: merged PR -> FINISHED (idempotent), closed PR ->
+      open-PR routing: merged direct PR -> FINISHED (idempotent), closed PR ->
       excluded, open PR with ``state:implementation-go`` -> MERGE_WAIT, open PR
       without it -> PR_REVIEW. A failed state/label fetch reads as
       "open, not yet reviewed" (-> pr_review), matching the existing

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -127,7 +127,7 @@ class ConditionalMergeResult:
 
 @dataclass(frozen=True)
 class ImplementationThreadReplyResult:
-    """Outcome of posting commit-gated implementation replies to review threads.
+    """Outcome of posting head-gated implementation replies to review threads.
 
     ``receipts`` are complete, host-read thread snapshots after the implementation
     reply is visible.  They are the only input a later reviewer-validation

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -207,6 +207,32 @@ PRE_PR_TEST_TIMEOUT_S = 1800
 #: issue-derived strings).
 PRE_PR_TEST_ARGV: tuple[str, ...] = ("uv", "run", "pytest", "tests", "-q", "--tb=short")
 
+NO_COMMIT_REPLY_WARNING = "[auto-msg] reply has no corresponding commit, review thoroughly"
+
+
+def _remediation_reply_head(
+    receipt: dict[str, object], snapshots: list[object]
+) -> tuple[str | None, bool]:
+    """Return the pushed or unchanged snapshotted head for a reply handoff."""
+    pushed = receipt.get("pushed") is True
+    receipt_head = receipt.get("head_sha")
+    if is_full_commit_sha(receipt_head):
+        return receipt_head, pushed
+    if pushed:
+        return None, True
+
+    snapshot_heads: set[str] = set()
+    for snapshot in snapshots:
+        if not isinstance(snapshot, dict):
+            continue
+        pr_state = snapshot.get("pr_state")
+        snapshot_head = pr_state.get("headRefOid") if isinstance(pr_state, dict) else None
+        if not is_full_commit_sha(snapshot_head):
+            snapshot_head = snapshot.get("review_commit_sha")
+        if is_full_commit_sha(snapshot_head):
+            snapshot_heads.add(snapshot_head)
+    return (snapshot_heads.pop() if len(snapshot_heads) == 1 else None), False
+
 
 def build_implementation_prompt(
     issue_number: int,
@@ -634,13 +660,21 @@ class ImplementationStage(Stage):
                         "implementation_reply_handoff_journal_read",
                     )
                 if recovered_handoff is not None:
-                    item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = recovered_handoff
-                    item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+                    current_head, _pushed = _remediation_reply_head({}, snapshots)
+                    if recovered_handoff.get("head_sha") == current_head:
+                        item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = recovered_handoff
+                        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+                        logger.info(
+                            "implementation:%d: recovered exact GitHub-journaled review "
+                            "reply handoff",
+                            issue,
+                        )
+                        return Continue(next_state=PR_CREATE)
                     logger.info(
-                        "implementation:%d: recovered exact GitHub-journaled review reply handoff",
+                        "implementation:%d: ignoring stale GitHub-journaled review reply "
+                        "handoff for a previous head",
                         issue,
                     )
-                    return Continue(next_state=PR_CREATE)
             job = AgentJob(
                 repo=item.repo,
                 issue=issue,
@@ -854,7 +888,9 @@ class ImplementationStage(Stage):
     def _on_commit_push_done(item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Record commit+push success, no-commit skip, or git failure."""
         if result.ok:
-            if not bool(result.value):
+            receipt = result.value if isinstance(result.value, dict) else {}
+            pushed = receipt.get("pushed") is True if receipt else bool(result.value)
+            if not pushed:
                 item.payload["no_commits"] = True
                 # The worker's no-commit path conditionally released the
                 # remote branch.  Keep the exact receipt so Finished can
@@ -886,7 +922,7 @@ class ImplementationStage(Stage):
     def _post_remediation_replies_after_push(
         item: WorkItem, result: JobResult, ctx: StageContext
     ) -> None:
-        """Prepare one commit-gated reply handoff after the writer runs.
+        """Prepare one head-gated reply handoff after the writer runs.
 
         GitHub can briefly expose the previous PR head immediately after a
         successful push.  The PR_CREATE state owns the bounded host-only
@@ -894,17 +930,20 @@ class ImplementationStage(Stage):
         without another implementation turn or commit. Before that retry can
         begin, this method records the exact batch in GitHub's immutable
         journal, allowing an interrupted loop to recover the original writer
-        response without a fresh no-op implementation claim.
+        response. A successful no-commit remediation is posted against the
+        unchanged reviewed head with an explicit warning so the reviewer—not
+        the implementation stage—decides whether the reply is sufficient.
         """
         if not item.payload.get("implementation_remediation"):
             return
         receipt = result.value if isinstance(result.value, dict) else {}
-        head_sha = receipt.get("head_sha")
         snapshots = item.payload.get("remediation_thread_snapshots")
         if not isinstance(snapshots, list):
             item.payload["remediation_reply_error"] = True
             return
-        if not receipt.get("pushed") or not is_full_commit_sha(head_sha):
+
+        head_sha, pushed = _remediation_reply_head(receipt, snapshots)
+        if not is_full_commit_sha(head_sha):
             item.payload["remediation_reply_error"] = True
             return
         replies = parse_addressed_replies(
@@ -914,6 +953,12 @@ class ImplementationStage(Stage):
         if replies is None or item.pr is None:
             item.payload["remediation_reply_error"] = True
             return
+        if not pushed:
+            replies = {
+                thread_id: f"{reply}\n\n{NO_COMMIT_REPLY_WARNING}"
+                for thread_id, reply in replies.items()
+            }
+            item.payload.pop("no_commits", None)
         handoff = implementation_reply_handoff(
             head_sha,
             snapshots,

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -68,6 +68,7 @@ from collections.abc import Callable
 from typing import cast
 
 from hephaestus.automation.address_review_core import (
+    MAX_ADDRESS_REPLY_CHARS,
     _parse_addressed_block,
     parse_addressed_replies,
 )
@@ -208,6 +209,17 @@ PRE_PR_TEST_TIMEOUT_S = 1800
 PRE_PR_TEST_ARGV: tuple[str, ...] = ("uv", "run", "pytest", "tests", "-q", "--tb=short")
 
 NO_COMMIT_REPLY_WARNING = "[auto-msg] reply has no corresponding commit, review thoroughly"
+_TRUNCATED_REPLY_WARNING = "[auto-msg] reply truncated to fit review limit"
+
+
+def _append_no_commit_reply_warning(reply: str) -> str:
+    """Append the reviewer warning while preserving the reply-size contract."""
+    suffix = f"\n\n{NO_COMMIT_REPLY_WARNING}"
+    if len(reply) + len(suffix) <= MAX_ADDRESS_REPLY_CHARS:
+        return f"{reply}{suffix}"
+    bounded_suffix = f"\n\n{_TRUNCATED_REPLY_WARNING}{suffix}"
+    content_budget = MAX_ADDRESS_REPLY_CHARS - len(bounded_suffix)
+    return f"{reply[:content_budget].rstrip()}{bounded_suffix}"
 
 
 def _remediation_reply_head(
@@ -955,7 +967,7 @@ class ImplementationStage(Stage):
             return
         if not pushed:
             replies = {
-                thread_id: f"{reply}\n\n{NO_COMMIT_REPLY_WARNING}"
+                thread_id: _append_no_commit_reply_warning(reply)
                 for thread_id, reply in replies.items()
             }
             item.payload.pop("no_commits", None)

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -81,6 +81,31 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+def _closed_issue_entry_outcome(item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+    """Fail closed on malformed state and terminalize a fresh close/merge race."""
+    if item.issue is None:  # Defensive; on_enter rejects this before calling.
+        return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+    issue_snapshot = ctx.github.gh_issue_json(item.issue)
+    if not isinstance(issue_snapshot, dict) or issue_snapshot.get("number") != item.issue:
+        logger.error("planning:%d: malformed issue snapshot", item.issue)
+        return StageOutcome(Disposition.FINISH_FAIL, "malformed issue snapshot")
+    issue_state = issue_snapshot.get("state")
+    if not isinstance(issue_state, str) or issue_state.upper() not in {"OPEN", "CLOSED"}:
+        logger.error("planning:%d: malformed issue state", item.issue)
+        return StageOutcome(Disposition.FINISH_FAIL, "malformed issue snapshot state")
+    if issue_state.upper() == "OPEN":
+        return None
+    merged_pr = ctx.github.find_merged_pr_for_issue(item.issue)
+    if merged_pr is None:
+        logger.error("planning:%d: closed without an exact merged closing PR", item.issue)
+        return StageOutcome(
+            Disposition.FINISH_FAIL,
+            "closed issue has no exact merged closing PR",
+        )
+    logger.info("planning:%d: closed by merged PR #%d; finishing", item.issue, merged_pr)
+    return StageOutcome(Disposition.FINISH_PASS, f"closed by merged PR #{merged_pr}")
+
+
 def build_plan_prompt(
     issue_number: int,
     issue_title: str = "",
@@ -402,7 +427,8 @@ class PlanningStage(Stage):
     - ``state:skip`` -> SKIP (checked BEFORE plan-go; skip wins over
       everything, even a contradictory plan-go, logging a WARNing — #1835)
     - already at-or-past ``state:plan-go`` -> ADVANCE (zero jobs)
-    - merged closing PR -> close issue as covered, SKIP
+    - freshly closed issue + exact merged closing PR -> FINISH_PASS
+    - open issue + historic merged closing PR -> continue planning
     - open PR -> SKIP (PR already covers implementation)
     - unlabeled entry -> idempotent bare add of ``state:needs-plan``; entry
       carrying ``state:plan-no-go`` (or a stale ``state:plan-go``) after a
@@ -430,6 +456,9 @@ class PlanningStage(Stage):
         if not item.issue:
             logger.warning("planning: work item has no issue number")
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        if issue_outcome := _closed_issue_entry_outcome(item, ctx):
+            return issue_outcome
 
         labels = _require_issue_labels(item, ctx)
 

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -461,14 +461,9 @@ class PlanningStage(Stage):
             logger.info("planning:%d: already plan-go; advancing", item.issue)
             return StageOutcome(Disposition.ADVANCE, "plan already approved")
 
-        # Re-housed _pr_coverage_skip gate A: merged closing PR covers the issue
-        merged_pr = ctx.github.find_merged_closing_pr(item.issue)
-        if merged_pr:
-            logger.info("planning:%d: merged PR #%d covers issue; closing", item.issue, merged_pr)
-            ctx.github.close_issue_as_covered(item.issue, merged_pr)
-            return StageOutcome(Disposition.SKIP, f"covered by merged PR #{merged_pr}")
-
-        # Re-housed _pr_coverage_skip gate B: open PR already in flight
+        # An open PR already in flight makes planning redundant. A historic
+        # merged PR is deliberately not a completion shortcut: only GitHub's
+        # current closed issue state may terminalize work at seeding.
         open_pr = ctx.github.find_pr_for_issue(item.issue)
         if open_pr:
             logger.info("planning:%d: open PR #%d exists; skipping", item.issue, open_pr)

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -40,7 +40,8 @@ state machine (docs/architecture.md §5.5 "pr_review" is the binding contract):
   exclusively for implementation-state labels. Every open review thread—regardless of
   author—is implementation work. The implementation agent investigates and
   fixes each thread, then returns a concise reply. The host posts that reply
-  only after the fix commit is pushed and never resolves the thread. The
+  against the verified current head and never resolves the thread. A reply
+  without a corresponding commit carries an explicit warning. The
   reviewer then performs a fresh comment validation of the current change,
   prior review, implementation reply, and every open thread. The reviewer is
   the sole actor that can resolve a valid
@@ -67,8 +68,9 @@ state machine (docs/architecture.md §5.5 "pr_review" is the binding contract):
   not recreate, replace, or suppress existing threads; it only gives the
   reviewer the authority to reconcile current implementation replies.
 - The implementation stage owns rebase, commit/push, and reply handoff. It
-  posts the `[Response]` reply only after a real writer-branch commit reaches
-  GitHub; the review stage does not commit, push, or rebase.
+  binds every `[Response]` reply to the verified current head and marks a
+  no-commit reply for thorough reviewer analysis; the review stage does not
+  commit, push, or rebase.
 - Recovery for interrupted pre-migration items is read-only and fail-closed:
   it may preserve an already-pushed reply handoff or take a fresh detached
   snapshot, but it cannot dispatch a writer agent or publish a branch from
@@ -551,8 +553,9 @@ def _normalize_remediation_threads(
     The reviewer audit contains proposed findings, not durable GitHub thread
     identities. Address jobs must instead consume the live post/read-back
     snapshot so every open thread—regardless of author—is investigated.  The
-    implementation agent replies after a real fix commit; the reviewer later
-    performs a fresh review and resolves or returns the exact thread.
+    implementation agent replies against the verified current head; the
+    reviewer later performs a fresh review and resolves or returns the exact
+    thread. No-commit replies are explicitly marked for thorough analysis.
     """
     normalized: list[dict[str, Any]] = []
     for thread in threads:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2542,7 +2542,15 @@ class WorkerPool:
             if isinstance(publish_state, JobResult):
                 return publish_state
             if not publish_state:
-                return JobResult(ok=True, value=False)
+                if job.kwargs.get("expected_remote_sha") is not None:
+                    return JobResult(ok=True, value=False)
+                clean_head = self._read_publish_head(Path(worktree_path), timeout=job.timeout_s)
+                if isinstance(clean_head, JobResult):
+                    return clean_head
+                return JobResult(
+                    ok=True,
+                    value={"pushed": False, "head_sha": clean_head},
+                )
             status = git_utils.run(
                 ["git", "status", "--porcelain"],
                 cwd=Path(worktree_path),

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2542,8 +2542,6 @@ class WorkerPool:
             if isinstance(publish_state, JobResult):
                 return publish_state
             if not publish_state:
-                if job.kwargs.get("expected_remote_sha") is not None:
-                    return JobResult(ok=True, value=False)
                 clean_head = self._read_publish_head(Path(worktree_path), timeout=job.timeout_s)
                 if isinstance(clean_head, JobResult):
                     return clean_head

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -480,7 +480,7 @@ class PipelineGitHub:
         candidates = json.loads(stdout)
         if not isinstance(candidates, list) or len(candidates) >= 1000:
             raise RuntimeError(f"could not verify existing PR state for issue #{issue_number}")
-        closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
+        closes_pattern = re.compile(rf"^Closes #{issue_number}\r?$", re.MULTILINE)
         matching_pr: int | None = None
         for candidate in candidates:
             if not isinstance(candidate, dict):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -506,12 +506,6 @@ class PipelineGitHub:
             selected_pr = self._find_open_pr_for_branch(issue_auto_impl_branch_name(issue_number))
             if selected_pr is not None:
                 return selected_pr
-        else:
-            selected_pr = self._find_pr_on_branch(
-                issue_auto_impl_branch_name(issue_number), state, issue_number
-            )
-            if selected_pr is not None:
-                return selected_pr
         return self._find_closing_pr(issue_number, state)
 
     def _repo_unresolved_threads(  # noqa: C901 - complete thread hydration is fail-closed
@@ -1561,7 +1555,7 @@ class PipelineGitHub:
         replies: dict[str, str],
         batch_nonce: str,
     ) -> ImplementationThreadReplyResult:
-        """Post implementation-agent replies after a real fix commit reached GitHub.
+        """Post implementation-agent replies against a verified current PR head.
 
         Every target must be an ID from the complete host-provided thread
         snapshot. The method never resolves threads: the next reviewer pass

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -37,6 +37,7 @@ from hephaestus.automation._review_utils import (
     find_merged_closing_pr,
     find_merged_pr_for_issue,
     get_pr_head_branch,
+    has_exact_closing_line,
 )
 from hephaestus.automation.arming_state import (
     ArmingStateStore,
@@ -480,7 +481,6 @@ class PipelineGitHub:
         candidates = json.loads(stdout)
         if not isinstance(candidates, list) or len(candidates) >= 1000:
             raise RuntimeError(f"could not verify existing PR state for issue #{issue_number}")
-        closes_pattern = re.compile(rf"^Closes #{issue_number}\r?$", re.MULTILINE)
         matching_pr: int | None = None
         for candidate in candidates:
             if not isinstance(candidate, dict):
@@ -489,7 +489,7 @@ class PipelineGitHub:
             number = candidate.get("number")
             if not isinstance(body, str) or not isinstance(number, int) or number <= 0:
                 raise RuntimeError(f"could not verify existing PR state for issue #{issue_number}")
-            if closes_pattern.search(body):
+            if has_exact_closing_line(body, issue_number):
                 if state.lower() == "open":
                     head_branch = self._verified_open_pr_head_branch(number, issue_number)
                     open_prs = self._open_prs_for_branch(head_branch)

--- a/hephaestus/prompts/templates/default/address_review/address_review.j2
+++ b/hephaestus/prompts/templates/default/address_review/address_review.j2
@@ -108,12 +108,13 @@ Rules for the JSON block:
 - `addressed`: array containing EVERY supplied `thread_id` exactly once, after
   fixing each corresponding concern in code.
 - `replies`: a one-line explanation for EVERY supplied id, keyed by that exact
-  id. The coordinator posts these only after it proves a real fix commit reached
-  the PR head; it never resolves a thread in this implementation step.
+  id. The coordinator binds these to the verified PR head. If no corresponding
+  commit exists, it appends an automatic warning for the reviewer. The coordinator
+  never resolves a thread in this implementation step.
 - Do not omit an unaddressable or difficult thread. Investigate and fix it; a
   partial result is rejected and no reply is posted.
 - Emit only one JSON block, at the very end of your response (the parser takes the LAST one).
 - Do not attempt to resolve a GitHub thread. Return the required reply text in
-  the JSON instead; the coordinator posts it after the pushed fix is verified.
+  the JSON instead; the coordinator posts it after the current head is verified.
   The reviewer performs a fresh review of the fix and reply, resolves verified threads,
   and explains what remains wrong on threads it leaves open.

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -65,6 +65,7 @@ class FakeStageGitHub(FakeGitHub):
         labels: list[str] | None = None,
         issue_title: str = "A task",
         issue_body: str = "",
+        issue_state: str = "OPEN",
         merged_pr: int | None = None,
         open_pr: int | None = None,
         pr_issue: int | None = None,
@@ -86,6 +87,7 @@ class FakeStageGitHub(FakeGitHub):
             labels: Seed labels applied to any issue on first read/mutation.
             issue_title: Canned issue title returned by gh_issue_json.
             issue_body: Canned issue body returned by gh_issue_json.
+            issue_state: Canned current GitHub issue state.
             merged_pr: Canned answer for find_merged_closing_pr.
             open_pr: Canned answer for find_pr_for_issue.
             pr_issue: Canned answer for find_issue_for_pr.
@@ -118,6 +120,7 @@ class FakeStageGitHub(FakeGitHub):
         self._seed_labels = list(labels or [])
         self._issue_title = issue_title
         self._issue_body = issue_body
+        self._issue_state = issue_state
         self._merged_pr = merged_pr
         self._open_pr = open_pr
         self._pr_issue = pr_issue
@@ -171,6 +174,7 @@ class FakeStageGitHub(FakeGitHub):
             "number": issue_number,
             "title": self._issue_title,
             "body": self._issue_body,
+            "state": self._issue_state,
             "labels": [{"name": name} for name in sorted(self._issue_labels(issue_number))],
         }
 
@@ -437,7 +441,7 @@ class FakeStageGitHub(FakeGitHub):
         replies: dict[str, str],
         batch_nonce: str,
     ) -> ImplementationThreadReplyResult:
-        """Record commit-gated implementation replies for stage tests."""
+        """Record head-gated implementation replies for stage tests."""
         del expected_head_sha, batch_nonce
         by_id = {
             str(thread.get("thread_id") or thread.get("id") or ""): thread for thread in threads

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -2108,6 +2108,14 @@ class TestCommitPushAndPrCreate:
             "[auto-msg] reply has no corresponding commit, review thoroughly"
         )
 
+    def test_no_commit_warning_reserves_space_at_reply_limit(self) -> None:
+        """Appending the required warning never invalidates a maximal reply."""
+        reply = implementation_module._append_no_commit_reply_warning("x" * 4_000)
+
+        assert len(reply) <= 4_000
+        assert "[auto-msg] reply truncated to fit review limit" in reply
+        assert reply.endswith("[auto-msg] reply has no corresponding commit, review thoroughly")
+
     def test_commit_push_requests_git_job(self, make_ctx: Any, make_work_item: Any) -> None:
         """COMMIT_PUSH_WAIT submits the commit_push GitJob."""
         stage = ImplementationStage()

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1961,6 +1961,31 @@ class TestCommitPushAndPrCreate:
             == 1
         )
 
+        stale = make_work_item(issue=1, pr=1001, state="IMPLEMENT_WAIT")
+        changed_head_snapshots = [
+            {
+                **post_push_snapshots[0],
+                "pr_state": {
+                    "state": "OPEN",
+                    "headRefOid": "c" * 40,
+                    "autoMergeRequest": None,
+                },
+            }
+        ]
+        stale.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_threads": changed_head_snapshots,
+                "remediation_thread_snapshots": changed_head_snapshots,
+            }
+        )
+
+        stale_result = stage.step(stale, ctx)
+
+        assert isinstance(stale_result, JobRequest)
+        assert stale_result.job.descr == "address_review"
+        assert "pending_implementation_reply_handoff" not in stale.payload
+
     def test_remediation_reply_handoff_retries_a_transient_journal_write_without_a_new_commit(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -2029,10 +2054,10 @@ class TestCommitPushAndPrCreate:
             == 1
         )
 
-    def test_remediation_reply_handoff_rejects_no_commit_on_the_source_review_head(
+    def test_remediation_reply_handoff_warns_when_source_review_head_is_unchanged(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """A no-op run may not answer a thread against unchanged reviewed code."""
+        """A no-op run posts its reply with a warning for thorough reviewer analysis."""
         stage = ImplementationStage()
         github = FakeStageGitHub(
             pr_state={"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None}
@@ -2049,21 +2074,39 @@ class TestCommitPushAndPrCreate:
                         "line": 3,
                         "side": "RIGHT",
                         "body": "fix it",
-                        "review_commit_sha": "a" * 40,
+                        "review_commit_sha": "b" * 40,
+                        "pr_state": {
+                            "state": "OPEN",
+                            "headRefOid": "a" * 40,
+                            "autoMergeRequest": None,
+                        },
                         "comments": [{"id": "comment-1", "author": "reviewer", "body": "fix it"}],
                     }
                 ],
                 "remediation_output": {
                     "addressed": ["thread-1"],
-                    "replies": {"thread-1": "[Response] This must not be posted."},
+                    "replies": {"thread-1": "[Response] The existing behavior is correct."},
                 },
             }
         )
 
-        stage.on_job_done(item, JobResult(ok=True, value=False), ctx)
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"pushed": False, "head_sha": "a" * 40}),
+            ctx,
+        )
 
-        assert item.payload["remediation_reply_error"] is True
-        assert "pending_implementation_reply_handoff" not in item.payload
+        assert "remediation_reply_error" not in item.payload
+        assert "pending_implementation_reply_handoff" in item.payload
+
+        item.state = "PR_CREATE"
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.ADVANCE, "PR #1001 ready for review"
+        )
+        assert github._thread_replies["thread-1"][-1]["body"] == (
+            "[Response] The existing behavior is correct.\n\n"
+            "[auto-msg] reply has no corresponding commit, review thoroughly"
+        )
 
     def test_commit_push_requests_git_job(self, make_ctx: Any, make_work_item: Any) -> None:
         """COMMIT_PUSH_WAIT submits the commit_push GitJob."""

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -144,6 +144,36 @@ class TestPlanningStageEnter:
         assert outcome is None
         assert github.mutation_log == [("gh_issue_add_labels", (3, (STATE_NEEDS_PLAN,)))]
 
+    def test_issue_closed_after_seeding_with_merged_pr_finishes_at_entry(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Planning revalidates a close/merge race before creating duplicate work."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(issue_state="CLOSED", merged_pr=123)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=3)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.FINISH_PASS
+        assert github.mutation_log == []
+
+    def test_malformed_issue_state_fails_closed_at_planning_entry(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A malformed refresh cannot authorize planning writes."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(issue_state="UNKNOWN")
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=3)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.FINISH_FAIL
+        assert github.mutation_log == []
+
     def test_open_pr_skips(self, make_ctx: Any, make_work_item: Any) -> None:
         """An open PR for the issue skips planning with zero writes (gate B)."""
         stage = PlanningStage()

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -130,8 +130,10 @@ class TestPlanningStageEnter:
         assert github.mutation_log == []
         assert any("state:skip AND state:plan-go" in record.message for record in caplog.records)
 
-    def test_merged_pr_closes_issue(self, make_ctx: Any, make_work_item: Any) -> None:
-        """A merged closing PR closes the issue as covered (gate A)."""
+    def test_historical_merged_pr_does_not_close_open_issue(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An open issue remains actionable despite a historic merged closing PR."""
         stage = PlanningStage()
         github = FakeStageGitHub(merged_pr=123)
         ctx = make_ctx(github=github)
@@ -139,9 +141,8 @@ class TestPlanningStageEnter:
 
         outcome = stage.on_enter(item, ctx)
 
-        assert outcome is not None
-        assert outcome.disposition == Disposition.SKIP
-        assert github.mutation_log == [("close_issue_as_covered", (3, 123))]
+        assert outcome is None
+        assert github.mutation_log == [("gh_issue_add_labels", (3, (STATE_NEEDS_PLAN,)))]
 
     def test_open_pr_skips(self, make_ctx: Any, make_work_item: Any) -> None:
         """An open PR for the issue skips planning with zero writes (gate B)."""

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -269,7 +269,7 @@ class TestQuiescence:
             loops=1,
             projects_dir=tmp_path,
         )
-        gh = FakeStageGitHub(merged_pr=1851)
+        gh = FakeStageGitHub(merged_pr=1851, issue_state="CLOSED")
 
         def fake_seed(
             repos_arg: list[str], issues_arg: list[int], prs_arg: list[int]

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -2035,6 +2035,53 @@ class TestImplementationAdmission:
         assert run_repos == ["repo-a"]
         assert "file_overlap_deferrals" not in repo_a.payload
 
+    def test_queued_overlap_is_recorded_once_until_active_claims_change(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stable in-flight claim must not create a polling hot loop."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_issues: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_issues.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active_handle = _fake_in_flight_item(
+            coordinator,
+            _issue_item(8, StageName.IMPLEMENTATION),
+            claimed_files={"shared.py"},
+        )
+        blocked = _issue_item(7, StageName.IMPLEMENTATION)
+        coordinator._push_item(blocked, StageName.IMPLEMENTATION, enter=True)
+        fetches = 0
+
+        def fetch_planned_files(_issue: int, repo: tuple[str, str]) -> set[str]:
+            nonlocal fetches
+            fetches += 1
+            return {"shared.py"}
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            fetch_planned_files,
+        )
+
+        coordinator._drain_implementation()
+        coordinator._drain_implementation()
+
+        assert fetches == 1
+        assert blocked.payload["file_overlap_deferrals"] == 1
+        assert run_issues == []
+
+        coordinator._handle_completion(active_handle, JobResult(ok=True))
+        run_issues.clear()
+        coordinator._drain_implementation()
+
+        assert fetches == 1
+        assert run_issues == [7]
+        assert "file_overlap_deferrals" not in blocked.payload
+
     def test_ambiguous_aged_overlap_beats_a_recurring_regular_contender(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2087,7 +2134,7 @@ class TestImplementationAdmission:
 
         assert run_order == ["repo-a#7"]
         assert "file_overlap_deferrals" not in ambiguous_a.payload
-        assert ambiguous_b.payload["file_overlap_deferrals"] == 2
+        assert ambiguous_b.payload["file_overlap_deferrals"] == 1
         assert recurring_regular.payload["file_overlap_deferrals"] == 1
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [
             ambiguous_b,

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -2078,7 +2078,6 @@ class TestImplementationAdmission:
         run_issues.clear()
         coordinator._drain_implementation()
 
-        assert fetches == 1
         assert run_issues == [7]
         assert "file_overlap_deferrals" not in blocked.payload
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -223,6 +223,90 @@ class TestQuiescence:
         assert item.branch == ""
         assert item.payload["existing_pr"] is True
 
+    def test_direct_issue_source_rotates_overlap_and_admits_independent_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An overlapping candidate cannot consume worker 2's live-work permit."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[22, 23],
+            loops=1,
+            max_workers=2,
+            projects_dir=tmp_path,
+        )
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
+        plans = {22: {"shared.py"}, 23: {"independent.py"}}
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._fetch_planned_files",
+            lambda issue, **_kwargs: plans[issue],
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(labels=["state:plan-go"]),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        active = _issue_item(21, StageName.IMPLEMENTATION)
+        assert coordinator._try_acquire_work_permit(active)
+        _fake_in_flight_item(coordinator, active, claimed_files={"shared.py"})
+        coordinator._begin_direct_issue_source("repo-a", "a" * 40)
+
+        assert coordinator._drain_direct_issue_source() == 1
+        queued = coordinator.queues[StageName.IMPLEMENTATION].snapshot()
+        assert [item.issue for item in queued] == [23]
+        assert queued[0].payload["_implementation_file_claims"] == {
+            (("org", "repo-a"), "independent.py")
+        }
+
+    def test_direct_issue_source_caches_unchanged_overlap_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A blocked cursor is rescanned only after active file claims change."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[22],
+            loops=1,
+            max_workers=2,
+            projects_dir=tmp_path,
+        )
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
+        fetches: list[int] = []
+
+        def planned(issue: int, **_kwargs: Any) -> set[str]:
+            fetches.append(issue)
+            return {"shared.py"}
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._fetch_planned_files",
+            planned,
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(labels=["state:plan-go"]),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        active = _issue_item(21, StageName.IMPLEMENTATION)
+        assert coordinator._try_acquire_work_permit(active)
+        handle = _fake_in_flight_item(coordinator, active, claimed_files={"shared.py"})
+        coordinator._begin_direct_issue_source("repo-a", "a" * 40)
+
+        assert coordinator._drain_direct_issue_source() == 0
+        assert coordinator._drain_direct_issue_source() == 0
+        assert fetches == [22]
+
+        coordinator._inflight_implementation_claims.pop(handle)
+        assert coordinator._drain_direct_issue_source() == 1
+        assert fetches == [22, 22]
+
     def test_metrics_server_starts_for_run_and_stops_on_teardown(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -328,6 +328,7 @@ def _classify_from_fake(
     *,
     open_pr: int | None = None,
     merged_pr: int | None = None,
+    issue_is_closed: bool = False,
     is_epic: bool = False,
 ) -> Any:
     """Re-run the seeding classifier against the FakeGitHub label journal."""
@@ -339,6 +340,7 @@ def _classify_from_fake(
         pr_number=open_pr if open_pr is not None else merged_pr,
         pr_is_open=open_pr is not None,
         pr_is_merged=merged_pr is not None,
+        issue_is_closed=issue_is_closed,
     )
     stage, _reason = classify_issue(facts)
     return stage
@@ -352,17 +354,18 @@ class TestCrashMatrixJournal:
     """Truncate after each durable mutation -> re-seed -> same-or-earlier stage."""
 
     @pytest.mark.parametrize(
-        ("case", "labels", "open_pr", "merged_pr", "is_epic", "expected"),
+        ("case", "labels", "open_pr", "merged_pr", "issue_is_closed", "is_epic", "expected"),
         [
-            ("no label", [], None, None, False, StageName.PLANNING),
-            ("needs-plan label", [STATE_NEEDS_PLAN], None, None, False, StageName.PLANNING),
-            ("plan-no-go label", [STATE_PLAN_NO_GO], None, None, False, StageName.PLANNING),
-            ("plan-go label", [STATE_PLAN_GO], None, None, False, StageName.IMPLEMENTATION),
+            ("no label", [], None, None, False, False, StageName.PLANNING),
+            ("needs-plan label", [STATE_NEEDS_PLAN], None, None, False, False, StageName.PLANNING),
+            ("plan-no-go label", [STATE_PLAN_NO_GO], None, None, False, False, StageName.PLANNING),
+            ("plan-go label", [STATE_PLAN_GO], None, None, False, False, StageName.IMPLEMENTATION),
             (
                 "open PR without implementation-go",
                 [STATE_IMPLEMENTATION_NO_GO],
                 77,
                 None,
+                False,
                 False,
                 StageName.PR_REVIEW,
             ),
@@ -372,11 +375,12 @@ class TestCrashMatrixJournal:
                 78,
                 None,
                 False,
+                False,
                 StageName.PR_REVIEW,
             ),
-            ("merged PR", [], None, 79, False, StageName.FINISHED),
-            ("state:skip", [STATE_SKIP], None, None, False, None),
-            ("untagged epic", [], None, None, True, None),
+            ("closed issue with merged PR", [], None, 79, True, False, StageName.FINISHED),
+            ("state:skip", [STATE_SKIP], None, None, False, False, None),
+            ("untagged epic", [], None, None, False, True, None),
         ],
     )
     def test_reconstruction_table_covers_every_github_journal_row(
@@ -385,6 +389,7 @@ class TestCrashMatrixJournal:
         labels: list[str],
         open_pr: int | None,
         merged_pr: int | None,
+        issue_is_closed: bool,
         is_epic: bool,
         expected: StageName | None,
     ) -> None:
@@ -399,6 +404,7 @@ class TestCrashMatrixJournal:
             issue,
             open_pr=open_pr,
             merged_pr=merged_pr,
+            issue_is_closed=issue_is_closed,
             is_epic=is_epic,
         )
 

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -462,6 +462,7 @@ class TestSeedIssueFetchLayer:
             "number": 102,
             "title": "A task",
             "body": "",
+            "state": "OPEN",
             "labels": [{"name": STATE_NEEDS_PLAN}],
         }
         github.issue_comments.side_effect = AssertionError("comments are not state authority")

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation import state_labels
+from hephaestus.automation.models import IssueState
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.seeding import (
     _LABEL_RANK,
@@ -50,6 +51,7 @@ def _facts(
     pr_number: int | None = None,
     pr_is_open: bool = False,
     pr_is_merged: bool = False,
+    issue_is_closed: bool = False,
     pr_has_implementation_go: bool = False,
     pr_has_implementation_no_go: bool = False,
 ) -> IssueFacts:
@@ -62,6 +64,7 @@ def _facts(
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
+        issue_is_closed=issue_is_closed,
         pr_has_implementation_go=pr_has_implementation_go,
         pr_has_implementation_no_go=pr_has_implementation_no_go,
         body=body,
@@ -118,10 +121,24 @@ class TestClassifyIssue:
     def test_pr_merged_finished(self) -> None:
         """Merged PR is genuinely finished (pass, idempotent) — NOT an exclusion."""
         stage, reason = classify_issue(
-            _facts(labels={STATE_IMPLEMENTATION_GO}, pr_number=42, pr_is_merged=True)
+            _facts(
+                labels={STATE_IMPLEMENTATION_GO},
+                pr_number=42,
+                pr_is_merged=True,
+                issue_is_closed=True,
+            )
         )
         assert stage is StageName.FINISHED
         assert "merged" in reason
+
+    def test_open_issue_with_historical_merged_pr_routes_by_current_label(self) -> None:
+        """An open/reopened issue must not be completed by a historic merged PR."""
+        stage, reason = classify_issue(
+            _facts(labels={STATE_PLAN_GO}, pr_number=42, pr_is_merged=True)
+        )
+
+        assert stage is StageName.IMPLEMENTATION
+        assert reason == f"#1 at-or-past {STATE_PLAN_GO}, no PR yet"
 
     def test_open_pr_with_issue_impl_go_uses_generic_pr_review_route(self) -> None:
         """An issue label alone cannot route an open PR to merge wait."""
@@ -298,11 +315,17 @@ def _fake_gh_backend(prs: list[dict[str, Any]]) -> Any:
     return _gh_call
 
 
-def _issue_info(number: int, labels: list[str], title: str = "A task") -> MagicMock:
+def _issue_info(
+    number: int,
+    labels: list[str],
+    title: str = "A task",
+    state: IssueState = IssueState.OPEN,
+) -> MagicMock:
     info = MagicMock()
     info.number = number
     info.labels = labels
     info.title = title
+    info.state = state
     return info
 
 
@@ -316,11 +339,12 @@ class TestSeedIssueFetchLayer:
         prs: list[dict[str, Any]],
         *,
         pr_labels: list[str] | None = None,
+        issue_state: IssueState = IssueState.OPEN,
     ) -> IssueFacts:
         with (
             patch(
                 "hephaestus.automation.pipeline.seeding.fetch_issue_info",
-                return_value=_issue_info(issue, labels),
+                return_value=_issue_info(issue, labels, state=issue_state),
             ),
             patch(
                 "hephaestus.automation._review_utils._gh_call",
@@ -363,6 +387,7 @@ class TestSeedIssueFetchLayer:
             7,
             [STATE_IMPLEMENTATION_GO],
             [{"number": 43, "state": "MERGED", "headRefName": "7-auto-impl", "body": "Closes #7"}],
+            issue_state=IssueState.CLOSED,
         )
         assert facts.pr_number == 43
         assert facts.pr_is_open is False
@@ -370,6 +395,18 @@ class TestSeedIssueFetchLayer:
         # And the classifier reaches the doc's "PR merged → finished" row.
         stage, _ = classify_issue(facts)
         assert stage is StageName.FINISHED
+
+    def test_merged_pr_without_exact_closes_line_is_not_terminal(self) -> None:
+        """A merged auto-implementation branch alone cannot complete an issue."""
+        facts = self._seed(
+            7,
+            [STATE_PLAN_GO],
+            [{"number": 43, "state": "MERGED", "headRefName": "7-auto-impl", "body": ""}],
+        )
+
+        assert facts.pr_number is None
+        assert facts.pr_is_merged is False
+        assert classify_issue(facts)[0] is StageName.IMPLEMENTATION
 
     def test_merged_pr_found_via_body_search(self) -> None:
         """A merged PR on a NON-canonical branch is still found via Closes-body search."""

--- a/tests/unit/automation/pipeline/test_seeding_contracts.py
+++ b/tests/unit/automation/pipeline/test_seeding_contracts.py
@@ -21,6 +21,7 @@ class TestSeedIssueFromGitHubContract:
             "number": 104,
             "title": "A task",
             "body": "",
+            "state": "OPEN",
             "labels": [{"name": STATE_PLAN_GO}],
         }
         github.find_pr_for_issue.return_value = None
@@ -47,6 +48,24 @@ class TestSeedIssueFromGitHubContract:
         github.gh_issue_json.side_effect = RuntimeError("issue fetch down")
 
         with pytest.raises(RuntimeError, match="issue fetch down"):
+            seed_issue_from_github(104, github)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            {},
+            {"number": 104, "state": None, "labels": []},
+            {"number": 104, "state": "UNKNOWN", "labels": []},
+            {"number": 999, "state": "OPEN", "labels": []},
+        ],
+    )
+    def test_malformed_issue_snapshot_fails_closed(self, payload: object) -> None:
+        """Missing or contradictory live issue facts never become actionable."""
+        github = self._github()
+        github.gh_issue_json.return_value = payload
+
+        with pytest.raises((TypeError, ValueError), match="issue snapshot"):
             seed_issue_from_github(104, github)
 
     def test_open_pr_lookup_failure_raises(self) -> None:

--- a/tests/unit/automation/pipeline/test_seeding_contracts.py
+++ b/tests/unit/automation/pipeline/test_seeding_contracts.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from hephaestus.automation.pipeline.seeding import seed_issue_from_github
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.seeding import classify_issue, seed_issue_from_github
 from hephaestus.automation.state_labels import STATE_PLAN_GO
 
 
@@ -63,3 +64,14 @@ class TestSeedIssueFromGitHubContract:
 
         with pytest.raises(RuntimeError, match="merged probe down"):
             seed_issue_from_github(104, github)
+
+    def test_open_issue_with_merged_closing_pr_remains_actionable(self) -> None:
+        """A reopened issue is not terminal merely because a closing PR merged."""
+        github = self._github()
+        github.gh_issue_json.return_value["state"] = "OPEN"
+        github.find_merged_pr_for_issue.return_value = 105
+
+        facts = seed_issue_from_github(104, github)
+
+        assert facts.pr_is_merged is True
+        assert classify_issue(facts)[0] is StageName.IMPLEMENTATION

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2509,13 +2509,15 @@ class TestGitOps:
             ),
             patch("hephaestus.automation.git_utils.delete_reserved_branch_if_unchanged") as release,
             patch("hephaestus.automation.git_utils.push_branch") as normal_push,
+            patch.object(pool, "_read_publish_head", return_value=pin) as read_head,
         ):
             pool.submit(job, StageName.IMPLEMENTATION)
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is True
-        assert result.value is False
+        assert result.value == {"pushed": False, "head_sha": pin}
         release.assert_called_once_with("5-auto", pin, tmp_path, timeout=60)
+        read_head.assert_called_once_with(tmp_path, timeout=60)
         normal_push.assert_not_called()
 
     def test_commit_push_returns_clean_head_without_pushing_when_nothing_committed(

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2518,13 +2518,13 @@ class TestGitOps:
         release.assert_called_once_with("5-auto", pin, tmp_path, timeout=60)
         normal_push.assert_not_called()
 
-    def test_commit_push_value_false_does_not_push_when_nothing_committed(
+    def test_commit_push_returns_clean_head_without_pushing_when_nothing_committed(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
     ) -> None:
-        """commit_push reports value=False without pushing a clean tree."""
+        """commit_push reports the verified clean head without pushing it."""
         job = GitJob(
             repo="test/repo",
             op="commit_push",
@@ -2534,13 +2534,14 @@ class TestGitOps:
         with (
             patch("hephaestus.automation.git_utils.commit_if_changes", return_value=False),
             patch("hephaestus.automation.git_utils.push_branch") as mock_push,
+            patch.object(pool, "_read_publish_head", return_value="a" * 40),
         ):
             pool.submit(job, StageName.PR_REVIEW)
             _, result = completion_q.get(timeout=10)
 
         mock_push.assert_not_called()
         assert result.ok is True
-        assert result.value is False
+        assert result.value == {"pushed": False, "head_sha": "a" * 40}
 
     def test_commit_push_publishes_agent_precommitted_change(
         self,

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -3160,7 +3160,7 @@ class TestRepoScoping:
             pg,
             "gh_call",
             lambda _argv, **_kwargs: SimpleNamespace(
-                stdout=json.dumps([{"number": 5, "body": "Closes #5\n"}])
+                stdout=json.dumps([{"number": 5, "body": "Closes #5\r\n"}])
             ),
         )
 
@@ -3169,7 +3169,12 @@ class TestRepoScoping:
 
     @pytest.mark.parametrize(
         "body",
-        ["Closes #5, #6\n", "Closes #5: reason\n", "Closes #5 trailing\n"],
+        [
+            "Closes #5, #6\r\n",
+            "Closes #5-extra\r\n",
+            "Closes #5: reason\r\n",
+            "Closes #5 trailing\r\n",
+        ],
     )
     def test_repo_scoped_merged_pr_lookup_rejects_trailing_text(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -3167,6 +3167,25 @@ class TestRepoScoping:
         adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
         assert adapter.find_merged_pr_for_issue(5) == 5
 
+    @pytest.mark.parametrize(
+        "body",
+        ["Closes #5, #6\n", "Closes #5: reason\n", "Closes #5 trailing\n"],
+    )
+    def test_repo_scoped_merged_pr_lookup_rejects_trailing_text(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str
+    ) -> None:
+        """Repo-scoped merged lookup requires the complete canonical line."""
+        monkeypatch.setattr(
+            pg,
+            "gh_call",
+            lambda _argv, **_kwargs: SimpleNamespace(
+                stdout=json.dumps([{"number": 5, "body": body}])
+            ),
+        )
+
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        assert adapter.find_merged_pr_for_issue(5) is None
+
     def test_repo_scoped_unresolved_threads_returns_every_open_thread(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -3152,14 +3152,16 @@ class TestRepoScoping:
         with pytest.raises(RuntimeError, match="could not verify existing PR state"):
             adapter.find_pr_for_issue(5)
 
-    def test_repo_scoped_merged_pr_lookup_preserves_head_branch_fallback(
+    def test_repo_scoped_merged_pr_lookup_requires_exact_closing_line(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Merged lookup still finds a PR on the canonical issue branch."""
+        """A merged PR is linked only by the exact policy closing line."""
         monkeypatch.setattr(
             pg,
             "gh_call",
-            lambda _argv, **_kwargs: SimpleNamespace(stdout=json.dumps([{"number": 5}])),
+            lambda _argv, **_kwargs: SimpleNamespace(
+                stdout=json.dumps([{"number": 5, "body": "Closes #5\n"}])
+            ),
         )
 
         adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1011,7 +1011,7 @@ class TestAddressReviewPrompt:
         """The final JSON-block contract the pipeline parses must be intact.
 
         The implementation agent must return one reply for every fixed thread.
-        The host posts that reply after verifying the pushed fix; the reviewer
+        The host posts that reply after verifying the current head; the reviewer
         then performs a fresh review before resolving or leaving feedback.
         """
         out = self._build()

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -763,6 +763,18 @@ class TestFindMergedClosingPr:
 
         assert result is None
 
+    @pytest.mark.parametrize(
+        "body",
+        ["Closes #12, #18\n", "Closes #12: reason\n", "Closes #12 trailing\n"],
+    )
+    def test_rejects_trailing_text_after_target_issue(self, body: str) -> None:
+        """The target number must occupy the complete policy line."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result([{"number": 5000, "body": body}]),
+        ):
+            assert find_merged_closing_pr(12) is None
+
     def test_returns_none_when_no_merged_pr(self) -> None:
         """No merged PR found → None."""
         with patch(
@@ -824,6 +836,18 @@ class TestFindMergedPrForIssue:
             result = find_merged_pr_for_issue(7)
 
         assert result == 44
+
+    @pytest.mark.parametrize(
+        "body",
+        ["Closes #7, #8\n", "Closes #7: reason\n", "Closes #7 trailing\n"],
+    )
+    def test_rejects_trailing_text_after_target_issue(self, body: str) -> None:
+        """Merged lookup follows the same whole-line PR policy contract."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result([{"number": 44, "body": body}]),
+        ):
+            assert find_merged_pr_for_issue(7) is None
 
     def test_returns_none_when_no_merged_pr(self) -> None:
         """Neither strategy finds a merged PR → None (closed PRs stay invisible)."""

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -722,7 +722,7 @@ class TestFindMergedClosingPr:
 
         def _side_effect(args: list[str], **kw: Any) -> MagicMock:
             captured["args"] = args
-            return _make_gh_result([{"number": 1358, "body": "Summary.\n\nCloses #1357\n"}])
+            return _make_gh_result([{"number": 1358, "body": "Summary.\r\n\r\nCloses #1357\r\n"}])
 
         with patch(
             "hephaestus.automation._review_utils._gh_call",
@@ -765,7 +765,12 @@ class TestFindMergedClosingPr:
 
     @pytest.mark.parametrize(
         "body",
-        ["Closes #12, #18\n", "Closes #12: reason\n", "Closes #12 trailing\n"],
+        [
+            "Closes #12, #18\n",
+            "Closes #12-extra\n",
+            "Closes #12: reason\n",
+            "Closes #12 trailing\n",
+        ],
     )
     def test_rejects_trailing_text_after_target_issue(self, body: str) -> None:
         """The target number must occupy the complete policy line."""

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -792,13 +792,13 @@ class TestFindMergedClosingPr:
 class TestFindMergedPrForIssue:
     """Tests for find_merged_pr_for_issue — the tri-state fetch's merged lookup."""
 
-    def test_finds_via_merged_branch_name(self) -> None:
-        """Strategy 1: ``{issue}-auto-impl`` head lookup with ``--state merged``."""
+    def test_finds_via_exact_merged_closing_line(self) -> None:
+        """Only an exact closing line can associate merged work to an issue."""
         captured: dict[str, list[str]] = {}
 
         def _side_effect(args: list[str], **kw: Any) -> MagicMock:
             captured["args"] = args
-            return _make_gh_result([{"number": 43}])
+            return _make_gh_result([{"number": 43, "body": "Closes #7\n"}])
 
         with patch(
             "hephaestus.automation._review_utils._gh_call",
@@ -807,16 +807,14 @@ class TestFindMergedPrForIssue:
             result = find_merged_pr_for_issue(7)
 
         assert result == 43
-        assert "--head" in captured["args"]
-        assert "7-auto-impl" in captured["args"]
+        assert "--search" in captured["args"]
+        assert "--head" not in captured["args"]
         assert "merged" in captured["args"]
 
-    def test_falls_back_to_merged_body_search(self) -> None:
-        """Branch miss → falls through to find_merged_closing_pr's body search."""
+    def test_uses_exact_merged_body_search(self) -> None:
+        """The sole merged lookup delegates to exact body search."""
 
         def _side_effect(args: list[str], **kw: Any) -> MagicMock:
-            if "--head" in args:
-                return _make_gh_result([])
             return _make_gh_result([{"number": 44, "body": "Fix.\n\nCloses #7\n"}])
 
         with patch(
@@ -837,14 +835,12 @@ class TestFindMergedPrForIssue:
 
         assert result is None
 
-    def test_branch_lookup_failure_still_tries_body_search(self) -> None:
-        """A branch-strategy gh failure is swallowed; body search still runs."""
+    def test_exact_body_search_does_not_probe_branch_name(self) -> None:
+        """Branch names cannot turn a merged PR into completion evidence."""
         calls: list[list[str]] = []
 
         def _side_effect(args: list[str], **kw: Any) -> MagicMock:
             calls.append(args)
-            if "--head" in args:
-                raise RuntimeError("gh boom")
             return _make_gh_result([{"number": 45, "body": "Closes #7\n"}])
 
         with patch(
@@ -854,7 +850,8 @@ class TestFindMergedPrForIssue:
             result = find_merged_pr_for_issue(7)
 
         assert result == 45
-        assert len(calls) == 2
+        assert len(calls) == 1
+        assert "--head" not in calls[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Keep open and reopened issues actionable when they retain historical merged PR relationships.
- Post successful no-commit remediation replies against the verified current head with the required `[auto-msg]` warning, leaving acceptance and resolution to the reviewer.
- Return exact clean-head receipts from commit jobs and ignore stale reply journals after head changes.
- Update architecture, prompt contracts, and regression coverage for the complete workflow.

## Live validation

- PR #2590 received the warned no-commit reply.
- Terra analyzed that reply and left the thread open with specific evidence feedback, proving reviewer-owned disposition.

## Verification

- 876 focused tests passed across routing and remediation suites.
- Full locked pre-push suite: 7,101 passed, 6 skipped, 84.65% coverage.
- All pre-commit hooks passed.
- Signed commit and DCO trailer verified.

Closes #2591
