### PR TITLE
fix(automation): allow explicit gh installation root

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1429,6 +1429,13 @@ pre-PR test gate. Its vetted default is `uv run pytest tests -q --tb=short`;
 programmatic callers can supply `PipelineConfig.pre_pr_test_argv` for a
 different vetted test command.
 
+For hosts that cannot install GitHub CLI in the system-owned locations, the
+automation loop accepts the explicit, CLI-only
+`--gh-extra-path-root ROOT` exception. It admits only `ROOT/bin/gh`; `ROOT`
+must be absolute, the executable must be executable, and its resolved path
+must remain below `ROOT`. The loop does not read an environment equivalent and
+does not discover this exception through `PATH`.
+
 Three Codex-only flags control per-role reasoning effort:
 `--planner-reasoning-effort {default|low|medium|high|xhigh}` and the
 analogous `--reviewer-reasoning-effort` and `--implementer-reasoning-effort`

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -114,6 +114,30 @@ def _parse_positive_int(value: str) -> int:
     return number
 
 
+def _parse_gh_extra_path_root(value: str) -> Path:
+    """Validate an explicit root whose only admitted executable is ``bin/gh``."""
+    root = Path(value).expanduser()
+    if not root.is_absolute():
+        raise argparse.ArgumentTypeError("--gh-extra-path-root must be an absolute path")
+    try:
+        resolved_root = root.resolve(strict=True)
+        executable = (resolved_root / "bin" / "gh").resolve(strict=True)
+    except OSError as exc:
+        raise argparse.ArgumentTypeError(
+            "--gh-extra-path-root must contain an executable bin/gh"
+        ) from exc
+    if (
+        not resolved_root.is_dir()
+        or not executable.is_file()
+        or not os.access(executable, os.X_OK)
+        or not executable.is_relative_to(resolved_root)
+    ):
+        raise argparse.ArgumentTypeError(
+            "--gh-extra-path-root must contain an executable bin/gh without symlink escapes"
+        )
+    return resolved_root
+
+
 def _parse_positive_int_list(value: str, label: str) -> list[int]:
     """Split a comma-separated list into positive integers."""
     numbers: list[int] = []
@@ -226,6 +250,9 @@ class LoopConfig:
     planner_reasoning_effort: str = ""
     reviewer_reasoning_effort: str = ""
     implementer_reasoning_effort: str = ""
+    # Explicit, CLI-only extension to the system ``gh`` installation roots.
+    # The parser admits only ``<root>/bin/gh`` and never consults an env var.
+    gh_extra_path_root: Path | None = None
     gh_global_rate: float = 10.0
     gh_global_burst: float = 30.0
     # Org is resolved at runtime from --org / --repos / cwd detection; no
@@ -344,6 +371,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--run-pre-pr-tests",
         action="store_true",
         help=("Run the implementation-stage pre-PR test gate before committing and creating PRs."),
