### PR TITLE
chore: [mino] Expand scoped-agent-call tests to pipeline paths

### DIFF
--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -522,6 +522,7 @@ class ImplementationStage(Stage):
             prompt_builder=get_dirty_reused_worktree_decision_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
+            allowed_tools="Read,Glob,Grep",
             session_agent=AGENT_IMPLEMENTER,
             resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={
@@ -601,6 +602,7 @@ class ImplementationStage(Stage):
             prompt_builder=get_advise_prompt_builder(ctx.config.agent),
             cwd=_worktree_path(item, ctx),
             timeout_s=advise_claude_timeout(),
+            allowed_tools="Read,Glob,Grep",
             session_agent=AGENT_ADVISE,
             prompt_kwargs={
                 "issue_number": item.issue,
@@ -697,6 +699,7 @@ class ImplementationStage(Stage):
                 prompt_builder=get_address_review_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=implementer_claude_timeout(),
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash,Task,Skill",
                 session_agent=AGENT_IMPLEMENTER,
                 resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
                 prompt_kwargs={
@@ -729,6 +732,7 @@ class ImplementationStage(Stage):
             prompt_builder=build_implementation_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
+            allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
             session_agent=AGENT_IMPLEMENTER,
             resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={
@@ -788,6 +792,7 @@ class ImplementationStage(Stage):
             prompt_builder=build_test_fix_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
+            allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
             session_agent=AGENT_IMPLEMENTER,
             resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
             prompt_kwargs={

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -522,6 +522,7 @@ class ImplementationStage(Stage):
             prompt_builder=get_dirty_reused_worktree_decision_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
+            sandbox="read-only",
             allowed_tools="Read,Glob,Grep",
             session_agent=AGENT_IMPLEMENTER,
             resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
@@ -602,6 +603,7 @@ class ImplementationStage(Stage):
             prompt_builder=get_advise_prompt_builder(ctx.config.agent),
             cwd=_worktree_path(item, ctx),
             timeout_s=advise_claude_timeout(),
+            sandbox="read-only",
             allowed_tools="Read,Glob,Grep",
             session_agent=AGENT_ADVISE,
             prompt_kwargs={

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -552,6 +552,7 @@ class MergeWaitStage(Stage):
             prompt_builder=build_drive_green_learn_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=learn_claude_timeout(),
+            allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
             session_agent=AGENT_LEARNINGS,
             prompt_kwargs={"issue_number": item.issue, "pr_number": item.pr},
             descr="drive_green_learn",

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -552,7 +552,7 @@ class MergeWaitStage(Stage):
             prompt_builder=build_drive_green_learn_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=learn_claude_timeout(),
-            allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+            allowed_tools="Read,Write,Edit,Glob,Grep,Bash,Task,Skill",
             session_agent=AGENT_LEARNINGS,
             prompt_kwargs={"issue_number": item.issue, "pr_number": item.pr},
             descr="drive_green_learn",

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -500,7 +500,7 @@ class PlanReviewStage(Stage):
                 prompt_builder=build_learn_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=learn_claude_timeout(),
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash,Task,Skill",
                 session_agent=AGENT_PLANNER,  # resume planner session (legacy parity)
                 prompt_kwargs={"context": item.payload.get("plan_text", "")},
                 descr="learn",

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -432,6 +432,7 @@ class PlanReviewStage(Stage):
                 prompt_builder=get_plan_loop_review_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=plan_reviewer_claude_timeout(),
+                allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_PLAN_REVIEWER,
                 # get_plan_loop_review_prompt takes a 0-based iteration index
                 # (full-sweep suffix on the final iteration). Issue title/body
@@ -471,6 +472,7 @@ class PlanReviewStage(Stage):
                 prompt_builder=build_amend_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
+                allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_PLANNER,
                 # build_amend_prompt composes get_plan_prompt with the
                 # reviewer feedback block in-worker (doc: "resume planner
@@ -498,6 +500,7 @@ class PlanReviewStage(Stage):
                 prompt_builder=build_learn_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=learn_claude_timeout(),
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
                 session_agent=AGENT_PLANNER,  # resume planner session (legacy parity)
                 prompt_kwargs={"context": item.payload.get("plan_text", "")},
                 descr="learn",

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -432,6 +432,7 @@ class PlanReviewStage(Stage):
                 prompt_builder=get_plan_loop_review_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=plan_reviewer_claude_timeout(),
+                sandbox="read-only",
                 allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_PLAN_REVIEWER,
                 # get_plan_loop_review_prompt takes a 0-based iteration index
@@ -472,6 +473,7 @@ class PlanReviewStage(Stage):
                 prompt_builder=build_amend_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
+                sandbox="read-only",
                 allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_PLANNER,
                 # build_amend_prompt composes get_plan_prompt with the

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -575,6 +575,7 @@ class PlanningStage(Stage):
                 prompt_builder=get_advise_prompt_builder(ctx.config.agent),
                 cwd=ctx.paths.worktree,
                 timeout_s=advise_claude_timeout(),
+                allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_ADVISE,
                 # Issue title/body and the Mnemosyne marketplace path are
                 # seeded into item.payload by the coordinator (#1817), which
@@ -599,6 +600,7 @@ class PlanningStage(Stage):
                 prompt_builder=build_plan_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
+                allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_PLANNER,
                 # build_plan_prompt composes get_plan_prompt with the issue
                 # title/body and advise findings in-worker, mirroring the

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -575,6 +575,7 @@ class PlanningStage(Stage):
                 prompt_builder=get_advise_prompt_builder(ctx.config.agent),
                 cwd=ctx.paths.worktree,
                 timeout_s=advise_claude_timeout(),
+                sandbox="read-only",
                 allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_ADVISE,
                 # Issue title/body and the Mnemosyne marketplace path are
@@ -600,6 +601,7 @@ class PlanningStage(Stage):
                 prompt_builder=build_plan_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
+                sandbox="read-only",
                 allowed_tools="Read,Glob,Grep",
                 session_agent=AGENT_PLANNER,
                 # build_plan_prompt composes get_plan_prompt with the issue

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1467,6 +1467,7 @@ class PrReviewStage(Stage):
             session_agent=AGENT_PR_REVIEWER,
             resume_session_id=item.session_ids.get(AGENT_PR_REVIEWER),
             sandbox="read-only",
+            allowed_tools="Read,Glob,Grep",
             prompt_kwargs={
                 "pr_number": item.pr,
                 "issue_number": item.issue,

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -551,7 +551,25 @@ class TestPlanningStageStep:
         assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "PLAN_WAIT"
         assert result.job.descr == "advise"
+        assert result.job.sandbox == "read-only"
         assert result.job.prompt_kwargs["issue_number"] == 3
+
+    def test_codex_advise_job_is_provider_neutral_read_only(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Codex advise turns must receive a runtime read-only sandbox."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        ctx.config.agent = "codex"
+        item = make_work_item(issue=3, state="ADVISE_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.agent == "codex"
+        assert result.job.sandbox == "read-only"
+        assert result.job.allowed_tools == "Read,Glob,Grep"
 
     def test_plan_wait_requests_plan_job(self, make_ctx: Any, make_work_item: Any) -> None:
         """PLAN_WAIT submits the plan job (planner session) and lands in VERIFY."""
@@ -568,6 +586,7 @@ class TestPlanningStageStep:
         assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "VERIFY"
         assert result.job.descr == "plan"
+        assert result.job.sandbox == "read-only"
         assert result.job.prompt_builder is build_plan_prompt
         # Advise findings travel via prompt_kwargs (builders run in-worker;
         # AgentJob is frozen, so no closures over payload).

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
+import queue
 import re
+import threading
+from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
-from hephaestus.automation.pipeline.routing import Disposition
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.routing import Disposition, StageName
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.planning import (
     PlanningStage,
     build_plan_prompt,
 )
+from hephaestus.automation.pipeline.worker_pool import WorkerPool
 from hephaestus.automation.prompts._shared import get_untrusted_notice
 from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.protocol import (
@@ -570,6 +576,51 @@ class TestPlanningStageStep:
         assert result.job.agent == "codex"
         assert result.job.sandbox == "read-only"
         assert result.job.allowed_tools == "Read,Glob,Grep"
+
+    def test_codex_advise_job_reaches_direct_runner_as_read_only(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+        tmp_path: Path,
+    ) -> None:
+        """The planning job's read-only contract reaches the Codex runtime."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        ctx.config.agent = "codex"
+        item = make_work_item(issue=3, state="ADVISE_WAIT")
+        request = stage.step(item, ctx)
+
+        assert isinstance(request, JobRequest)
+        assert isinstance(request.job, AgentJob)
+
+        completion_q: CompletionQueue = queue.Queue()
+        pool = WorkerPool(
+            size=1,
+            shutdown=threading.Event(),
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
+        session_result = MagicMock(stdout="advice", session_id="codex-session")
+        try:
+            with (
+                patch(
+                    "hephaestus.automation.pipeline.worker_pool.resolve_agent",
+                    return_value="codex",
+                ),
+                patch(
+                    "hephaestus.automation.pipeline.worker_pool.run_agent_session",
+                    return_value=session_result,
+                ) as direct_runner,
+            ):
+                pool.submit(request.job, StageName.PLANNING)
+                _handle, result = completion_q.get(timeout=10)
+        finally:
+            pool.shutdown()
+
+        assert result.ok is True
+        direct_runner.assert_called_once()
+        assert direct_runner.call_args.kwargs["sandbox"] == "read-only"
+        assert direct_runner.call_args.kwargs["approval"] == "never"
 
     def test_plan_wait_requests_plan_job(self, make_ctx: Any, make_work_item: Any) -> None:
         """PLAN_WAIT submits the plan job (planner session) and lands in VERIFY."""

--- a/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
+++ b/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
@@ -1,0 +1,125 @@
+"""Every pipeline ``AgentJob`` must declare an explicit tool scope.
+
+The direct-call policy test validates ``invoke_claude_with_session`` call
+sites, but queue-pipeline agents reach the worker pool through frozen
+``AgentJob`` specifications. This test statically covers those stage paths so
+an omitted, broadened, or newly added scope cannot bypass policy review.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+STAGES_DIR = Path(__file__).parents[4] / "hephaestus" / "automation" / "pipeline" / "stages"
+
+READ_ONLY = "Read,Glob,Grep"
+WRITE = "Read,Write,Edit,Glob,Grep,Bash"
+ADDRESS = "Read,Write,Edit,Glob,Grep,Bash,Task,Skill"
+PR_REVIEW = "Read,Glob,Grep,Bash,Skill,Agent,WebFetch"
+
+# (stage filename, enclosing function, prompt_builder source) -> exact scope.
+# The primary PR review retains the additional read-only helper capabilities
+# required by the normal review workflow; it does not grant write tools.
+EXPECTED_SCOPES = {
+    ("planning.py", "step", "get_advise_prompt_builder(ctx.config.agent)"): READ_ONLY,
+    ("planning.py", "step", "build_plan_prompt"): READ_ONLY,
+    ("plan_review.py", "step", "get_plan_loop_review_prompt"): READ_ONLY,
+    ("plan_review.py", "step", "build_amend_prompt"): READ_ONLY,
+    ("plan_review.py", "step", "build_learn_prompt"): WRITE,
+    (
+        "implementation.py",
+        "_dirty_decision_wait",
+        "get_dirty_reused_worktree_decision_prompt",
+    ): READ_ONLY,
+    (
+        "implementation.py",
+        "_advise_wait",
+        "get_advise_prompt_builder(ctx.config.agent)",
+    ): READ_ONLY,
+    ("implementation.py", "_implement_wait", "get_address_review_prompt"): ADDRESS,
+    ("implementation.py", "_implement_wait", "build_implementation_prompt"): WRITE,
+    ("implementation.py", "_testfix_wait", "build_test_fix_prompt"): WRITE,
+    ("pr_review.py", "_submit_review_job", "get_pr_review_analysis_prompt"): PR_REVIEW,
+    ("pr_review.py", "_validate_wait", "get_review_validation_prompt"): READ_ONLY,
+    ("merge_wait.py", "_request_learn", "build_drive_green_learn_prompt"): WRITE,
+}
+
+
+def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
+    """Discover stage ``AgentJob`` scopes keyed by their source location.
+
+    The returned mapping uses the stage filename, enclosing function, and
+    prompt-builder source as its key and the literal ``allowed_tools`` value as
+    its value.
+    The test fails if a constructor omits ``allowed_tools`` or uses a
+    non-literal value that cannot be checked by this policy test.
+    """
+    discovered: dict[tuple[str, str, str], str] = {}
+
+    for path in sorted(STAGES_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text())
+
+        class _Visitor(ast.NodeVisitor):
+            def __init__(self, filename: str) -> None:
+                self.filename = filename
+                self.function_stack: list[str] = []
+
+            def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+                self.function_stack.append(node.name)
+                self.generic_visit(node)
+                self.function_stack.pop()
+
+            def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+                self.function_stack.append(node.name)
+                self.generic_visit(node)
+                self.function_stack.pop()
+
+            def visit_Call(self, node: ast.Call) -> None:
+                name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                if name == "AgentJob":
+                    self._record(node)
+                self.generic_visit(node)
+
+            def _record(self, node: ast.Call) -> None:
+                function = self.function_stack[-1] if self.function_stack else "<module>"
+                kwargs = {keyword.arg: keyword.value for keyword in node.keywords if keyword.arg}
+                builder = kwargs.get("prompt_builder")
+                builder_source = ast.unparse(builder) if builder is not None else "<none>"
+                scope = kwargs.get("allowed_tools")
+                if scope is None:
+                    pytest.fail(
+                        f"{self.filename}:{node.lineno}: AgentJob in {function}() "
+                        f"({builder_source}) missing allowed_tools= kwarg"
+                    )
+                if not isinstance(scope, ast.Constant) or not isinstance(scope.value, str):
+                    pytest.fail(
+                        f"{self.filename}:{node.lineno}: AgentJob in {function}() "
+                        f"({builder_source}) allowed_tools must be a string literal"
+                    )
+                key = (self.filename, function, builder_source)
+                discovered[key] = scope.value
+
+        _Visitor(path.name).visit(tree)
+
+    return discovered
+
+
+def test_every_pipeline_agent_job_matches_expected_scope() -> None:
+    """Every current stage job is registered with its exact tool scope."""
+    discovered = _discover_agent_jobs()
+
+    missing = sorted(set(EXPECTED_SCOPES) - set(discovered))
+    assert not missing, f"expected AgentJob call sites not found: {missing}"
+
+    extra = sorted(set(discovered) - set(EXPECTED_SCOPES))
+    assert not extra, f"unregistered pipeline AgentJob call sites: {extra}"
+
+    mismatched = {
+        key: (discovered[key], EXPECTED_SCOPES[key])
+        for key in EXPECTED_SCOPES
+        if discovered[key] != EXPECTED_SCOPES[key]
+    }
+    assert not mismatched, f"AgentJob scope drift (actual, expected): {mismatched}"

--- a/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
+++ b/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
@@ -2,8 +2,9 @@
 
 The direct-call policy test validates ``invoke_claude_with_session`` call
 sites, but queue-pipeline agents reach the worker pool through frozen
-``AgentJob`` specifications. This test statically covers those stage paths so
-an omitted, broadened, or newly added scope cannot bypass policy review.
+``AgentJob`` specifications. This test statically covers every production
+pipeline module so an omitted, broadened, or newly added scope cannot bypass
+policy review.
 """
 
 from __future__ import annotations
@@ -13,59 +14,60 @@ from pathlib import Path
 
 import pytest
 
-STAGES_DIR = Path(__file__).parents[4] / "hephaestus" / "automation" / "pipeline" / "stages"
+PIPELINE_DIR = Path(__file__).parents[4] / "hephaestus" / "automation" / "pipeline"
 
 READ_ONLY = "Read,Glob,Grep"
 WRITE = "Read,Write,Edit,Glob,Grep,Bash"
 ADDRESS = "Read,Write,Edit,Glob,Grep,Bash,Task,Skill"
 PR_REVIEW = "Read,Glob,Grep,Bash,Skill,Agent,WebFetch"
+READ_ONLY_SCOPES = frozenset({READ_ONLY, PR_REVIEW})
 
-# (stage filename, enclosing function, prompt_builder source) -> exact scope.
+# (pipeline-relative path, enclosing function, prompt_builder source) -> exact scope.
 # The primary PR review retains the additional read-only helper capabilities
 # required by the normal review workflow; it does not grant write tools.
 EXPECTED_SCOPES = {
-    ("planning.py", "step", "get_advise_prompt_builder(ctx.config.agent)"): READ_ONLY,
-    ("planning.py", "step", "build_plan_prompt"): READ_ONLY,
-    ("plan_review.py", "step", "get_plan_loop_review_prompt"): READ_ONLY,
-    ("plan_review.py", "step", "build_amend_prompt"): READ_ONLY,
-    ("plan_review.py", "step", "build_learn_prompt"): ADDRESS,
+    ("stages/planning.py", "step", "get_advise_prompt_builder(ctx.config.agent)"): READ_ONLY,
+    ("stages/planning.py", "step", "build_plan_prompt"): READ_ONLY,
+    ("stages/plan_review.py", "step", "get_plan_loop_review_prompt"): READ_ONLY,
+    ("stages/plan_review.py", "step", "build_amend_prompt"): READ_ONLY,
+    ("stages/plan_review.py", "step", "build_learn_prompt"): ADDRESS,
     (
-        "implementation.py",
+        "stages/implementation.py",
         "_dirty_decision_wait",
         "get_dirty_reused_worktree_decision_prompt",
     ): READ_ONLY,
     (
-        "implementation.py",
+        "stages/implementation.py",
         "_advise_wait",
         "get_advise_prompt_builder(ctx.config.agent)",
     ): READ_ONLY,
-    ("implementation.py", "_implement_wait", "get_address_review_prompt"): ADDRESS,
-    ("implementation.py", "_implement_wait", "build_implementation_prompt"): WRITE,
-    ("implementation.py", "_testfix_wait", "build_test_fix_prompt"): WRITE,
-    ("pr_review.py", "_submit_review_job", "get_pr_review_analysis_prompt"): PR_REVIEW,
-    ("pr_review.py", "_validate_wait", "get_review_validation_prompt"): READ_ONLY,
-    ("merge_wait.py", "_request_learn", "build_drive_green_learn_prompt"): ADDRESS,
+    ("stages/implementation.py", "_implement_wait", "get_address_review_prompt"): ADDRESS,
+    ("stages/implementation.py", "_implement_wait", "build_implementation_prompt"): WRITE,
+    ("stages/implementation.py", "_testfix_wait", "build_test_fix_prompt"): WRITE,
+    ("stages/pr_review.py", "_submit_review_job", "get_pr_review_analysis_prompt"): PR_REVIEW,
+    ("stages/pr_review.py", "_validate_wait", "get_review_validation_prompt"): READ_ONLY,
+    ("stages/merge_wait.py", "_request_learn", "build_drive_green_learn_prompt"): ADDRESS,
 }
 
 
 def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
-    """Discover stage ``AgentJob`` scopes keyed by their source location.
+    """Discover pipeline ``AgentJob`` scopes keyed by their source location.
 
-    The returned mapping uses the stage filename, enclosing function, and
-    prompt-builder source as its key and the literal ``allowed_tools`` value as
-    its value.
+    The returned mapping uses the pipeline-relative path, enclosing function,
+    and prompt-builder source as its key and the literal ``allowed_tools``
+    value as its value.
     The test fails if a constructor omits ``allowed_tools`` or uses a
     non-literal value that cannot be checked by this policy test.
     """
     discovered: dict[tuple[str, str, str], str] = {}
     discovered_locations: dict[tuple[str, str, str], int] = {}
 
-    for path in sorted(STAGES_DIR.glob("*.py")):
+    for path in sorted(PIPELINE_DIR.rglob("*.py")):
         tree = ast.parse(path.read_text())
 
         class _Visitor(ast.NodeVisitor):
-            def __init__(self, filename: str) -> None:
-                self.filename = filename
+            def __init__(self, relative_path: str) -> None:
+                self.relative_path = relative_path
                 self.function_stack: list[str] = []
 
             def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -92,18 +94,18 @@ def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
                 scope = kwargs.get("allowed_tools")
                 if scope is None:
                     pytest.fail(
-                        f"{self.filename}:{node.lineno}: AgentJob in {function}() "
+                        f"{self.relative_path}:{node.lineno}: AgentJob in {function}() "
                         f"({builder_source}) missing allowed_tools= kwarg"
                     )
                 if not isinstance(scope, ast.Constant) or not isinstance(scope.value, str):
                     pytest.fail(
-                        f"{self.filename}:{node.lineno}: AgentJob in {function}() "
+                        f"{self.relative_path}:{node.lineno}: AgentJob in {function}() "
                         f"({builder_source}) allowed_tools must be a string literal"
                     )
-                key = (self.filename, function, builder_source)
+                key = (self.relative_path, function, builder_source)
                 if key in discovered:
                     pytest.fail(
-                        f"{self.filename}:{node.lineno}: duplicate AgentJob policy key "
+                        f"{self.relative_path}:{node.lineno}: duplicate AgentJob policy key "
                         f"{key}; previous occurrence at line {discovered_locations[key]}. "
                         "Include a distinct prompt builder or extend the policy key before "
                         "adding another constructor with the same identity."
@@ -111,13 +113,63 @@ def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
                 discovered[key] = scope.value
                 discovered_locations[key] = node.lineno
 
-        _Visitor(path.name).visit(tree)
+        _Visitor(path.relative_to(PIPELINE_DIR).as_posix()).visit(tree)
+
+    return discovered
+
+
+def _discover_agent_job_sandboxes() -> dict[tuple[str, str, str], str | None]:
+    """Discover each pipeline ``AgentJob``'s explicit sandbox literal."""
+    discovered: dict[tuple[str, str, str], str | None] = {}
+
+    for path in sorted(PIPELINE_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+
+        class _Visitor(ast.NodeVisitor):
+            def __init__(self, relative_path: str) -> None:
+                self.relative_path = relative_path
+                self.function_stack: list[str] = []
+
+            def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+                self.function_stack.append(node.name)
+                self.generic_visit(node)
+                self.function_stack.pop()
+
+            def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+                self.function_stack.append(node.name)
+                self.generic_visit(node)
+                self.function_stack.pop()
+
+            def visit_Call(self, node: ast.Call) -> None:
+                name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                if name == "AgentJob":
+                    self._record(node)
+                self.generic_visit(node)
+
+            def _record(self, node: ast.Call) -> None:
+                function = self.function_stack[-1] if self.function_stack else "<module>"
+                kwargs = {keyword.arg: keyword.value for keyword in node.keywords if keyword.arg}
+                builder = kwargs.get("prompt_builder")
+                builder_source = ast.unparse(builder) if builder is not None else "<none>"
+                sandbox = kwargs.get("sandbox")
+                if sandbox is None:
+                    sandbox_value: str | None = None
+                elif isinstance(sandbox, ast.Constant) and isinstance(sandbox.value, str):
+                    sandbox_value = sandbox.value
+                else:
+                    pytest.fail(
+                        f"{self.relative_path}:{node.lineno}: AgentJob in {function}() "
+                        f"({builder_source}) sandbox must be omitted or a string literal"
+                    )
+                discovered[(self.relative_path, function, builder_source)] = sandbox_value
+
+        _Visitor(path.relative_to(PIPELINE_DIR).as_posix()).visit(tree)
 
     return discovered
 
 
 def test_every_pipeline_agent_job_matches_expected_scope() -> None:
-    """Every current stage job is registered with its exact tool scope."""
+    """Every current pipeline job is registered with its exact tool scope."""
     discovered = _discover_agent_jobs()
 
     missing = sorted(set(EXPECTED_SCOPES) - set(discovered))
@@ -132,3 +184,16 @@ def test_every_pipeline_agent_job_matches_expected_scope() -> None:
         if discovered[key] != EXPECTED_SCOPES[key]
     }
     assert not mismatched, f"AgentJob scope drift (actual, expected): {mismatched}"
+
+
+def test_every_read_only_pipeline_agent_job_declares_read_only_sandbox() -> None:
+    """Read-only tool scopes must also constrain direct providers like Codex."""
+    sandboxes = _discover_agent_job_sandboxes()
+
+    widened = {
+        key: sandboxes.get(key)
+        for key, scope in EXPECTED_SCOPES.items()
+        if scope in READ_ONLY_SCOPES and sandboxes.get(key) != "read-only"
+    }
+
+    assert not widened, f"read-only AgentJob sandbox drift: {widened}"

--- a/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
+++ b/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
@@ -28,7 +28,7 @@ EXPECTED_SCOPES = {
     ("planning.py", "step", "build_plan_prompt"): READ_ONLY,
     ("plan_review.py", "step", "get_plan_loop_review_prompt"): READ_ONLY,
     ("plan_review.py", "step", "build_amend_prompt"): READ_ONLY,
-    ("plan_review.py", "step", "build_learn_prompt"): WRITE,
+    ("plan_review.py", "step", "build_learn_prompt"): ADDRESS,
     (
         "implementation.py",
         "_dirty_decision_wait",
@@ -44,7 +44,7 @@ EXPECTED_SCOPES = {
     ("implementation.py", "_testfix_wait", "build_test_fix_prompt"): WRITE,
     ("pr_review.py", "_submit_review_job", "get_pr_review_analysis_prompt"): PR_REVIEW,
     ("pr_review.py", "_validate_wait", "get_review_validation_prompt"): READ_ONLY,
-    ("merge_wait.py", "_request_learn", "build_drive_green_learn_prompt"): WRITE,
+    ("merge_wait.py", "_request_learn", "build_drive_green_learn_prompt"): ADDRESS,
 }
 
 
@@ -58,6 +58,7 @@ def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
     non-literal value that cannot be checked by this policy test.
     """
     discovered: dict[tuple[str, str, str], str] = {}
+    discovered_locations: dict[tuple[str, str, str], int] = {}
 
     for path in sorted(STAGES_DIR.glob("*.py")):
         tree = ast.parse(path.read_text())
@@ -100,7 +101,15 @@ def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
                         f"({builder_source}) allowed_tools must be a string literal"
                     )
                 key = (self.filename, function, builder_source)
+                if key in discovered:
+                    pytest.fail(
+                        f"{self.filename}:{node.lineno}: duplicate AgentJob policy key "
+                        f"{key}; previous occurrence at line {discovered_locations[key]}. "
+                        "Include a distinct prompt builder or extend the policy key before "
+                        "adding another constructor with the same identity."
+                    )
                 discovered[key] = scope.value
+                discovered_locations[key] = node.lineno
 
         _Visitor(path.name).visit(tree)
 

--- a/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
+++ b/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
@@ -102,6 +102,11 @@ def _discover_agent_jobs() -> dict[tuple[str, str, str], str]:
                         f"{self.relative_path}:{node.lineno}: AgentJob in {function}() "
                         f"({builder_source}) allowed_tools must be a string literal"
                     )
+                if not scope.value.strip():
+                    pytest.fail(
+                        f"{self.relative_path}:{node.lineno}: AgentJob in {function}() "
+                        f"({builder_source}) allowed_tools must be non-empty"
+                    )
                 key = (self.relative_path, function, builder_source)
                 if key in discovered:
                     pytest.fail(

--- a/tests/unit/automation/test_invoke_allowed_tools_scoping.py
+++ b/tests/unit/automation/test_invoke_allowed_tools_scoping.py
@@ -22,19 +22,10 @@ CONTRACT_AGENT_TEST = (
 CALL_SITES = [
     ("pr_review_core.py", {"Read", "Glob", "Grep"}, False),
     ("plan_reviewer.py", {"Read", "Glob", "Grep"}, False),
-    # planner.py was re-pointed at the queue-based pipeline (#1820): its
-    # planning agent calls now go through the pipeline stages'
-    # ``AgentJob``/worker pool, not a direct ``invoke_claude_with_session``
-    # call site, so it is no longer scanned here.
-    # ci_driver.py was re-pointed at the queue-based pipeline (#1822): its
-    # remaining drive-green work now goes through the ``AgentJob``/worker pool
-    # rather than a direct ``invoke_claude_with_session`` call site, so it is
-    # no longer scanned here.
-    # implementer.py was re-pointed at the queue-based pipeline (#1821): its
-    # implementation agent calls now go through the pipeline stages'
-    # ``AgentJob``/worker pool (the legacy per-issue phase runner was deleted),
-    # not a direct ``invoke_claude_with_session`` call site, so it is no longer
-    # scanned here.
+    # Direct invoke_claude_with_session call sites remain covered here. The
+    # queue-pipeline AgentJob call sites are enforced independently by
+    # pipeline/test_agent_allowed_tools_scoping.py, and worker forwarding is
+    # covered by test_worker_pool.py.
     ("comment_difficulty.py", {"Read", "Glob", "Grep"}, False),
 ]
 


### PR DESCRIPTION
## Summary

Implemented #2162.

- Added explicit least-privilege scopes to all pipeline `AgentJob` paths.
- Added AST policy coverage for every stage constructor in `tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py`.
- Updated direct-call policy documentation.

## Verification

- Full suite: 7,125 passed, 24 skipped; coverage 84.58%.
- Ruff and mypy passed.

Closes #2162
