### PR TITLE
fix(automation): record test commands in PRs

### DIFF
--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+import shlex
 from collections.abc import Callable
 from typing import cast
 
@@ -754,8 +755,10 @@ class ImplementationStage(Stage):
             return Continue(next_state=COMMIT_PUSH_WAIT)
         item.payload.pop("tests_failed", None)
         item.payload.pop("test_output", None)
+        item.payload.pop("test_receipt", None)
         logger.info("implementation:%d: requesting pre-PR test job", issue)
         test_argv = tuple(getattr(ctx.config, "pre_pr_test_argv", PRE_PR_TEST_ARGV))
+        item.payload["test_command"] = shlex.join(test_argv)
         test_job = BuildTestJob(
             repo=item.repo,
             cwd=_worktree_path(item, ctx),
@@ -1258,6 +1261,9 @@ class ImplementationStage(Stage):
         if result.ok and result.value in (0, None, True):
             item.payload.pop("tests_failed", None)
             item.payload.pop("test_output", None)
+            command = item.payload.pop("test_command", None)
+            if isinstance(command, str) and command:
+                item.payload["test_receipt"] = f"`{command}` — passed"
             return
         item.payload["tests_failed"] = True
         item.payload["test_output"] = "\n".join(
@@ -1567,7 +1573,7 @@ class ImplementationStage(Stage):
                 summary=item.payload.get("implement_summary", "")
                 or f"Automated implementation for issue #{item.issue}.",
                 changes="See the PR diff for the full change set.",
-                testing=item.payload.get("test_output") or "uv run pytest tests -q --tb=short",
+                testing=item.payload.get("test_receipt") or "Not run by the automation pipeline.",
             )
             pr_number = ctx.github.create_pr(item.issue, item.branch, title, body)
             item.pr = pr_number

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -442,7 +442,7 @@ def _fallback_pr_message(issue_number: int, issue_title: str, agent: str) -> _Pr
         title=f"feat: {issue_title}",
         summary=f"Implements #{issue_number}",
         changes=f"- Automated implementation via {_agent_display_name(agent)}",
-        testing="- Automated tests included",
+        testing="- Test commands were not recorded by automation.",
     )
 
 

--- a/hephaestus/prompts/templates/default/implementation/implementation.j2
+++ b/hephaestus/prompts/templates/default/implementation/implementation.j2
@@ -55,6 +55,9 @@ Implement GitHub issue #{{ issue_number }}.
 - Write unit tests for new functionality
 - Ensure existing tests still pass
 - Use pytest fixtures and parametrize where appropriate
+- In your final summary, list every test or verification command you actually
+  ran and its outcome. Do not claim a command ran when it did not. The
+  orchestrator records its own host-run test receipt in the PR's Testing section.
 
 **Code Quality:**
 - Type hint all function signatures
@@ -82,7 +85,8 @@ agent turn returns.
   makes every commit unverifiable (`no_user`) and fails the signed-commit gate.
   Express agent attribution only via the orchestrator's `Co-Authored-By:` trailer.
 - Leave the final implementation changes in the working tree.
-- When you finish, summarize what changed and what tests you ran.
+- When you finish, summarize what changed and provide the exact test commands
+  you ran with their outcomes; this is the evidence that belongs in the PR.
 
 After you return, the orchestrator will:
 1. Create a cryptographically signed and DCO-signed commit with `git commit -S -s`.

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1559,6 +1559,20 @@ class TestTestsAndFix:
         assert "tests_failed" not in item.payload
         assert "test_output" not in item.payload
 
+    def test_green_tests_record_command_receipt_for_pr(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A passing host test run leaves its exact command and outcome for the PR."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        ctx.config.run_pre_pr_tests = True
+        item = make_work_item(issue=1, state="TEST_WAIT")
+
+        stage.step(item, ctx)
+        stage.on_job_done(item, JobResult(ok=True, value=0), ctx)
+
+        assert item.payload["test_receipt"] == "`uv run pytest tests -q --tb=short` — passed"
+
     def test_testfix_requests_resume_job(self, make_ctx: Any, make_work_item: Any) -> None:
         """TESTFIX_WAIT submits the composed test-failure resume job."""
         stage = ImplementationStage()
@@ -2288,7 +2302,7 @@ class TestCommitPushAndPrCreate:
         assert [name for name, _ in github.mutation_log] == ["gh_pr_create"]
         # The PR body is a get_pr_description body carrying the closing line.
         assert "Closes #9" in github.prs[1001]["body"]
-        assert "uv run pytest tests -q --tb=short" in github.prs[1001]["body"]
+        assert "Not run by the automation pipeline" in github.prs[1001]["body"]
         assert github.prs[1001]["title"] == "chore: Add the widget"
 
     @pytest.mark.parametrize(
@@ -2316,6 +2330,22 @@ class TestCommitPushAndPrCreate:
         ImplementationStage().step(item, ctx)
 
         assert github.prs[1001]["title"] == expected_title
+
+    def test_pr_create_includes_passing_host_test_receipt(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """PR testing metadata identifies the command the host actually ran."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=9, state="PR_CREATE")
+        item.branch = "9-auto-impl"
+        item.payload["test_receipt"] = "`uv run pytest tests/unit/example.py -q` — passed"
+
+        stage.step(item, ctx)
+
+        assert item.pr == 1001
+        assert "`uv run pytest tests/unit/example.py -q` — passed" in github.prs[1001]["body"]
 
     def test_pr_create_does_not_call_the_removed_auto_merge_mutator(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -599,6 +599,7 @@ class TestCreatePR:
         assert kwargs["base"] == "main"
         assert "Closes #5" in kwargs["body"]
         assert "Automated implementation via Codex" in kwargs["body"]
+        assert "Test commands were not recorded by automation" in kwargs["body"]
         assert "Claude Code" not in kwargs["body"]
 
     def test_uses_message_agent_for_pr_title_and_body(self) -> None:

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -79,6 +79,12 @@ class TestImplementationPrompt:
         assert "gh pr list --head" not in out
         assert "DO NOT open a second PR" not in out
 
+    def test_implementation_prompt_requires_test_command_receipts(self) -> None:
+        """Implementers must return the commands and outcomes for PR evidence (#2599)."""
+        out = prompts.get_implementation_prompt(issue_number=42)
+        assert "exact test commands" in out
+        assert "their outcomes" in out
+
 
 class TestPRReviewAnalysisPrompt:
     """Tests for the policy-aware PR review analysis prompt."""


### PR DESCRIPTION
## Summary

- Record the exact successful pre-PR host test command and outcome in the PR Testing section.
- Explicitly identify when automation did not run tests rather than implying a command ran.
- Require implementers to return executed test commands and outcomes in their final summary.

## Testing

- `uv run pytest tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/test_prompts.py tests/unit/automation/test_pr_manager.py -v --no-cov` (260 passed)
- `uv run ruff check hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pr_manager.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/test_prompts.py tests/unit/automation/test_pr_manager.py`
- `uv run ruff format --check hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pr_manager.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/test_prompts.py tests/unit/automation/test_pr_manager.py`
- `uv run mypy hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pr_manager.py`

Closes #2599