### PR TITLE
fix(review): attach host receipts to reply validation

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1374,6 +1374,11 @@ class PrReviewStage(Stage):
                 StageOutcome(Disposition.FINISH_FAIL, "review_thread_receipts_unavailable"),
             )
         if not live_threads:
+            if item.payload.get(_COMMENT_VALIDATION_ONLY):
+                # A reply may resolve the last thread while the immutable
+                # host checks are running.  Keep the already-selected
+                # validation-only route instead of opening a second audit.
+                return Continue(next_state=VALIDATE_WAIT)
             return self._submit_review_job(item, ctx)
         snapshots = _validation_thread_snapshots(live_threads, receipts)
         remediation_threads = _normalize_remediation_threads(live_threads)

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1249,11 +1249,6 @@ class PrReviewStage(Stage):
         if isinstance(prior_generation, bool) or not isinstance(prior_generation, int):
             prior_generation = 0
         item.payload["reviewed_pr_proof_generation"] = prior_generation + 1
-        if item.payload.get(_COMMENT_VALIDATION_ONLY):
-            # The original audit already left these threads.  At this point
-            # the reviewer only validates the implementation's current-head
-            # replies, so do not create a second broad review batch.
-            return Continue(next_state=VALIDATE_WAIT)
         verifications = _host_verification_specs(item.payload.get("pr_diff"))
         if verifications:
             logger.info(

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1328,6 +1328,63 @@ class TestPrReviewStageStep:
         assert item.payload["review_audit"] == audit
         assert item.payload["host_verification_receipts"] == receipts
 
+    def test_comment_validation_carries_fresh_host_verification_receipts(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Reply validation receives exact-head host evidence without a broad review."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(1, 0)])
+        github._thread_replies["live-thread-1001-0"] = [
+            {
+                "id": "implementation-reply-live-thread-1001-0",
+                "author": "hephaestus[bot]",
+                "body": "[Response] The regression passes on this head.",
+            }
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state=REVIEW_CHECKOUT_WAIT)
+        item.worktree = "/tmp/detached-review"
+        item.payload.update(
+            {
+                "review_checkout_expected_head": "a" * 40,
+                "review_checkout_ready": True,
+                "reviewer_comment_validation_only": True,
+                "pr_diff": (
+                    "diff --git a/tests/unit/validation/test_test_layout.py "
+                    "b/tests/unit/validation/test_test_layout.py\n"
+                    "--- a/tests/unit/validation/test_test_layout.py\n"
+                    "+++ b/tests/unit/validation/test_test_layout.py\n"
+                ),
+            }
+        )
+
+        result = stage.step(item, ctx)
+        while isinstance(result, JobRequest) and isinstance(result.job, BuildTestJob):
+            receipt = {
+                "head_sha": "a" * 40,
+                "argv": list(result.job.argv),
+                "immutable_source": True,
+                "failure_kind": "none",
+                "ok": True,
+                "stdout_tail": "65 passed in 0.5s",
+                "stderr_tail": "",
+            }
+            stage.on_job_done(item, JobResult(ok=True, value=receipt), ctx)
+            item.state = result.on_done_state
+            result = stage.step(item, ctx)
+
+        receipts = item.payload["host_verification_receipts"]
+        assert receipts
+        assert result == Continue(next_state="VALIDATE_WAIT")
+        item.state = result.next_state
+        validation = stage.step(item, ctx)
+
+        assert isinstance(validation, JobRequest)
+        assert isinstance(validation.job, AgentJob)
+        assert validation.job.descr == "validate"
+        assert json.loads(validation.job.prompt_kwargs["host_verifications_json"]) == receipts
+        assert 1001 not in github.reviews
+
     def test_deleted_unit_tests_do_not_schedule_changed_pytest_specs(self) -> None:
         """Deleted tests have no new-side path for host pytest to execute."""
         deleted_path = "tests/unit/automation/pipeline/stages/test_deleted.py"

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1385,6 +1385,67 @@ class TestPrReviewStageStep:
         assert json.loads(validation.job.prompt_kwargs["host_verifications_json"]) == receipts
         assert 1001 not in github.reviews
 
+    def test_comment_validation_stays_validation_only_if_threads_resolve_during_host_checks(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A last-thread resolution during host checks must not start a broad audit."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(
+            pr_head_branch="1-auto-impl-direct-" + "b" * 32,
+            by_severity=[(1, 0, 0), (1, 0, 0), (0, 0, 0)],
+        )
+        github._thread_replies["live-thread-1001-0"] = [
+            {
+                "id": "implementation-reply-live-thread-1001-0",
+                "author": "hephaestus[bot]",
+                "body": "[Response] The regression passes on this head.",
+            }
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        assert item.payload["reviewer_comment_validation_only"] is True
+
+        item.state = REVIEW_CHECKOUT_WAIT
+        item.worktree = "/tmp/detached-review"
+        item.payload.update(
+            {
+                "review_checkout_expected_head": "a" * 40,
+                "review_checkout_ready": True,
+                "pr_diff": (
+                    "diff --git a/tests/unit/validation/test_test_layout.py "
+                    "b/tests/unit/validation/test_test_layout.py\n"
+                    "--- a/tests/unit/validation/test_test_layout.py\n"
+                    "+++ b/tests/unit/validation/test_test_layout.py\n"
+                ),
+            }
+        )
+
+        result = stage.step(item, ctx)
+        while isinstance(result, JobRequest) and isinstance(result.job, BuildTestJob):
+            receipt = {
+                "head_sha": "a" * 40,
+                "argv": list(result.job.argv),
+                "immutable_source": True,
+                "failure_kind": "none",
+                "ok": True,
+                "stdout_tail": "65 passed in 0.5s",
+                "stderr_tail": "",
+            }
+            stage.on_job_done(item, JobResult(ok=True, value=receipt), ctx)
+            item.state = result.on_done_state
+            result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="VALIDATE_WAIT")
+        item.state = result.next_state
+        validation = stage.step(item, ctx)
+
+        assert isinstance(validation, JobRequest)
+        assert isinstance(validation.job, AgentJob)
+        assert validation.job.descr == "validate"
+        assert 1001 not in github.reviews
+
     def test_deleted_unit_tests_do_not_schedule_changed_pytest_specs(self) -> None:
         """Deleted tests have no new-side path for host pytest to execute."""
         deleted_path = "tests/unit/automation/pipeline/stages/test_deleted.py"


### PR DESCRIPTION
Comment-only reviewer validation now executes the deterministic immutable host-verification plan for the fresh reviewed head and passes normalized receipts to Terra. The route remains validation-only and does not create a second broad review.

Validation: 218 focused stage tests pass; full locked suite 7,186 passed, 11 skipped, 5 deselected; 84.81% coverage.

Closes #2624