### PR TITLE
docs(policy): reduce volatile operational claims

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -16,7 +16,8 @@ Continuous Integration pipeline that runs on every push and pull request to `mai
 
 **Jobs:**
 
-- **Unit tests**: pytest with coverage (≥80%)
+- **Unit tests**: pytest with the coverage floor defined by
+  [`pyproject.toml [tool.coverage.report]`](../pyproject.toml)
 - **Integration tests**: import smoke tests + wheel build/install
 - **Structure check**: enforces test mirrors source layout
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,17 @@ repos:
         pass_filenames: false
         files: ^(README\.md|COMPATIBILITY\.md|AGENTS\.md|CLAUDE\.md|pyproject\.toml|docs/.*\.md)$
 
+  # Living documentation ownership and source-currency guard
+  - repo: local
+    hooks:
+      - id: check-doc-maintenance
+        name: Check normative documentation maintenance
+        description: Reject unowned volatile claims and invalid maintained sources
+        entry: uv run python -m hephaestus.validation.doc_maintenance
+        language: system
+        pass_filenames: false
+        files: ^(.*\.md|pyproject\.toml|hephaestus/automation/pipeline/routing\.py|hephaestus/prompts/catalog\.py|\.github/CODEOWNERS|\.github/workflows/_required\.yml)$
+
   # Claude settings permission path check
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,7 +150,7 @@ repos:
         entry: uv run python -m hephaestus.validation.doc_maintenance
         language: system
         pass_filenames: false
-        files: ^(.*\.md|pyproject\.toml|hephaestus/automation/pipeline/routing\.py|hephaestus/prompts/catalog\.py|\.github/CODEOWNERS|\.github/workflows/_required\.yml)$
+        files: ^(.*\.md|pyproject\.toml|hephaestus/automation/pipeline(?:_github\.py|/.*\.py)|hephaestus/prompts/(?:catalog\.py|templates/.*|overrides/.*)|\.github/CODEOWNERS|\.github/workflows/(?:_required|test)\.yml)$
 
   # Claude settings permission path check
   - repo: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ common abstractions used throughout the HomericIntelligence suite.
 
 ```text
 Hephaestus/
-├── hephaestus/                 # Python source code (21 documented subpackages)
+├── hephaestus/                 # Python source packages
 │   ├── agents/                 # Agent frontmatter + loader + runtime
 │   ├── automation/             # Queue-based issue planning / implementation / PR review pipeline
 │   ├── benchmarks/             # Benchmark comparison utilities
@@ -72,8 +72,8 @@ lowercase_snake_case.
 
 ## Library vs product layer
 
-`hephaestus/automation/` is a **product layer** (26.1k LoC, 53.9% of the
-codebase) co-located with the utility library. It is gated behind the
+`hephaestus/automation/` is an opt-in product layer co-located with the utility
+library. It is gated behind the
 `HomericIntelligence-Hephaestus[automation]` optional extra. The base
 `import hephaestus` surface MUST NOT pull `curses`, `fcntl`, `pydantic`,
 or any `hephaestus.automation.*` module. Enforced by

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -17,9 +17,10 @@ follows the deprecation policy below.
 
 ## Stability Tiers
 
