### PR TITLE
test(contract): add authenticated external GitHub and agent end-to-end coverage

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,7 @@
 | auto-label-needs-plan.yml | Applies `state:needs-plan` to opened or reopened issues and exposes the reusable issue-label workflow. | workflow_call, issues opened/reopened |
 | auto-label-severity.yml | Reconciles `severity:*` labels from issue form content. | issues opened/edited |
 | auto-tag.yml | Manually computes and pushes the next signed release tag. | workflow_dispatch |
+| contract.yml | Opt-in authenticated GitHub and agent contract tests. | workflow_dispatch |
 | merge-queue-smoke.yml | Single fast `merge-queue-smoke` job for merge-queue entries (lockfile, workflow-schema, and symlink validation). | merge_group |
 | nightly-tests.yml | Runs the high-cost functional tests excluded from pull-request checks. | schedule, workflow_dispatch |
 | performance.yml | Runs bounded worker-pool capacity, latency, and sustained-concurrency tests and retains the JSON report. | schedule, workflow_dispatch |

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,39 @@
+name: Contract Tests (opt-in)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  github-contract:
+    name: GitHub contract lane
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install locked project environment
+        run: uv sync --all-groups --all-extras --locked
+
+      - name: Run contract lane (agent tests self-skip without the second opt-in)
+        env:
+          HEPHAESTUS_CONTRACT_TESTS: "1"
+          GH_TOKEN: ${{ github.token }}
+          HEPHAESTUS_CONTRACT_REPO: ${{ github.repository }}
+        run: uv run pytest tests/integration/contract --override-ini="addopts=" -v --strict-markers

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -1,0 +1,53 @@
+# Contract Testing
+
+The contract lane exercises the real external command-line boundaries used by
+the automation layer:
+
+- `hephaestus.github.client.gh_call` for authenticated, read-only GitHub calls.
+- `hephaestus.automation.claude_invoke.invoke_claude_with_session` for a real
+  Claude session create-and-resume flow.
+
+The lane is opt-in and skipped by normal unit, integration, and required CI
+runs. Run the GitHub contract checks with:
+
+```bash
+HEPHAESTUS_CONTRACT_TESTS=1 just test-contract
+```
+
+The `just` recipe sets `HEPHAESTUS_CONTRACT_TESTS=1` itself, so the shorter
+form is normally sufficient:
+
+```bash
+just test-contract
+```
+
+The agent check spends model tokens and requires a separate opt-in:
+
+```bash
+HEPHAESTUS_CONTRACT_TESTS=1 HEPHAESTUS_CONTRACT_AGENT=1 \
+  uv run pytest tests/integration/contract/test_agent_contract.py \
+  --override-ini="addopts=" -v --strict-markers
+```
+
+Environment variables:
+
+- `HEPHAESTUS_CONTRACT_TESTS=1` enables collection of the contract marker.
+- `HEPHAESTUS_CONTRACT_AGENT=1` enables the real Claude invocation test.
+- `HEPHAESTUS_CONTRACT_REPO=OWNER/REPOSITORY` pins GitHub calls to a target
+  repository. If omitted, the repository is resolved once from the checkout
+  root with an explicit working directory.
+- `HEPHAESTUS_CONTRACT_MODEL` selects the Claude model for the agent lane; the
+  default is `haiku`.
+
+The GitHub lane only calls read endpoints (`rate_limit`, `repo view`, and
+`issue list`) through `gh_call`. Its negative case confirms a missing endpoint
+fails promptly without retrying a deterministic 404. The agent lane uses
+pytest's `tmp_path` as its working directory and a trivial prompt. The default
+model is intentionally inexpensive. Both lanes first require the corresponding
+CLI to be installed and authenticated; missing credentials produce skips, not
+failures.
+
+The repository also provides a manual-only `.github/workflows/contract.yml`
+workflow. It supplies the workflow's read-only GitHub token and pins the target
+repository to `github.repository`. The agent lane remains skipped there unless
+the second token-cost opt-in is added deliberately.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ See the [README](../README.md) for installation and development setup instructio
 - [Observability: metrics, alerts, and SLOs](observability.md) — Automation pipeline metric catalog, alert ownership, and SLOs
 - [Operations Runbooks](runbooks/index.md) — Operator recovery procedures for the automation pipeline (loop crash, corrupted worktree, drive-green stall, quota exhaustion)
 - [Performance Testing](performance-testing.md) — Bounded worker-pool load, capacity, latency, and sustained-concurrency testing