+    )
+    p.add_argument(
+        "--gh-extra-path-root",
+        type=_parse_gh_extra_path_root,
+        default=None,
+        metavar="ROOT",
+        help=(
+            "Explicitly allow only ROOT/bin/gh in addition to system gh locations. "
+            "ROOT must be absolute and contain an executable bin/gh that does not escape ROOT."
+        ),
     )
     p.add_argument(
         "--model",
@@ -703,6 +740,7 @@ def _build_pipeline_config(
         planner_reasoning_effort=cfg.planner_reasoning_effort,
         reviewer_reasoning_effort=cfg.reviewer_reasoning_effort,
         implementer_reasoning_effort=cfg.implementer_reasoning_effort,
+        gh_extra_path_root=cfg.gh_extra_path_root,
         no_advise=cfg.no_advise,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
@@ -873,6 +911,7 @@ def main(argv: list[str] | None = None) -> int:
         planner_reasoning_effort=args.planner_reasoning_effort,
         reviewer_reasoning_effort=args.reviewer_reasoning_effort,
         implementer_reasoning_effort=args.implementer_reasoning_effort,
+        gh_extra_path_root=args.gh_extra_path_root,
         gh_global_rate=args.gh_global_rate,
         gh_global_burst=args.gh_global_burst,
         org=org,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -302,6 +302,9 @@ class PipelineConfig:
     planner_reasoning_effort: str = ""
     reviewer_reasoning_effort: str = ""
     implementer_reasoning_effort: str = ""
+    # Explicit CLI-provided root that may supply only ``bin/gh``.  No
+    # environment-derived executable locations are admitted.
+    gh_extra_path_root: Path | None = None
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
@@ -525,6 +528,7 @@ class Coordinator:
                 size=work_window,
                 shutdown=self.shutdown,
                 completion_q=self.completion_q,
+                gh_extra_path_root=config.gh_extra_path_root,
             )
         else:
             # The coordinator owns the cross-thread transport.  An injected

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1126,9 +1126,17 @@ def _trusted_git_executable() -> str | None:
     return None
 
 
-def _trusted_gh_executable() -> str | None:
-    """Return a supported absolute ``gh`` binary without consulting ``PATH``."""
-    for candidate in _TRUSTED_GH_CANDIDATES:
+def _trusted_gh_executable(extra_path_root: Path | None = None) -> str | None:
+    """Return an allowed absolute ``gh`` binary without consulting ``PATH``.
+
+    ``extra_path_root`` is an explicit operator authority passed only through
+    the loop CLI.  It contributes exactly ``<root>/bin/gh`` and rejects a
+    candidate whose resolved path escapes that root.
+    """
+    candidates: tuple[Path, ...] = _TRUSTED_GH_CANDIDATES
+    if extra_path_root is not None:
+        candidates = (*candidates, extra_path_root / "bin" / "gh")
+    for candidate in candidates:
         try:
             resolved = candidate.resolve(strict=True)
         except OSError:
@@ -1137,6 +1145,13 @@ def _trusted_gh_executable() -> str | None:
             continue
         if any(resolved.is_relative_to(root) for root in _TRUSTED_GH_ROOTS):
             return str(resolved)
+        if extra_path_root is not None:
+            try:
+                resolved_root = extra_path_root.resolve(strict=True)
+            except OSError:
+                continue
+            if resolved.is_relative_to(resolved_root):
+                return str(resolved)
     return None
 
 
@@ -1313,6 +1328,7 @@ class WorkerPool:
         shutdown: threading.Event,
         completion_q: CompletionQueue,
         lock_dir: Path | None = None,
+        gh_extra_path_root: Path | None = None,
     ) -> None:
         """Initialize the pool.
 
@@ -1325,6 +1341,8 @@ class WorkerPool:
             lock_dir: Optional override for the cross-process git lock
                 directory (tests inject a temp dir; defaults to the shared
                 automation state dir — see :func:`_repo_lock_path`).
+            gh_extra_path_root: Explicit CLI-provided root that may supply
+                only ``bin/gh`` for checkout synchronization.
 
         """
         self._executor = ThreadPoolExecutor(
@@ -1338,6 +1356,7 @@ class WorkerPool:
         self._repo_locks: dict[str, _RepoLockEntry] = {}
         self._repo_locks_guard = threading.Lock()
         self._lock_dir = lock_dir
+        self._gh_extra_path_root = gh_extra_path_root
 
     @contextmanager
     def _repo_lock(self, repo: str) -> Iterator[None]:
@@ -2079,9 +2098,15 @@ class WorkerPool:
         branch = branch_result.stdout.strip()
         if branch_result.returncode != 0 or not branch:
             return JobResult(ok=False, error=f"checkout is detached: {checkout}")
-        gh_command = _trusted_gh_executable()
+        gh_command = _trusted_gh_executable(self._gh_extra_path_root)
         if gh_command is None:
-            return JobResult(ok=False, error="required GitHub executable is unavailable")
+            return JobResult(
+                ok=False,
+                error=(
+                    "required GitHub executable is unavailable; pass "
+                    "--gh-extra-path-root ROOT when ROOT/bin/gh is the intended installation"
+                ),
+            )
         default_branch = git_utils.run(
             [gh_command, "api", f"repos/{expected_repo}", "--jq", ".default_branch"],
             cwd=checkout,

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -25,14 +25,22 @@ class _RecordingWorkerPool:
         shutdown: Event,
         completion_q: Any,
         lock_dir: Path | None = None,
+        gh_extra_path_root: Path | None = None,
     ) -> None:
         del lock_dir
         self.size = size
         self.shutdown_event = shutdown
         self.completion_q = completion_q
+        self.gh_extra_path_root = gh_extra_path_root
 
 
-def _config(tmp_path: Path, *, parallel_repos: int = 2, max_workers: int = 3) -> PipelineConfig:
+def _config(
+    tmp_path: Path,
+    *,
+    parallel_repos: int = 2,
+    max_workers: int = 3,
+    gh_extra_path_root: Path | None = None,
+) -> PipelineConfig:
     """Build a configuration whose global work capacity is easy to inspect."""
     return PipelineConfig(
         org="org",
@@ -40,6 +48,7 @@ def _config(tmp_path: Path, *, parallel_repos: int = 2, max_workers: int = 3) ->
         parallel_repos=parallel_repos,
         max_workers=max_workers,
         projects_dir=tmp_path,
+        gh_extra_path_root=gh_extra_path_root,
     )
 
 
@@ -59,6 +68,21 @@ def test_coordinator_uses_one_capacity_for_all_queues_and_worker_pool(
     assert coordinator.completion_q.maxsize == capacity
     assert coordinator.pool.size == capacity
     assert coordinator.pool.completion_q is coordinator.completion_q
+    assert coordinator.pool.gh_extra_path_root is None
+
+
+def test_coordinator_passes_extra_gh_root_to_worker_pool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI-admitted GitHub root reaches the worker-pool trust boundary."""
+    from hephaestus.automation.pipeline import worker_pool as worker_pool_mod
+
+    monkeypatch.setattr(worker_pool_mod, "WorkerPool", _RecordingWorkerPool)
+    config = _config(tmp_path, gh_extra_path_root=tmp_path)
+
+    coordinator = Coordinator(config, github=FakeStageGitHub(), install_signals=False)
+
+    assert coordinator.pool.gh_extra_path_root == tmp_path
 
 
 def test_admission_rejects_when_global_worker_capacity_is_live(tmp_path: Path) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -128,20 +128,34 @@ class TestWiring:
         created: dict[str, Any] = {}
 
         class SpyPool:
-            def __init__(self, size: int, shutdown: Any, completion_q: Any) -> None:
+            def __init__(
+                self,
+                size: int,
+                shutdown: Any,
+                completion_q: Any,
+                gh_extra_path_root: Path | None = None,
+            ) -> None:
                 created["size"] = size
                 created["shutdown"] = shutdown
                 created["completion_q"] = completion_q
+                created["gh_extra_path_root"] = gh_extra_path_root
 
         monkeypatch.setattr("hephaestus.automation.pipeline.worker_pool.WorkerPool", SpyPool)
+        gh_root = tmp_path / "custom-gh"
         config = PipelineConfig(
-            org="org", repos=["r"], parallel_repos=3, max_workers=4, projects_dir=tmp_path
+            org="org",
+            repos=["r"],
+            parallel_repos=3,
+            max_workers=4,
+            projects_dir=tmp_path,
+            gh_extra_path_root=gh_root,
         )
         coordinator = Coordinator(config, github=FakeStageGitHub(), install_signals=False)
 
         assert created["size"] == 12
         assert created["shutdown"] is coordinator.shutdown
         assert created["completion_q"] is coordinator.completion_q
+        assert created["gh_extra_path_root"] == gh_root
 
     def test_run_pipeline_wires_accessor_and_runs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -113,6 +113,22 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.event_log_path.parent == Path(DEFAULT_STATE_DIR)
 
 
+def test_build_pipeline_config_maps_explicit_gh_root(
+    dispatch: dict[str, MagicMock], tmp_path: Path
+) -> None:
+    """The CLI-only executable exception reaches the checkout worker config."""
+    gh_root = tmp_path / "gh-root"
+    executable = gh_root / "bin" / "gh"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\n")
+    executable.chmod(0o755)
+
+    loop_runner.main(["--gh-extra-path-root", str(gh_root)])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.gh_extra_path_root == gh_root
+
+
 def test_drive_green_all_maps_all_authors_and_bots(dispatch: dict[str, MagicMock]) -> None:
     """The legacy drive-green-all flag preserves its configuration mapping."""
     loop_runner.main(["--drive-green-all", "--dry-run"])

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -71,6 +71,20 @@ def _executable_path(name: str, *, path: str | None = None) -> str:
     return str(Path(executable).resolve())
 
 
+def test_trusted_gh_executable_accepts_explicit_extra_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit root contributes only its contained ``bin/gh`` executable."""
+    gh_root = tmp_path / "custom-gh"
+    executable = gh_root / "bin" / "gh"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\n")
+    executable.chmod(0o755)
+    monkeypatch.setattr(f"{_WP}._TRUSTED_GH_CANDIDATES", ())
+
+    assert _trusted_gh_executable(gh_root) == str(executable)
+
+
 @pytest.fixture
 def shutdown_event() -> threading.Event:
     """Fresh shutdown event for each test."""
@@ -1527,6 +1541,15 @@ class TestInterruptedPostCheck:
 
 class TestGitOps:
     """Tests for every GitJob op dispatch (helpers mocked)."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_trusted_gh_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep checkout-sync tests independent of the host's gh install layout."""
+        def executable(_root: Path | None = None) -> str:
+            return "/usr/bin/gh"
+
+        monkeypatch.setattr(f"{_WP}._trusted_gh_executable", executable)
+        monkeypatch.setattr(f"{__name__}._trusted_gh_executable", executable)
 
     def test_create_worktree_dispatch(
         self,
@@ -3051,6 +3074,32 @@ class TestGitOps:
         assert (checkout / ".git" / ".hephaestus-git-metadata.lock").is_file()
         assert result.ok is True
         assert result.value == "a" * 40
+
+    def test_sync_checkout_missing_gh_explains_extra_root_flag(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """A missing trusted executable gives the operator the supported escape hatch."""
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        with (
+            patch("hephaestus.automation.git_utils.run") as mock_run,
+            patch(f"{_WP}._trusted_gh_executable", return_value=None),
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout="https://github.com/owner/name.git\n"),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="main\n"),
+            ]
+            result = pool._sync_checkout_locked(
+                checkout=checkout,
+                expected_repo="owner/name",
+                timeout_s=120,
+            )
+
+        assert result.error == (
+            "required GitHub executable is unavailable; pass "
+            "--gh-extra-path-root ROOT when ROOT/bin/gh is the intended installation"
+        )
 
     def test_sync_checkout_rechecks_clean_state_after_fetch_before_merge(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1545,6 +1545,7 @@ class TestGitOps:
     @pytest.fixture(autouse=True)
     def _mock_trusted_gh_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Keep checkout-sync tests independent of the host's gh install layout."""
+
         def executable(_root: Path | None = None) -> str:
             return "/usr/bin/gh"
 

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -629,6 +629,12 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "Run the implementation-stage pre-PR test gate before committing and creating PRs.",
         ),
         _action_spec(
+            ("--gh-extra-path-root",),
+            "gh_extra_path_root",
+            "_StoreAction",
+            None,
+        ),
+        _action_spec(
             ("--model",),
             "model",
             "_StoreAction",

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -107,6 +107,27 @@ def test_parse_args_accepts_explicit_codex_agent() -> None:
     assert args.agent == "codex"
 
 
+def test_loop_help_documents_explicit_gh_root_override() -> None:
+    """The executable exception is an explicit, discoverable CLI authority."""
+    assert "--gh-extra-path-root" in loop_runner._build_parser().format_help()
+
+
+def test_parse_args_rejects_gh_root_that_escapes_through_a_symlink(tmp_path: Path) -> None:
+    """The explicit root cannot authorize an executable outside its boundary."""
+    gh_root = tmp_path / "gh-root"
+    gh_root.mkdir()
+    outside = tmp_path / "outside-gh"
+    outside.write_text("#!/bin/sh\n")
+    outside.chmod(0o755)
+    (gh_root / "bin").mkdir()
+    (gh_root / "bin" / "gh").symlink_to(outside)
+
+    with pytest.raises(SystemExit) as excinfo:
+        loop_runner._parse_args(["--gh-extra-path-root", str(gh_root)])
+
+    assert excinfo.value.code == 2
+
+
 def test_parse_args_accepts_no_advise() -> None:
     """The loop runner can disable advise across child phases."""
     args = loop_runner._parse_args(["--no-advise"])


### PR DESCRIPTION
## Summary

- Adds the CLI-only --gh-extra-path-root ROOT exception for hosts without a system-owned GitHub CLI installation.
- Validates the absolute root, executable ROOT/bin/gh layout, and symlink containment before the pipeline starts.
- Propagates the explicit root only to checkout synchronization and explains the flag when no trusted executable is available.

## Root cause

Checkout synchronization admitted gh only from fixed system paths, even when an operator had an authenticated, usable installation elsewhere.

## Validation

- 332 targeted unit and documentation tests passed.
- Ruff and mypy passed for the changed Python modules.

Closes #2628
