### PR TITLE
fix(automation): exclude remediation self claims

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1922,6 +1922,16 @@ class Coordinator:
                 item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(item_claims)
             else:
                 item_claims = set(payload_claims)
+            # A PR may return from review before a coordinator-wide claim
+            # refresh materializes its verified diff paths.  Its selected
+            # reservation must include those realized paths immediately so a
+            # later candidate in this same admission batch cannot overlap.
+            changed_paths = item.payload.get("review_changed_paths")
+            if isinstance(changed_paths, list):
+                for changed_path in changed_paths:
+                    if isinstance(changed_path, str) and changed_path:
+                        item_claims.add((repo, changed_path))
+                item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(item_claims)
             if item_claims and (item_claims & claimed):
                 self._record_file_overlap_deferral(item, identity)
                 item.payload[_FILE_OVERLAP_BLOCKED_CLAIMS_KEY] = set(claimed)

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1937,6 +1937,11 @@ class Coordinator:
                 item.payload[_FILE_OVERLAP_BLOCKED_CLAIMS_KEY] = set(claimed)
                 continue
             item.payload.pop(_FILE_OVERLAP_BLOCKED_CLAIMS_KEY, None)
+            # Keep the host-owned reservation in sync with the selected
+            # snapshot.  A returning PR already has its planned claims in
+            # this map; without updating it here, its verified review paths
+            # would disappear when the implementation job captures claims.
+            self._implementation_file_claims[id(item)] = set(item_claims)
             selected_claims.update(item_claims)
             # Preserve an empty snapshot too: unknown plans fail open, but
             # must not be fetched again after being admitted.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1895,12 +1895,18 @@ class Coordinator:
         candidates: list[tuple[WorkItem, str]],
     ) -> tuple[list[WorkItem], dict[int, set[_admission.PlanFileClaim]]]:
         """Apply one repo-scoped overlap safety rule to every candidate class."""
-        claimed = self._active_implementation_file_claims()
         dispatch: list[WorkItem] = []
         snapshots: dict[int, set[_admission.PlanFileClaim]] = {}
+        selected_claims: set[_admission.PlanFileClaim] = set()
         for item, identity in candidates:
             if item.issue is None:  # defensive: candidate construction excludes this case
                 continue
+            # A reviewed PR returning for remediation still owns its claims so
+            # it can block every *other* issue.  It must not block itself.
+            # Recompute per candidate rather than subtracting from an aggregate:
+            # another active item may independently own the same path.
+            claimed = self._active_implementation_file_claims(exclude_item=item)
+            claimed.update(selected_claims)
             blocked_claims = item.payload.get(_FILE_OVERLAP_BLOCKED_CLAIMS_KEY)
             if blocked_claims is not None and set(blocked_claims) == claimed:
                 # The same active reservation still blocks this item. Polling
@@ -1921,7 +1927,7 @@ class Coordinator:
                 item.payload[_FILE_OVERLAP_BLOCKED_CLAIMS_KEY] = set(claimed)
                 continue
             item.payload.pop(_FILE_OVERLAP_BLOCKED_CLAIMS_KEY, None)
-            claimed.update(item_claims)
+            selected_claims.update(item_claims)
             # Preserve an empty snapshot too: unknown plans fail open, but
             # must not be fetched again after being admitted.
             snapshots[id(item)] = set(item_claims)
@@ -1943,14 +1949,21 @@ class Coordinator:
                 seen.add(key)
         return duplicates
 
-    def _active_implementation_file_claims(self) -> set[_admission.PlanFileClaim]:
-        """Return plan plus verified-diff claims held by active PR work."""
+    def _active_implementation_file_claims(
+        self, *, exclude_item: WorkItem | None = None
+    ) -> set[_admission.PlanFileClaim]:
+        """Return active claims, optionally excluding one candidate's ownership."""
         claims: set[_admission.PlanFileClaim] = set()
-        for item_claims in self._implementation_file_claims.values():
+        excluded_id = id(exclude_item) if exclude_item is not None else None
+        for item_id, item_claims in self._implementation_file_claims.items():
+            if item_id == excluded_id:
+                continue
             claims.update(item_claims)
         for active_claims in self._inflight_implementation_claims.values():
             claims.update(active_claims)
         for item in self.items:
+            if item is exclude_item:
+                continue
             if item.stage not in _REALIZED_DIFF_CLAIM_STAGES:
                 continue
             item_claims = set(item.payload.get(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD, ()))

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1994,12 +1994,14 @@ class TestImplementationAdmission:
     ) -> None:
         """A returning PR keeps exclusive ownership without self-deadlocking."""
         coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
-        claim = (("org", "repo-a"), "shared.py")
+        plan_claim = (("org", "repo-a"), "planned.py")
+        realized_claim = (("org", "repo-a"), "shared.py")
         returning = _issue_item(21, StageName.IMPLEMENTATION)
-        returning.payload["_implementation_file_claims"] = {claim}
-        coordinator._implementation_file_claims[id(returning)] = {claim}
+        returning.payload["_implementation_file_claims"] = {plan_claim}
+        returning.payload["review_changed_paths"] = ["shared.py"]
+        coordinator._implementation_file_claims[id(returning)] = {plan_claim}
         overlapping = _issue_item(22, StageName.IMPLEMENTATION)