+- [Contract Testing](contract-testing.md) — Opt-in authenticated GitHub and agent end-to-end contract coverage
 - [Privacy, Retention, and Deletion Policy](../PRIVACY.md) — data inventory, retention periods, deletion procedures, and GDPR contact (issue #2175)
 - [Third-Party Services](third-party-services.md) — Vendor inventory, responsibility split, and availability expectations for GitHub, PyPI, and agent providers (issue #2177)
 

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -208,7 +208,8 @@ def invoke_claude_with_session(
             budget is assumed (#1415).
         system_prompt_file: Optional ``--system-prompt`` file.
         allowed_tools: Optional ``--allowedTools`` value (e.g.
-            ``"Read,Glob,Grep"``).
+            ``"Read,Glob,Grep"``). Pass an empty string to explicitly disable
+            all tools; only ``None`` omits the CLI flag.
         permission_mode: Optional ``--permission-mode`` value.
         extra_args: Any additional flags.
         output_format: ``--output-format`` (``"text"``, ``"json"``, or
@@ -314,7 +315,7 @@ def _invoke_claude_once(
     ]
     if system_prompt_file is not None and system_prompt_file.exists():
         cmd += ["--system-prompt", str(system_prompt_file)]
-    if allowed_tools:
+    if allowed_tools is not None:
         cmd += ["--allowedTools", allowed_tools]
     if permission_mode:
         cmd += ["--permission-mode", permission_mode]

--- a/justfile
+++ b/justfile
@@ -33,6 +33,10 @@ test-unit:
 test-integration:
     uv run pytest {{ integration_test_dir }}
 
+# Run the opt-in external contract lane (the agent lane needs a second opt-in).
+test-contract:
+    HEPHAESTUS_CONTRACT_TESTS=1 uv run pytest tests/integration/contract --override-ini="addopts=" -v --strict-markers
+
 # Run BATS shell tests (recursive under tests/shell)
 test-shell:
     bats --recursive tests/shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ markers = [
     "performance: bounded capacity, latency, and sustained-concurrency tests",
     "nightly: high-cost functional tests run by the scheduled nightly workflow",
     "requires_posix: requires POSIX coreutils (echo, false, ls) and/or git on PATH; skipped on win32",
+    "contract: opt-in sandboxed contract tests against real gh/claude CLIs; skipped unless HEPHAESTUS_CONTRACT_TESTS=1",
 ]
 
 [tool.mypy]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,24 @@
 
 import contextlib
 import json
+import os
 
 import pytest
 import yaml
+
+CONTRACT_OPT_IN_ENV = "HEPHAESTUS_CONTRACT_TESTS"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip contract-marked tests unless the opt-in environment is enabled."""
+    del config
+    if os.environ.get(CONTRACT_OPT_IN_ENV) == "1":
+        return
+
+    skip = pytest.mark.skip(reason=f"contract lane is opt-in; set {CONTRACT_OPT_IN_ENV}=1 to run")
+    for item in items:
+        if item.get_closest_marker("contract"):
+            item.add_marker(skip)
 
 
 @pytest.fixture(autouse=True)
@@ -35,6 +50,8 @@ def _agents_authenticated_by_default(
     (last-writer-wins).
     """
     if request.module.__name__.endswith("agents.test_runtime"):
+        return
+    if request.node.get_closest_marker("contract"):
         return
     monkeypatch.setattr(
         "hephaestus.agents.runtime.is_agent_authenticated",

--- a/tests/integration/contract/__init__.py
+++ b/tests/integration/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in authenticated external contract tests."""

--- a/tests/integration/contract/conftest.py
+++ b/tests/integration/contract/conftest.py
@@ -1,0 +1,59 @@
+"""Preflight fixtures for the opt-in contract lane (issue #2146).
+
+Lane gating (``HEPHAESTUS_CONTRACT_TESTS``) lives in ``tests/conftest.py``;
+these fixtures skip individual tests whose external prerequisite is absent.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hephaestus.utils.helpers import run_subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="session")
+def gh_authenticated() -> None:
+    """Skip unless a real, authenticated ``gh`` CLI is available."""
+    try:
+        result = run_subprocess(
+            ["gh", "auth", "status"],
+            check=False,
+            timeout=30,
+            log_on_error=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("gh CLI not installed")
+    if result.returncode != 0:
+        pytest.skip("gh CLI is not authenticated (gh auth status failed)")
+
+
+@pytest.fixture(scope="session")
+def contract_repo(gh_authenticated: None) -> str:
+    """Return the explicitly selected repository slug for contract calls.
+
+    ``HEPHAESTUS_CONTRACT_REPO`` takes precedence. Otherwise the repository is
+    resolved once from the checked-out root with an explicit ``cwd`` so the
+    lane cannot target an ambient working directory's repository.
+    """
+    slug = os.environ.get("HEPHAESTUS_CONTRACT_REPO", "").strip()
+    if slug:
+        return slug
+
+    result = run_subprocess(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        cwd=str(REPO_ROOT),
+        timeout=60,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def agent_lane_enabled() -> None:
+    """Skip the token-costly agent lane unless explicitly enabled."""
+    if os.environ.get("HEPHAESTUS_CONTRACT_AGENT") != "1":
+        pytest.skip("agent contract lane spends model tokens; set HEPHAESTUS_CONTRACT_AGENT=1")

--- a/tests/integration/contract/test_agent_contract.py
+++ b/tests/integration/contract/test_agent_contract.py
@@ -1,0 +1,46 @@
+"""Claude agent end-to-end contract tests (opt-in; spends tokens)."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+from hephaestus.agents.runtime import is_agent_authenticated
+from hephaestus.automation.claude_invoke import invoke_claude_with_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.contract]
+
+CONTRACT_MODEL = os.environ.get("HEPHAESTUS_CONTRACT_MODEL", "haiku")
+
+
+def test_invoke_and_resume_session(agent_lane_enabled: None, tmp_path: Path) -> None:
+    """Create a real session and then resume its deterministic lineage."""
+    if not is_agent_authenticated("claude"):
+        pytest.skip("claude CLI not installed/authenticated")
+
+    issue = f"contract-{uuid.uuid4().hex[:8]}"
+    stdout1, session1 = invoke_claude_with_session(
+        repo="hephaestus-contract",
+        issue=issue,
+        agent="contract-probe",
+        prompt="Reply with exactly the word OK and nothing else.",
+        model=CONTRACT_MODEL,
+        cwd=tmp_path,
+        timeout=300,
+    )
+    assert "OK" in stdout1
+
+    stdout2, session2 = invoke_claude_with_session(
+        repo="hephaestus-contract",
+        issue=issue,
+        agent="contract-probe",
+        prompt="Reply with exactly the word RESUMED and nothing else.",
+        model=CONTRACT_MODEL,
+        cwd=tmp_path,
+        timeout=300,
+    )
+    assert session2 == session1
+    assert "RESUMED" in stdout2

--- a/tests/integration/contract/test_agent_contract.py
+++ b/tests/integration/contract/test_agent_contract.py
@@ -10,6 +10,7 @@ import pytest
 
 from hephaestus.agents.runtime import is_agent_authenticated
 from hephaestus.automation.claude_invoke import invoke_claude_with_session
+from hephaestus.automation.session_naming import AGENT_ADVISE
 
 pytestmark = [pytest.mark.integration, pytest.mark.contract]
 
@@ -25,22 +26,26 @@ def test_invoke_and_resume_session(agent_lane_enabled: None, tmp_path: Path) -> 
     stdout1, session1 = invoke_claude_with_session(
         repo="hephaestus-contract",
         issue=issue,
-        agent="contract-probe",
+        agent=AGENT_ADVISE,
         prompt="Reply with exactly the word OK and nothing else.",
         model=CONTRACT_MODEL,
         cwd=tmp_path,
         timeout=300,
+        allowed_tools="",
+        permission_mode="dontAsk",
     )
     assert "OK" in stdout1
 
     stdout2, session2 = invoke_claude_with_session(
         repo="hephaestus-contract",
         issue=issue,
-        agent="contract-probe",
+        agent=AGENT_ADVISE,
         prompt="Reply with exactly the word RESUMED and nothing else.",
         model=CONTRACT_MODEL,
         cwd=tmp_path,
         timeout=300,
+        allowed_tools="",
+        permission_mode="dontAsk",
     )
     assert session2 == session1
     assert "RESUMED" in stdout2

--- a/tests/integration/contract/test_github_contract.py
+++ b/tests/integration/contract/test_github_contract.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
+import shlex
+import shutil
 import subprocess
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -53,29 +57,34 @@ def test_issue_list_json_fields(contract_repo: str) -> None:
         assert {"number", "title", "labels"} <= issues[0].keys()
 
 
-def test_missing_endpoint_raises_promptly(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_endpoint_raises_promptly(
+    gh_authenticated: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """A deterministic 404 bypasses the retry budget after one CLI attempt."""
-    calls: list[list[str]] = []
     endpoint = f"repos/missing-{uuid.uuid4().hex[:12]}"
+    real_gh = shutil.which("gh")
+    assert real_gh is not None
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    invocation_log = tmp_path / "gh-invocations"
+    wrapper = wrapper_dir / "gh"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' call >> {shlex.quote(str(invocation_log))}\n"
+        f'exec {shlex.quote(real_gh)} "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{wrapper_dir}{os.pathsep}{os.environ['PATH']}")
 
-    def missing_endpoint(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append(command)
-        raise subprocess.CalledProcessError(
-            1,
-            command,
-            output="",
-            stderr="gh: Not Found (HTTP 404)",
-        )
-
-    # Keep this regression assertion local: a generated real endpoint makes the
-    # outcome depend on GitHub, while this seam verifies gh_call's retry contract.
     github_client._GH_BREAKER.reset()
-    monkeypatch.setattr(github_client, "run_subprocess", missing_endpoint)
     try:
         with pytest.raises(subprocess.CalledProcessError) as excinfo:
             gh_call(["api", endpoint], max_retries=3)
     finally:
         github_client._GH_BREAKER.reset()
 
-    assert excinfo.value.stderr == "gh: Not Found (HTTP 404)"
-    assert calls == [["gh", "api", endpoint]]
+    assert excinfo.value.stderr.strip() == "gh: Not Found (HTTP 404)"
+    assert invocation_log.read_text(encoding="utf-8").splitlines() == ["call"]

--- a/tests/integration/contract/test_github_contract.py
+++ b/tests/integration/contract/test_github_contract.py
@@ -13,14 +13,13 @@ from pathlib import Path
 import pytest
 
 import hephaestus.github.client as github_client
-from hephaestus.github.client import gh_call
 
 pytestmark = [pytest.mark.integration, pytest.mark.contract]
 
 
 def test_rate_limit_envelope(gh_authenticated: None) -> None:
     """``gh api rate_limit`` returns the envelope consumed by the client."""
-    result = gh_call(["api", "rate_limit"])
+    result = github_client.gh_call(["api", "rate_limit"])
     payload = json.loads(result.stdout)
     core = payload["resources"]["core"]
     assert core["limit"] > 0
@@ -29,7 +28,9 @@ def test_rate_limit_envelope(gh_authenticated: None) -> None:
 
 def test_repo_view_json_fields(contract_repo: str) -> None:
     """``gh repo view --json`` serves the fields automation queries."""
-    result = gh_call(["repo", "view", contract_repo, "--json", "nameWithOwner,defaultBranchRef"])
+    result = github_client.gh_call(
+        ["repo", "view", contract_repo, "--json", "nameWithOwner,defaultBranchRef"]
+    )
     payload = json.loads(result.stdout)
     assert payload["nameWithOwner"].lower() == contract_repo.lower()
     assert payload["defaultBranchRef"]["name"]
@@ -37,7 +38,7 @@ def test_repo_view_json_fields(contract_repo: str) -> None:
 
 def test_issue_list_json_fields(contract_repo: str) -> None:
     """``gh issue list --json`` exposes the pipeline's parsed fields."""
-    result = gh_call(
+    result = github_client.gh_call(
         [
             "issue",
             "list",
@@ -72,8 +73,10 @@ def test_missing_endpoint_raises_promptly(
     wrapper = wrapper_dir / "gh"
     wrapper.write_text(
         "#!/bin/sh\n"
-        f"printf '%s\\n' call >> {shlex.quote(str(invocation_log))}\n"
-        f'exec {shlex.quote(real_gh)} "$@"\n',
+        f'{shlex.quote(real_gh)} "$@"\n'
+        "status=$?\n"
+        f"printf '%s\\n' delegated >> {shlex.quote(str(invocation_log))}\n"
+        'exit "$status"\n',
         encoding="utf-8",
     )
     wrapper.chmod(0o755)
@@ -82,9 +85,9 @@ def test_missing_endpoint_raises_promptly(
     github_client._GH_BREAKER.reset()
     try:
         with pytest.raises(subprocess.CalledProcessError) as excinfo:
-            gh_call(["api", endpoint], max_retries=3)
+            github_client.gh_call(["api", endpoint], max_retries=3)
     finally:
         github_client._GH_BREAKER.reset()
 
     assert excinfo.value.stderr.strip() == "gh: Not Found (HTTP 404)"
-    assert invocation_log.read_text(encoding="utf-8").splitlines() == ["call"]
+    assert invocation_log.read_text(encoding="utf-8").splitlines() == ["delegated"]

--- a/tests/integration/contract/test_github_contract.py
+++ b/tests/integration/contract/test_github_contract.py
@@ -1,0 +1,60 @@
+"""Authenticated GitHub contract tests (opt-in; see docs/contract-testing.md)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import uuid
+
+import pytest
+
+from hephaestus.github.client import gh_call
+
+pytestmark = [pytest.mark.integration, pytest.mark.contract]
+
+
+def test_rate_limit_envelope(gh_authenticated: None) -> None:
+    """``gh api rate_limit`` returns the envelope consumed by the client."""
+    result = gh_call(["api", "rate_limit"])
+    payload = json.loads(result.stdout)
+    core = payload["resources"]["core"]
+    assert core["limit"] > 0
+    assert {"remaining", "reset"} <= core.keys()
+
+
+def test_repo_view_json_fields(contract_repo: str) -> None:
+    """``gh repo view --json`` serves the fields automation queries."""
+    result = gh_call(["repo", "view", contract_repo, "--json", "nameWithOwner,defaultBranchRef"])
+    payload = json.loads(result.stdout)
+    assert payload["nameWithOwner"].lower() == contract_repo.lower()
+    assert payload["defaultBranchRef"]["name"]
+
+
+def test_issue_list_json_fields(contract_repo: str) -> None:
+    """``gh issue list --json`` exposes the pipeline's parsed fields."""
+    result = gh_call(
+        [
+            "issue",
+            "list",
+            "-R",
+            contract_repo,
+            "--limit",
+            "1",
+            "--json",
+            "number,title,labels",
+            "--state",
+            "all",
+        ]
+    )
+    issues = json.loads(result.stdout)
+    assert isinstance(issues, list)
+    if issues:
+        assert {"number", "title", "labels"} <= issues[0].keys()
+
+
+def test_missing_endpoint_raises_promptly(contract_repo: str) -> None:
+    """A 404 is non-transient and does not trigger a retry storm."""
+    bogus = f"repos/{contract_repo}/definitely-missing-{uuid.uuid4().hex[:12]}"
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        gh_call(["api", bogus], max_retries=1)
+    assert "404" in (excinfo.value.stderr or "")

--- a/tests/integration/contract/test_github_contract.py
+++ b/tests/integration/contract/test_github_contract.py
@@ -8,6 +8,7 @@ import uuid
 
 import pytest
 
+import hephaestus.github.client as github_client
 from hephaestus.github.client import gh_call
 
 pytestmark = [pytest.mark.integration, pytest.mark.contract]
@@ -52,9 +53,29 @@ def test_issue_list_json_fields(contract_repo: str) -> None:
         assert {"number", "title", "labels"} <= issues[0].keys()
 
 
-def test_missing_endpoint_raises_promptly(contract_repo: str) -> None:
-    """A 404 is non-transient and does not trigger a retry storm."""
-    bogus = f"repos/{contract_repo}/definitely-missing-{uuid.uuid4().hex[:12]}"
-    with pytest.raises(subprocess.CalledProcessError) as excinfo:
-        gh_call(["api", bogus], max_retries=1)
-    assert "404" in (excinfo.value.stderr or "")
+def test_missing_endpoint_raises_promptly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deterministic 404 bypasses the retry budget after one CLI attempt."""
+    calls: list[list[str]] = []
+    endpoint = f"repos/missing-{uuid.uuid4().hex[:12]}"
+
+    def missing_endpoint(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            output="",
+            stderr="gh: Not Found (HTTP 404)",
+        )
+
+    # Keep this regression assertion local: a generated real endpoint makes the
+    # outcome depend on GitHub, while this seam verifies gh_call's retry contract.
+    github_client._GH_BREAKER.reset()
+    monkeypatch.setattr(github_client, "run_subprocess", missing_endpoint)
+    try:
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            gh_call(["api", endpoint], max_retries=3)
+    finally:
+        github_client._GH_BREAKER.reset()
+
+    assert excinfo.value.stderr == "gh: Not Found (HTTP 404)"
+    assert calls == [["gh", "api", endpoint]]

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -237,6 +237,29 @@ class TestArgvAssembly:
         assert argv[-2] == "--print"
         assert argv[-1] == "hi"
 
+    def test_empty_allowed_tools_is_forwarded_as_zero_tool_scope(
+        self, stub_run: MagicMock, fake_home: Path
+    ) -> None:
+        """An explicit empty scope reaches Claude instead of restoring CLI defaults."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+
+        invoke_claude_with_session(
+            repo="R",
+            issue=1,
+            agent=AGENT_PLANNER,
+            prompt="hi",
+            model="sonnet",
+            cwd=cwd,
+            allowed_tools="",
+            permission_mode="dontAsk",
+        )
+
+        argv = _argv(stub_run.call_args)
+        allowed_tools_index = argv.index("--allowedTools")
+        assert argv[allowed_tools_index + 1] == ""
+        assert argv[argv.index("--permission-mode") + 1] == "dontAsk"
+
     def test_input_via_stdin_drops_prompt_from_argv(
         self, stub_run: MagicMock, fake_home: Path
     ) -> None:

--- a/tests/unit/automation/test_invoke_allowed_tools_scoping.py
+++ b/tests/unit/automation/test_invoke_allowed_tools_scoping.py
@@ -8,6 +8,13 @@ import pathlib
 import pytest
 
 AUTOMATION_DIR = pathlib.Path(__file__).parents[3] / "hephaestus" / "automation"
+CONTRACT_AGENT_TEST = (
+    pathlib.Path(__file__).parents[3]
+    / "tests"
+    / "integration"
+    / "contract"
+    / "test_agent_contract.py"
+)
 
 # (filename, minimum tools, gh_required)
 # gh_required=True means the agent itself may shell to gh and so needs "Bash".
@@ -70,3 +77,29 @@ def test_call_site_scope(filename: str, min_tools: set[str], gh_required: bool) 
         assert not missing, f"{filename} scope {v!r} missing {missing}"
         if gh_required:
             assert "Bash" in tools, f"{filename} scope {v!r} must include Bash for gh CLI access"
+
+
+def test_contract_agent_lane_has_explicit_zero_tool_noninteractive_scope() -> None:
+    """The token-spending contract lane must not inherit interactive CLI defaults."""
+    tree = ast.parse(CONTRACT_AGENT_TEST.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and (getattr(node.func, "attr", None) or getattr(node.func, "id", None))
+        == "invoke_claude_with_session"
+    ]
+
+    assert len(calls) == 2, "the contract must preserve its create-and-resume invocations"
+    for call in calls:
+        kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg}
+        assert _string_literal(kwargs.get("allowed_tools")) == ""
+        assert _string_literal(kwargs.get("permission_mode")) == "dontAsk"
+        agent = kwargs.get("agent")
+        assert isinstance(agent, ast.Name)
+        assert agent.id == "AGENT_ADVISE"
+
+
+def _string_literal(node: ast.AST | None) -> str | None:
+    """Return a string literal value for focused call-site policy assertions."""
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -36,6 +36,7 @@ SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
 TEST_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
 PERFORMANCE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "performance.yml"
 NIGHTLY_TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly-tests.yml"
+CONTRACT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "contract.yml"
 PERFORMANCE_DOC = REPO_ROOT / "docs" / "performance-testing.md"
 SETUP_PI_ACTION = REPO_ROOT / ".github" / "actions" / "setup-pi-cli" / "action.yml"
 
@@ -314,6 +315,37 @@ class TestNightlyTestsWorkflow:
         """Commands that override pytest defaults retain the nightly exclusion."""
         for workflow_path in (REQUIRED_WORKFLOW, TEST_WORKFLOW):
             assert '-m "not nightly"' in workflow_path.read_text(encoding="utf-8")
+
+
+class TestContractWorkflow:
+    """Contracts for the opt-in external integration lane."""
+
+    def _load(self) -> dict[str, Any]:
+        workflow: dict[str, Any] = yaml.load(
+            CONTRACT_WORKFLOW.read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        return workflow
+
+    def test_lane_is_manual_only(self) -> None:
+        """The contract lane must never run on pushes or pull requests."""
+        workflow = self._load()
+        assert set(workflow["on"]) == {"workflow_dispatch"}
+
+    def test_github_job_is_opted_in_and_tokened(self) -> None:
+        """The GitHub job enables the lane and passes the workflow token."""
+        workflow = self._load()
+        steps = workflow["jobs"]["github-contract"]["steps"]
+        pytest_step = next(
+            step for step in steps if "tests/integration/contract" in str(step.get("run", ""))
+        )
+        assert pytest_step["env"]["HEPHAESTUS_CONTRACT_TESTS"] == "1"
+        assert pytest_step["env"]["GH_TOKEN"] == "${{ github.token }}"  # noqa: S105
+
+    def test_permissions_are_read_only(self) -> None:
+        """The workflow token may only read repository contents and issues."""
+        workflow = self._load()
+        assert workflow["permissions"]["contents"] == "read"
 
 
 class TestIsCheckoutStep:


### PR DESCRIPTION
## Summary
- Added opt-in `contract` marker/gating and authenticated GitHub/Claude contract tests.
- Added read-only manual workflow, `just test-contract`, and documentation.
- Added workflow contract assertions.

Validation:

- `uv run python -m pytest tests/ -v`: 7,077 passed, 29 skipped.
- GitHub live lane: 4 passed.
- Ruff, mypy, structure checks, workflow inventory, and pre-commit: passed.
- Claude lane not run; it requires `HEPHAESTUS_CONTRACT_AGENT=1` and spends model tokens.

Changes remain uncommitted for the orchestrator.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests -q --tb=short

## Closes
Closes #2146

Generated by Hephaestus automation
