### PR TITLE
fix(automation): make PR evidence head-bound

### DIFF
--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -1570,8 +1570,10 @@ class ImplementationStage(Stage):
             title = normalize_strict_conventional_title(str(raw_title))
             body = get_pr_description(
                 item.issue,
-                summary=item.payload.get("implement_summary", "")
-                or f"Automated implementation for issue #{item.issue}.",
+                # Agent summaries may contain local paths, stale working-tree
+                # state, or unbound test totals. The durable PR journal must
+                # be deterministic; the reviewed diff carries the detail.
+                summary=f"Implements the requested changes for issue #{item.issue}.",
                 changes="See the PR diff for the full change set.",
                 testing=item.payload.get("test_receipt") or "Not run by the automation pipeline.",
             )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -336,19 +336,48 @@ _PATH_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
 HOST_VERIFICATION_TIMEOUT_S = 300
 HOST_VERIFICATION_DIAGNOSTIC_MAX = 4_000
 
+_DIFF_GIT_HEADER_RE = re.compile(r"^diff --git a/(.+?) b/(.+?)$", flags=re.MULTILINE)
+
+
+def _changed_new_side_paths(pr_diff: str) -> frozenset[str]:
+    """Return non-deleted changed paths from each diff's new-file side."""
+    paths: set[str] = set()
+    pending_header_path: str | None = None
+
+    def flush_pending_header_path() -> None:
+        nonlocal pending_header_path
+        if pending_header_path is not None:
+            paths.add(pending_header_path)
+            pending_header_path = None
+
+    for raw_line in pr_diff.splitlines():
+        header = _DIFF_GIT_HEADER_RE.match(raw_line)
+        if header:
+            flush_pending_header_path()
+            pending_header_path = header.group(2)
+            continue
+
+        if raw_line.startswith("+++ ") and pending_header_path is not None:
+            target = raw_line[4:].strip()
+            pending_header_path = None
+            if target == "/dev/null":
+                continue
+            paths.add(target[2:] if target.startswith("b/") else target)
+
+    flush_pending_header_path()
+    return frozenset(paths)
+
 
 def _host_verification_specs(pr_diff: object) -> tuple[_HostVerificationSpec, ...]:
     """Return the complete fixed host plan activated by the verified diff."""
     if not isinstance(pr_diff, str):
         return ()
-    changed_paths = {
-        match.group(2)
-        for match in re.finditer(r"^diff --git a/(.+?) b/(.+?)$", pr_diff, flags=re.MULTILINE)
-    }
+    changed_paths = {match.group(2) for match in _DIFF_GIT_HEADER_RE.finditer(pr_diff)}
     if not any(
         path.endswith(".py") or path in _PYTHON_VALIDATION_CONFIG_PATHS for path in changed_paths
     ):
         return ()
