### PR TITLE
fix(review): bind validation to live PR metadata

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -196,7 +196,7 @@ class StageGitHub(Protocol):
         pass
 
     def pr_review_context(self, pr_number: int) -> dict[str, str] | None:
-        """Return PR metadata; the verified checkout later derives the review diff."""
+        """Return title/body/head metadata; checkout later derives the review diff."""
         ...
 
     def has_existing_plan(self, issue_number: int) -> bool:

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -502,6 +502,7 @@ _ROUND_PAYLOAD_KEYS = (
     "prior_comments_json",
     "validation_threads",
     "validation_receipt_fingerprints",
+    "validation_pr_metadata_fingerprint",
     "scope_retraction_paths",
     "reviewed_pr_base_sha",
     "host_verification_receipts",
@@ -804,6 +805,30 @@ def _validation_receipt_fingerprints(
         )
         fingerprints[thread_id] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return fingerprints
+
+
+def _validation_pr_metadata_fingerprint(
+    pr_context: dict[str, str] | None, reviewed_head: str
+) -> str | None:
+    """Bind a validator decision to the exact live title/body it reviewed."""
+    if (
+        pr_context is None
+        or pr_context.get("pr_head_sha") != reviewed_head
+        or not isinstance(pr_context.get("pr_title"), str)
+        or not isinstance(pr_context.get("pr_description"), str)
+    ):
+        return None
+    canonical = json.dumps(
+        {
+            "head_sha": reviewed_head,
+            "pr_description": pr_context["pr_description"],
+            "pr_title": pr_context["pr_title"],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _reviewer_thread_decisions(  # noqa: C901
@@ -1408,18 +1433,17 @@ class PrReviewStage(Stage):
             )
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
-        if (
-            pr_context is None
-            or pr_context.get("pr_head_sha") != reviewed_head
-            or not isinstance(pr_context.get("pr_title"), str)
-            or not isinstance(pr_context.get("pr_description"), str)
-        ):
+        metadata_fingerprint = _validation_pr_metadata_fingerprint(pr_context, reviewed_head)
+        if metadata_fingerprint is None:
             logger.warning(
                 "pr_review:%s: fresh validation metadata did not match reviewed head",
                 item.issue,
             )
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
+        validated_pr_context = cast(dict[str, str], pr_context)
+        pr_title = validated_pr_context["pr_title"]
+        pr_description = validated_pr_context["pr_description"]
         validation_threads = _validation_thread_snapshots(live_threads, receipts)
         receipt_fingerprints = _validation_receipt_fingerprints(receipts)
         if validation_threads is None or receipt_fingerprints is None:
@@ -1427,6 +1451,7 @@ class PrReviewStage(Stage):
             return Continue(next_state=EVAL)
         item.payload["validation_threads"] = validation_threads
         item.payload["validation_receipt_fingerprints"] = receipt_fingerprints
+        item.payload["validation_pr_metadata_fingerprint"] = metadata_fingerprint
         item.payload["prior_comments_json"] = json.dumps(
             validation_threads, ensure_ascii=False, sort_keys=True
         )
@@ -1447,8 +1472,8 @@ class PrReviewStage(Stage):
                 "issue_number": item.issue,
                 "prior_comments_json": item.payload["prior_comments_json"],
                 "diff_text": item.payload.get("pr_diff", ""),
-                "pr_title": pr_context["pr_title"],
-                "pr_description": pr_context["pr_description"],
+                "pr_title": pr_title,
+                "pr_description": pr_description,
                 "host_verifications_json": json.dumps(
                     item.payload.get("host_verification_receipts", []), sort_keys=True
                 ),
@@ -2088,9 +2113,10 @@ class PrReviewStage(Stage):
                 if is_full_commit_sha(reviewed_head)
                 else []
             )
+            pr_context = ctx.github.pr_review_context(item.pr)
         except Exception as error:
             logger.warning(
-                "pr_review:%s: could not refresh reviewer validation receipts (%s)",
+                "pr_review:%s: could not refresh reviewer validation inputs (%s)",
                 item.issue,
                 type(error).__name__,
             )
@@ -2098,9 +2124,33 @@ class PrReviewStage(Stage):
             return Continue(next_state=EVAL)
         live_receipt_fingerprints = _validation_receipt_fingerprints(validation_receipts)
         validated_receipt_fingerprints = item.payload.get("validation_receipt_fingerprints")
+        live_metadata_fingerprint = _validation_pr_metadata_fingerprint(pr_context, reviewed_head)
+        validated_metadata_fingerprint = item.payload.get("validation_pr_metadata_fingerprint")
         if live_receipt_fingerprints is None:
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
+        metadata_guard_expected = validated_receipt_fingerprints is not None or (
+            "validation_pr_metadata_fingerprint" in item.payload
+        )
+        if metadata_guard_expected and (
+            live_metadata_fingerprint is None
+            or not isinstance(validated_metadata_fingerprint, str)
+            or validated_metadata_fingerprint != live_metadata_fingerprint
+        ):
+            # The validator reviewed a different PR title/body (or head) than
+            # the current live metadata.  Metadata-only remediations are
+            # reviewable evidence, so a same-head edit after validation must
+            # restart validation before any thread reconciliation can happen.
+            item.payload.pop("validation_result", None)
+            item.payload.pop("validation_threads", None)
+            item.payload.pop("validation_receipt_fingerprints", None)
+            item.payload.pop("validation_pr_metadata_fingerprint", None)
+            logger.info(
+                "pr_review:%s: PR metadata changed after validation; "
+                "revalidating before reconciliation",
+                item.issue,
+            )
+            return Continue(next_state=VALIDATE_WAIT)
         if validated_receipt_fingerprints is not None and (
             not isinstance(validated_receipt_fingerprints, dict)
             or validated_receipt_fingerprints != live_receipt_fingerprints
@@ -2111,6 +2161,7 @@ class PrReviewStage(Stage):
             item.payload.pop("validation_result", None)
             item.payload.pop("validation_threads", None)
             item.payload.pop("validation_receipt_fingerprints", None)
+            item.payload.pop("validation_pr_metadata_fingerprint", None)
             logger.info(
                 "pr_review:%s: implementation reply receipt changed after validation; "
                 "revalidating before reconciliation",
@@ -2156,6 +2207,7 @@ class PrReviewStage(Stage):
                 item.payload.pop("validation_result", None)
                 item.payload.pop("validation_threads", None)
                 item.payload.pop("validation_receipt_fingerprints", None)
+                item.payload.pop("validation_pr_metadata_fingerprint", None)
                 return Continue(next_state=REVIEW_WAIT)
             # A concurrent mutation can make one receipt ineligible after a
             # previous receipt was safely resolved or received feedback.  Do

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1399,11 +1399,24 @@ class PrReviewStage(Stage):
                 if is_full_commit_sha(reviewed_head)
                 else []
             )
+            pr_context = ctx.github.pr_review_context(item.pr)
         except Exception as error:
             logger.warning(
                 "pr_review:%s: could not fetch validation receipts (%s)",
                 item.issue,
                 type(error).__name__,
+            )
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        if (
+            pr_context is None
+            or pr_context.get("pr_head_sha") != reviewed_head
+            or not isinstance(pr_context.get("pr_title"), str)
+            or not isinstance(pr_context.get("pr_description"), str)
+        ):
+            logger.warning(
+                "pr_review:%s: fresh validation metadata did not match reviewed head",
+                item.issue,
             )
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
@@ -1434,6 +1447,8 @@ class PrReviewStage(Stage):
                 "issue_number": item.issue,
                 "prior_comments_json": item.payload["prior_comments_json"],
                 "diff_text": item.payload.get("pr_diff", ""),
+                "pr_title": pr_context["pr_title"],
+                "pr_description": pr_context["pr_description"],
                 "host_verifications_json": json.dumps(
                     item.payload.get("host_verification_receipts", []), sort_keys=True
                 ),

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -2036,7 +2036,13 @@ class PipelineGitHub:
         """
         try:
             body_result = self._gh(
-                ["pr", "view", str(pr_number), "--json", "body,headRefOid,baseRefName"]
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "title,body,headRefOid,baseRefName",
+                ]
             )
             body_data = json.loads(body_result.stdout or "{}")
             if not isinstance(body_data, dict):
@@ -2044,11 +2050,13 @@ class PipelineGitHub:
         except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
             logger.warning("PR #%s: review context read failed: %s", pr_number, exc)
             return None
+        title = body_data.get("title")
         body = body_data.get("body")
         head = body_data.get("headRefOid")
         base_branch = body_data.get("baseRefName")
         if (
-            not isinstance(body, str)
+            not isinstance(title, str)
+            or not isinstance(body, str)
             or not isinstance(head, str)
             or not head
             or not isinstance(base_branch, str)
@@ -2056,6 +2064,7 @@ class PipelineGitHub:
         ):
             return None
         return {
+            "pr_title": github_api.strip_null_bytes(title),
             "pr_description": github_api.strip_null_bytes(body),
             "pr_head_sha": head,
             "pr_base_branch": base_branch,

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -103,6 +103,8 @@ def get_review_validation_prompt(
     prior_comments_json: str,
     diff_text: str = "",
     host_verifications_json: str = "",
+    pr_title: str = "",
+    pr_description: str = "",
     review_context_kind: str = "issue",
 ) -> str:
     """Get the prompt that validates whether prior review comments were addressed.
@@ -126,6 +128,8 @@ def get_review_validation_prompt(
         diff_text: The current cumulative PR diff.
         host_verifications_json: Host-captured output from every fixed,
             repository-owned validation command bound to the reviewed head.
+        pr_title: Current GitHub PR title captured with the reviewed head.
+        pr_description: Current GitHub PR body captured with the reviewed head.
         review_context_kind: Human-readable numeric context kind for the
             prompt header (defaults to ``"issue"``).
 
@@ -145,6 +149,8 @@ def get_review_validation_prompt(
             "HOST_VERIFICATIONS",
             host_verifications_json or "[]",
         ),
+        pr_title_block=fenced.fence("PR_TITLE", pr_title),
+        pr_description_block=fenced.fence("PR_DESCRIPTION", pr_description),
         untrusted_notice=fenced.untrusted_notice,
         terse_output_directive=get_terse_output_directive(),
     )

--- a/hephaestus/prompts/templates/default/pr_review/validation.j2
+++ b/hephaestus/prompts/templates/default/pr_review/validation.j2
@@ -3,7 +3,8 @@ You are VALIDATING the implementation agent's handling of prior review
 comments on PR #{{ pr_number }} ({{ review_context_kind }} #{{ issue_number }}).
 
 Perform a fresh validation review of EVERY open review thread below using the
-current diff, the prior review conversation, and the implementation reply. Do
+current diff, the prior review conversation, and the implementation reply,
+plus current PR metadata. Do
 not create replacement threads or expand the task beyond those existing
 threads. This is the comment-review pass, not the original implementation
 review. Do not independently adjudicate the original code-level concern or
@@ -37,6 +38,12 @@ The block above is a JSON array where each element has:
 - `implementation_reply_submitted`: whether that response is present and this
   thread is eligible for a reviewer resolution or feedback reply in this pass
 
+**Current PR title (untrusted, captured with the reviewed head):**
+{{ pr_title_block }}
+
+**Current PR description (untrusted, captured with the reviewed head):**
+{{ pr_description_block }}
+
 **Current diff (untrusted):**
 {{ diff_block }}
 
@@ -51,8 +58,8 @@ receipt is missing or failed, do not claim the plan passed.
 
 Evidence-provenance rule: validate whether the implementation reply supplies
 concrete, internally coherent evidence (for example, the exact command and
-result, an added regression test, or a linked artifact) that supports its
-claimed handling. Do not independently reproduce, rerun, or require host/CI
+result, an added regression test, a linked artifact, or a current PR-metadata
+change) that supports its claimed handling. Do not independently reproduce, rerun, or require host/CI
 execution of that evidence. Do not independently adjudicate the original
 code-level concern. A sandbox access failure, the absence of an independent
 execution, or a new opinion about the implementation is not a reason to leave

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -150,6 +150,7 @@ class FakeStageGitHub(FakeGitHub):
             pr_review_context
             if pr_review_context is not None
             else {
+                "pr_title": "A current PR title",
                 "pr_description": "Closes #1",
                 "pr_head_sha": "a" * 40,
                 "pr_base_branch": "main",

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -3206,6 +3206,72 @@ class TestReviewThreadLifecycle:
         assert result == Continue(next_state="VALIDATE_WAIT")
         assert github.reconciliation_calls == []
 
+    def test_same_head_pr_metadata_mutation_restarts_validation_before_reconciliation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A validator decision for one title/body cannot act after metadata changes."""
+        thread = self._thread("thread-1", 3, "fix this")
+        thread["comments"].append(
+            {
+                "id": "implementation-reply",
+                "author": "hephaestus[bot]",
+                "body": "Updated the PR metadata only.",
+            }
+        )
+
+        class MetadataRaceGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(
+                    pr_review_context={
+                        "pr_title": "docs(policy): corrected",
+                        "pr_description": "Current factual summary.\n\nCloses #1",
+                        "pr_head_sha": "a" * 40,
+                        "pr_base_branch": "main",
+                    }
+                )
+                self.reconciliation_calls: list[dict[str, Any]] = []
+
+            def list_unresolved_review_threads(self, pr_number: int) -> list[dict[str, Any]]:
+                del pr_number
+                return [dict(thread)]
+
+            def reconcile_reviewer_validated_threads(self, *args: Any, **kwargs: Any) -> Any:
+                self.reconciliation_calls.append(dict(kwargs))
+                return super().reconcile_reviewer_validated_threads(*args, **kwargs)
+
+        github = MetadataRaceGitHub()
+        ctx = make_ctx(github=github)
+        stage = PrReviewStage()
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
+
+        validation = stage.step(item, ctx)
+        assert isinstance(validation, JobRequest)
+        original_fingerprint = item.payload["validation_pr_metadata_fingerprint"]
+
+        github._pr_review_context = {
+            "pr_title": "docs(policy): stale claim restored",
+            "pr_description": "Stale factual summary.\n\nCloses #1",
+            "pr_head_sha": "a" * 40,
+            "pr_base_branch": "main",
+        }
+        item.state = "POST"
+        item.payload.update(
+            {
+                "validation_result": {"resolved": ["thread-1"], "unaddressed": []},
+                "review_audit": _valid_audit(),
+                "review_threads": [],
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="VALIDATE_WAIT")
+        assert github.reconciliation_calls == []
+        assert item.payload.get("validation_pr_metadata_fingerprint") is None
+        assert item.payload.get("validation_result") is None
+        assert original_fingerprint
+
     @pytest.mark.parametrize(
         ("pr_state", "validation_result", "authors"),
         [

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -996,6 +996,7 @@ class TestPrReviewStageStep:
         stage = PrReviewStage()
         ctx = make_ctx(config=SimpleNamespace(agent="codex"))
         item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
         item.session_ids["pr-reviewer"] = "review-session-id"
 
         result = stage.step(item, ctx)
@@ -1090,6 +1091,7 @@ class TestPrReviewStageStep:
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
 
         validation = stage.step(item, ctx)
         assert isinstance(validation, JobRequest)
@@ -1144,12 +1146,59 @@ class TestPrReviewStageStep:
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
         assert result.on_done_state == "POST"
         assert result.job.descr == "validate"
+
+    def test_validate_wait_includes_fresh_head_bound_pr_metadata(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A PR-body-only remediation is visible to the reply validator."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_review_context={
+                "pr_title": "docs(policy): remove stale claim",
+                "pr_description": "Current factual summary.\n\nCloses #1",
+                "pr_head_sha": "a" * 40,
+                "pr_base_branch": "main",
+            }
+        )
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
+
+        result = stage.step(item, make_ctx(github=github))
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.prompt_kwargs["pr_title"] == "docs(policy): remove stale claim"
+        assert result.job.prompt_kwargs["pr_description"] == (
+            "Current factual summary.\n\nCloses #1"
+        )
+
+    def test_validate_wait_fails_closed_when_fresh_metadata_head_drifted(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Metadata from a different head cannot resolve reviewed-head threads."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_review_context={
+                "pr_title": "changed title",
+                "pr_description": "changed body",
+                "pr_head_sha": "b" * 40,
+                "pr_base_branch": "main",
+            }
+        )
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
+
+        result = stage.step(item, make_ctx(github=github))
+
+        assert result == Continue(next_state="EVAL")
+        assert item.payload["review_audit_failure"] is True
 
     def test_checkout_runs_registered_host_verification_before_primary_reviewer(
         self, make_ctx: Any, make_work_item: Any
@@ -2931,6 +2980,7 @@ class TestReviewThreadLifecycle:
         """The reviewer validates every open host-read thread, not only reply receipts."""
         stage = PrReviewStage()
         item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
         first_thread = self._thread("thread-1", 3, "fix this")
         inherited = self._thread("inherited", 8, "manual review")
 

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -4565,6 +4565,7 @@ class TestReadSurface:
                 return SimpleNamespace(
                     stdout=json.dumps(
                         {
+                            "title": "docs(policy): current metadata",
                             "body": "Closes #1899\n",
                             "headRefOid": "a" * 40,
                             "baseRefName": "main",
@@ -4580,6 +4581,7 @@ class TestReadSurface:
         )
 
         assert context == {
+            "pr_title": "docs(policy): current metadata",
             "pr_description": "Closes #1899\n",
             "pr_head_sha": "a" * 40,
             "pr_base_branch": "main",
@@ -4590,7 +4592,7 @@ class TestReadSurface:
                 "view",
                 "1984",
                 "--json",
-                "body,headRefOid,baseRefName",
+                "title,body,headRefOid,baseRefName",
                 "--repo",
                 "org/repo-a",
             ],
@@ -4607,6 +4609,7 @@ class TestReadSurface:
             return SimpleNamespace(
                 stdout=json.dumps(
                     {
+                        "title": "current title",
                         "body": "Closes #1899",
                         "headRefOid": "a" * 40,
                         "baseRefName": "main",

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1168,6 +1168,22 @@ class TestReviewValidationPrompt:
         assert "_HOST_VERIFICATIONS\n" in out
         assert "UNTRUSTED" in out
 
+    def test_includes_current_pr_metadata_as_fenced_untrusted_input(self) -> None:
+        """Metadata-only remediation is reviewable without trusting GitHub prose."""
+        out = prompts.get_review_validation_prompt(
+            pr_number=42,
+            issue_number=7,
+            prior_comments_json="[]",
+            pr_title="docs(policy): remove stale claim",
+            pr_description="Current factual summary.\n\nCloses #7",
+        )
+
+        assert "docs(policy): remove stale claim" in out
+        assert "Current factual summary." in out
+        assert "_PR_TITLE\n" in out
+        assert "_PR_DESCRIPTION\n" in out
+        assert "UNTRUSTED" in out
+
     def test_renders_with_brace_containing_body(self) -> None:
         out = prompts.get_review_validation_prompt(
             pr_number=1,


### PR DESCRIPTION
Captures the current PR title and body with the live head before reply validation, supplies both as nonce-fenced untrusted context, and fails closed when that metadata head differs from the reviewed head. The existing no-commit reply warning and reviewer-owned disposition remain unchanged.

Validation: 469 focused tests passed; Ruff passed; mypy passed; full pre-push suite passed (7163 passed, 11 skipped, 5 deselected; 84.76% coverage).

Closes #2618