### PR TITLE
fix(automation): resume sessions across worktree cwd

### DIFF
--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -63,6 +63,11 @@ given the same tuple, will produce the same UUID. Different ``agent`` produces
 a different UUID, preserving the "planner and reviewer are independent
 sessions" property while still letting each agent resume itself across loop
 iterations.
+
+The UUID is artifact-stable, while transcript lookup is restricted to the
+current Git checkout's registered worktree family. This lets repo-root and
+worktree callers share a transcript without allowing same-slug repositories
+from unrelated checkouts to resume one another's sessions.
 """
 
 from __future__ import annotations
@@ -557,6 +562,61 @@ def session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     return Path.home() / ".claude" / "projects" / encoded / f"{uuid_str}.jsonl"
 
 
+def _registered_worktree_roots(cwd: Path) -> tuple[Path, ...]:
+    """Return worktree roots registered to cwd's exact Git repository.
+
+    The explicit invocation path is authoritative. Ambient Git repository
+    environment variables are removed so an outer checkout cannot redirect
+    this discovery to a different repository.
+    """
+    resolved_cwd = cwd.resolve()
+    roots = {resolved_cwd}
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(resolved_cwd),
+                "worktree",
+                "list",
+                "--porcelain",
+                "-z",
+            ],
+            check=True,
+            capture_output=True,
+            env=_repo_scoped_git_env(),
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (resolved_cwd,)
+
+    for field in result.stdout.split("\0"):
+        if field.startswith("worktree "):
+            roots.add(Path(field.removeprefix("worktree ")).resolve())
+    return tuple(sorted(roots, key=str))
+
+
+def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
+    """Resolve an existing transcript within cwd's registered worktree family.
+
+    The exact cwd path remains the create location when no transcript exists.
+    Existing transcripts are selected only from worktrees registered to the
+    same Git repository, with lexical ordering making historical duplicates
+    deterministic.
+    """
+    expected = session_jsonl_path(uuid_str, cwd)
+    candidates = {expected}
+    candidates.update(
+        session_jsonl_path(uuid_str, root) for root in _registered_worktree_roots(cwd)
+    )
+    existing = sorted(
+        (candidate for candidate in candidates if candidate.is_file()),
+        key=str,
+    )
+    return existing[0] if existing else expected
+
+
 __all__ = [
     # Session naming
     "AGENT_ADDRESS_REVIEW",
@@ -619,6 +679,7 @@ __all__ = [
     "planner_model",
     "pr_reviewer_claude_timeout",
     "read_timeout_env",
+    "resolve_session_jsonl_path",
     "reviewer_agent",
     "reviewer_model",
     "session_jsonl_path",

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -56,13 +56,12 @@ reuse across loop iterations *and* across main-bumps (#841): the artifact
 being worked on is the issue/PR, not the commit at which the loop started,
 so the session must persist as long as the issue does.
 
-Human-readable name: ``<repo>_<issue>_<agent>``; the session ID is
-``str(uuid.uuid5(NAMESPACE_DNS, <human-readable>))``. UUIDv5 is
-deterministic, so no state file is needed — two callers on different machines,
-given the same tuple, will produce the same UUID. Different ``agent`` produces
-a different UUID, preserving the "planner and reviewer are independent
-sessions" property while still letting each agent resume itself across loop
-iterations.
+Human-readable name: ``<repo>_<issue>_<agent>``; the session ID is a UUIDv5
+derived from that name plus a collision-resistant identity for the current Git
+checkout. The identity is shared by a repository root and its registered
+worktrees, but differs for unrelated clones. Different ``agent`` produces a
+different UUID, preserving the "planner and reviewer are independent sessions"
+property while still letting each agent resume itself across loop iterations.
 
 The UUID is artifact-stable, while transcript lookup is restricted to the
 current Git checkout's registered worktree family. This lets repo-root and
@@ -77,6 +76,7 @@ import os
 import re
 import subprocess
 import uuid
+from hashlib import sha256
 from pathlib import Path
 
 from hephaestus.constants import (
@@ -498,9 +498,49 @@ def session_name(repo: str, issue: int | str, agent: str, model: str | None = No
     return f"{base}_{model_token}" if model_token else base
 
 
-def session_uuid(repo: str, issue: int | str, agent: str, model: str | None = None) -> str:
-    """Return the deterministic UUIDv5 session ID for the (repo, issue, agent, model) key."""
+def _checkout_identity(cwd: Path) -> str:
+    """Return a collision-resistant identity shared by one Git worktree family."""
+    resolved_cwd = cwd.resolve()
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(resolved_cwd),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            check=True,
+            capture_output=True,
+            env=_repo_scoped_git_env(),
+            text=True,
+            timeout=5,
+        )
+        identity_path = Path(result.stdout.strip()).resolve()
+    except (OSError, subprocess.SubprocessError):
+        identity_path = resolved_cwd
+    return sha256(os.fsencode(identity_path)).hexdigest()
+
+
+def session_uuid(
+    repo: str,
+    issue: int | str,
+    agent: str,
+    model: str | None = None,
+    *,
+    cwd: Path | None = None,
+) -> str:
+    """Return the deterministic UUIDv5 session ID for one artifact and checkout.
+
+    When ``cwd`` is provided, unrelated checkouts get distinct session IDs even
+    if Claude's lossy cwd encoding maps their project directories to the same
+    path. A repository root and its linked worktrees share the Git common-dir
+    identity and therefore keep one resumable session lineage.
+    """
     name = session_name(repo, issue, agent, model)
+    if cwd is not None:
+        name = f"{name}@{_checkout_identity(cwd)}"
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
 
 

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -533,14 +533,16 @@ def session_uuid(
 ) -> str:
     """Return the deterministic UUIDv5 session ID for one artifact and checkout.
 
