### PR TITLE
fix(automation): preserve current review heads

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2001,21 +2001,12 @@ class WorkerPool:
                 timeout=job.timeout_s,
             )
             if ancestry.returncode == 0:
-                source_sha = self._read_publish_head(cwd, timeout=job.timeout_s)
-                if isinstance(source_sha, JobResult):
-                    return source_sha
-                if source_sha != expected_remote_sha:
-                    return JobResult(
-                        ok=False,
-                        error="current writer head does not match expected remote head",
-                    )
-                return JobResult(
-                    ok=True,
-                    value={
-                        "rebased": False,
-                        "published": False,
-                        "head_sha": source_sha,
-                    },
+                return self._verify_noop_writer_rebase(
+                    cwd,
+                    remote=remote,
+                    branch=branch,
+                    expected_remote_sha=expected_remote_sha,
+                    timeout=job.timeout_s,
                 )
             if ancestry.returncode != 1:
                 return JobResult(ok=False, error="cannot determine writer base ancestry")
@@ -2861,6 +2852,68 @@ class WorkerPool:
         if not _is_full_commit_sha(head):
             return JobResult(ok=False, error="cannot bind implementation publish head")
         return head
+
+    @staticmethod
+    def _read_remote_branch_head(
+        worktree_path: Path,
+        *,
+        remote: str,
+        branch: str,
+        timeout: int,
+    ) -> str | JobResult:
+        """Read one exact remote branch head without updating local refs."""
+        expected_ref = f"refs/heads/{branch}"
+        try:
+            fields = git_utils.run(
+                ["git", "ls-remote", "--refs", remote, expected_ref],
+                cwd=worktree_path,
+                timeout=timeout,
+            ).stdout.split()
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return JobResult(ok=False, error="cannot verify remote writer head")
+        if len(fields) != 2 or not _is_full_commit_sha(fields[0]) or fields[1] != expected_ref:
+            return JobResult(ok=False, error="cannot verify remote writer head")
+        return fields[0]
+
+    def _verify_noop_writer_rebase(
+        self,
+        worktree_path: Path,
+        *,
+        remote: str,
+        branch: str,
+        expected_remote_sha: str,
+        timeout: int,
+    ) -> JobResult:
+        """Bind an already-current local writer to its unchanged remote head."""
+        source_sha = self._read_publish_head(worktree_path, timeout=timeout)
+        if isinstance(source_sha, JobResult):
+            return source_sha
+        if source_sha != expected_remote_sha:
+            return JobResult(
+                ok=False,
+                error="current writer head does not match expected remote head",
+            )
+        remote_head = self._read_remote_branch_head(
+            worktree_path,
+            remote=remote,
+            branch=branch,
+            timeout=timeout,
+        )
+        if isinstance(remote_head, JobResult):
+            return remote_head
+        if remote_head != expected_remote_sha:
+            return JobResult(
+                ok=False,
+                error="remote writer head changed during rebase preparation",
+            )
+        return JobResult(
+            ok=True,
+            value={
+                "rebased": False,
+                "published": False,
+                "head_sha": source_sha,
+            },
+        )
 
     @staticmethod
     def _commit_push_requires_publish(

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1982,6 +1982,43 @@ class WorkerPool:
         publish_rebased_head = bool(kwargs.pop("publish_rebased_head", False))
         branch = str(kwargs.pop("branch", "") or "")
         expected_remote_sha = kwargs.pop("expected_remote_sha", None)
+        cwd = Path(str(kwargs.get("cwd") or ""))
+        if publish_rebased_head:
+            if not branch or not _is_full_commit_sha(expected_remote_sha) or not cwd.is_dir():
+                return JobResult(ok=False, error="writer rebase publish arguments invalid")
+            remote = str(kwargs.get("remote", "origin"))
+            base_branch = str(kwargs.get("base_branch", "main"))
+            base_ref = f"{remote}/{base_branch}"
+            git_utils.run(
+                ["git", "fetch", remote, base_branch],
+                cwd=cwd,
+                timeout=job.timeout_s,
+            )
+            ancestry = git_utils.run(
+                ["git", "merge-base", "--is-ancestor", base_ref, "HEAD"],
+                cwd=cwd,
+                check=False,
+                timeout=job.timeout_s,
+            )
+            if ancestry.returncode == 0:
+                source_sha = self._read_publish_head(cwd, timeout=job.timeout_s)
+                if isinstance(source_sha, JobResult):
+                    return source_sha
+                if source_sha != expected_remote_sha:
+                    return JobResult(
+                        ok=False,
+                        error="current writer head does not match expected remote head",
+                    )
+                return JobResult(
+                    ok=True,
+                    value={
+                        "rebased": False,
+                        "published": False,
+                        "head_sha": source_sha,
+                    },
+                )
+            if ancestry.returncode != 1:
+                return JobResult(ok=False, error="cannot determine writer base ancestry")
         result = git_utils.rebase_worktree_onto(**kwargs, timeout=job.timeout_s)
         if not result:
             if not publish_rebased_head:
@@ -1997,9 +2034,6 @@ class WorkerPool:
             )
         if not publish_rebased_head:
             return JobResult(ok=True, value=True)
-        cwd = Path(str(kwargs.get("cwd") or ""))
-        if not branch or not _is_full_commit_sha(expected_remote_sha) or not cwd.is_dir():
-            return JobResult(ok=False, error="writer rebase publish arguments invalid")
         source_sha = self._read_publish_head(cwd, timeout=job.timeout_s)
         if isinstance(source_sha, JobResult):
             return source_sha

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2436,16 +2436,70 @@ class TestGitOps:
                 "expected_remote_sha": "a" * 40,
             },
         )