+    changed_new_side_paths = _changed_new_side_paths(pr_diff)
     changed_unit_tests = tuple(
         _HostVerificationSpec(
             changed_path=path,
@@ -358,7 +387,7 @@ def _host_verification_specs(pr_diff: object) -> tuple[_HostVerificationSpec, ..
         for index, path in enumerate(
             sorted(
                 path
-                for path in changed_paths
+                for path in changed_new_side_paths
                 if path.startswith("tests/unit/")
                 and path.endswith(".py")
                 and path not in _NONHERMETIC_HOST_UNIT_TEST_PATHS

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -308,6 +308,12 @@ _PYTHON_VALIDATION_CONFIG_PATHS = frozenset(
         "tox.ini",
     }
 )
+#: This suite exercises the host verifier's own disk-image and sandbox
+#: primitives. Running it inside that verifier would require nested mounts and
+#: produces runner failures rather than meaningful code evidence.
+_NONHERMETIC_HOST_UNIT_TEST_PATHS = frozenset(
+    {"tests/unit/automation/pipeline/test_worker_pool.py"}
+)
 #: Some Python regressions require additional bounded execution beyond the
 #: baseline review plan.  Their path trigger is derived only from a real Git
 #: diff header, never from reviewer or GitHub prose.
@@ -353,7 +359,9 @@ def _host_verification_specs(pr_diff: object) -> tuple[_HostVerificationSpec, ..
             sorted(
                 path
                 for path in changed_paths
-                if path.startswith("tests/unit/") and path.endswith(".py")
+                if path.startswith("tests/unit/")
+                and path.endswith(".py")
+                and path not in _NONHERMETIC_HOST_UNIT_TEST_PATHS
             )
         )
     )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -267,11 +267,9 @@ class _HostVerificationSpec:
     descr: str
 
 
-#: Python reviews run read-only by design.  The host therefore performs the
-#: deterministic static validation against an immutable snapshot before the
-#: reviewer sees it.  Full test suites belong to the implementation stage and
-#: CI: a repository's unit tests can legitimately require controlled service,
-#: Git, or process fixtures that the no-network reviewer boundary must deny.
+#: Python reviews run read-only by design. The host therefore performs a
+#: deterministic validation plan against an immutable snapshot before the
+#: reviewer sees it, including pytest evidence bound to the reviewed head.
 _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
     _HostVerificationSpec(
         changed_path=None,
@@ -295,6 +293,11 @@ _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
             "tests/",
         ),
         descr="review_python_mypy",
+    ),
+    _HostVerificationSpec(
+        changed_path=None,
+        argv=("uv", "run", "pytest", "tests/", "-q", "--tb=short"),
+        descr="review_python_pytest",
     ),
 )
 _PYTHON_VALIDATION_CONFIG_PATHS = frozenset(

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -296,7 +296,7 @@ _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
     ),
     _HostVerificationSpec(
         changed_path=None,
-        argv=("uv", "run", "pytest", "tests/", "-q", "--tb=short"),
+        argv=("uv", "run", "pytest", "-o", "addopts=", "tests/", "-q", "--tb=short"),
         descr="review_python_pytest",
     ),
 )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -267,9 +267,10 @@ class _HostVerificationSpec:
     descr: str
 
 
-#: Python reviews run read-only by design. The host therefore performs a
-#: deterministic validation plan against an immutable snapshot before the
-#: reviewer sees it, including pytest evidence bound to the reviewed head.
+#: Python reviews run read-only by design. The host therefore performs the
+#: deterministic static validation against an immutable snapshot before the
+#: reviewer sees it. Changed unit tests are added separately below; broader
+#: suites can legitimately require host capabilities denied to the reviewer.
 _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
     _HostVerificationSpec(
         changed_path=None,
@@ -293,11 +294,6 @@ _PYTHON_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
             "tests/",
         ),
         descr="review_python_mypy",
