### PR TITLE
fix(verification): relocate long-path uv launchers

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -7,6 +7,7 @@ perform GitHub API mutations (enforced by test_pipeline_architecture.py).
 
 from __future__ import annotations
 
+import csv
 import hashlib
 import io
 import logging
@@ -118,7 +119,7 @@ _TRUSTED_GIT_CANDIDATES = (
     Path("/usr/bin/git"),
 )
 _HOST_RUNTIME_CACHE_DIRNAME = "hephaestus-host-validation-runtime"
-_HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v5-dependency-manifest"
+_HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v6-shell-launchers"
 
 # The host verification handles code from an untrusted pull request.  Bound
 # the Git archive before extraction and bound every child output/write path.
@@ -242,8 +243,12 @@ def _rewrite_runtime_launchers(runtime: Path, source_runtime: Path) -> None:
     the mutable checkout, so those launchers must name the copied interpreter
     before the runtime is sealed.
     """
-    source_prefix = f"#!{source_runtime.resolve()}".encode()
-    target_prefix = f"#!{runtime.resolve()}".encode()
+    source_path = str(source_runtime.resolve()).encode()
+    target_path = str(runtime.resolve()).encode()
+    source_prefix = b"#!" + source_path
+    target_prefix = b"#!" + target_path
+    shell_source_prefix = b"'''exec' '" + source_path + b"/"
+    shell_target_prefix = b"'''exec' '" + target_path + b"/"
     for launcher in (runtime / "bin").iterdir():
         if launcher.is_symlink() or not launcher.is_file():
             continue
@@ -252,10 +257,25 @@ def _rewrite_runtime_launchers(runtime: Path, source_runtime: Path) -> None:
         except OSError:
             continue
         first_line, separator, remainder = content.partition(b"\n")
-        if not first_line.startswith(source_prefix):
+        if first_line.startswith(source_prefix):
+            launcher.write_bytes(
+                target_prefix + first_line[len(source_prefix) :] + separator + remainder
+            )
+            continue
+        if first_line != b"#!/bin/sh":
+            continue
+        trampoline, trampoline_separator, script = remainder.partition(b"\n")
+        if not (
+            trampoline.startswith(shell_source_prefix) and trampoline.endswith(b'\' "$0" "$@"')
+        ):
             continue
         launcher.write_bytes(
-            target_prefix + first_line[len(source_prefix) :] + separator + remainder
+            first_line
+            + separator
+            + shell_target_prefix
+            + trampoline[len(shell_source_prefix) :]
+            + trampoline_separator
+            + script
         )
 
 
@@ -264,8 +284,8 @@ def _sealed_runtime_marker(target: Path) -> Path:
     return target.with_name(f"{target.name}.sealed")
 
 
-def _is_sealed_runtime_cache(target: Path) -> bool:
-    """Return whether *target* was completely sealed by this verifier."""
+def _sealed_runtime_marker_matches(target: Path) -> bool:
+    """Return whether *target* has this verifier's structurally valid marker."""
     marker = _sealed_runtime_marker(target)
     try:
         return (
@@ -278,6 +298,41 @@ def _is_sealed_runtime_cache(target: Path) -> bool:
         )
     except OSError:
         return False
+
+
+def _runtime_manifest_files_exist(runtime: Path) -> bool:
+    """Return whether installed RECORD entries still exist inside *runtime*."""
+    try:
+        root = runtime.resolve()
+        if not (runtime / "pyvenv.cfg").is_file() or not (runtime / "bin" / "python").is_file():
+            return False
+        for record in runtime.rglob("*.dist-info/RECORD"):
+            site_packages = record.parent.parent
+            with record.open(encoding="utf-8", newline="") as manifest:
+                for row in csv.reader(manifest):
+                    if not row or not row[0]:
+                        continue
+                    candidate = (site_packages / row[0]).resolve()
+                    if not candidate.is_relative_to(root) or not candidate.is_file():
+                        return False
+    except (OSError, csv.Error):
+        return False
+    return True
+
+
+def _is_sealed_runtime_cache(target: Path) -> bool:
+    """Return whether *target* is marked, sealed, and manifest-complete."""
+    return _sealed_runtime_marker_matches(target) and _runtime_manifest_files_exist(target)
+
+
+def _remove_corrupted_sealed_runtime(target: Path) -> None:
+    """Remove a marked cache after making its sealed directories removable."""
+    for path in (target, *target.rglob("*")):
+        if path.is_symlink():
+            continue
+        path.chmod(path.stat().st_mode | (0o700 if path.is_dir() else 0o600))
+    shutil.rmtree(target)
+    _sealed_runtime_marker(target).unlink()
 
 
 def _verifier_owned_runtime_environment(checkout: Path) -> Path:
