### PR TITLE
fix(test): isolate Hypothesis cache from source scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ dist/
 *.egg
 *.pyc
 
+# Legacy Hypothesis cache location (tests route storage under build/)
+/.hypothesis/
+
 # Virtual environments
 .venv/
 venv/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,14 @@
 import contextlib
 import json
 import os
+from pathlib import Path
+
+# Repository policy requires generated files to live under build/. Hypothesis
+# consults this environment variable lazily when it first opens its storage,
+# so set the suite-wide location before importing test modules.
+os.environ["HYPOTHESIS_STORAGE_DIRECTORY"] = str(
+    Path(__file__).resolve().parents[1] / "build" / ".hypothesis"
+)
 
 import pytest
 import yaml

--- a/tests/unit/docs/test_agent_contract.py
+++ b/tests/unit/docs/test_agent_contract.py
@@ -1,5 +1,6 @@
 """Regression contract for the canonical repository agent guidance."""
 
+import os
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -59,6 +60,7 @@ ALLOWED_CLAUDE_REFERENCE_LINES = {
 
 EXCLUDED_PARTS = {
     ".git",
+    ".hypothesis",
     ".mypy_cache",
     ".pytest_cache",
     ".ruff_cache",
@@ -77,6 +79,12 @@ def _section(text: str, heading: str) -> str:
 def test_claude_md_is_exact_pointer() -> None:
     """The legacy entry point must contain only the compatibility pointer."""
     assert (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8") == EXPECTED_POINTER
+
+
+def test_hypothesis_cache_is_not_repository_source() -> None:
+    """Property-test caches stay under build and outside policy scans."""
+    assert ".hypothesis" in EXCLUDED_PARTS
+    assert Path(os.environ["HYPOTHESIS_STORAGE_DIRECTORY"]) == (REPO_ROOT / "build" / ".hypothesis")
 
 
 def test_source_sections_and_directives_are_preserved() -> None:


### PR DESCRIPTION
Routes Hypothesis state into build/.hypothesis before test collection and excludes the legacy root cache from source-policy scans.

Validation: uv run pytest -o addopts= tests/unit/automation/test_address_review_property.py tests/unit/docs/test_agent_contract.py -q --tb=short; full pre-push suite (7160 passed, 11 skipped, 5 deselected; 84.75% coverage).

Closes #2615