-    When ``cwd`` is provided, unrelated checkouts get distinct session IDs even
-    if Claude's lossy cwd encoding maps their project directories to the same
-    path. A repository root and its linked worktrees share the Git common-dir
-    identity and therefore keep one resumable session lineage.
+    Unrelated checkouts get distinct session IDs even if Claude's lossy cwd
+    encoding maps their project directories to the same path. A repository
+    root and its linked worktrees share the Git common-dir identity and
+    therefore keep one resumable session lineage. When callers omit ``cwd``,
+    the process working directory supplies the checkout identity; session IDs
+    are never unscoped by accident.
     """
     name = session_name(repo, issue, agent, model)
-    if cwd is not None:
-        name = f"{name}@{_checkout_identity(cwd)}"
+    checkout_cwd = cwd if cwd is not None else Path.cwd()
+    name = f"{name}@{_checkout_identity(checkout_cwd)}"
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
 
 

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -534,11 +534,14 @@ def session_uuid(
     """Return the deterministic UUIDv5 session ID for one artifact and checkout.
 
     Unrelated checkouts get distinct session IDs even if Claude's lossy cwd
-    encoding maps their project directories to the same path. A repository
-    root and its linked worktrees share the Git common-dir identity and
-    therefore keep one resumable session lineage. When callers omit ``cwd``,
-    the process working directory supplies the checkout identity; session IDs
-    are never unscoped by accident.
+    encoding maps their project directories to the same transcript directory.
+    The checkout identity is folded into the UUID filename itself before
+    transcript lookup, so a pre-existing transcript from another checkout
+    cannot satisfy :func:`resolve_session_jsonl_path` for this checkout. A
+    repository root and its linked worktrees share the Git common-dir identity
+    and therefore keep one resumable session lineage. When callers omit
+    ``cwd``, the process working directory supplies the checkout identity;
+    session IDs are never unscoped by accident.
     """
     name = session_name(repo, issue, agent, model)
     checkout_cwd = cwd if cwd is not None else Path.cwd()

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -602,6 +602,12 @@ def session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     returns False even though the JSONL is on disk, the caller goes down
     the ``--session-id`` create path, and the CLI rejects with ``Session ID
     <uuid> is already in use``. (#822)
+
+    That directory encoding is lossy (for example, ``owner.a`` and
+    ``owner-a`` collide), so checkout isolation is provided by the
+    collision-resistant checkout identity folded into ``uuid_str`` by
+    :func:`session_uuid`. The UUID filename, not the encoded parent directory,
+    is therefore the isolation boundary.
     """
     encoded = str(cwd.resolve()).replace("/", "-").replace(".", "-")
     return Path.home() / ".claude" / "projects" / encoded / f"{uuid_str}.jsonl"
@@ -650,6 +656,9 @@ def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     same Git repository, with lexical ordering making historical duplicates
     deterministic.
     """
+    # ``uuid_str`` is checkout-scoped by session_uuid. This matters before any
+    # registered-worktree lookup: Claude's lossy cwd encoding can make the
+    # expected parent directory belong to more than one unrelated checkout.
     expected = session_jsonl_path(uuid_str, cwd)
     candidates = {session_jsonl_path(uuid_str, root) for root in _registered_worktree_roots(cwd)}
     existing = sorted(

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -646,10 +646,7 @@ def resolve_session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     deterministic.
     """
     expected = session_jsonl_path(uuid_str, cwd)
