### PR TITLE
[mino] Constrain the Windows-only tzdata dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,10 +144,10 @@ Platform notes:
   `pyproject.toml` describes what `pip install` accepts; no platform-restriction
   classifier is published.
 - **Windows wheels pull in `tzdata` automatically.** The
-  `"tzdata; platform_system == 'Windows'"` marker in `[project.dependencies]`
-  exists because `hephaestus.github.rate_limit` uses `zoneinfo.ZoneInfo`,
-  which has no IANA database bundled on Windows. POSIX installs skip this
-  dependency.
+  `"tzdata>=2026.2,<2027; platform_system == 'Windows'"` marker in
+  `[project.dependencies]` exists because `hephaestus.github.rate_limit` uses
+  `zoneinfo.ZoneInfo`, which has no IANA database bundled on Windows. POSIX
+  installs skip this dependency.
 
 Use `uv sync` to develop and run the test suite on macOS, Linux, or Windows.
 Native-Windows runs skip only the tests explicitly marked `requires_posix`; do

--- a/tests/unit/scripts/test_notice_runtime_completeness.py
+++ b/tests/unit/scripts/test_notice_runtime_completeness.py
@@ -20,7 +20,7 @@ def _dist_name(spec: str) -> str:
 
     Args:
         spec: A PEP 508 dependency specifier, e.g.
-            ``"tzdata; platform_system == 'Windows'"``.
+            ``"tzdata>=2026.2,<2027; platform_system == 'Windows'"``.
 
     Returns:
         The PEP 503-normalized distribution name (lowercase; runs of ``-``,

--- a/tests/unit/validation/test_tzdata_dependency.py
+++ b/tests/unit/validation/test_tzdata_dependency.py
@@ -1,0 +1,42 @@
+"""Regression tests for the Windows-only tzdata requirement (issue #2149)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+_PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
+
+
+def _tzdata_requirement() -> Requirement:
+    """Return the sole tzdata requirement from project dependencies."""
+    project = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]
+    requirements = [Requirement(spec) for spec in project["dependencies"]]
+    matches = [requirement for requirement in requirements if requirement.name == "tzdata"]
+    assert len(matches) == 1, f"expected one tzdata dependency, found {matches}"
+    return matches[0]
+
+
+def test_tzdata_uses_supported_2026_range() -> None:
+    """Tzdata must stay within the supported 2026 release series."""
+    requirement = _tzdata_requirement()
+
+    assert requirement.specifier == SpecifierSet(">=2026.2,<2027")
+
+
+def test_tzdata_remains_windows_only() -> None:
+    """POSIX installations must not acquire the Windows timezone-data fallback."""
+    marker = _tzdata_requirement().marker
+
+    assert marker is not None
+    assert marker.evaluate({"platform_system": "Windows"})
+    assert not marker.evaluate({"platform_system": "Linux"})
+    assert not marker.evaluate({"platform_system": "Darwin"})

--- a/tests/unit/validation/test_tzdata_dependency.py
+++ b/tests/unit/validation/test_tzdata_dependency.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-import sys
+import tomllib
 from pathlib import Path
 
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:  # pragma: no cover
-    import tomli as tomllib
 
 _PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
 


### PR DESCRIPTION
## Summary
- Updated Windows `tzdata` documentation and dependency example.
- Added regression tests for `>=2026.2,<2027` and Windows-only marker.
- Verified existing metadata and lockfile with `uv lock --check`.

Tests: 7,084 passed, 24 skipped; coverage 84.57%. Ruff checks and formatting passed.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests -q --tb=short

## Closes
Closes #2149

Generated by Hephaestus automation