-        overlapping.payload["_implementation_file_claims"] = {claim}
+        overlapping.payload["_implementation_file_claims"] = {realized_claim}
         independent = _issue_item(23, StageName.IMPLEMENTATION)
         independent_claim = (("org", "repo-a"), "independent.py")
         independent.payload["_implementation_file_claims"] = {independent_claim}
@@ -2010,8 +2012,12 @@ class TestImplementationAdmission:
 
         assert dispatch == [returning, independent]
         assert snapshots == {
-            id(returning): {claim},
+            id(returning): {plan_claim, realized_claim},
             id(independent): {independent_claim},
+        }
+        assert returning.payload["_implementation_file_claims"] == {
+            plan_claim,
+            realized_claim,
         }
         assert overlapping.payload["file_overlap_deferrals"] == 1
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1996,10 +1996,13 @@ class TestImplementationAdmission:
         coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
         plan_claim = (("org", "repo-a"), "planned.py")
         realized_claim = (("org", "repo-a"), "shared.py")
-        returning = _issue_item(21, StageName.IMPLEMENTATION)
+        returning = _issue_item(21, StageName.PR_REVIEW)
+        assert coordinator._push_item(returning, StageName.PR_REVIEW, enter=True)
         returning.payload["_implementation_file_claims"] = {plan_claim}
         returning.payload["review_changed_paths"] = ["shared.py"]
         coordinator._implementation_file_claims[id(returning)] = {plan_claim}
+        coordinator._route(returning, StageOutcome(Disposition.FAIL_BACK, "agent_error"))
+        assert returning.stage is StageName.IMPLEMENTATION
         overlapping = _issue_item(22, StageName.IMPLEMENTATION)
         overlapping.payload["_implementation_file_claims"] = {realized_claim}
         independent = _issue_item(23, StageName.IMPLEMENTATION)
@@ -2019,7 +2022,19 @@ class TestImplementationAdmission:
             plan_claim,
             realized_claim,
         }
-        assert overlapping.payload["file_overlap_deferrals"] == 1
+        assert coordinator._implementation_file_claims[id(returning)] == {
+            plan_claim,
+            realized_claim,
+        }
+        assert coordinator._capture_implementation_file_claims(returning) == {
+            plan_claim,
+            realized_claim,
+        }
+        later_dispatch, _ = coordinator._select_file_overlap_implementation_items(
+            [(overlapping, "#22")]
+        )
+        assert later_dispatch == []
+        assert overlapping.payload["file_overlap_deferrals"] == 2
 
     def test_remediation_candidate_still_honors_same_claim_owned_by_peer(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1989,6 +1989,53 @@ class TestImplementationAdmission:
             (("org", "repo-a"), "new.py"),
         }
 
+    def test_remediation_candidate_does_not_block_itself_but_blocks_peer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A returning PR keeps exclusive ownership without self-deadlocking."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        claim = (("org", "repo-a"), "shared.py")
+        returning = _issue_item(21, StageName.IMPLEMENTATION)
+        returning.payload["_implementation_file_claims"] = {claim}
+        coordinator._implementation_file_claims[id(returning)] = {claim}
+        overlapping = _issue_item(22, StageName.IMPLEMENTATION)
+        overlapping.payload["_implementation_file_claims"] = {claim}
+        independent = _issue_item(23, StageName.IMPLEMENTATION)
+        independent_claim = (("org", "repo-a"), "independent.py")
+        independent.payload["_implementation_file_claims"] = {independent_claim}
+
+        dispatch, snapshots = coordinator._select_file_overlap_implementation_items(
+            [(returning, "#21"), (overlapping, "#22"), (independent, "#23")]
+        )
+
+        assert dispatch == [returning, independent]
+        assert snapshots == {
+            id(returning): {claim},
+            id(independent): {independent_claim},
+        }
+        assert overlapping.payload["file_overlap_deferrals"] == 1
+
+    def test_remediation_candidate_still_honors_same_claim_owned_by_peer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Excluding self ownership must not subtract a peer's equal claim."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        claim = (("org", "repo-a"), "shared.py")
+        returning = _issue_item(21, StageName.IMPLEMENTATION)
+        returning.payload["_implementation_file_claims"] = {claim}
+        coordinator._implementation_file_claims[id(returning)] = {claim}
+        peer = _issue_item(20, StageName.PR_REVIEW)
+        peer.payload["_implementation_file_claims"] = {claim}
+        coordinator._implementation_file_claims[id(peer)] = {claim}
+        assert coordinator._push_item(peer, StageName.PR_REVIEW, enter=True)
+
+        dispatch, _snapshots = coordinator._select_file_overlap_implementation_items(
+            [(returning, "#21")]
+        )
+
+        assert dispatch == []
+        assert returning.payload["file_overlap_deferrals"] == 1
+
     def test_overlap_claims_survive_review_and_merge_wait_until_finished(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Exclude a returning remediation item from its own retained file claims during admission.
- Preserve claims owned by other active items, including identical-path claims.
- Add regressions for self-admission, peer blocking, and duplicate ownership.

## Verification

- Coordinator suite: 98 passed, 3 deselected.
- Full suite: 7,144 passed, 6 skipped, 5 deselected; coverage 84.73%.
- Ruff and mypy passed.

Closes #2608