-    candidates = {expected}
-    candidates.update(
-        session_jsonl_path(uuid_str, root) for root in _registered_worktree_roots(cwd)
-    )
+    candidates = {session_jsonl_path(uuid_str, root) for root in _registered_worktree_roots(cwd)}
     existing = sorted(
         (candidate for candidate in candidates if candidate.is_file()),
         key=str,

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -36,7 +36,7 @@ from hephaestus.automation import subprocess_registry
 from hephaestus.automation.agent_config import (
     agent_default_timeout,
     fallback_model,
-    session_jsonl_path,
+    resolve_session_jsonl_path,
     session_name,
 )
 from hephaestus.github.client import ClaudeUsageCapError, PromptTooLongError
@@ -299,11 +299,13 @@ def _invoke_claude_once(
     # auto-create — it errors "No conversation found" for an unknown id — so the
     # first call for a (repo, issue, agent, model) key must use ``--session-id``
     # to create the transcript; every later call ``--resume``s it to reuse cached
-    # context. The probe is the transcript file's existence, which is model-keyed
-    # because ``sid`` is. This is NOT the old recreate-on-failure cascade (that
-    # mis-fired on 429s, re-sending full prompts 3x and crossing models); a
-    # ``--resume``/``--session-id`` failure now simply propagates.
-    create = not session_jsonl_path(sid, cwd).exists()
+    # context. The first transcript is created under the caller's exact cwd;
+    # later probes search only registered worktrees of that same Git checkout.
+    # This is NOT the old recreate-on-failure cascade (that mis-fired on 429s,
+    # re-sending full prompts 3x and crossing models); a ``--resume``/``--session-id``
+    # failure now simply propagates.
+    transcript = resolve_session_jsonl_path(sid, cwd)
+    create = not transcript.is_file()
     mode_args = ["--session-id", sid, "--name", display_name] if create else ["--resume", sid]
     cmd: list[str] = [
         "claude",

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -13,7 +13,7 @@ What lives here:
   ``--resume`` targets a session that no longer exists locally.
 - :func:`invoke_claude_with_session` — the single entry point every
   automation phase must use. Picks ``--session-id`` (first call) vs
-  ``--resume`` (subsequent calls) based on whether the model-keyed JSONL
+  ``--resume`` (subsequent calls) based on whether the checkout-scoped JSONL
   transcript already exists. No recreate-on-failure cascade — a create/resume
   error propagates (#1168). On a model-specific usage cap it retries the same
   request once on :func:`agent_config.fallback_model` and pins the fallback
@@ -29,7 +29,6 @@ import os
 import re
 import signal
 import subprocess
-import uuid
 from pathlib import Path
 
 from hephaestus.automation import subprocess_registry
@@ -38,6 +37,7 @@ from hephaestus.automation.agent_config import (
     fallback_model,
     resolve_session_jsonl_path,
     session_name,
+    session_uuid,
 )
 from hephaestus.github.client import ClaudeUsageCapError, PromptTooLongError
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch
@@ -162,18 +162,19 @@ def invoke_claude_with_session(
 ) -> tuple[str, str]:
     """Invoke Claude with a deterministic per-(repo, issue, agent, model) session.
 
-    The session id is ``uuid5`` of ``(repo, issue, agent, model)``. The FIRST
-    call for a key uses ``--session-id`` to create the transcript; every later
-    call ``--resume``s it so cached context is reused instead of re-sent (#1166,
-    #1168). ``claude --resume`` does NOT auto-create — it errors "No conversation
-    found" for an unknown id — so create-on-first-use is required; the probe is
-    the model-keyed transcript file's existence. There is no expired/contention
-    recreate cascade (the old one mis-fired on 429s, re-sending full prompts 3×
-    and crossing models); a ``--session-id``/``--resume`` failure simply
-    propagates. Because ``--resume`` is locked to the creating model, the model
-    is part of the key: switching a per-agent model starts that model's own
-    create-once-then-resume lineage rather than colliding with another model's
-    transcript.
+    The session id is ``uuid5`` of ``(repo, issue, agent, model)`` plus the
+    collision-resistant Git checkout identity. The FIRST call for a key uses
+    ``--session-id`` to create the transcript; every later call ``--resume``s it
+    so cached context is reused instead of re-sent (#1166, #1168).
+    ``claude --resume`` does NOT auto-create — it errors "No conversation found"
+    for an unknown id — so create-on-first-use is required; the probe searches
+    only the current checkout's registered worktree family. There is no
+    expired/contention recreate cascade (the old one mis-fired on 429s,
+    re-sending full prompts 3× and crossing models); a
+    ``--session-id``/``--resume`` failure simply propagates. Because
+    ``--resume`` is locked to the creating model, the model is part of the key:
+    switching a per-agent model starts that model's own create-once-then-resume
+    lineage rather than colliding with another model's transcript.
 
     The session is scoped to the artifact (issue/PR), not a commit SHA, so the
     transcript persists across main-bumps for the issue's lifetime (#841).
@@ -220,8 +221,8 @@ def invoke_claude_with_session(
             recreate toggle.
 
     Returns:
-        ``(stdout, session_uuid)`` — the deterministic id derived from
-        ``(repo, issue, agent, model)`` — for the model actually used (the
+        ``(stdout, session_uuid)`` — the deterministic id derived from the
+        artifact key and checkout identity for the model actually used (the
         fallback's id when a cap forced a switch).
 
     Raises:
@@ -293,7 +294,7 @@ def _invoke_claude_once(
     docstring for the session-key semantics.
     """
     display_name = session_name(repo, issue, agent, model)
-    sid = str(uuid.uuid5(uuid.NAMESPACE_DNS, display_name))
+    sid = session_uuid(repo, issue, agent, model, cwd=cwd)
 
     # Create on FIRST use, resume after (#1168). ``claude --resume`` does NOT
     # auto-create — it errors "No conversation found" for an unknown id — so the

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -402,7 +402,7 @@ def compact_session(
         a non-zero exit code (e.g. /compact skill not registered).
 
     """
-    sid = session_uuid(repo, issue, agent, model)
+    sid = session_uuid(repo, issue, agent, model, cwd=cwd)
     timeout_s = learn_claude_timeout() if timeout is None else timeout
     try:
         result = subprocess.run(

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -132,13 +132,11 @@ class PostMergeProcessor:
         self._last_learn_evidence = mnemosyne_update_evidence("")
         try:
             repo_slug = get_repo_slug(repo_root)
-            # Best-effort: try to resume in the original worktree (so the
-            # AGENT_CI_DRIVER transcript is found by ``session_jsonl_path``).
-            # In the post-merge code path (#840) the PR's head branch may be
-            # gone from the remote, so ``_get_worktree_path`` could fail. In
-            # that case fall back to ``repo_root`` cwd — the prompt is
-            # self-contained, and a fresh ``--session-id`` create still
-            # captures the lesson.
+            # Prefer the original worktree for agent tool context. If it is
+            # unavailable, repo_root remains safe: checkout-family transcript
+            # resolution can resume a transcript from any still-registered
+            # worktree, otherwise it creates under repo_root without searching
+            # unrelated repositories.
             try:
                 cwd = self._get_worktree_path(issue_number, pr_number)
             except Exception as wt_err:
@@ -198,9 +196,10 @@ class PostMergeProcessor:
         """Compact the AGENT_CI_DRIVER session transcript after /learn (#842).
 
         Mirrors the cwd-derivation of ``run_drive_green_learnings``: try the
-        worktree first so the deterministic JSONL probe in ``session_jsonl_path``
-        finds the transcript, fall back to ``repo_root`` when the branch is
-        already gone post-merge. Non-fatal.
+        worktree first so the deterministic JSONL probe finds the transcript,
+        fall back to ``repo_root`` when the branch is already gone post-merge.
+        Checkout-family resolution may still find a registered worktree
+        transcript from that fallback cwd. Non-fatal.
 
         Args:
             issue_number: GitHub issue number.

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -14,6 +14,7 @@ from hephaestus.automation.agent_config import (
     AGENT_PR_REVIEWER as AGENT_PR_REVIEWER,
     current_trunk_githash as current_trunk_githash,
     issue_auto_impl_branch_name as issue_auto_impl_branch_name,
+    resolve_session_jsonl_path as resolve_session_jsonl_path,
     reviewer_agent as reviewer_agent,
     session_jsonl_path as session_jsonl_path,
     session_name as session_name,

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 import sys
 from collections.abc import Generator
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -49,6 +50,10 @@ def stub_run() -> Generator[MagicMock]:
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect $HOME so session_jsonl_path resolves under tmp_path."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hephaestus.automation.agent_config._checkout_identity",
+        lambda cwd: sha256(str(cwd.resolve()).encode()).hexdigest(),
+    )
     return tmp_path
 
 
@@ -89,14 +94,14 @@ class TestCreateThenResume:
         assert sid in argv
         assert out == "ok"
         # The session id includes the model (#1166).
-        assert sid == session_uuid("R", 1, AGENT_PLANNER, "sonnet")
+        assert sid == session_uuid("R", 1, AGENT_PLANNER, "sonnet", cwd=cwd)
 
     def test_subsequent_call_resumes_existing_transcript(
         self, stub_run: MagicMock, fake_home: Path
     ) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet")
+        sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet", cwd=cwd)
         _make_existing_jsonl(fake_home, cwd, sid)
 
         invoke_claude_with_session(
@@ -131,8 +136,8 @@ class TestCreateThenResume:
             repo="R", issue=1, agent=AGENT_PLANNER, prompt="hi", model="opus", cwd=cwd
         )
         assert sid_sonnet != sid_opus
-        assert sid_sonnet == session_uuid("R", 1, AGENT_PLANNER, "sonnet")
-        assert sid_opus == session_uuid("R", 1, AGENT_PLANNER, "opus")
+        assert sid_sonnet == session_uuid("R", 1, AGENT_PLANNER, "sonnet", cwd=cwd)
+        assert sid_opus == session_uuid("R", 1, AGENT_PLANNER, "opus", cwd=cwd)
 
     def test_different_agents_get_different_uuids(
         self, stub_run: MagicMock, fake_home: Path
@@ -340,7 +345,7 @@ class TestEndToEndSessionResume:
     def test_create_then_resume_same_uuid_distinct_prompts(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        expected_sid = session_uuid("Scylla", 1944, AGENT_PLANNER, "sonnet")
+        expected_sid = session_uuid("Scylla", 1944, AGENT_PLANNER, "sonnet", cwd=cwd)
 
         # First call writes the transcript so the second call's probe finds it.
         def _side_effect(*args: Any, **kwargs: Any) -> MagicMock:
@@ -383,16 +388,17 @@ class TestEndToEndSessionResume:
         assert second_argv[-1] == "iter 1"
 
     def test_session_id_is_githash_invariant(self, fake_home: Path) -> None:
-        """The session UUID depends only on (repo, issue, agent, model) — #841/#1166.
+        """The session UUID omits the trunk SHA — #841/#1166.
 
         Regression for #841: the prior behavior fed ``current_trunk_githash``
         into the session-naming tuple, so every main-bump forked a new session
-        family. The loop is PR/issue-scoped: the same (repo, issue, agent, model)
-        key must always resume the same transcript regardless of the trunk SHA.
+        family. The loop is PR/issue-scoped within one checkout: the same
+        (repo, issue, agent, model) key must always resume the same transcript
+        regardless of the trunk SHA.
         """
         cwd = fake_home / "work"
         cwd.mkdir()
-        expected_sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet")
+        expected_sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet", cwd=cwd)
         # Existing transcript → resume path.
         _make_existing_jsonl(fake_home, cwd, expected_sid)
 
@@ -662,7 +668,7 @@ class TestModelCapFallback:
                 model="claude-fable-5",
                 cwd=cwd,
             )
-        assert sid == session_uuid("R", 1, AGENT_PLANNER, OPUS_48)
+        assert sid == session_uuid("R", 1, AGENT_PLANNER, OPUS_48, cwd=cwd)
 
     def test_heph_fallback_model_env_override(
         self, fake_home: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -119,6 +119,45 @@ class TestCreateThenResume:
         assert "--session-id" not in argv
         assert "--name" not in argv
 
+    def test_lossy_path_collision_does_not_resume_unregistered_checkout(
+        self, stub_run: MagicMock, fake_home: Path
+    ) -> None:
+        """Dotted/dashed checkout path collisions stay isolated by checkout id."""
+        dotted = fake_home / "owner.a" / "Repo"
+        dashed = fake_home / "owner-a" / "Repo"
+        dotted.mkdir(parents=True)
+        dashed.mkdir(parents=True)
+
+        dotted_sid = session_uuid("Repo", 2284, AGENT_PLANNER, "sonnet", cwd=dotted)
+        dashed_sid = session_uuid("Repo", 2284, AGENT_PLANNER, "sonnet", cwd=dashed)
+        assert dotted_sid != dashed_sid
+
+        dotted_path = session_jsonl_path(dotted_sid, dotted)
+        dashed_path = session_jsonl_path(dashed_sid, dashed)
+        assert dotted_path.parent == dashed_path.parent
+        dashed_path.parent.mkdir(parents=True, exist_ok=True)
+        dashed_path.write_text("{}\n", encoding="utf-8")
+
+        with patch(
+            "hephaestus.automation.agent_config._registered_worktree_roots",
+            return_value=(dotted.resolve(),),
+        ):
+            _, sid = invoke_claude_with_session(
+                repo="Repo",
+                issue=2284,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="sonnet",
+                cwd=dotted,
+            )
+
+        argv = _argv(stub_run.call_args)
+        assert sid == dotted_sid
+        assert "--session-id" in argv
+        assert dotted_sid in argv
+        assert "--resume" not in argv
+        assert dashed_sid not in argv
+
     def test_different_models_get_different_uuids(
         self, stub_run: MagicMock, fake_home: Path
     ) -> None:

--- a/tests/unit/automation/test_compact.py
+++ b/tests/unit/automation/test_compact.py
@@ -13,6 +13,13 @@ from hephaestus.automation.session_naming import AGENT_CI_DRIVER, session_uuid
 class TestCompactSession:
     """Test suite for compact_session helper."""
 
+    @pytest.fixture(autouse=True)
+    def _stable_checkout_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "hephaestus.automation.agent_config._checkout_identity",
+            lambda _cwd: "test-checkout",
+        )
+
     def test_compact_session_issues_resume_and_print(self, tmp_path: Path) -> None:
         """Verify compact_session invokes claude with --resume and --print /compact."""
         with patch("hephaestus.automation.learn.subprocess.run") as mock_run:
@@ -54,7 +61,7 @@ class TestCompactSession:
             actual_uuid = cmd[resume_idx + 1]
 
             # Compare to the real session_uuid function
-            expected_uuid = session_uuid(repo, issue, agent)
+            expected_uuid = session_uuid(repo, issue, agent, cwd=tmp_path)
             assert actual_uuid == expected_uuid
 
     def test_compact_session_forwards_cwd(self, tmp_path: Path) -> None:

--- a/tests/unit/automation/test_session_cwd_resume.py
+++ b/tests/unit/automation/test_session_cwd_resume.py
@@ -1,0 +1,114 @@
+"""Regression tests for checkout-scoped Claude session transcript lookup."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation import agent_config
+from hephaestus.automation.models import PlanReviewerOptions
+from hephaestus.automation.pipeline.jobs import AgentJob
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.worker_pool import WorkerPool
+from hephaestus.automation.plan_reviewer import PlanReviewer
+from hephaestus.automation.session_naming import session_jsonl_path, session_uuid
+
+
+def test_registered_worktree_resolves_repo_root_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worktree caller finds a session first created from the repo root."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo_root = tmp_path / "owner-a" / "Hephaestus"
+    worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+    worktree.mkdir(parents=True)
+    sid = session_uuid("Hephaestus", 2284, "plan-reviewer", "fable")
+
+    transcript = session_jsonl_path(sid, repo_root)
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text("{}\n", encoding="utf-8")
+
+    with patch(
+        "hephaestus.automation.agent_config._registered_worktree_roots",
+        return_value=(repo_root.resolve(), worktree.resolve()),
+    ):
+        assert agent_config.resolve_session_jsonl_path(sid, worktree) == transcript
+
+
+def test_plan_reviewer_then_pipeline_worker_resumes_same_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The repo-root and pipeline-worktree Claude paths share one session."""
+    repo_root = tmp_path / "owner-a" / "Hephaestus"
+    worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+    worktree.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    model = "fable"
+    sid = session_uuid("Hephaestus", 2284, "plan-reviewer", model)
+    calls: list[list[str]] = []
+
+    def fake_run_tracked(argv: list[str], **_kwargs: object) -> MagicMock:
+        calls.append(argv)
+        if len(calls) == 1:
+            transcript = session_jsonl_path(sid, repo_root)
+            transcript.parent.mkdir(parents=True, exist_ok=True)
+            transcript.write_text("{}\n", encoding="utf-8")
+        return MagicMock(stdout="Verdict: GO", stderr="", returncode=0)
+
+    reviewer = PlanReviewer(
+        PlanReviewerOptions(issues=[2284], dry_run=False, max_workers=1, enable_ui=False)
+    )
+    completion_q: queue.Queue[tuple[object, object]] = queue.Queue()
+    shutdown = threading.Event()
+    pool = WorkerPool(size=1, shutdown=shutdown, completion_q=completion_q, lock_dir=tmp_path)
+
+    try:
+        with (
+            patch(
+                "hephaestus.automation.agent_config._registered_worktree_roots",
+                return_value=(repo_root.resolve(), worktree.resolve()),
+            ),
+            patch("hephaestus.automation.claude_invoke._run_tracked", side_effect=fake_run_tracked),
+            patch("hephaestus.automation.plan_reviewer.get_repo_root", return_value=repo_root),
+            patch(
+                "hephaestus.automation.plan_reviewer.get_repo_slug",
+                return_value="Hephaestus",
+            ),
+            patch("hephaestus.automation.plan_reviewer.reviewer_model", return_value=model),
+            patch(
+                "hephaestus.automation.pipeline.worker_pool.resolve_agent",
+                return_value="claude",
+            ),
+        ):
+            assert reviewer._run_claude_analysis(2284, "title", "body", "plan") == "Verdict: GO"
+            job = AgentJob(
+                repo="Hephaestus",
+                issue=2284,
+                agent="claude",
+                session_agent="plan-reviewer",
+                model=model,
+                prompt_builder=lambda: "pipeline turn",
+                cwd=worktree,
+                timeout_s=60,
+            )
+            pool.submit(job, StageName.PLAN_REVIEW)
+            _handle, result = completion_q.get(timeout=10)
+
+            assert agent_config.resolve_session_jsonl_path(
+                sid, repo_root
+            ) == agent_config.resolve_session_jsonl_path(sid, worktree)
+
+        assert result.ok is True
+    finally:
+        pool.shutdown(mark_interrupted=False)
+
+    assert "--session-id" in calls[0]
+    assert "--resume" not in calls[0]
+    assert "--resume" in calls[1]
+    assert "--session-id" not in calls[1]
+    assert sid in calls[0] and sid in calls[1]

--- a/tests/unit/automation/test_session_cwd_resume.py
+++ b/tests/unit/automation/test_session_cwd_resume.py
@@ -12,6 +12,7 @@ import pytest
 from hephaestus.automation import agent_config
 from hephaestus.automation.models import PlanReviewerOptions
 from hephaestus.automation.pipeline.jobs import AgentJob
+from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.worker_pool import WorkerPool
 from hephaestus.automation.plan_reviewer import PlanReviewer
@@ -63,7 +64,7 @@ def test_plan_reviewer_then_pipeline_worker_resumes_same_transcript(
     reviewer = PlanReviewer(
         PlanReviewerOptions(issues=[2284], dry_run=False, max_workers=1, enable_ui=False)
     )
-    completion_q: queue.Queue[tuple[object, object]] = queue.Queue()
+    completion_q: CompletionQueue = queue.Queue()
     shutdown = threading.Event()
     pool = WorkerPool(size=1, shutdown=shutdown, completion_q=completion_q, lock_dir=tmp_path)
 

--- a/tests/unit/automation/test_session_cwd_resume.py
+++ b/tests/unit/automation/test_session_cwd_resume.py
@@ -27,7 +27,8 @@ def test_registered_worktree_resolves_repo_root_transcript(
     repo_root = tmp_path / "owner-a" / "Hephaestus"
     worktree = repo_root / "build" / ".worktrees" / "issue-2284"
     worktree.mkdir(parents=True)
-    sid = session_uuid("Hephaestus", 2284, "plan-reviewer", "fable")
+    monkeypatch.setattr(agent_config, "_checkout_identity", lambda _cwd: "checkout-family")
+    sid = session_uuid("Hephaestus", 2284, "plan-reviewer", "fable", cwd=repo_root)
 
     transcript = session_jsonl_path(sid, repo_root)
     transcript.parent.mkdir(parents=True, exist_ok=True)
@@ -48,9 +49,10 @@ def test_plan_reviewer_then_pipeline_worker_resumes_same_transcript(
     worktree = repo_root / "build" / ".worktrees" / "issue-2284"
     worktree.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(agent_config, "_checkout_identity", lambda _cwd: "checkout-family")
 
     model = "fable"
-    sid = session_uuid("Hephaestus", 2284, "plan-reviewer", model)
+    sid = session_uuid("Hephaestus", 2284, "plan-reviewer", model, cwd=repo_root)
     calls: list[list[str]] = []
 
     def fake_run_tracked(argv: list[str], **_kwargs: object) -> MagicMock:

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -164,6 +164,30 @@ class TestSessionUUID:
 
         assert root_sid == worktree_sid
 
+    def test_implicit_cwd_is_checkout_scoped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Omitting cwd still isolates sessions when callers run in each checkout."""
+        dotted = tmp_path / "owner.a" / "Repo"
+        dashed = tmp_path / "owner-a" / "Repo"
+        dotted.mkdir(parents=True)
+        dashed.mkdir(parents=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.agent_config._checkout_identity",
+            lambda cwd: str(cwd.resolve()),
+        )
+
+        monkeypatch.chdir(dotted)
+        dotted_sid = session_uuid("Repo", 2284, AGENT_PLANNER, "fable")
+        monkeypatch.chdir(dashed)
+        dashed_sid = session_uuid("Repo", 2284, AGENT_PLANNER, "fable")
+
+        assert dotted_sid != dashed_sid
+        assert (
+            session_jsonl_path(dotted_sid, dotted).parent
+            == session_jsonl_path(dashed_sid, dashed).parent
+        )
+
     def test_omitting_model_preserves_legacy_key(self) -> None:
         """Backward compat: no model reproduces the historical (repo, issue, agent) id."""
         from hephaestus.automation.session_naming import session_name

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -390,11 +390,12 @@ class TestSessionJsonlPath:
     def test_lossy_path_pair_cannot_resume_unregistered_checkout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Dotted/dashed checkout paths are separated before transcript lookup."""
+        """Dotted/dashed checkouts isolate sessions but registered worktrees resume."""
         monkeypatch.setenv("HOME", str(tmp_path / "home"))
         dotted = tmp_path / "owner.a" / "Repo"
+        dotted_worktree = dotted / "build" / ".worktrees" / "issue-2284"
         dashed = tmp_path / "owner-a" / "Repo"
-        dotted.mkdir(parents=True)
+        dotted_worktree.mkdir(parents=True)
         dashed.mkdir(parents=True)
 
         legacy_sid = str(
@@ -416,6 +417,7 @@ class TestSessionJsonlPath:
         dotted_path = session_jsonl_path(dotted_sid, dotted)
         dashed_path = session_jsonl_path(dashed_sid, dashed)
         assert dotted_path.parent == dashed_path.parent
+        assert dotted_path != dashed_path
         assert dotted_sid != dashed_sid
 
         dashed_path.parent.mkdir(parents=True, exist_ok=True)
@@ -429,6 +431,14 @@ class TestSessionJsonlPath:
         assert resolved == dotted_path
         assert resolved != dashed_path
         assert not resolved.exists()
+
+        dotted_path.parent.mkdir(parents=True, exist_ok=True)
+        dotted_path.write_text("{}\n", encoding="utf-8")
+        with patch(
+            "hephaestus.automation.agent_config._registered_worktree_roots",
+            return_value=(dotted.resolve(), dotted_worktree.resolve()),
+        ):
+            assert resolve_session_jsonl_path(dotted_sid, dotted_worktree) == dotted_path
 
     def test_worktree_discovery_parses_nul_output_and_scrubs_git_environment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -7,9 +7,11 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation import agent_config
 from hephaestus.automation.session_naming import (
     AGENT_ADDRESS_REVIEW,
     AGENT_ADVISE,
@@ -20,6 +22,7 @@ from hephaestus.automation.session_naming import (
     AGENT_PLANNER,
     AGENT_PR_REVIEWER,
     current_trunk_githash,
+    resolve_session_jsonl_path,
     reviewer_agent,
     session_jsonl_path,
     session_name,
@@ -289,6 +292,127 @@ class TestSessionJsonlPath:
         p = session_jsonl_path("u", target)
         assert "v1-2-3" in p.parent.name
         assert "v1.2.3" not in p.parent.name
+
+    @pytest.mark.parametrize("created_in", ["repo_root", "worktree"])
+    def test_registered_family_cwds_resolve_same_existing_transcript(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        created_in: str,
+    ) -> None:
+        """Repo-root and worktree callers resolve one existing transcript."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "owner-a" / "Repo"
+        worktree = repo_root / "build" / ".worktrees" / "issue-2284"
+        worktree.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        source = repo_root if created_in == "repo_root" else worktree
+        transcript = session_jsonl_path(sid, source)
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text("{}\n", encoding="utf-8")
+
+        with patch(
+            "hephaestus.automation.agent_config._registered_worktree_roots",
+            return_value=(repo_root.resolve(), worktree.resolve()),
+        ):
+            assert resolve_session_jsonl_path(sid, repo_root) == transcript
+            assert resolve_session_jsonl_path(sid, worktree) == transcript
+
+    def test_same_slug_unrelated_checkout_transcript_is_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A same-key transcript from an unrelated checkout is not resumed."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        local = tmp_path / "owner-a" / "Repo"
+        local_worktree = local / "build" / ".worktrees" / "issue-2284"
+        unrelated = tmp_path / "owner-b" / "Repo"
+        local_worktree.mkdir(parents=True)
+        unrelated.mkdir(parents=True)
+
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+        foreign_transcript = session_jsonl_path(sid, unrelated)
+        foreign_transcript.parent.mkdir(parents=True, exist_ok=True)
+        foreign_transcript.write_text("{}\n", encoding="utf-8")
+
+        with patch(
+            "hephaestus.automation.agent_config._registered_worktree_roots",
+            return_value=(local.resolve(), local_worktree.resolve()),
+        ):
+            resolved = resolve_session_jsonl_path(sid, local_worktree)
+
+        assert resolved == session_jsonl_path(sid, local_worktree)
+        assert resolved != foreign_transcript
+        assert not resolved.exists()
+
+    def test_worktree_discovery_parses_nul_output_and_scrubs_git_environment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Discovery uses the explicit cwd and parses Git's NUL records."""
+        repo_root = tmp_path / "Repo"
+        worktree = tmp_path / "worktree"
+        repo_root.mkdir()
+        worktree.mkdir()
+        monkeypatch.setenv("GIT_DIR", str(tmp_path / "foreign.git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "foreign-tree"))
+        output = (
+            f"worktree {repo_root}\0HEAD deadbeef\0branch refs/heads/main\0\0"
+            f"worktree {worktree}\0HEAD cafefood\0branch refs/heads/issue\0\0"
+        )
+
+        with patch(
+            "hephaestus.automation.agent_config.subprocess.run",
+            return_value=MagicMock(stdout=output),
+        ) as run:
+            roots = agent_config._registered_worktree_roots(worktree)
+
+        assert roots == tuple(sorted((repo_root.resolve(), worktree.resolve()), key=str))
+        argv = run.call_args.args[0]
+        assert argv[:3] == ["git", "-C", str(worktree.resolve())]
+        assert argv[-2:] == ["--porcelain", "-z"]
+        kwargs = run.call_args.kwargs
+        assert kwargs["timeout"] == 5
+        assert "GIT_DIR" not in kwargs["env"]
+        assert "GIT_WORK_TREE" not in kwargs["env"]
+
+    def test_git_discovery_failure_falls_back_to_exact_cwd_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed Git probe preserves the old exact-cwd create behavior."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        cwd = tmp_path / "not-a-repository"
+        cwd.mkdir()
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+
+        with patch(
+            "hephaestus.automation.agent_config.subprocess.run",
+            side_effect=subprocess.CalledProcessError(128, ["git"]),
+        ):
+            assert resolve_session_jsonl_path(sid, cwd) == session_jsonl_path(sid, cwd)
+
+    def test_historical_duplicates_choose_lexicographically_first_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Duplicate same-family transcripts have deterministic selection."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        repo_root = tmp_path / "owner-a" / "Repo"
+        worktree_a = repo_root / "build" / ".worktrees" / "a"
+        worktree_b = repo_root / "build" / ".worktrees" / "b"
+        worktree_b.mkdir(parents=True)
+        worktree_a.mkdir(parents=True)
+        sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable")
+        paths = [session_jsonl_path(sid, root) for root in (repo_root, worktree_a, worktree_b)]
+        for path in paths:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{}\n", encoding="utf-8")
+
+        with patch(
+            "hephaestus.automation.agent_config._registered_worktree_roots",
+            return_value=tuple(root.resolve() for root in (repo_root, worktree_a, worktree_b)),
+        ):
+            expected = min(paths, key=str)
+            assert resolve_session_jsonl_path(sid, repo_root) == expected
+            assert resolve_session_jsonl_path(sid, worktree_b) == expected
 
 
 @pytest.mark.requires_posix

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -390,12 +390,20 @@ class TestSessionJsonlPath:
     def test_lossy_path_pair_cannot_resume_unregistered_checkout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Dotted and dashed checkout paths cannot collide through Claude encoding."""
+        """Dotted/dashed checkout paths are separated before transcript lookup."""
         monkeypatch.setenv("HOME", str(tmp_path / "home"))
         dotted = tmp_path / "owner.a" / "Repo"
         dashed = tmp_path / "owner-a" / "Repo"
         dotted.mkdir(parents=True)
         dashed.mkdir(parents=True)
+
+        legacy_sid = str(
+            uuid.uuid5(
+                uuid.NAMESPACE_DNS,
+                session_name("Repo", 2284, AGENT_PLAN_REVIEWER, "fable"),
+            )
+        )
+        assert session_jsonl_path(legacy_sid, dotted) == session_jsonl_path(legacy_sid, dashed)
 
         git_failure = subprocess.CalledProcessError(128, ["git"])
         with patch(

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -146,6 +147,23 @@ class TestSessionUUID:
         b = session_uuid("R", 1, AGENT_PLANNER, "claude-opus-4-8")
         assert a != b
 
+    def test_registered_worktree_family_gets_same_checkout_uuid(self, tmp_path: Path) -> None:
+        """Repo-root and linked-worktree callers share their common-dir identity."""
+        repo_root = tmp_path / "owner-a" / "Repo"
+        worktree = tmp_path / "worktrees" / "issue-2284"
+        common_dir = repo_root / ".git"
+        repo_root.mkdir(parents=True)
+        worktree.mkdir(parents=True)
+
+        with patch(
+            "hephaestus.automation.agent_config.subprocess.run",
+            return_value=MagicMock(stdout=f"{common_dir}\n"),
+        ):
+            root_sid = session_uuid("Repo", 2284, AGENT_PLANNER, "fable", cwd=repo_root)
+            worktree_sid = session_uuid("Repo", 2284, AGENT_PLANNER, "fable", cwd=worktree)
+
+        assert root_sid == worktree_sid
+
     def test_omitting_model_preserves_legacy_key(self) -> None:
         """Backward compat: no model reproduces the historical (repo, issue, agent) id."""
         from hephaestus.automation.session_naming import session_name
@@ -189,7 +207,7 @@ class TestSessionUUID:
         to the now-githash-free signatures — otherwise this very test
         would itself be flagged as "wrong arg name" on every PR scan.
         """
-        bad_kwargs = {"githash": "abc1234"}
+        bad_kwargs: dict[str, Any] = {"githash": "abc1234"}
         with pytest.raises(TypeError):
             session_uuid("R", 1, AGENT_PLANNER, **bad_kwargs)
         with pytest.raises(TypeError):
@@ -343,6 +361,41 @@ class TestSessionJsonlPath:
 
         assert resolved == session_jsonl_path(sid, local_worktree)
         assert resolved != foreign_transcript
+        assert not resolved.exists()
+
+    def test_lossy_path_pair_cannot_resume_unregistered_checkout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dotted and dashed checkout paths cannot collide through Claude encoding."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        dotted = tmp_path / "owner.a" / "Repo"
+        dashed = tmp_path / "owner-a" / "Repo"
+        dotted.mkdir(parents=True)
+        dashed.mkdir(parents=True)
+
+        git_failure = subprocess.CalledProcessError(128, ["git"])
+        with patch(
+            "hephaestus.automation.agent_config.subprocess.run",
+            side_effect=git_failure,
+        ):
+            dotted_sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable", cwd=dotted)
+            dashed_sid = session_uuid("Repo", 2284, AGENT_PLAN_REVIEWER, "fable", cwd=dashed)
+
+        dotted_path = session_jsonl_path(dotted_sid, dotted)
+        dashed_path = session_jsonl_path(dashed_sid, dashed)
+        assert dotted_path.parent == dashed_path.parent
+        assert dotted_sid != dashed_sid
+
+        dashed_path.parent.mkdir(parents=True, exist_ok=True)
+        dashed_path.write_text("{}\n", encoding="utf-8")
+        with patch(
+            "hephaestus.automation.agent_config._registered_worktree_roots",
+            return_value=(dotted.resolve(),),
+        ):
+            resolved = resolve_session_jsonl_path(dotted_sid, dotted)
+
+        assert resolved == dotted_path
+        assert resolved != dashed_path
         assert not resolved.exists()
 
     def test_worktree_discovery_parses_nul_output_and_scrubs_git_environment(


### PR DESCRIPTION
## Summary

- Added checkout-scoped transcript resolution with Git worktree discovery, environment scrubbing, deterministic duplicate selection, and safe fallback.
- Updated Claude probing, compatibility exports, and post-merge documentation.
- Added cross-worktree, collision-isolation, and PlanReviewer-to-WorkerPool regression tests.

## Testing

- `uv run pytest tests -q --tb=short`
- Ruff and mypy

Closes #2284