-    ),
-    _HostVerificationSpec(
-        changed_path=None,
-        argv=("uv", "run", "pytest", "-o", "addopts=", "tests/", "-q", "--tb=short"),
-        descr="review_python_pytest",
     ),
 )
 _PYTHON_VALIDATION_CONFIG_PATHS = frozenset(
@@ -347,8 +343,23 @@ def _host_verification_specs(pr_diff: object) -> tuple[_HostVerificationSpec, ..
         path.endswith(".py") or path in _PYTHON_VALIDATION_CONFIG_PATHS for path in changed_paths
     ):
         return ()
+    changed_unit_tests = tuple(
+        _HostVerificationSpec(
+            changed_path=path,
+            argv=("uv", "run", "pytest", "-o", "addopts=", path, "-q", "--tb=short"),
+            descr=f"review_changed_unit_test_{index}",
+        )
+        for index, path in enumerate(
+            sorted(
+                path
+                for path in changed_paths
+                if path.startswith("tests/unit/") and path.endswith(".py")
+            )
+        )
+    )
     return (
         *_PYTHON_HOST_VERIFICATION_SPECS,
+        *changed_unit_tests,
         *(spec for spec in _PATH_HOST_VERIFICATION_SPECS if spec.changed_path in changed_paths),
     )
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -844,7 +844,11 @@ def _host_validation_failure_kind(
         if (
             tool == "ruff"
             and returncode == 1
-            and re.search(r"(?m)^(Found |Would reformat )", transcript)
+            and re.search(
+                r"(?m)^(?:Found |Would reformat |unformatted: |"
+                r"[1-9]\d* files? would be reformatted$)",
+                transcript,
+            )
         ):
             return "validation"
         if (

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -2292,7 +2292,11 @@ class TestCommitPushAndPrCreate:
         item = make_work_item(issue=9, state="PR_CREATE")
         item.branch = "9-auto-impl"
         item.payload["issue_title"] = "Add the widget"
-        item.payload["implement_summary"] = "Added the widget."
+        item.payload["implement_summary"] = (
+            "Added the widget.\n\n"
+            "Full suite: 7,000 passed. Changes remain uncommitted at "
+            "/private/tmp/issue-9."
+        )
 
         result = stage.step(item, ctx)
 
@@ -2303,6 +2307,9 @@ class TestCommitPushAndPrCreate:
         # The PR body is a get_pr_description body carrying the closing line.
         assert "Closes #9" in github.prs[1001]["body"]
         assert "Not run by the automation pipeline" in github.prs[1001]["body"]
+        assert "7,000 passed" not in github.prs[1001]["body"]
+        assert "remain uncommitted" not in github.prs[1001]["body"]
+        assert "/private/tmp" not in github.prs[1001]["body"]
         assert github.prs[1001]["title"] == "chore: Add the widget"
 
     @pytest.mark.parametrize(

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1272,6 +1272,35 @@ class TestPrReviewStageStep:
         assert item.payload["review_audit"] == audit
         assert item.payload["host_verification_receipts"] == receipts
 
+    def test_deleted_unit_tests_do_not_schedule_changed_pytest_specs(self) -> None:
+        """Deleted tests have no new-side path for host pytest to execute."""
+        deleted_path = "tests/unit/automation/pipeline/stages/test_deleted.py"
+        kept_path = "tests/unit/automation/pipeline/stages/test_kept.py"
+        specs = stage_module._host_verification_specs(
+            f"diff --git a/{deleted_path} b/{deleted_path}\n"
+            "deleted file mode 100644\n"
+            f"--- a/{deleted_path}\n"
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-def test_removed() -> None:\n"
+            "-    pass\n"
+            f"diff --git a/{kept_path} b/{kept_path}\n"
+            f"--- a/{kept_path}\n"
+            f"+++ b/{kept_path}\n"
+            "@@ -1 +1 @@\n"
+            "-def test_old() -> None: pass\n"
+            "+def test_new() -> None: pass\n"
+        )
+
+        changed_pytest_specs = tuple(
+            spec for spec in specs if spec.descr.startswith("review_changed_unit_test_")
+        )
+
+        assert len(changed_pytest_specs) == 1
+        assert changed_pytest_specs[0].changed_path == kept_path
+        assert kept_path in changed_pytest_specs[0].argv
+        assert deleted_path not in changed_pytest_specs[0].argv
+
     def test_python_changes_run_complete_host_validation_before_primary_reviewer(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1187,6 +1187,10 @@ class TestPrReviewStageStep:
                 ),
             ),
             (
+                "review_python_pytest",
+                ("uv", "run", "pytest", "tests/", "-q", "--tb=short"),
+            ),
+            (
                 "review_stalled_consumer_verification",
                 (
                     "uv",
@@ -1319,7 +1323,7 @@ class TestPrReviewStageStep:
             }
         )
         request = stage.step(item, ctx)
-        for _ in range(3):
+        for _ in range(4):
             assert isinstance(request, JobRequest)
             item.state = request.on_done_state
             stage.on_job_done(
@@ -1403,7 +1407,7 @@ class TestPrReviewStageStep:
         request = stage.step(item, ctx)
         assert isinstance(request, JobRequest)
         assert isinstance(request.job, BuildTestJob)
-        for _ in range(3):
+        for _ in range(4):
             item.state = request.on_done_state
             stage.on_job_done(
                 item,
@@ -1469,7 +1473,7 @@ class TestPrReviewStageStep:
         )
         request = stage.step(item, ctx)
         assert isinstance(request, JobRequest)
-        for _ in range(3):
+        for _ in range(4):
             item.state = request.on_done_state
             stage.on_job_done(
                 item,

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1188,7 +1188,16 @@ class TestPrReviewStageStep:
             ),
             (
                 "review_python_pytest",
-                ("uv", "run", "pytest", "tests/", "-q", "--tb=short"),
+                (
+                    "uv",
+                    "run",
+                    "pytest",
+                    "-o",
+                    "addopts=",
+                    "tests/",
+                    "-q",
+                    "--tb=short",
+                ),
             ),
             (
                 "review_stalled_consumer_verification",

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1158,6 +1158,8 @@ class TestPrReviewStageStep:
                 "pr_diff": (
                     "diff --git a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py "
                     "b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py\n"
+                    "diff --git a/tests/unit/automation/pipeline/test_worker_pool.py "
+                    "b/tests/unit/automation/pipeline/test_worker_pool.py\n"
                     "diff --git a/tests/performance/test_worker_pool_load.py "
                     "b/tests/performance/test_worker_pool_load.py\n"
                     "--- a/tests/performance/test_worker_pool_load.py\n"

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1156,6 +1156,8 @@ class TestPrReviewStageStep:
                 "review_checkout_expected_head": "a" * 40,
                 "review_checkout_ready": True,
                 "pr_diff": (
+                    "diff --git a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py "
+                    "b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py\n"
                     "diff --git a/tests/performance/test_worker_pool_load.py "
                     "b/tests/performance/test_worker_pool_load.py\n"
                     "--- a/tests/performance/test_worker_pool_load.py\n"
@@ -1187,14 +1189,14 @@ class TestPrReviewStageStep:
                 ),
             ),
             (
-                "review_python_pytest",
+                "review_changed_unit_test_0",
                 (
                     "uv",
                     "run",
                     "pytest",
                     "-o",
                     "addopts=",
-                    "tests/",
+                    "tests/unit/automation/pipeline/stages/test_stage_pr_review.py",
                     "-q",
                     "--tb=short",
                 ),
@@ -1332,7 +1334,7 @@ class TestPrReviewStageStep:
             }
         )
         request = stage.step(item, ctx)
-        for _ in range(4):
+        for _ in range(3):
             assert isinstance(request, JobRequest)
             item.state = request.on_done_state
             stage.on_job_done(
@@ -1416,7 +1418,7 @@ class TestPrReviewStageStep:
         request = stage.step(item, ctx)
         assert isinstance(request, JobRequest)
         assert isinstance(request.job, BuildTestJob)
-        for _ in range(4):
+        for _ in range(3):
             item.state = request.on_done_state
             stage.on_job_done(
                 item,
@@ -1482,7 +1484,7 @@ class TestPrReviewStageStep:
         )
         request = stage.step(item, ctx)
         assert isinstance(request, JobRequest)
-        for _ in range(4):
+        for _ in range(3):
             item.state = request.on_done_state
             stage.on_job_done(
                 item,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -662,6 +662,15 @@ class TestWorkerPoolSubmitComplete:
         )
         assert (
             _host_validation_failure_kind(
+                ("uv", "run", "ruff", "format", "--check", "hephaestus/"),
+                1,
+                "unformatted: File would be reformatted\n3 files would be reformatted\n",
+                "",
+            )
+            == "validation"
+        )
+        assert (
+            _host_validation_failure_kind(
                 ("uv", "run", "ruff", "check", "hephaestus/"),
                 2,
                 "",


### PR DESCRIPTION
Summary:
- keep generated PR handoffs deterministic and free of agent-supplied local state
- add a head-bound pytest receipt before Python PR review
- route current Ruff format failures back to implementation remediation

Testing:
- uv run pytest -o addopts= tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_worker_pool.py -q --tb=short
- uv run mypy --cache-dir=/dev/null hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pipeline/stages/pr_review.py hephaestus/automation/pipeline/worker_pool.py
- pre-push: 7152 passed, 11 skipped, 5 deselected; 84.74% coverage

Closes #2613