-Hephaestus ships 20 documented subpackages with different maturity levels. Only the
-**stable** subpackages below are covered by the [deprecation policy](#deprecation-policy);
-**provisional** subpackages may change without notice, even across minor versions.
+Hephaestus documents subpackages with different maturity levels. Only the
+**stable** subpackages below are covered by the
+[deprecation policy](#deprecation-policy); **provisional** subpackages may
+change without notice, even across minor versions.
 
 ### Stable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,9 @@ links to the full section below.
 3. **Pick an issue** ([Code Contributions](#code-contributions)) — pick or open a
    GitHub issue, then branch as `<issue-number>-description`.
 4. **Make the change test-first** ([Testing](#testing)) — write a failing test,
-   make it pass, keep coverage at 83%+ (target 90%).
+   make it pass, and keep coverage at the configured floor in
+   [`pyproject.toml`](pyproject.toml) while working toward the target in
+   [`AGENTS.md`](AGENTS.md).
 5. **Open the PR** ([Pull Request Process](#pull-request-process)) — use a
    Conventional Commit PR title, sign every commit (`git commit -S`), put
    `Closes #<issue-number>` on its own line in the body, and keep auto-merge
@@ -52,6 +54,8 @@ Before opening a PR, locate the work in:
 - [`.github/pull_request_template.md`](.github/pull_request_template.md)
   — the PR scaffolding (`Closes #N` line is enforced by the
   `pr-policy` CI gate).
+- [`docs/documentation-maintenance.md`](docs/documentation-maintenance.md) —
+  ownership, sources, review triggers, and automated guards for living docs.
 
 Hephaestus uses trunk-based development: create one short-lived feature
 branch per issue, open a pull request, squash-merge it back to `main`, and cut

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -19,7 +19,7 @@ A piece of work is **done** when every item below is true.
 | 6 | `uv run ruff check hephaestus/ tests/` passes | CI job `lint` |
 | 7 | `uv run ruff format --check hephaestus/ tests/` passes (no files would be reformatted) | CI job `lint` |
 | 8 | `uv run mypy hephaestus/ scripts/ tests/` returns `Success: no issues found in N source files` | CI job `lint` |
-| 9 | Full unit suite passes: `uv run pytest tests/unit` (currently 2,500+ tests on Python 3.13) | CI jobs `unit-tests`, `test (ubuntu-latest, 3.13, unit)` |
+| 9 | Full unit suite passes: `uv run pytest tests/unit` | CI jobs `unit-tests` and `test (ubuntu-latest, 3.13, unit)` |
 | 10 | Coverage gate satisfied: `--cov-fail-under=83` (configured in `pyproject.toml [tool.coverage.report].fail_under`) | CI job `unit-tests` |
 | 11 | No new warnings introduced (pytest, deprecation, ruff) | PR reviewer |
 | 12 | Integration tests pass: `uv run pytest tests/integration` | CI job `integration-tests` |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,23 +1,9 @@
 # Migration Guide
 
-> **Historical status for v0.10.0 (as of 2026-07-24):** The latest released version is **0.10.0** (tag-driven
-> via hatch-vcs). **1.0 has not been released yet** — the section below is the
-> *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
-> prepare. 0.10.0's headline change is the queue pipeline's reviewed-head review
-> interlock: `pr_review` writes `state:implementation-go` only for the current
-> process's reviewed head. `merge_wait` revalidates that proof before every
-> individual SHA-conditional normal REST squash-merge request on a
-> confirmed-unarmed PR. The merge budget (default: five) still bounds actual
-> requests and transport-ambiguity retries. No queue stage invokes `gh pr merge`, arms native
-> auto-merge, manages a merge queue, or uses an administrator bypass. There are
-> **no breaking changes
-> to the documented public API** from 0.9.x: upgrading requires no code changes for
-> code that uses only the documented public API in
-> [`COMPATIBILITY.md`](../COMPATIBILITY.md). Operators of the automation loop should
-> note `--max-merge-attempts` was replaced by `--drive-green-loops` (default 5). The `Development Status ::
-> 5 - Production/Stable` classifier in `pyproject.toml` reflects the maturity of the
-> stable public API surface, not a 1.0 tag; the package remains tag-driven and is
-> currently on the 0.10.x series.
+> **Release status:** The latest released version is **0.10.0** (tag-driven
+> via hatch-vcs). **1.0 has not been released yet** — the section below is
+> forthcoming 1.0 migration guidance. The package remains on the 0.x release
+> line until a signed `v1.0.0` tag is published.
 
 ## Current main (unreleased; post-v0.10.0)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,21 +6,21 @@ Hephaestus is the foundational utilities and tooling repository of the HomericIn
 
 ## Current Focus (Q3 2026)
 
-Remediation of the strict 2026-05-28 audit findings (`audit-finding` issues) continues, now alongside hardening of the queue-based automation pipeline delivered under Epic #1809 and the fail-closed auto-merge bootstrap (#2054/#2055). This ongoing work spans:
+Current focus is reconciled from
+[open epics](https://github.com/HomericIntelligence/Hephaestus/issues?q=is%3Aopen%20label%3Aepic)
+and
+[open audit findings](https://github.com/HomericIntelligence/Hephaestus/issues?q=is%3Aopen%20label%3Aaudit-finding)
+at the maintenance triggers below.
 
-1. **Audit Remediation** — Addressing the open `audit-finding` issues across the 15 audit dimensions. Focus areas include documentation currency, automation module test coverage, fixing f-string logging anti-patterns, and continued hardening of the 3-stage review-PR pipeline (collapsed from the prior 6-phase design in #677/#679).
-
-2. **Automation Pipeline Hardening** — Stabilizing the queue-based
-   plan → implement → review pipeline (Epic #1809): drive-green loop
-   behavior, linked-issue PR recovery, epic/skip-tag scoping, and restoring
-   the reviewed-head interlock and bounded SHA-conditional normal merge in
-   `merge_wait` for a confirmed-unarmed PR.
-
-3. **CLI Tool Coverage Expansion** — Expanding the CLI entry point test suite from 13 of 47 declared tools to full coverage, ensuring all command-line interfaces are properly validated.
-
-4. **Test Coverage Hardening** — Bringing 12 excluded automation modules into coverage measurement with mocked unit tests for core orchestration logic.
-
-5. **Security & Dependency Management** — Hard-blocking pip-audit failures in CI and resolving dependency consistency issues across pyproject.toml and pyproject.toml.
+1. **Audit Remediation** — Address documentation currency, testability,
+   security, and maintainability findings represented by open audit issues.
+2. **Automation Pipeline Hardening** — Improve queue convergence, recovery,
+   review gates, and merge-wait safety using the queue pipeline's source and
+   architecture contracts.
+3. **CLI Inventory Parity** — Keep declared console scripts documented and
+   tested from the `[project.scripts]` source of truth.
+4. **Coverage Hardening** — Reduce orchestration coverage omissions while
+   retaining unit coverage for pure helpers.
 
 ## Near-term (Next 1-2 Quarters)
 
@@ -48,9 +48,9 @@ Conservative, directional items:
 
 ## How We Plan
 
-Hephaestus uses an Epic-and-children issue pattern for project planning. Major initiatives are tracked as Epic issues (labeled `epic`), with breakdown into concrete child issues tagged by audit section and severity.
-
-**Exemplar:** Epic #310 (Strict audit 2026-04-28, now closed) contained 29 child issues spanning all 15 audit dimensions, with clear scoping and evidence-based requirements.
+Hephaestus uses an Epic-and-children issue pattern for project planning. Major
+initiatives are represented by open Epic issues, with concrete child issues
+carrying their own acceptance evidence.
 
 We also capture session learnings in Mnemosyne via the `/learn` skill, preserving team knowledge about patterns, anti-patterns, and decisions across the ecosystem.
 
@@ -77,4 +77,4 @@ that is the release maintainer; there is no separate roadmap committee.
 PR editing it directly). The roadmap is refreshed to reflect current focus
 areas as Epics are created or priorities shift.
 
-Last updated: 2026-07-18
+Last updated: 2026-07-20

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,10 +7,17 @@ The [`docs/adr/`](adr/) records remain the bind-points for individual
 architectural decisions (`0006-queue-based-in-process-automation-pipeline`,
 …) — this document is the unified reference; ADRs are the historical record.
 This file is source-grounded: every operational claim links to the module
-that backs it, in the form ``module/file.py`` or
-``§module/Class.func``. Per the project convention
+that backs it. Source citations use the forms
+`module/file.py` and `§module/Class.func`, each paired with a relative link.
+Per the project convention
 (`"Code References": 'DO'` in [`AGENTS.md`](../AGENTS.md) §"Claude Code
 Optimization"), file paths are repo-relative.
+
+> **Maintenance:** Ownership follows
+> [CODEOWNERS](../.github/CODEOWNERS). Changes to a cited pipeline module,
+> route, stage, template, or workflow trigger review of the corresponding
+> section. Local source targets and selected semantic source symbols are checked
+> by `hephaestus.validation.doc_maintenance`.
 
 ---
 

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -49,12 +49,15 @@ automation authority and is not a required context.
 
 - **Owner:** The `.github/` owner in
   [CODEOWNERS](../../.github/CODEOWNERS).
-- **Versioned source:** The `jobs` mapping in
-  [`_required.yml`](../../.github/workflows/_required.yml).
+- **Versioned sources:** Maintain this document from the `jobs` mappings in
+  [`_required.yml`](../../.github/workflows/_required.yml) and
+  [`test.yml`](../../.github/workflows/test.yml); the latter defines the classic
+  matrix-test contexts listed above.
 - **External source:** The live branch-protection and ruleset output collected
   by the commands under [Live audit](#live-audit).
-- **Trigger:** Reconcile this document whenever a workflow context,
-  branch-protection rule, or ruleset changes, and during the pre-release review.
+- **Trigger:** Reconcile this document whenever either workflow's jobs, matrix,
+  or context names change (including a `test.yml` test-job rename), whenever a
+  branch-protection rule or ruleset changes, and during the pre-release review.
 
 ## Aggregate workflow coverage
 

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -45,6 +45,17 @@ The active ruleset requires these direct contexts:
 `auto-merge-policy` is advisory. It reports GitHub state but does not grant
 automation authority and is not a required context.
 
+## Maintenance
+
+- **Owner:** The `.github/` owner in
+  [CODEOWNERS](../../.github/CODEOWNERS).
+- **Versioned source:** The `jobs` mapping in
+  [`_required.yml`](../../.github/workflows/_required.yml).
+- **External source:** The live branch-protection and ruleset output collected
+  by the commands under [Live audit](#live-audit).
+- **Trigger:** Reconcile this document whenever a workflow context,
+  branch-protection rule, or ruleset changes, and during the pre-release review.
+
 ## Aggregate workflow coverage
 
 `required-checks-gate` depends on the code-validation jobs in

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -1,0 +1,17 @@
+# Documentation Maintenance
+
+Living normative documentation includes root policy files, `.github/**/*.md`,
+`scripts/README.md`, and `docs/**/*.md`, including `docs/specs/**/*.md`.
+Accepted ADR bodies and component-scoped release-note bodies are point-in-time
+records; their README/index files remain living documentation.
+
+Ownership follows [CODEOWNERS](../.github/CODEOWNERS).
+
+| Surface | Maintained source | Review trigger | Validation |
+|---|---|---|---|
+| Roadmap focus | Open GitHub epics and audit findings; [release checklist](RELEASING.md) | Release, epic state change, or priority change | `validate_roadmap_maintenance` |
+| Architecture | Linked source modules, especially [`ROUTES`](../hephaestus/automation/pipeline/routing.py) | Change to a cited module or pipeline contract | semantic-source and link validation |
+| Prompt specifications | [`PromptCatalog`](../hephaestus/prompts/catalog.py) and packaged templates | Prompt catalog, layout, or override change | semantic-source validation |
+| Required checks | [required workflow](../.github/workflows/_required.yml) plus live GitHub audit | Workflow, branch-protection, or ruleset change | local YAML validation plus documented live audit |
+| CLI inventory | [`pyproject.toml [project.scripts]`](../pyproject.toml) | Console-script registration change | `check_cli_table_sync` |
+| Coverage floor | [`pyproject.toml [tool.coverage.report]`](../pyproject.toml) | Coverage configuration change | `hephaestus-check-doc-config` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,8 @@ See the [README](../README.md) for installation and development setup instructio
 - [Contract Testing](contract-testing.md) — Opt-in authenticated GitHub and agent end-to-end contract coverage
 - [Privacy, Retention, and Deletion Policy](../PRIVACY.md) — data inventory, retention periods, deletion procedures, and GDPR contact (issue #2175)
 - [Third-Party Services](third-party-services.md) — Vendor inventory, responsibility split, and availability expectations for GitHub, PyPI, and agent providers (issue #2177)
+- [Documentation Maintenance](documentation-maintenance.md) — Living-doc scope,
+  source ownership, review triggers, and automated currency checks
 
 ## Contributing
 

--- a/docs/specs/2026-07-16-jinja-prompt-templates-design.md
+++ b/docs/specs/2026-07-16-jinja-prompt-templates-design.md
@@ -2,6 +2,15 @@
 
 **Status:** Proposed
 
+**Owner:** The prompt subsystem owner defined by
+[CODEOWNERS](../../.github/CODEOWNERS).
+
+**Review trigger:** Any change to `PromptCatalog`, packaged template layout,
+override precedence, or prompt parity requirements.
+
+**Maintained sources:** [`PromptCatalog`](../../hephaestus/prompts/catalog.py)
+and the [packaged default templates](../../hephaestus/prompts/templates/default/).
+
 ## Goal
 
 Move every built-in, agent-facing Hephaestus prompt and reusable prompt

--- a/docs/third-party-services.md
+++ b/docs/third-party-services.md
@@ -48,7 +48,7 @@ SLA the project does not hold would itself be an audit finding.
 | Astral (`astral-sh/setup-uv`) | Provisions the uv toolchain in CI (ADR-0008) | High for CI — uv is the sole environment manager | Pin the action by SHA; uv binaries are cached by `actions/cache` | Release-artifact availability | GitHub-hosted release artifacts — best-effort |
 | Third-party GitHub Actions (`astral-sh/setup-uv`, `pypa/gh-action-pypi-publish`, `crazy-max/ghaction-import-gpg`, `softprops/action-gh-release`, `extractions/setup-just`) | uv provisioning, PyPI publishing, GPG import, release creation, `just` provisioning | Medium — release and CI ergonomics | SHA-pinning (done — see `release.yml` and `_required.yml`), `github-actions` Dependabot updates (ADR-0003) | Correctness of the pinned action code | Not a hosted service — vendored, pinned code |
 | Dependabot (`.github/dependabot.yml`) | Automated `uv` and `github-actions` dependency-update PRs | Low — dependency hygiene | Keep the ecosystem list correct; review update PRs (ADR-0003) | Update-generation availability | GitHub-native — best-effort |
-| Renovate (Mend app) | Historical audit record: it owned the retired Pixi/conda ecosystem (ADR-0003) and is not configured after the uv-only migration (ADR-0008) | None — not used by the project | None — no project configuration | Not applicable | Not applicable |
+| Renovate (Mend app) | Historical pixi/conda ownership per ADR-0003; no `renovate.json` is tracked after the uv-only migration in ADR-0008 | None while no configuration is tracked | If pixi/conda returns, add a scoped `renovate.json` per ADR-0003 and update this row in the same change | App availability when configured | Best-effort when configured |
 
 ## Responsibility policy
 

--- a/hephaestus/validation/doc_maintenance.py
+++ b/hephaestus/validation/doc_maintenance.py
@@ -1,0 +1,570 @@
+"""Validate ownership and currency contracts for living documentation.
+
+The validator is intentionally read-only.  It scans normative Markdown,
+checks the small set of source-backed documentation contracts, and reports
+claims that are likely to become stale without an explicit maintenance owner.
+Generated material, examples, accepted ADR bodies, and release-note bodies
+are outside the living-documentation boundary.
+
+Usage::
+
+    python -m hephaestus.validation.doc_maintenance --repo-root .
+    python -m hephaestus.validation.doc_maintenance --repo-root . --json
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
+from hephaestus.scripts_lib.check_cli_table_sync import _load_scripts, check_prose_counts
+
+EXCLUDED_PREFIXES: tuple[str, ...] = (
+    ".git/",
+    ".pytest_cache/",
+    ".venv/",
+    ".worktrees/",
+    "build/",
+    "tests/fixtures/",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A documentation maintenance violation."""
+
+    file: str
+    line: int
+    rule: str
+    message: str
+    severity: str = "error"
+    content: str = ""
+
+    def as_dict(self) -> dict[str, str | int]:
+        """Return a JSON-serializable representation of the finding."""
+        return {
+            "file": self.file,
+            "line": self.line,
+            "rule": self.rule,
+            "message": self.message,
+            "severity": self.severity,
+            "content": self.content.strip(),
+        }
+
+
+@dataclass(frozen=True)
+class SourceContract:
+    """Describe a source file and semantic selector cited by a document."""
+
+    document: str
+    source: str
+    selector: str
+
+
+SOURCE_CONTRACTS: tuple[SourceContract, ...] = (
+    SourceContract(
+        document="docs/architecture.md",
+        source="hephaestus/automation/pipeline/routing.py",
+        selector="ROUTES",
+    ),
+    SourceContract(
+        document="docs/specs/2026-07-16-jinja-prompt-templates-design.md",
+        source="hephaestus/prompts/catalog.py",
+        selector="PromptCatalog",
+    ),
+    SourceContract(
+        document="docs/ci/required-checks.md",
+        source=".github/workflows/_required.yml",
+        selector="jobs",
+    ),
+    SourceContract(
+        document="docs/ROADMAP.md",
+        source="docs/RELEASING.md",
+        selector="Pre-Release Checklist",
+    ),
+)
+
+_EXCLUDED_DOCUMENT_DIRS = ("docs/adr/", "docs/release-notes/")
+_LIVING_RECORD_NAMES = frozenset({"README.md", "index.md"})
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+_DATE_STATE_RE = re.compile(r"\b(?:as of|last updated:)\s+\d{4}-\d{2}-\d{2}\b", re.IGNORECASE)
+_TEMPORARY_STATE_RE = re.compile(
+    r"\b(?:(?:currently|temporarily)\s+(?:inactive|unavailable|planned)|"
+    r"(?:issue|pr)\s+#\d+\s+(?:is|was|remains?)\s+"
+    r"(?:open|closed|active|inactive|in progress|blocked))\b",
+    re.IGNORECASE,
+)
+_SNAPSHOT_METRIC_RES = (
+    re.compile(r"\b\d+(?:\.\d+)?[kK]?\s+LoC\b"),
+    re.compile(r"\b\d+\+?\s+(?:documented\s+)?(?:Python\s+)?subpackages?\b"),
+    re.compile(r"\b\d+\+?\s+(?:documented\s+)?packages?\b"),
+    re.compile(r"\b\d+\+?\s+tests?\s+(?:across|in|total)\b", re.IGNORECASE),
+    re.compile(r"\b\d+\s+of\s+\d+\s+(?:declared\s+)?(?:tools|entry points|modules)\b"),
+    re.compile(r"\b\d+(?:\.\d+)?%\s+of\s+the\s+(?:codebase|source tree)\b", re.IGNORECASE),
+)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+_CURRENT_FOCUS_RE = re.compile(r"^##\s+Current Focus \(Q([1-4])\s+(\d{4})\)\s*$", re.MULTILINE)
+_LAST_UPDATED_RE = re.compile(r"^Last updated:\s*(\S+)\s*$", re.MULTILINE)
+
+_MAINTENANCE_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "docs/documentation-maintenance.md": (
+        "Ownership follows",
+        "Review trigger",
+        "Maintained source",
+    ),
+    "docs/architecture.md": (
+        "Maintenance:",
+        "CODEOWNERS",
+        "Changes to a cited",
+    ),
+    "docs/specs/2026-07-16-jinja-prompt-templates-design.md": (
+        "**Owner:**",
+        "**Review trigger:**",
+        "**Maintained sources:**",
+    ),
+    "docs/ci/required-checks.md": (
+        "## Maintenance",
+        "**Owner:**",
+        "**Trigger:**",
+    ),
+}
+
+
+def _relative_path(path: Path, repo_root: Path) -> str:
+    """Return a stable POSIX path relative to *repo_root*."""
+    return path.relative_to(repo_root).as_posix()
+
+
+def _is_excluded(relative_path: str) -> bool:
+    """Return whether a repository-relative path is outside the scan boundary."""
+    if any(relative_path.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+        return True
+    if relative_path.startswith(_EXCLUDED_DOCUMENT_DIRS[0]):
+        return Path(relative_path).name not in _LIVING_RECORD_NAMES
+    if relative_path.startswith(_EXCLUDED_DOCUMENT_DIRS[1]):
+        return Path(relative_path).name not in _LIVING_RECORD_NAMES
+    return False
+
+
+def discover_normative_markdown(repo_root: Path) -> list[Path]:
+    """Recursively discover living Markdown files under *repo_root*.
+
+    Args:
+        repo_root: Repository root to scan.
+
+    Returns:
+        Sorted paths for Markdown files in the normative documentation scope.
+
+    """
+    return sorted(
+        path
+        for path in repo_root.rglob("*.md")
+        if path.is_file() and not _is_excluded(_relative_path(path, repo_root))
+    )
+
+
+def _prose_lines(content: str) -> list[tuple[int, str]]:
+    """Return non-fenced lines with their original one-based line numbers."""
+    lines: list[tuple[int, str]] = []
+    in_fence = False
+    fence_char = ""
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        fence = _FENCE_RE.match(line)
+        if fence:
+            marker = fence.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_char = marker[0]
+            elif marker[0] == fence_char:
+                in_fence = False
+            continue
+        if not in_fence:
+            lines.append((line_number, line))
+    return lines
+
+
+def _finding(
+    relative_path: str,
+    line_number: int,
+    rule: str,
+    message: str,
+    content: str,
+) -> Finding:
+    """Build a standard line-oriented finding."""
+    return Finding(
+        file=relative_path,
+        line=line_number,
+        rule=rule,
+        message=message,
+        content=content,
+    )
+
+
+def validate_volatile_claims(file_path: Path, repo_root: Path) -> list[Finding]:
+    """Find unowned dated-state and repository-snapshot claims in one document."""
+    relative_path = _relative_path(file_path, repo_root)
+    content = file_path.read_text(encoding="utf-8", errors="replace")
+    findings: list[Finding] = []
+    for line_number, line in _prose_lines(content):
+        dated_state_match = _DATE_STATE_RE.search(line)
+        if dated_state_match and not (
+            relative_path == "docs/ROADMAP.md"
+            and dated_state_match.group(0).lower().startswith("last updated:")
+        ):
+            findings.append(
+                _finding(
+                    relative_path,
+                    line_number,
+                    "dated-state",
+                    "dated operational state must be maintained by a source and trigger",
+                    line,
+                )
+            )
+        if _TEMPORARY_STATE_RE.search(line):
+            findings.append(
+                _finding(
+                    relative_path,
+                    line_number,
+                    "temporary-state",
+                    "temporary issue or service state must be derived from a maintained source",
+                    line,
+                )
+            )
+        if any(pattern.search(line) for pattern in _SNAPSHOT_METRIC_RES):
+            findings.append(
+                _finding(
+                    relative_path,
+                    line_number,
+                    "snapshot-metric",
+                    "repository-size or test-count snapshots are not maintained documentation",
+                    line,
+                )
+            )
+    return findings
+
+
+def _source_selector_exists(source_path: Path, selector: str) -> bool:
+    """Check a Python symbol, YAML key, or Markdown heading selector."""
+    suffix = source_path.suffix.lower()
+    text = source_path.read_text(encoding="utf-8", errors="replace")
+    if suffix == ".py":
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            return False
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == selector
+            ):
+                return True
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                if any(
+                    isinstance(target, ast.Name) and target.id == selector for target in targets
+                ):
+                    return True
+        return False
+    if suffix in {".yml", ".yaml"}:
+        return re.search(rf"^\s*{re.escape(selector)}\s*:", text, re.MULTILINE) is not None
+    if suffix == ".md":
+        heading_re = re.compile(rf"^#{{1,6}}\s+{re.escape(selector)}\s*$")
+        return any(heading_re.match(line) for _, line in _prose_lines(text))
+    return False
+
+
+def _document_links_source(document_path: Path, source_path: Path) -> bool:
+    """Return whether a Markdown document links to the exact local source path."""
+    content = document_path.read_text(encoding="utf-8", errors="replace")
+    for raw_target in _MARKDOWN_LINK_RE.findall(content):
+        target = raw_target.strip().strip("<>")
+        parsed = urlparse(target)
+        if parsed.scheme or parsed.netloc:
+            continue
+        target_path = unquote(parsed.path)
+        if not target_path:
+            continue
+        if (document_path.parent / target_path).resolve() == source_path.resolve():
+            return True
+    return False
+
+
+def _source_finding(contract: SourceContract, rule: str, message: str) -> Finding:
+    """Create a finding anchored to a source contract's document."""
+    return Finding(file=contract.document, line=1, rule=rule, message=message)
+
+
+def validate_source_contracts(
+    repo_root: Path,
+    *,
+    contracts: tuple[SourceContract, ...] = SOURCE_CONTRACTS,
+) -> list[Finding]:
+    """Validate cited source paths, links, and semantic selectors."""
+    findings: list[Finding] = []
+    resolved_root = repo_root.resolve()
+    for contract in contracts:
+        document_path = repo_root / contract.document
+        source_path = repo_root / contract.source
+        if not document_path.is_file():
+            findings.append(
+                _source_finding(contract, "source-document", "cited document is missing")
+            )
+            continue
+        try:
+            source_path.resolve().relative_to(resolved_root)
+        except ValueError:
+            findings.append(
+                _source_finding(
+                    contract,
+                    "source-path",
+                    f"source must remain inside repository: {contract.source}",
+                )
+            )
+            continue
+        if not source_path.is_file():
+            findings.append(
+                _source_finding(
+                    contract, "source-path", f"source does not exist: {contract.source}"
+                )
+            )
+            continue
+        if not _document_links_source(document_path, source_path):
+            findings.append(
+                _source_finding(
+                    contract,
+                    "source-link",
+                    f"document must link to maintained source: {contract.source}",
+                )
+            )
+        if not _source_selector_exists(source_path, contract.selector):
+            findings.append(
+                _source_finding(
+                    contract,
+                    "source-selector",
+                    f"maintained source lacks selector: {contract.selector}",
+                )
+            )
+    return findings
+
+
+def _quarter_for(value: date) -> tuple[int, int]:
+    """Return the calendar quarter containing *value*."""
+    return value.year, (value.month - 1) // 3 + 1
+
+
+def _validate_roadmap_sections(content: str) -> list[Finding]:
+    """Validate roadmap ownership, trigger, focus, and source metadata."""
+    findings: list[Finding] = []
+    if _CURRENT_FOCUS_RE.search(content) is None:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "focus-quarter",
+                "roadmap must state a current focus quarter",
+            )
+        )
+    required_phrases = {
+        "roadmap-ownership": ("Trigger", "Responsibility"),
+        "roadmap-source": ("RELEASING.md",),
+    }
+    for rule, phrases in required_phrases.items():
+        if not all(phrase.lower() in content.lower() for phrase in phrases):
+            findings.append(
+                Finding(
+                    "docs/ROADMAP.md",
+                    1,
+                    rule,
+                    "roadmap must document its owner, review trigger, and maintained source",
+                )
+            )
+    return findings
+
+
+def _validate_last_updated(content: str, *, today: date) -> list[Finding]:
+    """Validate roadmap date syntax and freshness against an injected date."""
+    findings: list[Finding] = []
+    focus_match = _CURRENT_FOCUS_RE.search(content)
+    if focus_match is None:
+        return findings
+    focus_quarter = (int(focus_match.group(2)), int(focus_match.group(1)))
+    current_quarter = _quarter_for(today)
+    if focus_quarter < current_quarter:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "stale-current-focus",
+                "roadmap current focus quarter is older than the supplied current quarter",
+            )
+        )
+
+    updated_match = _LAST_UPDATED_RE.search(content)
+    if updated_match is None:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "last-updated",
+                "roadmap must contain Last updated: YYYY-MM-DD",
+            )
+        )
+        return findings
+    try:
+        last_updated = datetime.strptime(updated_match.group(1), "%Y-%m-%d").date()
+    except ValueError:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "last-updated",
+                "roadmap Last updated value must be an ISO date",
+            )
+        )
+        return findings
+    if last_updated > today:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "future-last-updated",
+                "roadmap Last updated date cannot be in the future",
+            )
+        )
+    if _quarter_for(last_updated) < focus_quarter:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "last-updated-before-focus",
+                "roadmap Last updated date must be within the stated focus quarter",
+            )
+        )
+    elif _quarter_for(last_updated) > focus_quarter:
+        findings.append(
+            Finding(
+                "docs/ROADMAP.md",
+                1,
+                "last-updated-outside-focus-quarter",
+                "roadmap Last updated date must be within the stated focus quarter",
+            )
+        )
+    return findings
+
+
+def validate_roadmap_maintenance(repo_root: Path, *, today: date | None = None) -> list[Finding]:
+    """Validate roadmap ownership and deterministic freshness rules."""
+    effective_today = today or date.today()
+    roadmap_path = repo_root / "docs" / "ROADMAP.md"
+    if not roadmap_path.is_file():
+        return [Finding("docs/ROADMAP.md", 1, "roadmap-missing", "roadmap is required")]
+    content = roadmap_path.read_text(encoding="utf-8", errors="replace")
+    findings = _validate_roadmap_sections(content)
+    findings.extend(_validate_last_updated(content, today=effective_today))
+    return findings
+
+
+def _validate_maintenance_metadata(repo_root: Path) -> list[Finding]:
+    """Ensure each volatile source surface states owner and review trigger."""
+    findings: list[Finding] = []
+    for relative_path, required_phrases in _MAINTENANCE_REQUIREMENTS.items():
+        path = repo_root / relative_path
+        if not path.is_file():
+            findings.append(
+                Finding(
+                    relative_path,
+                    1,
+                    "maintenance-document",
+                    "maintenance contract is missing",
+                )
+            )
+            continue
+        content = path.read_text(encoding="utf-8", errors="replace")
+        for phrase in required_phrases:
+            if phrase.lower() not in content.lower():
+                findings.append(
+                    Finding(
+                        relative_path,
+                        1,
+                        "maintenance-metadata",
+                        f"maintenance contract is missing: {phrase}",
+                    )
+                )
+    return findings
+
+
+def _validate_cli_counts(repo_root: Path) -> list[Finding]:
+    """Delegate documented CLI count validation to its authoritative checker."""
+    pyproject_path = repo_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        return [
+            Finding(
+                "pyproject.toml",
+                1,
+                "cli-source",
+                "pyproject.toml is required for CLI counts",
+            )
+        ]
+    try:
+        expected_count = len(_load_scripts(repo_root))
+    except (OSError, RuntimeError, ValueError) as exc:
+        return [Finding("pyproject.toml", 1, "cli-source", f"unable to load CLI source: {exc}")]
+    passed, mismatches = check_prose_counts(repo_root, expected_count)
+    if passed:
+        return []
+    return [Finding("pyproject.toml", 1, "cli-count", mismatch) for mismatch in mismatches]
+
+
+def validate_documentation(repo_root: Path) -> list[Finding]:
+    """Run the complete read-only documentation maintenance policy."""
+    findings: list[Finding] = []
+    for path in discover_normative_markdown(repo_root):
+        findings.extend(validate_volatile_claims(path, repo_root))
+    findings.extend(validate_source_contracts(repo_root))
+    findings.extend(validate_roadmap_maintenance(repo_root))
+    findings.extend(_validate_maintenance_metadata(repo_root))
+    findings.extend(_validate_cli_counts(repo_root))
+    return findings
+
+
+def _print_findings(findings: list[Finding]) -> None:
+    """Print human-readable findings."""
+    if not findings:
+        print("OK: normative documentation maintenance checks passed")
+        return
+    for finding in findings:
+        location = f"{finding.file}:{finding.line}"
+        print(f"{location}: {finding.rule}: {finding.message}")
+    print(f"Found {len(findings)} documentation maintenance finding(s).")
+
+
+def main() -> int:
+    """Run the documentation maintenance CLI and return its exit status."""
+    parser = create_validation_parser(
+        "Validate ownership and currency contracts for normative documentation",
+        epilog="Example: %(prog)s --repo-root /path/to/repository --json",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Print passing checks")
+    args = parser.parse_args()
+    repo_root = resolve_repo_root(args)
+    findings = validate_documentation(repo_root)
+    if args.json:
+        payload = {
+            "findings": [finding.as_dict() for finding in findings],
+            "passed": not findings,
+            "exit_code": 0 if not findings else 1,
+        }
+        print(format_output(payload, "json"))
+    else:
+        _print_findings(findings)
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hephaestus/validation/doc_maintenance.py
+++ b/hephaestus/validation/doc_maintenance.py
@@ -60,7 +60,7 @@ class Finding:
 
 @dataclass(frozen=True)
 class SourceContract:
-    """Describe a source file and semantic selector cited by a document."""
+    """Describe a source path and semantic selector cited by a document."""
 
     document: str
     source: str
@@ -84,6 +84,16 @@ SOURCE_CONTRACTS: tuple[SourceContract, ...] = (
         selector="jobs",
     ),
     SourceContract(
+        document="docs/ci/required-checks.md",
+        source=".github/workflows/test.yml",
+        selector="jobs",
+    ),
+    SourceContract(
+        document="docs/specs/2026-07-16-jinja-prompt-templates-design.md",
+        source="hephaestus/prompts/templates/default",
+        selector="",
+    ),
+    SourceContract(
         document="docs/ROADMAP.md",
         source="docs/RELEASING.md",
         selector="Pre-Release Checklist",
@@ -92,6 +102,17 @@ SOURCE_CONTRACTS: tuple[SourceContract, ...] = (
 
 _EXCLUDED_DOCUMENT_DIRS = ("docs/adr/", "docs/release-notes/")
 _LIVING_RECORD_NAMES = frozenset({"README.md", "index.md"})
+_ADR_STATUS_RE = re.compile(
+    r"^\s*(?:[-*+]\s+)?(?:\*\*Status\*\*\s*:|\*\*Status:\*\*|Status\s*:)"
+    r"\s*(?P<status>.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ACCEPTED_ADR_STATUS_RE = re.compile(
+    r"Accepted(?:\s*\([^\r\n)]+\))?",
+    re.IGNORECASE,
+)
+_MARKDOWN_SECTION_RE = re.compile(r"^##\s+", re.MULTILINE)
+_ROADMAP_UPDATE_SECTION_RE = re.compile(r"^##\s+Updating This Roadmap\s*$", re.MULTILINE)
 _FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 _DATE_STATE_RE = re.compile(r"\b(?:as of|last updated:)\s+\d{4}-\d{2}-\d{2}\b", re.IGNORECASE)
 _TEMPORARY_STATE_RE = re.compile(
@@ -141,12 +162,25 @@ def _relative_path(path: Path, repo_root: Path) -> str:
     return path.relative_to(repo_root).as_posix()
 
 
-def _is_excluded(relative_path: str) -> bool:
+def _is_accepted_adr(file_path: Path) -> bool:
+    """Return whether *file_path* declares an accepted ADR status."""
+    content = file_path.read_text(encoding="utf-8", errors="replace")
+    first_section = _MARKDOWN_SECTION_RE.search(content)
+    metadata = content[: first_section.start()] if first_section else content
+    statuses = [
+        match.group("status").strip().strip("*_` ") for match in _ADR_STATUS_RE.finditer(metadata)
+    ]
+    return bool(statuses) and all(
+        _ACCEPTED_ADR_STATUS_RE.fullmatch(status) is not None for status in statuses
+    )
+
+
+def _is_excluded(relative_path: str, file_path: Path) -> bool:
     """Return whether a repository-relative path is outside the scan boundary."""
     if any(relative_path.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
         return True
     if relative_path.startswith(_EXCLUDED_DOCUMENT_DIRS[0]):
-        return Path(relative_path).name not in _LIVING_RECORD_NAMES
+        return Path(relative_path).name not in _LIVING_RECORD_NAMES and _is_accepted_adr(file_path)
     if relative_path.startswith(_EXCLUDED_DOCUMENT_DIRS[1]):
         return Path(relative_path).name not in _LIVING_RECORD_NAMES
     return False
@@ -165,7 +199,7 @@ def discover_normative_markdown(repo_root: Path) -> list[Path]:
     return sorted(
         path
         for path in repo_root.rglob("*.md")
-        if path.is_file() and not _is_excluded(_relative_path(path, repo_root))
+        if path.is_file() and not _is_excluded(_relative_path(path, repo_root), path)
     )
 
 
@@ -251,6 +285,10 @@ def validate_volatile_claims(file_path: Path, repo_root: Path) -> list[Finding]:
 
 def _source_selector_exists(source_path: Path, selector: str) -> bool:
     """Check a Python symbol, YAML key, or Markdown heading selector."""
+    if source_path.is_dir():
+        return not selector and any(path.is_file() for path in source_path.rglob("*"))
+    if not selector:
+        return source_path.exists()
     suffix = source_path.suffix.lower()
     text = source_path.read_text(encoding="utf-8", errors="replace")
     if suffix == ".py":
@@ -327,7 +365,7 @@ def validate_source_contracts(
                 )
             )
             continue
-        if not source_path.is_file():
+        if not source_path.exists():
             findings.append(
                 _source_finding(
                     contract, "source-path", f"source does not exist: {contract.source}"
@@ -358,6 +396,16 @@ def _quarter_for(value: date) -> tuple[int, int]:
     return value.year, (value.month - 1) // 3 + 1
 
 
+def _roadmap_update_section(content: str) -> str:
+    """Return the normalized ``Updating This Roadmap`` section body."""
+    section_match = _ROADMAP_UPDATE_SECTION_RE.search(content)
+    if section_match is None:
+        return ""
+    next_section = _MARKDOWN_SECTION_RE.search(content, section_match.end())
+    section_end = next_section.start() if next_section else len(content)
+    return re.sub(r"\s+", " ", content[section_match.end() : section_end]).casefold()
+
+
 def _validate_roadmap_sections(content: str) -> list[Finding]:
     """Validate roadmap ownership, trigger, focus, and source metadata."""
     findings: list[Finding] = []
@@ -370,18 +418,26 @@ def _validate_roadmap_sections(content: str) -> list[Finding]:
                 "roadmap must state a current focus quarter",
             )
         )
+    update_section = _roadmap_update_section(content)
     required_phrases = {
-        "roadmap-ownership": ("Trigger", "Responsibility"),
+        "roadmap-cadence": ("release-driven", "Auto Tag Release", "not date-driven"),
+        "roadmap-ownership": ("Trigger", "Responsibility", "maintainer"),
         "roadmap-source": ("RELEASING.md",),
     }
     for rule, phrases in required_phrases.items():
-        if not all(phrase.lower() in content.lower() for phrase in phrases):
+        if not all(phrase.casefold() in update_section for phrase in phrases):
+            message = (
+                "roadmap update cadence must be release-driven through Auto Tag Release, "
+                "not date-driven"
+                if rule == "roadmap-cadence"
+                else "roadmap must document its owner, review trigger, and maintained source"
+            )
             findings.append(
                 Finding(
                     "docs/ROADMAP.md",
                     1,
                     rule,
-                    "roadmap must document its owner, review trigger, and maintained source",
+                    message,
                 )
             )
     return findings

--- a/tests/unit/docs/test_roadmap_cadence.py
+++ b/tests/unit/docs/test_roadmap_cadence.py
@@ -1,101 +1,14 @@
-"""Regression test: ROADMAP.md must define an explicit iteration cadence.
+"""Integration coverage for the roadmap maintenance contract."""
 
-Issue #1493 (S10 Planning, MODULARITY): the roadmap previously said it was
-"reviewed and updated at the end of each release cycle (typically monthly)"
-without defining the trigger, whether releases are date- or feature-driven,
-or who owns the review. This guard fails if that section regresses to vague
-prose. It asserts the HARD invariant (required phrases are present), never an
-unverifiable cadence value like "monthly".
-"""
+from __future__ import annotations
 
-import datetime
-import re
 from pathlib import Path
 
+from hephaestus.validation.doc_maintenance import validate_roadmap_maintenance
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
-ROADMAP_MD = REPO_ROOT / "docs" / "ROADMAP.md"
-
-_SECTION_RE = re.compile(
-    r"^##\s+Updating This Roadmap\s*$(.*?)(?=^##\s|\Z)",
-    re.MULTILINE | re.DOTALL,
-)
-
-_CURRENT_FOCUS_RE = re.compile(r"^##\s+Current Focus \(Q([1-4]) (\d{4})\)\s*$", re.MULTILINE)
-_LAST_UPDATED_RE = re.compile(r"^Last updated: (\d{4}-\d{2}-\d{2})\s*$", re.MULTILINE)
 
 
-def _updating_section() -> str:
-    text = ROADMAP_MD.read_text(encoding="utf-8")
-    match = _SECTION_RE.search(text)
-    assert match is not None, (
-        "ROADMAP.md no longer has an '## Updating This Roadmap' section; "
-        "restore it or update this test's heading regex."
-    )
-    return match.group(1)
-
-
-def test_cadence_is_release_driven_not_vague_monthly() -> None:
-    """Fail if the roadmap's cadence section lacks the explicit trigger/driver/owner."""
-    # Collapse whitespace so phrase checks are robust to line wrapping in the
-    # source markdown (e.g. "auto tag\nrelease" wraps across two lines).
-    section = re.sub(r"\s+", " ", _updating_section().lower())
-    # The vague phrasing this issue removed must not come back.
-    assert "typically monthly" not in section, (
-        "ROADMAP.md reverted to the vague 'typically monthly' cadence "
-        "(issue #1493); state the release-driven trigger explicitly instead."
-    )
-    # Trigger: tied to the Auto Tag Release pipeline, not a calendar.
-    assert "auto tag release" in section, (
-        "The cadence section must reference the 'Auto Tag Release' workflow "
-        "as the release-cycle trigger (see docs/RELEASING.md)."
-    )
-    # Driver: explicitly feature/fix-driven, not date-driven.
-    assert "not date-driven" in section, (
-        "The cadence section must state releases are feature/fix-driven, not date-driven."
-    )
-    # Responsible party must be named.
-    assert "maintainer" in section, (
-        "The cadence section must name who is responsible for the review "
-        "(the maintainer cutting the release)."
-    )
-
-
-def _stated_period() -> tuple[int, int]:
-    """Return (year, quarter) parsed from the Current Focus heading, failing loud."""
-    text = ROADMAP_MD.read_text(encoding="utf-8")
-    match = _CURRENT_FOCUS_RE.search(text)
-    assert match is not None, (
-        "ROADMAP.md must have a '## Current Focus (Q<n> <year>)' heading so the "
-        "current-period guard can parse it (issue #2158); restore the heading "
-        "or update _CURRENT_FOCUS_RE."
-    )
-    return int(match.group(2)), int(match.group(1))
-
-
-def test_current_focus_period_has_not_ended() -> None:
-    """Fail once the quarter named in 'Current Focus' is in the past (issue #2158)."""
-    today = datetime.date.today()
-    current = (today.year, (today.month - 1) // 3 + 1)
-    stated = _stated_period()
-    assert stated >= current, (
-        f"ROADMAP.md 'Current Focus' still names Q{stated[1]} {stated[0]}, but the "
-        f"current period is Q{current[1]} {current[0]}. Refresh the Current Focus "
-        "section per '## Updating This Roadmap' and bump the 'Last updated' line."
-    )
-
-
-def test_last_updated_not_before_stated_quarter() -> None:
-    """Fail if 'Last updated' predates the stated quarter (half-refreshed roadmap)."""
-    text = ROADMAP_MD.read_text(encoding="utf-8")
-    match = _LAST_UPDATED_RE.search(text)
-    assert match is not None, (
-        "ROADMAP.md must end with a 'Last updated: YYYY-MM-DD' line; restore it "
-        "or update _LAST_UPDATED_RE."
-    )
-    last_updated = datetime.date.fromisoformat(match.group(1))
-    year, quarter = _stated_period()
-    quarter_start = datetime.date(year, 3 * quarter - 2, 1)
-    assert last_updated >= quarter_start, (
-        f"ROADMAP.md says Current Focus is Q{quarter} {year} but 'Last updated' is "
-        f"{last_updated}, before that quarter began ({quarter_start}); refresh both together."
-    )
+def test_repository_roadmap_satisfies_maintenance_contract() -> None:
+    """The checked-in roadmap has an owner, trigger, source, and fresh period."""
+    assert validate_roadmap_maintenance(REPO_ROOT) == []

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -140,3 +140,13 @@ def test_doc_is_linked_from_index() -> None:
     """The inventory must be discoverable from the docs index."""
     text = INDEX.read_text(encoding="utf-8")
     assert "third-party-services.md" in text
+
+
+def test_renovate_inventory_matches_tracked_configuration() -> None:
+    """The inventory must change when Renovate configuration is introduced."""
+    row = next(row for row in _inventory_table_rows()[1:] if "Renovate" in row[0])
+    has_configuration = any(
+        (REPO_ROOT / name).is_file() for name in ("renovate.json", "renovate.json5", ".renovaterc")
+    )
+
+    assert ("no `renovate.json` is tracked" in " ".join(row)) is not has_configuration

--- a/tests/unit/validation/test_doc_maintenance.py
+++ b/tests/unit/validation/test_doc_maintenance.py
@@ -1,0 +1,171 @@
+"""Tests for the normative documentation maintenance validator."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from hephaestus.validation.doc_maintenance import (
+    SourceContract,
+    discover_normative_markdown,
+    main,
+    validate_documentation,
+    validate_roadmap_maintenance,
+    validate_source_contracts,
+    validate_volatile_claims,
+)
+
+
+def test_specs_are_normative_and_test_fixtures_are_excluded(tmp_path: Path) -> None:
+    """Nested specifications are scanned while nested fixtures are ignored."""
+    spec = tmp_path / "docs" / "specs" / "nested" / "design.md"
+    fixture = tmp_path / "tests" / "fixtures" / "docs" / "example.md"
+    spec.parent.mkdir(parents=True)
+    fixture.parent.mkdir(parents=True)
+    spec.write_text("# Design\nCurrently inactive.\n", encoding="utf-8")
+    fixture.write_text("# Fixture\nCurrently inactive.\n", encoding="utf-8")
+
+    discovered = {
+        path.relative_to(tmp_path).as_posix() for path in discover_normative_markdown(tmp_path)
+    }
+
+    assert "docs/specs/nested/design.md" in discovered
+    assert "tests/fixtures/docs/example.md" not in discovered
+    assert any(
+        finding.file == "docs/specs/nested/design.md"
+        for finding in validate_documentation(tmp_path)
+    )
+
+
+def test_historical_adr_and_release_note_bodies_are_excluded(tmp_path: Path) -> None:
+    """Accepted records may retain point-in-time claims without being living docs."""
+    accepted_adr = tmp_path / "docs" / "adr" / "0001-example.md"
+    adr_index = tmp_path / "docs" / "adr" / "README.md"
+    release_note = tmp_path / "docs" / "release-notes" / "v1.md"
+    release_index = tmp_path / "docs" / "release-notes" / "README.md"
+    release_index_alias = tmp_path / "docs" / "release-notes" / "index.md"
+    for path in (accepted_adr, adr_index, release_note, release_index, release_index_alias):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# Record\nAs of 2026-01-01, issue #12 was closed.\n", encoding="utf-8")
+
+    discovered = {
+        path.relative_to(tmp_path).as_posix() for path in discover_normative_markdown(tmp_path)
+    }
+
+    assert "docs/adr/0001-example.md" not in discovered
+    assert "docs/release-notes/v1.md" not in discovered
+    assert "docs/adr/README.md" in discovered
+    assert "docs/release-notes/README.md" in discovered
+    assert "docs/release-notes/index.md" in discovered
+
+
+def test_volatile_claims_inside_fenced_examples_are_ignored(tmp_path: Path) -> None:
+    """Examples can demonstrate stale prose without becoming normative claims."""
+    document = tmp_path / "docs" / "example.md"
+    document.parent.mkdir()
+    document.write_text(
+        "# Example\n\n"
+        "```text\n"
+        "The repository has 21 packages as of 2026-01-01.\n"
+        "Currently inactive.\n"
+        "```\n\n"
+        "The repository has 21 packages as of 2026-01-01.\n",
+        encoding="utf-8",
+    )
+
+    findings = validate_volatile_claims(document, tmp_path)
+
+    assert len(findings) == 2
+    assert all(finding.line == 8 for finding in findings)
+
+
+def test_source_contracts_validate_local_links_and_semantic_selectors(tmp_path: Path) -> None:
+    """A cited source must exist, be linked, and contain its selected symbol."""
+    source = tmp_path / "src" / "routing.py"
+    document = tmp_path / "docs" / "architecture.md"
+    source.parent.mkdir(parents=True)
+    document.parent.mkdir(parents=True)
+    source.write_text("ROUTES = {'start': 'finish'}\n", encoding="utf-8")
+    document.write_text("See [ROUTES](../src/routing.py).\n", encoding="utf-8")
+    contract = SourceContract(
+        document="docs/architecture.md",
+        source="src/routing.py",
+        selector="ROUTES",
+    )
+
+    assert validate_source_contracts(tmp_path, contracts=(contract,)) == []
+
+    source.write_text("OTHER = {}\n", encoding="utf-8")
+    document.write_text("See [ROUTES](../src/missing.py).\n", encoding="utf-8")
+    findings = validate_source_contracts(tmp_path, contracts=(contract,))
+    assert {finding.rule for finding in findings} == {"source-link", "source-selector"}
+
+
+def test_roadmap_freshness_uses_injected_today(tmp_path: Path) -> None:
+    """Roadmap freshness is deterministic and does not depend on wall-clock time."""
+    roadmap = tmp_path / "docs" / "ROADMAP.md"
+    roadmap.parent.mkdir(parents=True)
+    roadmap.write_text(
+        "# Roadmap\n\n"
+        "## Current Focus (Q3 2026)\n\nFocus from open epics.\n\n"
+        "## Updating This Roadmap\n\n"
+        "**Trigger:** release. **Responsibility:** maintainer.\n"
+        "Source: [RELEASING.md](RELEASING.md).\n\n"
+        "Last updated: 2026-07-20\n",
+        encoding="utf-8",
+    )
+
+    findings = validate_roadmap_maintenance(tmp_path, today=date(2026, 10, 1))
+
+    assert any(finding.rule == "stale-current-focus" for finding in findings)
+
+
+@pytest.mark.parametrize(
+    ("content", "rule"),
+    [
+        ("## Current Focus (Q3 2026)\n\nLast updated: 2026-06-30\n", "last-updated-before-focus"),
+        ("## Current Focus (Q3 2026)\n\nLast updated: 2026-08-01\n", "roadmap-ownership"),
+    ],
+)
+def test_roadmap_contract_reports_deterministic_boundary_errors(
+    tmp_path: Path, content: str, rule: str
+) -> None:
+    """Malformed roadmap metadata produces named findings rather than exceptions."""
+    roadmap = tmp_path / "docs" / "ROADMAP.md"
+    roadmap.parent.mkdir(parents=True)
+    roadmap.write_text(content, encoding="utf-8")
+
+    findings = validate_roadmap_maintenance(tmp_path, today=date(2026, 8, 3))
+
+    assert any(finding.rule == rule for finding in findings)
+
+
+def test_json_output_is_machine_readable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The validator's CLI emits structured findings when requested."""
+    document = tmp_path / "README.md"
+    document.write_text("The repository has 21 packages as of 2026-01-01.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["doc-maintenance", "--repo-root", str(tmp_path), "--json"],
+    )
+
+    assert main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is False
+    assert payload["findings"][0]["rule"] in {"dated-state", "snapshot-metric"}
+
+
+def test_current_repository_satisfies_documentation_contract() -> None:
+    """The checked-in normative documentation has no maintenance findings."""
+    repo_root = Path(__file__).resolve().parents[3]
+
+    assert validate_documentation(repo_root) == []

--- a/tests/unit/validation/test_doc_maintenance.py
+++ b/tests/unit/validation/test_doc_maintenance.py
@@ -44,19 +44,34 @@ def test_specs_are_normative_and_test_fixtures_are_excluded(tmp_path: Path) -> N
 def test_historical_adr_and_release_note_bodies_are_excluded(tmp_path: Path) -> None:
     """Accepted records may retain point-in-time claims without being living docs."""
     accepted_adr = tmp_path / "docs" / "adr" / "0001-example.md"
+    proposed_adr = tmp_path / "docs" / "adr" / "0002-proposed.md"
+    draft_adr = tmp_path / "docs" / "adr" / "0003-draft.md"
     adr_index = tmp_path / "docs" / "adr" / "README.md"
     release_note = tmp_path / "docs" / "release-notes" / "v1.md"
     release_index = tmp_path / "docs" / "release-notes" / "README.md"
     release_index_alias = tmp_path / "docs" / "release-notes" / "index.md"
-    for path in (accepted_adr, adr_index, release_note, release_index, release_index_alias):
+    for path in (adr_index, release_note, release_index, release_index_alias):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("# Record\nAs of 2026-01-01, issue #12 was closed.\n", encoding="utf-8")
+    accepted_adr.parent.mkdir(parents=True, exist_ok=True)
+    accepted_adr.write_text(
+        "# Accepted ADR\n\n- Status: Accepted\n\nAs of 2026-01-01, issue #12 was closed.\n",
+        encoding="utf-8",
+    )
+    proposed_adr.write_text(
+        "# Proposed ADR\n\n- Status: Proposed\n\nCurrently inactive.\n", encoding="utf-8"
+    )
+    draft_adr.write_text(
+        "# Draft ADR\n\n- Status: Draft\n\nCurrently inactive.\n", encoding="utf-8"
+    )
 
     discovered = {
         path.relative_to(tmp_path).as_posix() for path in discover_normative_markdown(tmp_path)
     }
 
     assert "docs/adr/0001-example.md" not in discovered
+    assert "docs/adr/0002-proposed.md" in discovered
+    assert "docs/adr/0003-draft.md" in discovered
     assert "docs/release-notes/v1.md" not in discovered
     assert "docs/adr/README.md" in discovered
     assert "docs/release-notes/README.md" in discovered
@@ -142,6 +157,25 @@ def test_roadmap_contract_reports_deterministic_boundary_errors(
     findings = validate_roadmap_maintenance(tmp_path, today=date(2026, 8, 3))
 
     assert any(finding.rule == rule for finding in findings)
+
+
+def test_roadmap_cadence_is_validated_inside_update_section(tmp_path: Path) -> None:
+    """Unrelated roadmap prose cannot satisfy the release-driven cadence guard."""
+    roadmap = tmp_path / "docs" / "ROADMAP.md"
+    roadmap.parent.mkdir(parents=True)
+    roadmap.write_text(
+        "# Roadmap\n\n"
+        "## Current Focus (Q3 2026)\n\n"
+        "The release-driven plan references Auto Tag Release and is not date-driven.\n\n"
+        "## Notes\n\nTrigger and maintainer references may appear elsewhere.\n\n"
+        "## Updating This Roadmap\n\nTypically monthly, when convenient.\n\n"
+        "Last updated: 2026-07-20\n",
+        encoding="utf-8",
+    )
+
+    findings = validate_roadmap_maintenance(tmp_path, today=date(2026, 8, 3))
+
+    assert any(finding.rule == "roadmap-cadence" for finding in findings)
 
 
 def test_json_output_is_machine_readable(

--- a/tests/unit/validation/test_markdown.py
+++ b/tests/unit/validation/test_markdown.py
@@ -99,11 +99,8 @@ class TestValidateLinksMain:
             ],
         )
         rc = main()
-        # Even if validate_all_links returns no broken links, the test must not
-        # depend on the validator's intra-file traversal — assert the exit
-        # code only.
-        assert rc in (0, 1), "main() must return an int exit code"
-        capsys.readouterr()  # drain output
+        assert rc == 0
+        capsys.readouterr()
 
     def test_main_json_output_emits_valid_json(
         self,

--- a/tests/unit/validation/test_validation_parser_usage.py
+++ b/tests/unit/validation/test_validation_parser_usage.py
@@ -10,6 +10,7 @@ VALIDATION_MODULES = {
     "complexity.py": 1,
     "coverage.py": 1,
     "doc_config.py": 1,
+    "doc_maintenance.py": 1,
     "doc_policy.py": 1,
     "docstrings.py": 1,
     "markdown.py": 2,


### PR DESCRIPTION
## Summary

- Added a recursive normative-documentation validator with source, ownership, roadmap, and volatile-claim checks.
- Added the documentation maintenance policy and pre-commit hook.
- Removed stale metrics, dates, and issue-state claims and repaired affected documentation.
- Added comprehensive tests.

## Testing

- `uv run pytest tests -q --tb=short`
- Pre-commit, Ruff, and mypy

Closes #2137