-        with patch(
-            "hephaestus.automation.git_utils.rebase_worktree_onto",
-            return_value=False,
+        with (
+            patch(
+                "hephaestus.automation.git_utils.rebase_worktree_onto",
+                return_value=False,
+            ),
+            patch(f"{_WP}.git_utils.run") as run,
         ):
+            run.side_effect = [
+                MagicMock(returncode=0),
+                MagicMock(returncode=1),
+            ]
             pool.submit(job, StageName.IMPLEMENTATION)
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
         assert result.value == {"rebased": False}
         assert result.error == "mechanical rebase hit conflicts; aborted"
+
+    def test_writer_rebase_keeps_exact_head_when_current_base_is_already_ancestor(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Review preparation must not rewrite or publish an already-current PR."""
+        head = "a" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="rebase",
+            timeout_s=60,
+            kwargs={
+                "cwd": tmp_path,
+                "base_branch": "main",
+                "remote": "origin",
+                "publish_rebased_head": True,
+                "branch": "7-auto-impl",
+                "expected_remote_sha": head,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.run") as run,
+            patch(f"{_WP}.git_utils.rebase_worktree_onto") as rebase,
+            patch(f"{_WP}.git_utils.push_head_to_branch") as push,
+        ):
+            run.side_effect = [
+                MagicMock(returncode=0),
+                MagicMock(returncode=0),
+                MagicMock(returncode=0, stdout=f"{head}\n"),
+            ]
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {
+            "rebased": False,
+            "published": False,
+            "head_sha": head,
+        }
+        assert [call.args[0] for call in run.call_args_list[:2]] == [
+            ["git", "fetch", "origin", "main"],
+            ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
+        ]
+        rebase.assert_not_called()
+        push.assert_not_called()
 
     def test_direct_rebase_dispatch_rejects_the_retired_publish_mode(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2484,6 +2484,10 @@ class TestGitOps:
                 MagicMock(returncode=0),
                 MagicMock(returncode=0),
                 MagicMock(returncode=0, stdout=f"{head}\n"),
+                MagicMock(
+                    returncode=0,
+                    stdout=f"{head}\trefs/heads/7-auto-impl\n",
+                ),
             ]
             pool.submit(job, StageName.IMPLEMENTATION)
             _, result = completion_q.get(timeout=10)
@@ -2494,10 +2498,68 @@ class TestGitOps:
             "published": False,
             "head_sha": head,
         }
-        assert [call.args[0] for call in run.call_args_list[:2]] == [
+        assert [call.args[0] for call in run.call_args_list] == [
             ["git", "fetch", "origin", "main"],
             ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
+            ["git", "rev-parse", "HEAD"],
+            [
+                "git",
+                "ls-remote",
+                "--refs",
+                "origin",
+                "refs/heads/7-auto-impl",
+            ],
         ]
+        rebase.assert_not_called()
+        push.assert_not_called()
+
+    def test_writer_rebase_rejects_noop_when_remote_branch_moves(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Review preparation must reject a stale head after a concurrent push."""
+        expected_head = "a" * 40
+        moved_head = "b" * 40
+        branch = "7-auto-impl"
+        job = GitJob(
+            repo="test/repo",
+            op="rebase",
+            timeout_s=60,
+            kwargs={
+                "cwd": tmp_path,
+                "base_branch": "main",
+                "remote": "origin",
+                "publish_rebased_head": True,
+                "branch": branch,
+                "expected_remote_sha": expected_head,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.run") as run,
+            patch(f"{_WP}.git_utils.rebase_worktree_onto") as rebase,
+            patch(f"{_WP}.git_utils.push_head_to_branch") as push,
+        ):
+            run.side_effect = [
+                MagicMock(returncode=0),
+                MagicMock(returncode=0),
+                MagicMock(returncode=0, stdout=f"{expected_head}\n"),
+                MagicMock(
+                    returncode=0,
+                    stdout=f"{moved_head}\trefs/heads/{branch}\n",
+                ),
+            ]
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "remote writer head changed during rebase preparation"
+        assert run.call_args_list[-1] == call(
+            ["git", "ls-remote", "--refs", "origin", f"refs/heads/{branch}"],
+            cwd=tmp_path,
+            timeout=60,
+        )
         rebase.assert_not_called()
         push.assert_not_called()
 


### PR DESCRIPTION
## Summary

- preserve the exact writer head when current `origin/main` is already its ancestor
- skip the forced policy rebase and lease push for that no-op review-preparation case
- retain the existing signed/DCO policy rebase path for genuinely behind branches
- add a worker-pool regression proving no rebase or push occurs for a current PR head

## Verification

- 876 relevant automation tests passed
- Ruff check and format check passed
- MyPy passed for both changed files
- all applicable pre-commit hooks passed

Closes #2630