@@ -309,7 +364,10 @@ def _verifier_owned_runtime_environment(checkout: Path) -> Path:
             if _is_sealed_runtime_cache(target):
                 return target
             if target.exists() or target.is_symlink():
-                raise _HostVerificationBoundaryError("host_verification_runtime_cache_unsafe")
+                if _sealed_runtime_marker_matches(target):
+                    _remove_corrupted_sealed_runtime(target)
+                else:
+                    raise _HostVerificationBoundaryError("host_verification_runtime_cache_unsafe")
             staging = Path(tempfile.mkdtemp(prefix="runtime-", dir=cache_root))
             copied = staging / "environment"
             try:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -120,6 +120,7 @@ _TRUSTED_GIT_CANDIDATES = (
 )
 _HOST_RUNTIME_CACHE_DIRNAME = "hephaestus-host-validation-runtime"
 _HOST_RUNTIME_CACHE_FORMAT = b"sealed-runtime-v6-shell-launchers"
+_HOST_RUNTIME_MANIFEST_HEADER = "sealed-runtime-file-manifest-v1"
 
 # The host verification handles code from an untrusted pull request.  Bound
 # the Git archive before extraction and bound every child output/write path.
@@ -284,6 +285,11 @@ def _sealed_runtime_marker(target: Path) -> Path:
     return target.with_name(f"{target.name}.sealed")
 
 
+def _sealed_runtime_manifest(target: Path) -> Path:
+    """Return the verifier-owned file manifest for a cached runtime."""
+    return target.with_name(f"{target.name}.manifest")
+
+
 def _sealed_runtime_marker_matches(target: Path) -> bool:
     """Return whether *target* has this verifier's structurally valid marker."""
     marker = _sealed_runtime_marker(target)
@@ -300,21 +306,60 @@ def _sealed_runtime_marker_matches(target: Path) -> bool:
         return False
 
 
-def _runtime_manifest_files_exist(runtime: Path) -> bool:
-    """Return whether installed RECORD entries still exist inside *runtime*."""
+def _runtime_manifest_entries(runtime: Path) -> tuple[str, ...]:
+    """Return verifier-owned relative paths that must exist in a runtime cache."""
+    root = runtime.resolve()
+    entries: set[str] = set()
+    for required in (runtime / "pyvenv.cfg", runtime / "bin" / "python"):
+        candidate = required.resolve()
+        if not candidate.is_relative_to(root) or not candidate.is_file():
+            raise FileNotFoundError(required)
+        entries.add(candidate.relative_to(root).as_posix())
+    for path in runtime.rglob("*"):
+        if not path.is_file():
+            continue
+        candidate = path.resolve()
+        if not candidate.is_relative_to(root):
+            raise FileNotFoundError(path)
+        entries.add(candidate.relative_to(root).as_posix())
+    return tuple(sorted(entries))
+
+
+def _write_sealed_runtime_manifest(target: Path) -> None:
+    """Persist the expected runtime-cache files outside the sealed directory."""
+    content = io.StringIO()
+    writer = csv.writer(content, lineterminator="\n")
+    writer.writerow([_HOST_RUNTIME_MANIFEST_HEADER, target.name])
+    for entry in _runtime_manifest_entries(target):
+        writer.writerow([entry])
+    write_secure(
+        _sealed_runtime_manifest(target),
+        content.getvalue(),
+        permissions=0o400,
+    )
+
+
+def _sealed_runtime_manifest_matches(target: Path) -> bool:
+    """Return whether the verifier-owned manifest matches files in *target*."""
+    manifest_path = _sealed_runtime_manifest(target)
     try:
-        root = runtime.resolve()
-        if not (runtime / "pyvenv.cfg").is_file() or not (runtime / "bin" / "python").is_file():
+        root = target.resolve()
+        if (
+            not manifest_path.is_file()
+            or manifest_path.is_symlink()
+            or manifest_path.stat().st_mode & 0o222
+        ):
             return False
-        for record in runtime.rglob("*.dist-info/RECORD"):
-            site_packages = record.parent.parent
-            with record.open(encoding="utf-8", newline="") as manifest:
-                for row in csv.reader(manifest):
-                    if not row or not row[0]:
-                        continue
-                    candidate = (site_packages / row[0]).resolve()
-                    if not candidate.is_relative_to(root) or not candidate.is_file():
-                        return False
+        with manifest_path.open(encoding="utf-8", newline="") as manifest:
+            reader = csv.reader(manifest)
+            if next(reader, None) != [_HOST_RUNTIME_MANIFEST_HEADER, target.name]:
+                return False
+            for row in reader:
+                if len(row) != 1 or not row[0]:
+                    return False
+                candidate = (root / row[0]).resolve()
+                if not candidate.is_relative_to(root) or not candidate.is_file():
+                    return False
     except (OSError, csv.Error):
         return False
     return True
@@ -322,7 +367,7 @@ def _runtime_manifest_files_exist(runtime: Path) -> bool:
 
 def _is_sealed_runtime_cache(target: Path) -> bool:
     """Return whether *target* is marked, sealed, and manifest-complete."""
-    return _sealed_runtime_marker_matches(target) and _runtime_manifest_files_exist(target)
+    return _sealed_runtime_marker_matches(target) and _sealed_runtime_manifest_matches(target)
 
 
 def _remove_corrupted_sealed_runtime(target: Path) -> None:
@@ -333,6 +378,7 @@ def _remove_corrupted_sealed_runtime(target: Path) -> None:
         path.chmod(path.stat().st_mode | (0o700 if path.is_dir() else 0o600))
     shutil.rmtree(target)
     _sealed_runtime_marker(target).unlink()
+    _sealed_runtime_manifest(target).unlink(missing_ok=True)
 
 
 def _verifier_owned_runtime_environment(checkout: Path) -> Path:
@@ -379,13 +425,18 @@ def _verifier_owned_runtime_environment(checkout: Path) -> Path:
                 copied.replace(target)
                 try:
                     _rewrite_runtime_launchers(target, runtime)
+                    _write_sealed_runtime_manifest(target)
                     _seal_host_runtime(target)
                     write_secure(
                         _sealed_runtime_marker(target),
                         f"{target.name}\n",
                         permissions=0o400,
                     )
+                    if not _is_sealed_runtime_cache(target):
+                        raise OSError("sealed runtime cache failed validation")
                 except OSError:
+                    _sealed_runtime_manifest(target).unlink(missing_ok=True)
+                    _sealed_runtime_marker(target).unlink(missing_ok=True)
                     shutil.rmtree(target, ignore_errors=True)
                     raise
             finally:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -994,9 +994,11 @@ class TestWorkerPoolSubmitComplete:
             (runtime / "bin").mkdir(parents=True)
             (runtime / "bin" / "python").write_text("host interpreter\n", encoding="utf-8")
             (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
-            dist_info = runtime / "lib" / "python3.13" / "site-packages" / "demo-1.0.dist-info"
+            site_packages = runtime / "lib" / "python3.13" / "site-packages"
+            dist_info = site_packages / "demo-1.0.dist-info"
             dist_info.mkdir(parents=True)
             (dist_info / "RECORD").write_text(record, encoding="utf-8")
+            (site_packages / "demo.py").write_text("value = 1\n", encoding="utf-8")
             return runtime
 
         first_runtime = make_runtime("runtime-first", "demo.py,sha256=first,1\n")
@@ -1017,6 +1019,61 @@ class TestWorkerPoolSubmitComplete:
         assert (
             second / "lib" / "python3.13" / "site-packages" / "demo-1.0.dist-info" / "RECORD"
         ).read_text(encoding="utf-8") == "demo.py,sha256=second,2\n"
+
+    def test_verifier_runtime_rebuilds_cache_missing_recorded_file(self, tmp_path: Path) -> None:
+        """A completion marker cannot mask a missing installed runtime file."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        runtime = tmp_path / "runtime"
+        site_packages = runtime / "lib" / "python3.13" / "site-packages"
+        dist_info = site_packages / "demo-1.0.dist-info"
+        (runtime / "bin").mkdir(parents=True)
+        dist_info.mkdir(parents=True)
+        (runtime / "bin" / "python").write_text("host interpreter\n", encoding="utf-8")
+        (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+        (site_packages / "demo.py").write_text("value = 1\n", encoding="utf-8")
+        (dist_info / "RECORD").write_text("demo.py,sha256=fixture,10\n", encoding="utf-8")
+        cache_temp = tmp_path / "cache-temp"
+
+        with (
+            patch(f"{_WP}.sys.prefix", str(runtime)),
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+        ):
+            sealed = _verifier_owned_runtime_environment(checkout)
+            sealed_site_packages = sealed / "lib" / "python3.13" / "site-packages"
+            sealed_site_packages.chmod(sealed_site_packages.stat().st_mode | 0o200)
+            (sealed_site_packages / "demo.py").unlink()
+            rebuilt = _verifier_owned_runtime_environment(checkout)
+
+        assert rebuilt == sealed
+        assert (rebuilt / "lib" / "python3.13" / "site-packages" / "demo.py").read_text(
+            encoding="utf-8"
+        ) == "value = 1\n"
+
+    def test_verifier_runtime_reuses_intact_manifest_cache(self, tmp_path: Path) -> None:
+        """Integrity checks do not recopy an intact sealed environment."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        runtime = tmp_path / "runtime"
+        site_packages = runtime / "lib" / "python3.13" / "site-packages"
+        dist_info = site_packages / "demo-1.0.dist-info"
+        (runtime / "bin").mkdir(parents=True)
+        dist_info.mkdir(parents=True)
+        (runtime / "bin" / "python").write_text("host interpreter\n", encoding="utf-8")
+        (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+        (site_packages / "demo.py").write_text("value = 1\n", encoding="utf-8")
+        (dist_info / "RECORD").write_text("demo.py,sha256=fixture,10\n", encoding="utf-8")
+        cache_temp = tmp_path / "cache-temp"
+
+        with (
+            patch(f"{_WP}.sys.prefix", str(runtime)),
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+        ):
+            sealed = _verifier_owned_runtime_environment(checkout)
+            with patch(f"{_WP}.shutil.copytree", side_effect=AssertionError("unexpected copy")):
+                reused = _verifier_owned_runtime_environment(checkout)
+
+        assert reused == sealed
 
     def test_verifier_runtime_dereferences_the_python_launcher(self, tmp_path: Path) -> None:
         """The sealed copy does not retain a launcher back into its source runtime."""
@@ -1048,6 +1105,34 @@ class TestWorkerPoolSubmitComplete:
             .read_text(encoding="utf-8")
             .startswith(f"#!{sealed.resolve()}/bin/python\n")
         )
+
+    def test_verifier_runtime_rewrites_uv_long_path_shell_launcher(self, tmp_path: Path) -> None:
+        """A uv shell trampoline executes only the sealed runtime interpreter."""
+        checkout = tmp_path / "checkout"
+        runtime = checkout / ("long-runtime-path-" + "x" * 120) / ".venv"
+        launcher = runtime / "bin" / "python"
+        launcher.parent.mkdir(parents=True)
+        launcher.write_text("host interpreter\n", encoding="utf-8")
+        (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+        source_python = runtime.resolve() / "bin" / "python"
+        (runtime / "bin" / "mypy").write_text(
+            "#!/bin/sh\n"
+            f"'''exec' '{source_python}' \"$0\" \"$@\"\n"
+            "' '''\n"
+            "from mypy.__main__ import console_entry\n",
+            encoding="utf-8",
+        )
+        cache_temp = tmp_path / "cache-temp"
+
+        with (
+            patch(f"{_WP}.sys.prefix", str(runtime)),
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+        ):
+            sealed = _verifier_owned_runtime_environment(checkout)
+
+        copied = (sealed / "bin" / "mypy").read_text(encoding="utf-8")
+        assert str(source_python) not in copied
+        assert f"'''exec' '{sealed.resolve() / 'bin' / 'python'}'" in copied
 
     def test_host_verification_environment_keeps_tool_output_in_scratch(
         self, tmp_path: Path

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1044,11 +1044,51 @@ class TestWorkerPoolSubmitComplete:
             sealed_site_packages.chmod(sealed_site_packages.stat().st_mode | 0o200)
             (sealed_site_packages / "demo.py").unlink()
             rebuilt = _verifier_owned_runtime_environment(checkout)
+            with patch(f"{_WP}.shutil.copytree", side_effect=AssertionError("unexpected copy")):
+                reused = _verifier_owned_runtime_environment(checkout)
 
         assert rebuilt == sealed
+        assert reused == sealed
         assert (rebuilt / "lib" / "python3.13" / "site-packages" / "demo.py").read_text(
             encoding="utf-8"
         ) == "value = 1\n"
+
+    def test_verifier_runtime_rebuilds_cache_missing_record_manifest(self, tmp_path: Path) -> None:
+        """A missing RECORD file cannot make a sealed cache self-validate."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        runtime = tmp_path / "runtime"
+        site_packages = runtime / "lib" / "python3.13" / "site-packages"
+        dist_info = site_packages / "demo-1.0.dist-info"
+        (runtime / "bin").mkdir(parents=True)
+        dist_info.mkdir(parents=True)
+        (runtime / "bin" / "python").write_text("host interpreter\n", encoding="utf-8")
+        (runtime / "pyvenv.cfg").write_text("home = /usr/bin\n", encoding="utf-8")
+        (site_packages / "demo.py").write_text("value = 1\n", encoding="utf-8")
+        (dist_info / "RECORD").write_text(
+            "demo.py,sha256=fixture,10\ndemo-1.0.dist-info/RECORD,,\n",
+            encoding="utf-8",
+        )
+        cache_temp = tmp_path / "cache-temp"
+
+        with (
+            patch(f"{_WP}.sys.prefix", str(runtime)),
+            patch(f"{_WP}.tempfile.gettempdir", return_value=str(cache_temp)),
+        ):
+            sealed = _verifier_owned_runtime_environment(checkout)
+            sealed_dist_info = (
+                sealed / "lib" / "python3.13" / "site-packages" / "demo-1.0.dist-info"
+            )
+            sealed_dist_info.chmod(sealed_dist_info.stat().st_mode | 0o200)
+            (sealed_dist_info / "RECORD").unlink()
+            rebuilt = _verifier_owned_runtime_environment(checkout)
+
+        assert rebuilt == sealed
+        assert (
+            rebuilt / "lib" / "python3.13" / "site-packages" / "demo-1.0.dist-info" / "RECORD"
+        ).read_text(encoding="utf-8") == (
+            "demo.py,sha256=fixture,10\ndemo-1.0.dist-info/RECORD,,\n"
+        )
 
     def test_verifier_runtime_reuses_intact_manifest_cache(self, tmp_path: Path) -> None:
         """Integrity checks do not recopy an intact sealed environment."""


### PR DESCRIPTION
Relocates both direct Python shebangs and uv long-path shell trampolines into the sealed host-verification runtime, and bumps the runtime-cache format so previously sealed launchers are rebuilt.

Validation: exact long-path immutable mypy verifier passed; 158 worker-pool tests passed; Ruff and mypy passed; full pre-push suite passed (7161 passed, 11 skipped, 5 deselected; 84.75% coverage).

Closes #2617