### PR TITLE
fix(automation): move blocking GitHub I/O to workers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,7 @@ The main thread (coordinator) OWNS:
 - the timer heap ([`self.timers`](../hephaestus/automation/pipeline/coordinator.py))
 - the in-flight registry ([`self.in_flight`](../hephaestus/automation/pipeline/coordinator.py))
 - all routing and disposition semantics ([`_route`](../hephaestus/automation/pipeline/coordinator.py))
-- every GitHub API mutation, through
+- coordinator-local GitHub reads and mutations, through
  [`StageGitHub`](../hephaestus/automation/pipeline/stages/base.py)
  (label writes, comment upserts, and PR creation; the queue does not mutate
  auto-merge)
@@ -178,7 +178,15 @@ It NEVER launches agents, builds/tests or git/network operations. It never
 sleeps — wakeups are the timer's responsibility.
 The single worker pool ([`WorkerPool`](../hephaestus/automation/pipeline/worker_pool.py))
 executes everything else: agent invocations (Claude or Codex), build/test
-subprocesses and git/network operations. Every Claude agent invocation
+subprocesses, git operations, and the closed worker-owned GitHub operations.
+`StageContext.github` remains coordinator-thread-owned and never crosses this
+boundary. Each [`GitHubJob`](../hephaestus/automation/pipeline/github_jobs.py)
+contains one frozen request from a closed five-operation algebra; the production
+runner creates a fresh [`PipelineGitHub`](../hephaestus/automation/pipeline_github.py)
+accessor per job. Same-repository GitHub jobs serialize under `_repo_lock`, while
+different repositories may execute concurrently. No arbitrary callable, mutable
+kwargs, `WorkItem`, stage callback, or shared service response crosses the worker
+boundary. Every Claude agent invocation
 routed through the worker pool binds to an explicit least-privilege
 `--allowedTools` scope. An explicit [`AgentJob.allowed_tools`](../hephaestus/automation/pipeline/jobs.py)
 grant wins (the `pr_review` job uses it for the reviewer skill); absent that,
@@ -279,10 +287,14 @@ comment presence, PR existence) fast-forward through already-completed
 work. Interrupts therefore leave items RESUMABLE, never FAILED — a restart's
 seeding classifies them back into the same entry queue and `on_enter`
 restarts from the same state.
-Implementation: each stage method performs its durable op via a single
-[`ctx.github`](../hephaestus/automation/pipeline/stages/base.py) accessor call
-on the coordinator-owned [`StageGitHub`](../hephaestus/automation/pipeline/stages/base.py)
-protocol, then returns `StageOutcome(…)`. The coordinator's
+Implementation: coordinator-local writes use the single-owner
+[`ctx.github`](../hephaestus/automation/pipeline/stages/base.py) accessor. Reply
+journal recovery/append and delivery, PR-review reconciliation, and merge-wait
+admission/conditional merge instead submit a closed `GitHubJob`. Its receipt
+embeds the exact immutable request and is accepted only when it equals the
+item's pending request. The coordinator invokes `on_job_done()` while the item
+is still in its submitting state, so the receipt is applied before installing
+the next mini-state or routing to another queue. The coordinator's
 [`_route`](../hephaestus/automation/pipeline/coordinator.py) applies the
 disposition to the queue.
 
@@ -1295,9 +1307,10 @@ and require operator handling.
 
 [`WorkerPool`](../hephaestus/automation/pipeline/worker_pool.py) is the
 single executor. It receives frozen specs and returns bounded
-[`JobResult`](../hephaestus/automation/pipeline/jobs.py) tuples. Workers
-never touch WorkItems or stage queues and never perform GitHub API
-mutations.
+[`JobResult`](../hephaestus/automation/pipeline/jobs.py) tuples. Workers never
+touch `WorkItem`s or stage queues. GitHub I/O is allowed only through the
+closed typed runner; generic worker code does not import the GitHub
+implementation.
 
 ### Job kinds
 
@@ -1324,6 +1337,14 @@ mutations.
  expected snapshot SHA, and PR number. The worker rejects a dirty checkout,
  synchronizes the branch, requires `git rev-parse HEAD` to equal that SHA, and
  checks cleanliness again ([`_git_verify_pr_review_checkout`](../hephaestus/automation/pipeline/worker_pool.py)).
+- [`GitHubJob`](../hephaestus/automation/pipeline/github_jobs.py) — one of five
+ frozen typed requests: recover or append the version-one reply journal,
+ deliver an exact reply handoff, reconcile one exact-head PR review, or run one
+ complete merge-wait cycle. Nested service data uses canonical JSON snapshots;
+ each receipt contains its request and fresh decodes, so stage and worker never
+ share mutable GitHub responses. These jobs and their wait-state names are
+ process-local. The durable reply marker and `"format": 1` body are unchanged,
+ preserving restart, downgrade, and rollback recovery.
 - [`CompactJob`](../hephaestus/automation/pipeline/jobs.py) — a best-effort
  `/compact` turn for a persisted Claude, Codex, or Pi session; it never blocks
  the retry lifecycle.
@@ -1358,8 +1379,9 @@ and selects exit code 130.
 
 ### Per-repo lock layering
 
-[`_run_git`](../hephaestus/automation/pipeline/worker_pool.py) wraps every
-git operation in two locks:
+[`_run_git`](../hephaestus/automation/pipeline/worker_pool.py) wraps every git
+operation in two locks. `_run_github` uses the same outer repository lock but
+does not take the Git metadata file lock:
 
 1. **Outer**: in-process `threading.Lock` per repo ([`_repo_lock`](../hephaestus/automation/pipeline/worker_pool.py))
  — single-thread per process serializes at most one thread per
@@ -1369,8 +1391,11 @@ git operation in two locks:
  `<repo_root>/<DEFAULT_STATE_DIR>/locks/git-<repo>.lock`
  ([`_repo_lock_path`](../hephaestus/automation/pipeline/worker_pool.py))
  with a bounded wait using interruptible polling.
-Both locks are held for the entire operation because worktrees share
-`.git`.
+Both git locks are held for the entire git operation because worktrees share
+`.git`. A GitHub job holds only the outer lock for its entire fresh-client
+operation, enforcing the `StageGitHub` concurrency contract without implying
+cross-process GitHub serialization; exact live-state guards remain authoritative
+across processes.
 
 `sync_checkout` additionally takes the status-safe Git-metadata lock resolved
 by [`WorktreeManager.git_metadata_lock_path`](../hephaestus/automation/worktree_manager.py).

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -67,12 +67,17 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
             # Imported here, not module-top: WorkerPool is the pipeline's one
             # I/O-capable module and tests never need it.
             from hephaestus.automation.pipeline.worker_pool import WorkerPool
+            from hephaestus.automation.pipeline_github_jobs import PipelineGitHubJobRunner
 
             pool = WorkerPool(
                 size=work_window,
                 shutdown=self.shutdown,
                 completion_q=self.completion_q,
                 gh_extra_path_root=config.gh_extra_path_root,
+                github_job_runner=PipelineGitHubJobRunner(
+                    org=config.org,
+                    dry_run=config.dry_run,
+                ),
             )
         else:
             # The coordinator owns the cross-thread transport.  An injected

--- a/hephaestus/automation/pipeline/github_jobs.py
+++ b/hephaestus/automation/pipeline/github_jobs.py
@@ -342,4 +342,4 @@ class GitHubJobRunner(Protocol):
 
     def run(self, job: GitHubJob) -> GitHubReceipt:
         """Execute one closed GitHub request and return its immutable receipt."""
-        ...
+        raise NotImplementedError

--- a/hephaestus/automation/pipeline/github_jobs.py
+++ b/hephaestus/automation/pipeline/github_jobs.py
@@ -1,0 +1,345 @@
+"""Closed immutable requests and receipts for worker-owned GitHub I/O.
+
+Only the value objects in this module may cross the coordinator/worker GitHub
+boundary.  Nested service data is represented as canonical JSON so neither a
+stage nor a worker can retain a shared mutable response object.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, Self
+
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_JOURNAL_MARKER_RE = re.compile(
+    r"<!-- hephaestus-implementation-reply-handoff:"
+    r"pr=[1-9][0-9]*:head=[0-9a-f]{40}:batch=[0-9a-f]{32} -->"
+)
+
+
+@dataclass(frozen=True)
+class FrozenJson:
+    """Canonical immutable snapshot of JSON-compatible service data."""
+
+    encoded: str
+
+    @classmethod
+    def snapshot(cls, value: object) -> Self:
+        """Deep-copy *value* into a deterministic immutable representation."""
+        return cls(
+            encoded=json.dumps(
+                value,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+
+    def __post_init__(self) -> None:
+        """Reject invalid or non-canonical encoded values."""
+        try:
+            value = json.loads(self.encoded)
+            canonical = json.dumps(
+                value,
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        except (TypeError, ValueError, json.JSONDecodeError) as error:
+            raise ValueError("FrozenJson must contain canonical JSON") from error
+        if canonical != self.encoded:
+            raise ValueError("FrozenJson must contain canonical JSON")
+
+    def thaw(self) -> object:
+        """Return a fresh mutable decode without exposing shared state."""
+        return json.loads(self.encoded)
+
+
+def _positive_identifier(value: int, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{field_name} must be a positive integer")
+
+
+def _full_sha(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or _FULL_SHA_RE.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a full lowercase commit SHA")
+
+
+def _json_root(value: FrozenJson, expected: type[object], field_name: str) -> None:
+    if not isinstance(value, FrozenJson) or not isinstance(value.thaw(), expected):
+        raise ValueError(f"{field_name} must contain a JSON {expected.__name__}")
+
+
+@dataclass(frozen=True)
+class RecoverReplyJournalRequest:
+    """Recover a version-one reply journal for exact source threads."""
+
+    issue_number: int
+    pr_number: int
+    threads: FrozenJson
+
+    def __post_init__(self) -> None:
+        """Validate identifiers and the frozen thread snapshot."""
+        _positive_identifier(self.issue_number, "issue_number")
+        _positive_identifier(self.pr_number, "pr_number")
+        _json_root(self.threads, list, "threads")
+
+
+@dataclass(frozen=True)
+class AppendReplyJournalRequest:
+    """Append one replay-safe exact reply journal entry."""
+
+    issue_number: int
+    marker: str
+    body: str
+
+    def __post_init__(self) -> None:
+        """Validate the replay-safe journal marker and body."""
+        _positive_identifier(self.issue_number, "issue_number")
+        if not isinstance(self.marker, str) or _JOURNAL_MARKER_RE.fullmatch(self.marker) is None:
+            raise ValueError("marker must be an exact implementation reply journal marker")
+        if not isinstance(self.body, str) or not self.body.startswith(f"{self.marker}\n<!-- "):
+            raise ValueError("body must contain the exact journal marker and payload")
+
+
+@dataclass(frozen=True)
+class DeliverReplyHandoffRequest:
+    """Deliver one already-journaled exact reply batch."""
+
+    issue_number: int
+    pr_number: int
+    handoff: FrozenJson
+    visibility_retries: int
+
+    def __post_init__(self) -> None:
+        """Validate identifiers, handoff shape, and retry count."""
+        _positive_identifier(self.issue_number, "issue_number")
+        _positive_identifier(self.pr_number, "pr_number")
+        _json_root(self.handoff, dict, "handoff")
+        if (
+            isinstance(self.visibility_retries, bool)
+            or not isinstance(self.visibility_retries, int)
+            or self.visibility_retries < 0
+        ):
+            raise ValueError("visibility_retries must be a non-negative integer")
+
+
+@dataclass(frozen=True)
+class ReconcilePrReviewRequest:
+    """Reconcile one exact-head review using fresh GitHub facts."""
+
+    pr_number: int
+    reviewed_head_sha: str
+    validated_receipt_fingerprints: FrozenJson | None
+    validated_metadata_fingerprint: str | None
+    resolved_thread_ids: tuple[str, ...]
+    feedback: FrozenJson
+    findings: FrozenJson
+    review_diff: str
+
+    def __post_init__(self) -> None:
+        """Validate the exact-head reconciliation request."""
+        _positive_identifier(self.pr_number, "pr_number")
+        _full_sha(self.reviewed_head_sha, "reviewed_head_sha")
+        if self.validated_receipt_fingerprints is not None:
+            _json_root(
+                self.validated_receipt_fingerprints,
+                dict,
+                "validated_receipt_fingerprints",
+            )
+        if self.validated_metadata_fingerprint is not None and not isinstance(
+            self.validated_metadata_fingerprint, str
+        ):
+            raise ValueError("validated_metadata_fingerprint must be a string or None")
+        if not isinstance(self.resolved_thread_ids, tuple) or not all(
+            isinstance(thread_id, str) and thread_id for thread_id in self.resolved_thread_ids
+        ):
+            raise ValueError("resolved_thread_ids must be a tuple of non-empty strings")
+        _json_root(self.feedback, dict, "feedback")
+        _json_root(self.findings, list, "findings")
+        if not isinstance(self.review_diff, str):
+            raise ValueError("review_diff must be a string")
+
+
+@dataclass(frozen=True)
+class RunMergeWaitCycleRequest:
+    """Run one exact-head merge admission and conditional-request cycle."""
+
+    pr_number: int
+    reviewed_head_sha: str
+    proof_generation: int
+    declined_readiness_fingerprint: tuple[str, ...] | None
+
+    def __post_init__(self) -> None:
+        """Validate the exact-head merge proof and readiness fingerprint."""
+        _positive_identifier(self.pr_number, "pr_number")
+        _full_sha(self.reviewed_head_sha, "reviewed_head_sha")
+        if (
+            isinstance(self.proof_generation, bool)
+            or not isinstance(self.proof_generation, int)
+            or self.proof_generation < 0
+        ):
+            raise ValueError("proof_generation must be a non-negative integer")
+        fingerprint = self.declined_readiness_fingerprint
+        if fingerprint is not None and (
+            not isinstance(fingerprint, tuple)
+            or not all(isinstance(part, str) for part in fingerprint)
+        ):
+            raise ValueError("declined_readiness_fingerprint must be a tuple of strings or None")
+
+
+type GitHubRequest = (
+    RecoverReplyJournalRequest
+    | AppendReplyJournalRequest
+    | DeliverReplyHandoffRequest
+    | ReconcilePrReviewRequest
+    | RunMergeWaitCycleRequest
+)
+
+
+@dataclass(frozen=True)
+class GitHubJob:
+    """One closed GitHub operation submitted to the worker pool."""
+
+    repo: str
+    repo_root: Path
+    request: GitHubRequest
+    descr: str
+
+    def __post_init__(self) -> None:
+        """Validate the closed job envelope."""
+        if not isinstance(self.repo, str) or not self.repo:
+            raise ValueError("repo must be a non-empty string")
+        if not isinstance(self.repo_root, Path) or not self.repo_root.is_absolute():
+            raise ValueError("repo_root must be an absolute Path")
+        if not isinstance(
+            self.request,
+            (
+                RecoverReplyJournalRequest,
+                AppendReplyJournalRequest,
+                DeliverReplyHandoffRequest,
+                ReconcilePrReviewRequest,
+                RunMergeWaitCycleRequest,
+            ),
+        ):
+            raise TypeError("request must be a supported GitHub request")
+        if not isinstance(self.descr, str) or not self.descr:
+            raise ValueError("descr must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class ReplyJournalRecovered:
+    """Receipt for a journal recovery read."""
+
+    request: RecoverReplyJournalRequest
+    handoff: FrozenJson | None
+
+    def __post_init__(self) -> None:
+        """Validate the optional recovered handoff snapshot."""
+        if self.handoff is not None:
+            _json_root(self.handoff, dict, "handoff")
+
+
+@dataclass(frozen=True)
+class ReplyJournalAppended:
+    """Receipt for a durable replay-safe journal append."""
+
+    request: AppendReplyJournalRequest
+
+
+@dataclass(frozen=True)
+class ReplyHandoffAttempted:
+    """Detached receipt for one exact reply-delivery attempt."""
+
+    request: DeliverReplyHandoffRequest
+    status: Literal["completed", "visibility_wait", "stale", "invalid", "retry"]
+    remaining_handoff: FrozenJson | None
+    visibility_retries: int
+    retry_delay_s: float | None
+
+    def __post_init__(self) -> None:
+        """Validate detached retry and handoff state."""
+        if self.status not in {
+            "completed",
+            "visibility_wait",
+            "stale",
+            "invalid",
+            "retry",
+        }:
+            raise ValueError("status must be a supported reply-handoff outcome")
+        if self.remaining_handoff is not None:
+            _json_root(self.remaining_handoff, dict, "remaining_handoff")
+        if (
+            isinstance(self.visibility_retries, bool)
+            or not isinstance(self.visibility_retries, int)
+            or self.visibility_retries < 0
+        ):
+            raise ValueError("visibility_retries must be a non-negative integer")
+        if self.retry_delay_s is not None and (
+            isinstance(self.retry_delay_s, bool)
+            or not isinstance(self.retry_delay_s, (int, float))
+            or self.retry_delay_s < 0
+        ):
+            raise ValueError("retry_delay_s must be a non-negative number or None")
+
+
+@dataclass(frozen=True)
+class PrReviewReconciled:
+    """Immutable result of fresh PR-review reconciliation."""
+
+    request: ReconcilePrReviewRequest
+    action: Literal["apply", "revalidate", "fresh_review", "audit_failure"]
+    posted_receipts: FrozenJson
+    unresolved_threads: FrozenJson
+    remediation_threads: FrozenJson
+
+    def __post_init__(self) -> None:
+        """Validate immutable review response snapshots."""
+        if self.action not in {"apply", "revalidate", "fresh_review", "audit_failure"}:
+            raise ValueError("action must be a supported PR-review outcome")
+        _json_root(self.posted_receipts, list, "posted_receipts")
+        _json_root(self.unresolved_threads, list, "unresolved_threads")
+        _json_root(self.remediation_threads, list, "remediation_threads")
+
+
+@dataclass(frozen=True)
+class MergeWaitCycleCompleted:
+    """Immutable outcome of one merge admission/request cycle."""
+
+    request: RunMergeWaitCycleRequest
+    outcome: str
+    attempted: bool
+    readiness_fingerprint: tuple[str, ...] | None = None
+    retryable: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate merge-cycle outcome metadata."""
+        if not isinstance(self.outcome, str) or not self.outcome:
+            raise ValueError("outcome must be a non-empty string")
+        if not isinstance(self.attempted, bool) or not isinstance(self.retryable, bool):
+            raise ValueError("attempted and retryable must be booleans")
+        if self.readiness_fingerprint is not None and (
+            not isinstance(self.readiness_fingerprint, tuple)
+            or not all(isinstance(part, str) for part in self.readiness_fingerprint)
+        ):
+            raise ValueError("readiness_fingerprint must be a tuple of strings or None")
+
+
+type GitHubReceipt = (
+    ReplyJournalRecovered
+    | ReplyJournalAppended
+    | ReplyHandoffAttempted
+    | PrReviewReconciled
+    | MergeWaitCycleCompleted
+)
+
+
+class GitHubJobRunner(Protocol):
+    """Executes closed GitHub requests with job-scoped accessors."""
+
+    def run(self, job: GitHubJob) -> GitHubReceipt:
+        """Execute one closed GitHub request and return its immutable receipt."""
+        ...

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -16,6 +16,8 @@ from typing import Any
 
 from hephaestus.automation.pipeline.routing import StageName
 
+from .github_jobs import GitHubJob
+
 GIT_OPS: frozenset[str] = frozenset(
     {
         "clone",
@@ -167,5 +169,5 @@ class JobHandle:
     never break hashing.
     """
 
-    job: AgentJob | BuildTestJob | GitJob | CompactJob
+    job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob
     on_done_state: str | StageName

--- a/hephaestus/automation/pipeline/reply_handoff.py
+++ b/hephaestus/automation/pipeline/reply_handoff.py
@@ -18,6 +18,11 @@ from hashlib import sha256
 from typing import Any, Literal
 
 from hephaestus.automation.address_review_core import parse_addressed_replies
+from hephaestus.automation.pipeline.github_jobs import (
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    ReplyHandoffAttempted,
+)
 from hephaestus.automation.review_journal import IssueComment
 
 IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP = 2
@@ -458,4 +463,35 @@ def retry_pending_implementation_reply_handoff(
         batch_nonce=batch_nonce,
         issue_number=issue_number,
         logger=logger,
+    )
+
+
+def attempt_reply_handoff(
+    request: DeliverReplyHandoffRequest,
+    github: Any,
+) -> ReplyHandoffAttempted:
+    """Attempt a handoff against detached state and return an immutable receipt."""
+    payload: dict[str, Any] = {
+        PENDING_IMPLEMENTATION_REPLY_HANDOFF: request.handoff.thaw(),
+        PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES: request.visibility_retries,
+    }
+    status = retry_pending_implementation_reply_handoff(
+        payload,
+        pr_number=request.pr_number,
+        issue_number=request.issue_number,
+        github=github,
+        logger=logging.getLogger(__name__),
+    )
+    if status == "none":
+        status = "invalid"
+    remaining = payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF)
+    retry_delay = payload.get("retry_delay_s")
+    return ReplyHandoffAttempted(
+        request=request,
+        status=status,
+        remaining_handoff=(FrozenJson.snapshot(remaining) if remaining is not None else None),
+        visibility_retries=int(
+            payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, 0)
+        ),
+        retry_delay_s=(float(retry_delay) if isinstance(retry_delay, (int, float)) else None),
     )

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -65,6 +65,7 @@ from hephaestus.automation.state_labels import (
 )
 
 from ..events import StageEvent
+from ..github_jobs import GitHubJob
 from ..jobs import AgentJob, BuildTestJob, CompactJob, GitJob, JobHandle, JobResult
 from ..routing import ROUTES, Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
@@ -77,6 +78,7 @@ __all__ = [
     "ConditionalMergeResult",
     "Continue",
     "Disposition",
+    "GitHubJob",
     "GitJob",
     "ImplementationThreadReplyResult",
     "ItemKind",
@@ -161,7 +163,11 @@ class ReviewerThreadReconciliationResult:
 
 @runtime_checkable
 class StageGitHub(Protocol):
-    """Coordinator-owned GitHub accessor injected as ``StageContext.github``.
+    """Single-owner GitHub accessor.
+
+    ``StageContext.github`` is coordinator-thread-only and must never cross a
+    worker boundary. ``GitHubJob`` workers create a fresh structurally
+    conforming accessor per job and serialize same-repository operations.
 
     The single seam through which stages read GitHub facts and request
     durable mutations. Dry-run is honored INSIDE the accessor implementation
@@ -502,14 +508,14 @@ class JobRequest:
     """Request a job be submitted to the worker pool.
 
     Attributes:
-        job: The frozen job spec to submit (agent, build/test, git, or session
-            compaction — the same union :class:`~..jobs.JobHandle` carries).
+        job: The frozen job spec to submit (agent, build/test, git, GitHub, or
+            session compaction — the same union :class:`~..jobs.JobHandle` carries).
         on_done_state: The state the coordinator moves the item to after the
             job completes and ``on_job_done`` has run.
 
     """
 
-    job: AgentJob | BuildTestJob | GitJob | CompactJob
+    job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob
     on_done_state: str
 
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -66,6 +66,7 @@ import logging
 import secrets
 import shlex
 from collections.abc import Callable
+from pathlib import Path
 from typing import cast
 
 from hephaestus.automation.address_review_core import (
@@ -105,6 +106,16 @@ from hephaestus.automation.state_labels import (
 from hephaestus.automation.worktree_manager import BRANCH_WORKTREE_OWNED
 from hephaestus.prompts import PromptCatalog
 
+from ..github_jobs import (
+    AppendReplyJournalRequest,
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    GitHubJob,
+    RecoverReplyJournalRequest,
+    ReplyHandoffAttempted,
+    ReplyJournalAppended,
+    ReplyJournalRecovered,
+)
 from ..jobs import WORKTREE_MATERIALIZED_KEY
 from ..reply_handoff import (
     IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP,
@@ -113,10 +124,9 @@ from ..reply_handoff import (
     PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL,
     PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES,
     PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES,
     implementation_reply_handoff,
     implementation_reply_handoff_journal_entry,
-    journaled_implementation_reply_handoff,
-    retry_pending_implementation_reply_handoff,
 )
 from ..scope_retraction import is_safe_scope_retraction_path, scope_retraction_paths_for_threads
 from .base import (
@@ -165,6 +175,9 @@ IMPLEMENT_WAIT = "IMPLEMENT_WAIT"
 TEST_WAIT = "TEST_WAIT"
 TESTFIX_WAIT = "TESTFIX_WAIT"
 COMMIT_PUSH_WAIT = "COMMIT_PUSH_WAIT"
+REPLY_JOURNAL_RECOVERY_WAIT = "REPLY_JOURNAL_RECOVERY_WAIT"
+REPLY_JOURNAL_APPEND_WAIT = "REPLY_JOURNAL_APPEND_WAIT"
+REPLY_HANDOFF_WAIT = "REPLY_HANDOFF_WAIT"
 PR_CREATE = "PR_CREATE"
 
 _STEP_HANDLER_NAMES: dict[str, str] = {
@@ -179,8 +192,16 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     TEST_WAIT: "_test_wait",
     TESTFIX_WAIT: "_testfix_wait",
     COMMIT_PUSH_WAIT: "_commit_push_wait",
+    REPLY_JOURNAL_RECOVERY_WAIT: "_reply_journal_recovery_wait",
+    REPLY_JOURNAL_APPEND_WAIT: "_reply_journal_append_wait",
+    REPLY_HANDOFF_WAIT: "_reply_handoff_wait",
     PR_CREATE: "_create_pr",
 }
+
+_PENDING_GITHUB_REQUEST = "_pending_github_request"
+_REPLY_JOURNAL_RECOVERY_RESULT = "_reply_journal_recovery_result"
+_REPLY_JOURNAL_APPEND_RESULT = "_reply_journal_append_result"
+_REPLY_HANDOFF_RESULT = "_reply_handoff_result"
 
 
 def _issue_number(item: WorkItem) -> int:
@@ -660,39 +681,22 @@ class ImplementationStage(Stage):
                 item.payload.pop("scope_retraction_paths", None)
             snapshots = item.payload.get("remediation_thread_snapshots")
             if isinstance(snapshots, list):
-                try:
-                    recovered_handoff = journaled_implementation_reply_handoff(
-                        ctx.github.issue_comments(issue),
-                        pr_number=item.pr,
-                        threads=snapshots,
-                    )
-                except (OSError, RuntimeError, ValueError) as error:
-                    logger.warning(
-                        "implementation:%d: could not recover implementation reply handoff "
-                        "journal (%s)",
-                        issue,
-                        type(error).__name__,
-                    )
+                if item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF) is not None:
+                    return Continue(next_state=PR_CREATE)
+                recovery_result = item.payload.pop(_REPLY_JOURNAL_RECOVERY_RESULT, None)
+                if recovery_result == "retry":
+                    item.state = REPLY_JOURNAL_RECOVERY_WAIT
                     return StageOutcome(
                         Disposition.RETRY,
                         "implementation_reply_handoff_journal_read",
                     )
-                if recovered_handoff is not None:
-                    current_head, _pushed = _remediation_reply_head({}, snapshots)
-                    if recovered_handoff.get("head_sha") == current_head:
-                        item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = recovered_handoff
-                        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-                        logger.info(
-                            "implementation:%d: recovered exact GitHub-journaled review "
-                            "reply handoff",
-                            issue,
-                        )
-                        return Continue(next_state=PR_CREATE)
-                    logger.info(
-                        "implementation:%d: ignoring stale GitHub-journaled review reply "
-                        "handoff for a previous head",
-                        issue,
+                if recovery_result == "invalid":
+                    return StageOutcome(
+                        Disposition.FINISH_FAIL,
+                        "implementation_reply_handoff_journal_invalid",
                     )
+                if not item.payload.pop("_reply_journal_recovery_complete", False):
+                    return Continue(next_state=REPLY_JOURNAL_RECOVERY_WAIT)
             job = AgentJob(
                 repo=item.repo,
                 issue=issue,
@@ -853,7 +857,127 @@ class ImplementationStage(Stage):
         )
         return JobRequest(push_job, on_done_state=PR_CREATE)
 
-    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+    @staticmethod
+    def _github_job(
+        item: WorkItem,
+        ctx: StageContext,
+        request: RecoverReplyJournalRequest
+        | AppendReplyJournalRequest
+        | DeliverReplyHandoffRequest,
+        descr: str,
+    ) -> GitHubJob:
+        """Build one repository-scoped closed GitHub job."""
+        return GitHubJob(
+            repo=item.repo,
+            repo_root=Path(str(ctx.paths.repo_root)).resolve(),
+            request=request,
+            descr=descr,
+        )
+
+    def _reply_journal_recovery_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Dispatch a detached exact-thread journal recovery read."""
+        if item.issue is None or item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        snapshots = item.payload.get("remediation_thread_snapshots")
+        if not isinstance(snapshots, list):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        if pending is None:
+            pending = RecoverReplyJournalRequest(
+                issue_number=item.issue,
+                pr_number=item.pr,
+                threads=FrozenJson.snapshot(snapshots),
+            )
+            item.payload[_PENDING_GITHUB_REQUEST] = pending
+        if not isinstance(pending, RecoverReplyJournalRequest):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        return JobRequest(
+            self._github_job(item, ctx, pending, "recover_implementation_reply_journal"),
+            on_done_state=IMPLEMENT_WAIT,
+        )
+
+    def _reply_journal_append_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Dispatch the exact prepared journal append without GitHub I/O inline."""
+        if item.issue is None or item.pr is None:
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "implementation_reply_handoff_journal_invalid",
+            )
+        pending_journal = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL)
+        handoff = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF)
+        if not isinstance(pending_journal, dict):
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "implementation_reply_handoff_journal_invalid",
+            )
+        expected = implementation_reply_handoff_journal_entry(item.pr, handoff)
+        marker = pending_journal.get("marker")
+        body = pending_journal.get("body")
+        if (
+            expected is None
+            or not isinstance(marker, str)
+            or not isinstance(body, str)
+            or (marker, body) != expected
+        ):
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "implementation_reply_handoff_journal_invalid",
+            )
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        if pending is None:
+            pending = AppendReplyJournalRequest(
+                issue_number=item.issue,
+                marker=marker,
+                body=body,
+            )
+            item.payload[_PENDING_GITHUB_REQUEST] = pending
+        if not isinstance(pending, AppendReplyJournalRequest) or pending != (
+            AppendReplyJournalRequest(item.issue, marker, body)
+        ):
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "implementation_reply_handoff_journal_invalid",
+            )
+        return JobRequest(
+            self._github_job(item, ctx, pending, "append_implementation_reply_journal"),
+            on_done_state=PR_CREATE,
+        )
+
+    def _reply_handoff_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Dispatch an exact already-journaled reply handoff."""
+        if item.issue is None or item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        handoff = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF)
+        visibility_retries = item.payload.get(
+            PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES,
+            0,
+        )
+        if (
+            not isinstance(handoff, dict)
+            or isinstance(visibility_retries, bool)
+            or not isinstance(visibility_retries, int)
+            or visibility_retries < 0
+        ):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        if pending is None:
+            pending = DeliverReplyHandoffRequest(
+                issue_number=item.issue,
+                pr_number=item.pr,
+                handoff=FrozenJson.snapshot(handoff),
+                visibility_retries=visibility_retries,
+            )
+            item.payload[_PENDING_GITHUB_REQUEST] = pending
+        if not isinstance(pending, DeliverReplyHandoffRequest):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        return JobRequest(
+            self._github_job(item, ctx, pending, "deliver_implementation_reply_handoff"),
+            on_done_state=PR_CREATE,
+        )
+
+    def on_job_done(  # noqa: C901
+        self, item: WorkItem, result: JobResult, ctx: StageContext
+    ) -> None:
         """Store job results on the item payload (state is still the WAIT state).
 
         The implement attempt is counted HERE, on job completion (success or
@@ -904,11 +1028,125 @@ class ImplementationStage(Stage):
             item.attempts["test_fix"] = item.attempts.get("test_fix", 0) + 1
             return
 
+        if item.state == REPLY_JOURNAL_RECOVERY_WAIT:
+            self._on_reply_journal_recovery_done(item, result)
+            return
+
+        if item.state == REPLY_JOURNAL_APPEND_WAIT:
+            self._on_reply_journal_append_done(item, result)
+            return
+
+        if item.state == REPLY_HANDOFF_WAIT:
+            self._on_reply_handoff_done(item, result)
+            return
+
         if item.state == COMMIT_PUSH_WAIT:
-            self._on_commit_push_done(item, result, ctx)
+            self._on_commit_push_done(item, result)
 
     @staticmethod
-    def _on_commit_push_done(item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+    def _matching_receipt_request(item: WorkItem, receipt: object) -> bool:
+        """Return whether *receipt* belongs to the item's exact pending request."""
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        return getattr(receipt, "request", None) == pending
+
+    @staticmethod
+    def _on_reply_journal_recovery_done(item: WorkItem, result: JobResult) -> None:
+        """Apply a journal recovery receipt before the coordinator advances state."""
+        if not result.ok:
+            item.payload[_REPLY_JOURNAL_RECOVERY_RESULT] = "retry"
+            return
+        receipt = result.value
+        if not isinstance(receipt, ReplyJournalRecovered) or not (
+            ImplementationStage._matching_receipt_request(item, receipt)
+        ):
+            item.payload[_REPLY_JOURNAL_RECOVERY_RESULT] = "invalid"
+            return
+        item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+        item.payload["_reply_journal_recovery_complete"] = True
+        if receipt.handoff is None:
+            return
+        handoff = receipt.handoff.thaw()
+        snapshots = item.payload.get("remediation_thread_snapshots")
+        current_head, _pushed = _remediation_reply_head(
+            {},
+            snapshots if isinstance(snapshots, list) else [],
+        )
+        if isinstance(handoff, dict) and handoff.get("head_sha") == current_head:
+            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = handoff
+            item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+            logger.info(
+                "implementation:%s: recovered exact GitHub-journaled review reply handoff",
+                item.issue,
+            )
+
+    @staticmethod
+    def _on_reply_journal_append_done(item: WorkItem, result: JobResult) -> None:
+        """Apply a correlated append receipt or record a bounded host-only retry."""
+        if not result.ok:
+            retries = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, 0)
+            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
+                item.payload[_REPLY_JOURNAL_APPEND_RESULT] = "invalid"
+                return
+            retries += 1
+            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES] = retries
+            item.payload[_REPLY_JOURNAL_APPEND_RESULT] = (
+                "retry" if retries <= IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP else "failed"
+            )
+            return
+        receipt = result.value
+        if not isinstance(receipt, ReplyJournalAppended) or not (
+            ImplementationStage._matching_receipt_request(item, receipt)
+        ):
+            item.payload[_REPLY_JOURNAL_APPEND_RESULT] = "invalid"
+            return
+        item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL, None)
+        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, None)
+        item.payload[_REPLY_JOURNAL_APPEND_RESULT] = "completed"
+
+    @staticmethod
+    def _on_reply_handoff_done(item: WorkItem, result: JobResult) -> None:
+        """Apply a detached exact-reply receipt without retaining mutable state."""
+        receipt = result.value
+        if not result.ok:
+            status = "retry"
+        elif not isinstance(receipt, ReplyHandoffAttempted) or not (
+            ImplementationStage._matching_receipt_request(item, receipt)
+        ):
+            item.payload[_REPLY_HANDOFF_RESULT] = "invalid"
+            return
+        else:
+            status = receipt.status
+            item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+            if receipt.remaining_handoff is None:
+                item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+            else:
+                remaining = receipt.remaining_handoff.thaw()
+                if not isinstance(remaining, dict):
+                    item.payload[_REPLY_HANDOFF_RESULT] = "invalid"
+                    return
+                item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF] = remaining
+            if receipt.visibility_retries:
+                item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES] = (
+                    receipt.visibility_retries
+                )
+            else:
+                item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES, None)
+            if receipt.retry_delay_s is not None:
+                item.payload["retry_delay_s"] = receipt.retry_delay_s
+
+        if status == "retry":
+            retries = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, 0)
+            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
+                item.payload[_REPLY_HANDOFF_RESULT] = "invalid"
+                return
+            retries += 1
+            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES] = retries
+            status = "retry" if retries <= IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP else "failed"
+        item.payload[_REPLY_HANDOFF_RESULT] = status
+
+    @staticmethod
+    def _on_commit_push_done(item: WorkItem, result: JobResult) -> None:
         """Record commit+push success, no-commit skip, or git failure."""
         if result.ok:
             receipt = result.value if isinstance(result.value, dict) else {}
@@ -927,7 +1165,7 @@ class ImplementationStage(Stage):
                 # A published branch has real commits and must not be
                 # released by terminal cleanup.
                 item.payload.pop(DIRECT_SCOPE_RESERVATION_KEY, None)
-            ImplementationStage._post_remediation_replies_after_push(item, result, ctx)
+            ImplementationStage._post_remediation_replies_after_push(item, result)
             # A successful worker result ends the consecutive-git-failure
             # streak even when no commit was produced; PR_CREATE handles skip.
             item.payload.pop("git_error_retries", None)
@@ -942,9 +1180,7 @@ class ImplementationStage(Stage):
         item.payload["git_error"] = True
 
     @staticmethod
-    def _post_remediation_replies_after_push(
-        item: WorkItem, result: JobResult, ctx: StageContext
-    ) -> None:
+    def _post_remediation_replies_after_push(item: WorkItem, result: JobResult) -> None:
         """Prepare one head-gated reply handoff after the writer runs.
 
         GitHub can briefly expose the previous PR head immediately after a
@@ -1020,123 +1256,6 @@ class ImplementationStage(Stage):
         }
         item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, None)
         item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-        if ImplementationStage._persist_remediation_reply_handoff_journal(item, ctx) is not None:
-            return
-
-    @staticmethod
-    def _persist_remediation_reply_handoff_journal(
-        item: WorkItem, ctx: StageContext
-    ) -> StageOutcome | None:
-        """Durably append a prepared recovery journal with bounded host-only retries."""
-        pending = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL)
-        if pending is None:
-            return None
-        handoff = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF)
-        if item.issue is None or item.pr is None or not isinstance(pending, dict):
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_invalid"
-            )
-        expected_entry = implementation_reply_handoff_journal_entry(item.pr, handoff)
-        marker = pending.get("marker")
-        body = pending.get("body")
-        if (
-            expected_entry is None
-            or not isinstance(marker, str)
-            or not isinstance(body, str)
-            or (marker, body) != expected_entry
-        ):
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_invalid"
-            )
-        try:
-            ctx.github.append_issue_comment(item.issue, marker, body)
-        except Exception as error:
-            retries = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, 0)
-            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
-                return StageOutcome(
-                    Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_invalid"
-                )
-            retries += 1
-            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES] = retries
-            logger.warning(
-                "implementation:%d: could not persist implementation reply handoff journal; "
-                "retrying host-only append %d/%d (%s)",
-                item.issue,
-                retries,
-                IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP,
-                type(error).__name__,
-            )
-            if retries <= IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRY_CAP:
-                return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_journal_retry")
-            return StageOutcome(
-                Disposition.FINISH_FAIL, "implementation_reply_handoff_journal_failed"
-            )
-        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL, None)
-        item.payload.pop(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL_RETRIES, None)
-        return None
-
-    @staticmethod
-    def _complete_remediation_reply_handoff(
-        item: WorkItem, ctx: StageContext
-    ) -> StageOutcome | None:
-        """Advance, retry, or fail one persisted host-only response handoff."""
-        handoff_status = retry_pending_implementation_reply_handoff(
-            item.payload,
-            pr_number=item.pr,
-            issue_number=item.issue,
-            github=ctx.github,
-            logger=logger,
-        )
-        if handoff_status in {"none", "completed"}:
-            if handoff_status == "completed":
-                item.payload.pop("implementation_remediation", None)
-                item.payload.pop("remediation_output", None)
-            return None
-        if handoff_status == "visibility_wait":
-            return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
-        if handoff_status == "invalid":
-            logger.error(
-                "implementation:%d: refusing to replay malformed implementation reply handoff",
-                item.issue,
-            )
-            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
-        if handoff_status == "retry":
-            retries = item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, 0)
-            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
-                return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
-            retries += 1
-            item.payload[PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES] = retries
-            if retries <= IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP:
-                logger.warning(
-                    "implementation:%d: retrying exact implementation reply handoff %d/%d",
-                    item.issue,
-                    retries,
-                    IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP,
-                )
-                return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_retry")
-            logger.error(
-                "implementation:%d: implementation reply handoff retry cap reached",
-                item.issue,
-            )
-            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_failed")
-
-        # The shared handoff has proved that the pushed head or one of its
-        # source threads changed.  Do not replay the old response; return the
-        # existing PR to a fresh review entry instead.
-        item.payload.pop("implementation_remediation", None)
-        item.payload.pop("remediation_output", None)
-        if item.pr is None:
-            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
-        logger.info(
-            "implementation:%d: reply handoff became stale; returning PR #%d for a fresh "
-            "review snapshot",
-            item.issue,
-            item.pr,
-        )
-        return StageOutcome(
-            Disposition.ADVANCE,
-            f"PR #{item.pr} ready for fresh review after stale reply handoff",
-        )
 
     @staticmethod
     def _on_implement_done(item: WorkItem, result: JobResult) -> None:
@@ -1535,7 +1654,9 @@ class ImplementationStage(Stage):
             item.branch = issue_auto_impl_branch_name(item.issue)
         return Continue(next_state=WORKTREE_WAIT)
 
-    def _create_pr(self, item: WorkItem, ctx: StageContext) -> StageOutcome:
+    def _create_pr(  # noqa: C901
+        self, item: WorkItem, ctx: StageContext
+    ) -> StepResult:
         """PR_CREATE [M]: create the durable PR journal entry for review.
 
         The ``create_pr`` write is the stage's journal entry and happens
@@ -1546,13 +1667,52 @@ class ImplementationStage(Stage):
         if item.payload.pop("remediation_reply_error", None):
             return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_failed")
 
-        journal_outcome = self._persist_remediation_reply_handoff_journal(item, ctx)
-        if journal_outcome is not None:
-            return journal_outcome
+        append_result = item.payload.pop(_REPLY_JOURNAL_APPEND_RESULT, None)
+        if append_result == "retry":
+            item.state = REPLY_JOURNAL_APPEND_WAIT
+            return StageOutcome(
+                Disposition.RETRY,
+                "implementation_reply_handoff_journal_retry",
+            )
+        if append_result in {"failed", "invalid"}:
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "implementation_reply_handoff_journal_failed"
+                if append_result == "failed"
+                else "implementation_reply_handoff_journal_invalid",
+            )
+        if item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF_JOURNAL) is not None:
+            return Continue(next_state=REPLY_JOURNAL_APPEND_WAIT)
 
-        handoff_outcome = self._complete_remediation_reply_handoff(item, ctx)
-        if handoff_outcome is not None:
-            return handoff_outcome
+        handoff_result = item.payload.pop(_REPLY_HANDOFF_RESULT, None)
+        if handoff_result == "visibility_wait":
+            item.state = REPLY_HANDOFF_WAIT
+            return StageOutcome(
+                Disposition.RETRY,
+                "implementation_reply_handoff_visibility_wait",
+            )
+        if handoff_result == "retry":
+            item.state = REPLY_HANDOFF_WAIT
+            return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_retry")
+        if handoff_result in {"failed", "invalid"}:
+            return StageOutcome(
+                Disposition.FINISH_FAIL,
+                "implementation_reply_handoff_failed"
+                if handoff_result == "failed"
+                else "implementation_reply_handoff_invalid",
+            )
+        if handoff_result == "stale":
+            item.payload.pop("implementation_remediation", None)
+            item.payload.pop("remediation_output", None)
+            return StageOutcome(
+                Disposition.ADVANCE,
+                f"PR #{item.pr} ready for fresh review after stale reply handoff",
+            )
+        if handoff_result == "completed":
+            item.payload.pop("implementation_remediation", None)
+            item.payload.pop("remediation_output", None)
+        if item.payload.get(PENDING_IMPLEMENTATION_REPLY_HANDOFF) is not None:
+            return Continue(next_state=REPLY_HANDOFF_WAIT)
 
         if item.payload.get("no_commits"):
             # An item can retain a PR after an interrupted or re-entered

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -26,6 +26,7 @@ The implemented mini-state graph is:
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from hephaestus.automation.agent_config import implementer_model, learn_claude_timeout
@@ -33,6 +34,11 @@ from hephaestus.automation.learn import build_learn_prompt
 from hephaestus.automation.session_naming import AGENT_LEARNINGS
 from hephaestus.prompts import PromptCatalog
 
+from ..github_jobs import (
+    GitHubJob,
+    MergeWaitCycleCompleted,
+    RunMergeWaitCycleRequest,
+)
 from .base import (
     AgentJob,
     Continue,
@@ -55,6 +61,7 @@ logger = logging.getLogger(__name__)
 
 ENTER = "ENTER"
 MERGE = "MERGE"
+MERGE_APPLY = "MERGE_APPLY"
 LEARN_WAIT = "LEARN_WAIT"
 MW_FINISH = "MW_FINISH"
 FINISH = MW_FINISH
@@ -66,6 +73,9 @@ _READINESS_WAIT_INITIAL_S = 5.0
 _READINESS_WAIT_TIMEOUT_S = 30 * 60.0
 _READINESS_WAIT_DELAY_CAP_S = 60.0
 _DECLINED_READINESS_FINGERPRINT = "merge_readiness_declined_fingerprint"
+_PENDING_GITHUB_REQUEST = "_pending_github_request"
+_MERGE_CYCLE_RECEIPT = "_merge_wait_cycle_receipt"
+_MERGE_CYCLE_RECEIPT_ERROR = "_merge_wait_cycle_receipt_error"
 
 
 def build_drive_green_learn_prompt(issue_number: int, pr_number: int) -> str:
@@ -98,6 +108,8 @@ class MergeWaitStage(Stage):
             return Continue(next_state=MERGE)
         if item.state == MERGE:
             return self._merge(item, ctx)
+        if item.state == MERGE_APPLY:
+            return self._merge_apply(item, ctx)
         if item.state == LEARN_WAIT:
             return self._request_learn(item, ctx)
         if item.state == MW_FINISH:
@@ -108,51 +120,90 @@ class MergeWaitStage(Stage):
         return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
 
     def _merge(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Read final admission facts, then make at most one conditional request."""
-        admitted = self._admit(item, ctx)
-        if not isinstance(admitted, tuple):
-            return admitted
-        if item.attempts["merge"] >= ctx.budget("merge"):
-            return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
-        pr_state, reviewed_head = admitted
+        """Freeze one exact proof and dispatch the complete GitHub cycle."""
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
-        base_branch = pr_state.get("baseRefName")
-        if not isinstance(base_branch, str) or not base_branch:
-            return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unverified")
-        # A readiness wait only observes ordinary CI/mergeability state; it
-        # must not postpone admission failures.  Recheck both live
-        # conversation facts on every timer wake before parking again so an
-        # unresolved thread or weakened protection fails closed promptly.
-        safety_admission = self._admit_conversation_safety(
-            item.pr,
-            base_branch,
-            ctx,
-        )
-        if safety_admission is not None:
-            return safety_admission
-        readiness_wait = self._wait_for_readiness(item, ctx)
-        if readiness_wait is not None:
-            return readiness_wait
-
-        # Read the admission facts again after the non-authorizing readiness
-        # wait. The final conditional request must be bound to current label,
-        # head, and auto-merge facts rather than to the earlier polling read.
-        admitted = self._admit(item, ctx)
-        if not isinstance(admitted, tuple):
-            return admitted
-        pr_state, reviewed_head = admitted
-        base_branch = pr_state.get("baseRefName")
-        if not isinstance(base_branch, str) or not base_branch:
-            return StageOutcome(Disposition.FINISH_FAIL, "pr_state_unverified")
-        safety_admission = self._admit_conversation_safety(item.pr, base_branch, ctx)
-        if safety_admission is not None:
-            return safety_admission
         if item.attempts["merge"] >= ctx.budget("merge"):
             return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
-        item.attempts["merge"] += 1
-        result = ctx.github.merge_pr_if_head(item.pr, reviewed_head)
-        return self._reconcile_merge_request(item, ctx, result)
+        reviewed_head = item.payload.get("reviewed_pr_head_sha")
+        if not isinstance(reviewed_head, str) or not reviewed_head:
+            return StageOutcome(Disposition.FAIL_BACK, "reviewed_head_missing")
+        deadline = self._matching_readiness_deadline_outcome(item, ctx)
+        if deadline is not None:
+            return deadline
+        proof_generation = item.payload.get("reviewed_pr_proof_generation", 0)
+        declined = item.payload.get(_DECLINED_READINESS_FINGERPRINT)
+        if (
+            isinstance(proof_generation, bool)
+            or not isinstance(proof_generation, int)
+            or proof_generation < 0
+            or (
+                declined is not None
+                and (
+                    not isinstance(declined, (list, tuple))
+                    or not all(isinstance(part, str) for part in declined)
+                )
+            )
+        ):
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_readiness_state_invalid")
+        try:
+            request = RunMergeWaitCycleRequest(
+                pr_number=item.pr,
+                reviewed_head_sha=reviewed_head,
+                proof_generation=proof_generation,
+                declined_readiness_fingerprint=(tuple(declined) if declined is not None else None),
+            )
+        except ValueError:
+            return StageOutcome(Disposition.FAIL_BACK, "reviewed_head_missing")
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        if pending is None:
+            item.payload[_PENDING_GITHUB_REQUEST] = request
+        elif pending != request:
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_cycle_receipt_invalid")
+        return JobRequest(
+            GitHubJob(
+                repo=item.repo,
+                repo_root=Path(str(ctx.paths.repo_root)).resolve(),
+                request=request,
+                descr="merge_wait_admission_cycle",
+            ),
+            on_done_state=MERGE_APPLY,
+        )
+
+    def _merge_apply(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Apply one correlated immutable merge-cycle receipt locally."""
+        error = item.payload.pop(_MERGE_CYCLE_RECEIPT_ERROR, None)
+        if error is not None:
+            item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_cycle_failed")
+        receipt = item.payload.pop(_MERGE_CYCLE_RECEIPT, None)
+        if not isinstance(receipt, MergeWaitCycleCompleted) or receipt.request != item.payload.get(
+            _PENDING_GITHUB_REQUEST
+        ):
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_cycle_receipt_invalid")
+        item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+        if receipt.attempted:
+            item.attempts["merge"] += 1
+        if receipt.readiness_fingerprint is not None:
+            item.payload[_DECLINED_READINESS_FINGERPRINT] = list(receipt.readiness_fingerprint)
+        outcome = receipt.outcome
+        if outcome == "merged":
+            return self._route_merged(item, ctx)
+        if outcome == "closed":
+            return StageOutcome(Disposition.FINISH_FAIL, "closed")
+        if outcome == "auto_merge_already_armed":
+            return StageOutcome(Disposition.BLOCKED, outcome)
+        if outcome in {"not_implementation_go", "reviewed_head_drift"}:
+            return StageOutcome(Disposition.FAIL_BACK, outcome)
+        if outcome == "readiness_wait":
+            if receipt.attempted and item.attempts["merge"] >= ctx.budget("merge"):
+                return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
+            item.state = MERGE
+            return self._park_for_readiness(item, ctx)
+        if outcome in {"merge_not_ready", "merge_request_transport_error"} and receipt.retryable:
+            item.state = MERGE
+            return self._retry(item, ctx)
+        return StageOutcome(Disposition.FINISH_FAIL, outcome)
 
     def _reconcile_merge_request(
         self, item: WorkItem, ctx: StageContext, result: Any
@@ -561,6 +612,18 @@ class MergeWaitStage(Stage):
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Persist the post-merge learning result without changing merge outcome."""
+        if item.state == MERGE:
+            if not result.ok:
+                item.payload[_MERGE_CYCLE_RECEIPT_ERROR] = result.error or "merge cycle failed"
+                return
+            receipt = result.value
+            if not isinstance(
+                receipt, MergeWaitCycleCompleted
+            ) or receipt.request != item.payload.get(_PENDING_GITHUB_REQUEST):
+                item.payload[_MERGE_CYCLE_RECEIPT_ERROR] = "invalid"
+                return
+            item.payload[_MERGE_CYCLE_RECEIPT] = receipt
+            return
         if item.state != LEARN_WAIT or item.issue is None:
             return
         try:

--- a/hephaestus/automation/pipeline/stages/pr_review_gate.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_gate.py
@@ -27,7 +27,11 @@ class PrReviewGate(_PrReviewHost):
             )
             return StageOutcome(Disposition.FINISH_FAIL, "scope_retraction_incomplete")
 
-        handoff_status = self._retry_pending_implementation_reply_handoff(item, ctx)
+        if payload.get(_PENDING_IMPLEMENTATION_REPLY_HANDOFF) and not (
+            payload.get(_REPLY_HANDOFF_RECEIPT) or payload.get(_REPLY_HANDOFF_RECEIPT_ERROR)
+        ):
+            return Continue(next_state=RECOVERY_REPLY_WAIT)
+        handoff_status = self._consume_reply_handoff_receipt(item)
         if handoff_status == "visibility_wait":
             return StageOutcome(Disposition.RETRY, "implementation_reply_handoff_visibility_wait")
         if handoff_status == "invalid":

--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -12,14 +12,15 @@ from ..github_jobs import (
 )
 from .pr_review_threads import *
 from .pr_review_threads import (
-    _PENDING_GITHUB_REQUEST,
-    _PR_REVIEW_RECEIPT,
-    _PR_REVIEW_RECEIPT_ERROR,
     _REPLY_HANDOFF_RECEIPT,
     _REPLY_HANDOFF_RECEIPT_ERROR,
     POST_APPLY,
     _finding_key,
 )
+
+_PENDING_GITHUB_REQUEST = "_pending_github_request"
+_PR_REVIEW_RECEIPT = "_pr_review_reconciliation_receipt"
+_PR_REVIEW_RECEIPT_ERROR = "_pr_review_reconciliation_error"
 
 
 class PrReviewJobs(_PrReviewHost):

--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -1,6 +1,25 @@
 # This mixin consumes the stage thread namespace by design.
 # ruff: noqa: F403, F405
+from pathlib import Path
+
+from ..github_jobs import (
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    GitHubJob,
+    PrReviewReconciled,
+    ReconcilePrReviewRequest,
+    ReplyHandoffAttempted,
+)
 from .pr_review_threads import *
+from .pr_review_threads import (
+    _PENDING_GITHUB_REQUEST,
+    _PR_REVIEW_RECEIPT,
+    _PR_REVIEW_RECEIPT_ERROR,
+    _REPLY_HANDOFF_RECEIPT,
+    _REPLY_HANDOFF_RECEIPT_ERROR,
+    POST_APPLY,
+    _finding_key,
+)
 
 
 class PrReviewJobs(_PrReviewHost):
@@ -768,6 +787,12 @@ class PrReviewJobs(_PrReviewHost):
             ctx: Stage context.
 
         """
+        if item.state == POST:
+            self._on_reconciliation_done(item, result)
+            return
+        if item.state == RECOVERY_REPLY_WAIT:
+            self._on_reply_handoff_done(item, result)
+            return
         if self._consume_review_worktree_cleanup_result(item, result):
             return
         if self._consume_direct_worktree_result(item, result):
@@ -827,91 +852,6 @@ class PrReviewJobs(_PrReviewHost):
                         # code commit has already changed the review head.
                         item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF] = handoff
                         item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-                    batch_nonce = handoff["batch_nonce"] if handoff is not None else ""
-                    try:
-                        # The worker returns the local commit it actually
-                        # published.  A later arbitrary remote push must not
-                        # acquire this implementation reply by being read as
-                        # the current head.
-                        state = ctx.github.gh_pr_state(item.pr)
-                        if not _pr_is_current_open_head(state, published_head):
-                            raise RuntimeError("published implementation head no longer current")
-                        reply_result = ctx.github.post_implementation_thread_replies(
-                            item.pr,
-                            expected_head_sha=published_head,
-                            threads=thread_snapshots,
-                            replies=replies,
-                            batch_nonce=batch_nonce,
-                        )
-                    except Exception as error:
-                        logger.warning(
-                            "pr_review:%s: could not post implementation replies (%s)",
-                            item.issue,
-                            type(error).__name__,
-                        )
-                    else:
-                        replied = set(getattr(reply_result, "replied_thread_ids", ()))
-                        blocked = set(getattr(reply_result, "blocked_thread_ids", ()))
-                        receipts = list(getattr(reply_result, "receipts", ()))
-                        retryable = bool(getattr(reply_result, "retryable", False))
-                        expected_ids = set(replies)
-                        remaining_ids = expected_ids - replied
-                        result_retryable_ids = set(
-                            getattr(reply_result, "retryable_thread_ids", ())
-                        )
-                        retryable_ids = (
-                            result_retryable_ids
-                            if result_retryable_ids and result_retryable_ids.issubset(remaining_ids)
-                            else remaining_ids
-                            if retryable and not result_retryable_ids
-                            else set()
-                        )
-                        if replied != set(replies) or len(receipts) != len(replied):
-                            logger.warning(
-                                "pr_review:%s: some implementation replies could not be verified",
-                                item.issue,
-                            )
-                            if retryable_ids and handoff is not None:
-                                item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF] = (
-                                    _implementation_reply_handoff(
-                                        published_head,
-                                        [
-                                            snapshot
-                                            for snapshot in thread_snapshots
-                                            if str(snapshot.get("id") or "") in retryable_ids
-                                        ],
-                                        {
-                                            thread_id: reply
-                                            for thread_id, reply in replies.items()
-                                            if thread_id in retryable_ids
-                                        },
-                                        batch_nonce,
-                                    )
-                                )
-                            elif retryable_ids:
-                                logger.info(
-                                    "pr_review:%s: retaining an exact reply handoff after an "
-                                    "ambiguous host failure",
-                                    item.issue,
-                                )
-                            else:
-                                # A verified mismatch means the conversation changed.  Replaying
-                                # a stale snapshot can never repair it and eventually wedges the
-                                # work item; the fresh reviewer cycle will obtain new facts.
-                                item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-                                item.payload.pop(
-                                    _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None
-                                )
-                        else:
-                            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
-                            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
-                        if blocked:
-                            logger.info(
-                                "pr_review:%s: %d changed thread(s) remain open for a new "
-                                "implementation pass",
-                                item.issue,
-                                len(blocked),
-                            )
                 # The old audit and checkout receipt describe the pre-push
                 # head. Discard the entire round before EVAL can bind the new
                 # head to any implementation-state transition.
@@ -1114,225 +1054,92 @@ class PrReviewJobs(_PrReviewHost):
         elif item.state == ADDRESS_WAIT:
             item.payload["address_error"] = True
 
-    def _post(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
-        """Reconcile reviewer decisions, publish new findings, and queue remediation.
-
-        Reviewer validation can only resolve or return current implementation
-        reply receipts. Fresh audit findings are deduplicated against live
-        threads, then every remaining open thread enters implementation
-        remediation regardless of its author.
-        """
-        if item.pr is None:  # guarded by step(); kept for restart safety
-            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
-        validation_only = bool(item.payload.get(_COMMENT_VALIDATION_ONLY))
-        audit = item.payload.get("review_audit")
-        if not validation_only and (not isinstance(audit, ReviewAudit) or not audit.valid):
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        raw_threads = (
-            [] if validation_only else [dict(t) for t in item.payload.get("review_threads") or []]
-        )
-        # Validation controls only the reviewer-owned reconciliation of
-        # implementation replies. Fresh audit findings are independently
-        # deduplicated against live threads below; a validator must never
-        # recreate, replace, or suppress an open review conversation.
-        threads = raw_threads
-        item.payload["raw_review_threads"] = raw_threads
-
-        reviewed_head = str(item.payload.get("reviewed_pr_head_sha") or "")
-        try:
-            live_for_reconciliation = ctx.github.list_unresolved_review_threads(item.pr)
-            validation_receipts = (
-                ctx.github.reviewer_validation_receipts(
-                    item.pr,
-                    reviewed_head_sha=reviewed_head,
-                    threads=live_for_reconciliation,
-                )
-                if is_full_commit_sha(reviewed_head)
-                else []
+    @staticmethod
+    def _on_reconciliation_done(item: WorkItem, result: JobResult) -> None:
+        """Store only an exact request-bearing reconciliation receipt."""
+        if not result.ok:
+            retries = item.payload.get("pr_review_reconciliation_retries", 0)
+            if isinstance(retries, bool) or not isinstance(retries, int) or retries < 0:
+                item.payload[_PR_REVIEW_RECEIPT_ERROR] = "invalid"
+                return
+            retries += 1
+            item.payload["pr_review_reconciliation_retries"] = retries
+            item.payload[_PR_REVIEW_RECEIPT_ERROR] = (
+                "retry" if retries <= REVIEW_ERROR_RETRY_CAP else "failed"
             )
-            pr_context = ctx.github.pr_review_context(item.pr)
-        except Exception as error:
-            logger.warning(
-                "pr_review:%s: could not refresh reviewer validation inputs (%s)",
-                item.issue,
-                type(error).__name__,
-            )
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        live_receipt_fingerprints = _validation_receipt_fingerprints(validation_receipts)
-        validated_receipt_fingerprints = item.payload.get("validation_receipt_fingerprints")
-        live_metadata_fingerprint = _validation_pr_metadata_fingerprint(pr_context, reviewed_head)
-        validated_metadata_fingerprint = item.payload.get("validation_pr_metadata_fingerprint")
-        if live_receipt_fingerprints is None:
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        metadata_guard_expected = validated_receipt_fingerprints is not None or (
-            "validation_pr_metadata_fingerprint" in item.payload
-        )
-        if metadata_guard_expected and (
-            live_metadata_fingerprint is None
-            or not isinstance(validated_metadata_fingerprint, str)
-            or validated_metadata_fingerprint != live_metadata_fingerprint
+            return
+        receipt = result.value
+        if not isinstance(receipt, PrReviewReconciled) or receipt.request != item.payload.get(
+            _PENDING_GITHUB_REQUEST
         ):
-            # The validator reviewed a different PR title/body (or head) than
-            # the current live metadata. Metadata-only remediations are
-            # reviewable evidence, so a same-head edit after validation must
-            # restart validation before any thread reconciliation can happen.
+            item.payload[_PR_REVIEW_RECEIPT_ERROR] = "invalid"
+            return
+        item.payload[_PR_REVIEW_RECEIPT] = receipt
+
+    def _post_apply(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Apply a correlated immutable reconciliation receipt locally."""
+        del ctx
+        error = item.payload.pop(_PR_REVIEW_RECEIPT_ERROR, None)
+        if error == "retry":
+            item.state = POST
+            return StageOutcome(Disposition.RETRY, "pr_review_reconciliation_retry")
+        if error in {"failed", "invalid"}:
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        receipt = item.payload.pop(_PR_REVIEW_RECEIPT, None)
+        if not isinstance(receipt, PrReviewReconciled) or receipt.request != item.payload.get(
+            _PENDING_GITHUB_REQUEST
+        ):
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+        item.payload.pop("pr_review_reconciliation_retries", None)
+        if receipt.action == "revalidate":
             item.payload.pop("validation_result", None)
             item.payload.pop("validation_threads", None)
             item.payload.pop("validation_receipt_fingerprints", None)
             item.payload.pop("validation_pr_metadata_fingerprint", None)
-            logger.info(
-                "pr_review:%s: PR metadata changed after validation; "
-                "revalidating before reconciliation",
-                item.issue,
-            )
             return Continue(next_state=VALIDATE_WAIT)
-        if validated_receipt_fingerprints is not None and (
-            not isinstance(validated_receipt_fingerprints, dict)
-            or validated_receipt_fingerprints != live_receipt_fingerprints
-        ):
-            # The validation agent reviewed a different immutable receipt than
-            # the one currently open on GitHub.  Its decision must not act on
-            # a replacement reply, even if the durable thread ID is unchanged.
+        if receipt.action == "fresh_review":
             item.payload.pop("validation_result", None)
             item.payload.pop("validation_threads", None)
             item.payload.pop("validation_receipt_fingerprints", None)
             item.payload.pop("validation_pr_metadata_fingerprint", None)
-            logger.info(
-                "pr_review:%s: implementation reply receipt changed after validation; "
-                "revalidating before reconciliation",
-                item.issue,
-            )
-            return Continue(next_state=VALIDATE_WAIT)
-        if validation_receipts:
-            decisions = _reviewer_thread_decisions(
-                validation_receipts, item.payload.get("validation_result")
-            )
-            if decisions is None:
-                item.payload["review_audit_failure"] = True
-                return Continue(next_state=EVAL)
-            resolved_ids, feedback = decisions
-            try:
-                reconciliation = ctx.github.reconcile_reviewer_validated_threads(
-                    item.pr,
-                    reviewed_head_sha=reviewed_head,
-                    receipts=validation_receipts,
-                    resolved_thread_ids=resolved_ids,
-                    feedback=feedback,
-                )
-            except Exception as error:
-                logger.warning(
-                    "pr_review:%s: reviewer thread reconciliation failed (%s)",
-                    item.issue,
-                    type(error).__name__,
-                )
-                item.payload["review_audit_failure"] = True
-                return Continue(next_state=EVAL)
-            expected_ids = {_durable_thread_id(receipt) for receipt in validation_receipts}
-            completed_ids = set(reconciliation.resolved_thread_ids) | set(
-                reconciliation.feedback_thread_ids
-            )
-            if None in expected_ids or not completed_ids.issubset(expected_ids):
-                item.payload["review_audit_failure"] = True
-                return Continue(next_state=EVAL)
-            if reconciliation.blocked_thread_ids:
-                # Resolution status was not proven for at least one exact
-                # receipt.  The adapter deliberately does not issue an
-                # unresolve compensation mutation; discard this validator's
-                # decisions and obtain a new audit/check-out proof instead.
-                item.payload.pop("validation_result", None)
-                item.payload.pop("validation_threads", None)
-                item.payload.pop("validation_receipt_fingerprints", None)
-                item.payload.pop("validation_pr_metadata_fingerprint", None)
-                return Continue(next_state=REVIEW_WAIT)
-            # A concurrent mutation can make one receipt ineligible after a
-            # previous receipt was safely resolved or received feedback.  Do
-            # not retain that stale, partially consumed receipt set: doing so
-            # wedges the next validation pass because the completed thread is
-            # no longer open.  Drop all receipts and rebuild remediation from
-            # the fresh complete live snapshot below.  The adapter's snapshot
-            # checks prevent duplicate mutations for the blocked IDs.
-            if completed_ids != expected_ids:
-                logger.info(
-                    "pr_review:%s: reviewer reconciliation was partial; refreshing live threads",
-                    item.issue,
-                )
-        try:
-            live_before_post = ctx.github.list_unresolved_review_threads(item.pr)
-        except Exception as error:
-            logger.warning(
-                "pr_review:%s: review finding dedupe read failed (%s)",
-                item.issue,
-                type(error).__name__,
-            )
+            return Continue(next_state=REVIEW_WAIT)
+        if receipt.action == "audit_failure":
             item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
-        live_by_id = {
-            thread_id: thread
-            for thread in live_before_post
-            if (thread_id := _durable_thread_id(thread)) is not None
+
+        posted = receipt.posted_receipts.thaw()
+        unresolved = receipt.unresolved_threads.thaw()
+        remediation = receipt.remediation_threads.thaw()
+        if (
+            not isinstance(posted, list)
+            or not isinstance(unresolved, list)
+            or not isinstance(remediation, list)
+        ):
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        raw_findings = receipt.request.findings.thaw()
+        if not isinstance(raw_findings, list) or not all(
+            isinstance(value, dict) for value in raw_findings
+        ):
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        posted_keys = {
+            key for value in posted if isinstance(value, dict) and (key := _finding_key(value))
         }
-        threads = _without_duplicate_live_findings(threads, live_by_id)
-        threads = [
-            thread
-            for thread in threads
-            if str(thread.get("severity") or "").strip().lower() in BLOCKING_SEVERITIES
+        item.payload["review_threads"] = [
+            dict(value) for value in raw_findings if _finding_key(value) in posted_keys
         ]
-        if any(not _is_postable_finding(thread) for thread in threads):
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        # The surviving audit set is what gets posted. Classification and
-        # addressing use the normalized live read-back installed below.
-        item.payload["review_threads"] = threads
-        post_receipts: list[dict[str, Any]] = []
-        if threads:
-            try:
-                post_receipts = list(
-                    ctx.github.post_review_threads(
-                        item.pr,
-                        list(threads),
-                        expected_head_sha=reviewed_head,
-                        review_diff=str(item.payload.get("pr_diff") or ""),
-                    )
-                )
-            except Exception as error:
-                logger.warning(
-                    "pr_review:%s: review finding publication failed (%s)",
-                    item.issue,
-                    type(error).__name__,
-                )
-                item.payload["review_audit_failure"] = True
-                return Continue(next_state=EVAL)
-        if len(post_receipts) != len(threads):
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        item.payload["posted_thread_ids"] = [str(receipt["id"]) for receipt in post_receipts]
-        try:
-            live_threads = ctx.github.list_unresolved_review_threads(item.pr)
-        except Exception as error:
-            logger.warning(
-                "pr_review:%s: review finding live read-back failed (%s)",
-                item.issue,
-                type(error).__name__,
-            )
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        item.payload["unresolved_threads"] = [dict(thread) for thread in live_threads]
-        remediation_threads = _normalize_remediation_threads(live_threads)
-        if len(remediation_threads) != len(live_threads):
-            item.payload["review_audit_failure"] = True
-            return Continue(next_state=EVAL)
-        item.payload["remediation_threads"] = remediation_threads
-        item.payload["remediation_thread_snapshots"] = [dict(thread) for thread in live_threads]
-        item.payload["unresolved_threads_before_address"] = len(remediation_threads)
-        if validation_only:
-            # The validator has made the exhaustive current-head decisions
-            # for the original review's threads.  It is now the fresh review
-            # evidence for this comment-validation-only pass; no new broad
-            # audit findings are invented or posted.
-            item.payload.pop(_COMMENT_VALIDATION_ONLY, None)
+        item.payload["posted_thread_ids"] = [
+            str(value["id"]) for value in posted if isinstance(value, dict) and "id" in value
+        ]
+        item.payload["unresolved_threads"] = [dict(value) for value in unresolved]
+        item.payload["remediation_threads"] = [dict(value) for value in remediation]
+        item.payload["remediation_thread_snapshots"] = [dict(value) for value in unresolved]
+        item.payload["unresolved_threads_before_address"] = len(remediation)
+        if item.payload.pop(_COMMENT_VALIDATION_ONLY, None):
             item.payload["review_audit"] = ReviewAudit(
                 grade="A",
                 summary="Reviewer validated the implementation responses to all open threads.",
@@ -1340,12 +1147,106 @@ class PrReviewJobs(_PrReviewHost):
                 raw_feedback="",
                 valid=True,
             )
-        if not remediation_threads:
+        return Continue(next_state=ADDRESS_WAIT if remediation else EVAL)
+
+    def _post(  # noqa: C901
+        self, item: WorkItem, ctx: StageContext
+    ) -> StepResult:
+        """Freeze reconciliation inputs and dispatch all GitHub I/O to a worker."""
+        if item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        validation_only = bool(item.payload.get(_COMMENT_VALIDATION_ONLY))
+        audit = item.payload.get("review_audit")
+        if not validation_only and (not isinstance(audit, ReviewAudit) or not audit.valid):
+            item.payload["review_audit_failure"] = True
             return Continue(next_state=EVAL)
-        # The original review has already been submitted as one batch. Do not
-        # keep the detached reviewer checkout for a second classifier pass:
-        # implementation receives this complete snapshot directly.
-        return Continue(next_state=ADDRESS_WAIT)
+        reviewed_head = str(item.payload.get("reviewed_pr_head_sha") or "")
+        if not is_full_commit_sha(reviewed_head):
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+
+        findings = (
+            [] if validation_only else [dict(t) for t in item.payload.get("review_threads") or []]
+        )
+        item.payload["raw_review_threads"] = findings
+        validated_fingerprints = item.payload.get("validation_receipt_fingerprints")
+        if validated_fingerprints is not None and not isinstance(validated_fingerprints, dict):
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        metadata_fingerprint = item.payload.get("validation_pr_metadata_fingerprint")
+        if metadata_fingerprint is not None and not isinstance(metadata_fingerprint, str):
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+
+        resolved_ids: tuple[str, ...] = ()
+        feedback: dict[str, str] = {}
+        validation_result = item.payload.get("validation_result")
+        # An empty bound fingerprint set proves the validator saw no exact
+        # implementation reply receipts.  Its free-form output has no
+        # reconciliation authority and must not suppress fresh audit work.
+        if validation_result is not None and validated_fingerprints != {}:
+            parsed = _parse_validation_result(validation_result)
+            validation_is_bound = (
+                validation_only
+                or validated_fingerprints is not None
+                or (metadata_fingerprint is not None)
+            )
+            if parsed is None or set(parsed) != {"resolved", "unaddressed"}:
+                if validation_is_bound:
+                    item.payload["review_audit_failure"] = True
+                    return Continue(next_state=EVAL)
+            else:
+                raw_resolved = parsed.get("resolved")
+                raw_unaddressed = parsed.get("unaddressed")
+                if not isinstance(raw_resolved, list) or not isinstance(raw_unaddressed, list):
+                    item.payload["review_audit_failure"] = True
+                    return Continue(next_state=EVAL)
+                if not all(
+                    isinstance(thread_id, str) and thread_id.strip() for thread_id in raw_resolved
+                ):
+                    item.payload["review_audit_failure"] = True
+                    return Continue(next_state=EVAL)
+                resolved_ids = tuple(sorted(thread_id.strip() for thread_id in raw_resolved))
+                for entry in raw_unaddressed:
+                    if not isinstance(entry, dict):
+                        item.payload["review_audit_failure"] = True
+                        return Continue(next_state=EVAL)
+                    thread_id = str(entry.get("thread_id") or entry.get("id") or "").strip()
+                    detail = str(entry.get("detail") or "").strip()
+                    if not thread_id or not detail or thread_id in feedback:
+                        item.payload["review_audit_failure"] = True
+                        return Continue(next_state=EVAL)
+                    feedback[thread_id] = detail
+
+        request = ReconcilePrReviewRequest(
+            pr_number=item.pr,
+            reviewed_head_sha=reviewed_head,
+            validated_receipt_fingerprints=(
+                FrozenJson.snapshot(validated_fingerprints)
+                if validated_fingerprints is not None
+                else None
+            ),
+            validated_metadata_fingerprint=metadata_fingerprint,
+            resolved_thread_ids=resolved_ids,
+            feedback=FrozenJson.snapshot(feedback),
+            findings=FrozenJson.snapshot(findings),
+            review_diff=str(item.payload.get("pr_diff") or ""),
+        )
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        if pending is None:
+            item.payload[_PENDING_GITHUB_REQUEST] = request
+        elif pending != request:
+            item.payload["review_audit_failure"] = True
+            return Continue(next_state=EVAL)
+        return JobRequest(
+            GitHubJob(
+                repo=item.repo,
+                repo_root=Path(str(ctx.paths.repo_root)).resolve(),
+                request=request,
+                descr="reconcile_pr_review",
+            ),
+            on_done_state=POST_APPLY,
+        )
 
     def _address(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Record a NO-GO and hand immutable review findings to the writer.
@@ -1387,13 +1288,92 @@ class PrReviewJobs(_PrReviewHost):
         _clear_round_review_state(item)
         return None
 
-    @staticmethod
-    def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
-        """Delegate recovery to the common host-only reply handoff contract."""
-        return retry_pending_implementation_reply_handoff(
-            item.payload,
-            pr_number=item.pr,
-            issue_number=item.issue,
-            github=ctx.github,
-            logger=logger,
+    def _recovery_reply_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Dispatch one exact recovery-only reply handoff to a worker."""
+        if item.issue is None or item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        handoff = item.payload.get(_PENDING_IMPLEMENTATION_REPLY_HANDOFF)
+        retries = item.payload.get(
+            _REPLY_VISIBILITY_RETRIES,
+            0,
         )
+        if (
+            not isinstance(handoff, dict)
+            or isinstance(retries, bool)
+            or not isinstance(retries, int)
+            or retries < 0
+        ):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        try:
+            request = DeliverReplyHandoffRequest(
+                issue_number=item.issue,
+                pr_number=item.pr,
+                handoff=FrozenJson.snapshot(handoff),
+                visibility_retries=retries,
+            )
+        except (TypeError, ValueError):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        pending = item.payload.get(_PENDING_GITHUB_REQUEST)
+        if pending is None:
+            item.payload[_PENDING_GITHUB_REQUEST] = request
+        elif pending != request:
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid")
+        return JobRequest(
+            GitHubJob(
+                repo=item.repo,
+                repo_root=Path(str(ctx.paths.repo_root)).resolve(),
+                request=request,
+                descr="recover_implementation_reply_handoff",
+            ),
+            on_done_state=EVAL,
+        )
+
+    @staticmethod
+    def _on_reply_handoff_done(item: WorkItem, result: JobResult) -> None:
+        """Store only an exact request-bearing recovery receipt."""
+        if not result.ok:
+            item.payload[_REPLY_HANDOFF_RECEIPT_ERROR] = "retry"
+            return
+        receipt = result.value
+        if not isinstance(receipt, ReplyHandoffAttempted) or receipt.request != item.payload.get(
+            _PENDING_GITHUB_REQUEST
+        ):
+            item.payload[_REPLY_HANDOFF_RECEIPT_ERROR] = "invalid"
+            return
+        item.payload[_REPLY_HANDOFF_RECEIPT] = receipt
+
+    @staticmethod
+    def _consume_reply_handoff_receipt(item: WorkItem) -> str:
+        """Apply a correlated immutable recovery receipt to local payload."""
+        if not item.payload.get(_PENDING_IMPLEMENTATION_REPLY_HANDOFF):
+            item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+            item.payload.pop(_REPLY_HANDOFF_RECEIPT, None)
+            item.payload.pop(_REPLY_HANDOFF_RECEIPT_ERROR, None)
+            return "completed"
+        error = item.payload.pop(_REPLY_HANDOFF_RECEIPT_ERROR, None)
+        if error is not None:
+            item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+            return "retry" if error == "retry" else "invalid"
+        receipt = item.payload.pop(_REPLY_HANDOFF_RECEIPT, None)
+        if not isinstance(receipt, ReplyHandoffAttempted) or receipt.request != item.payload.get(
+            _PENDING_GITHUB_REQUEST
+        ):
+            return "invalid"
+        item.payload.pop(_PENDING_GITHUB_REQUEST, None)
+        remaining = (
+            receipt.remaining_handoff.thaw() if receipt.remaining_handoff is not None else None
+        )
+        if remaining is not None and not isinstance(remaining, dict):
+            return "invalid"
+        if remaining is None:
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF, None)
+        else:
+            item.payload[_PENDING_IMPLEMENTATION_REPLY_HANDOFF] = remaining
+        item.payload[_REPLY_VISIBILITY_RETRIES] = receipt.visibility_retries
+        if receipt.retry_delay_s is None:
+            item.payload.pop("retry_delay_s", None)
+        else:
+            item.payload["retry_delay_s"] = receipt.retry_delay_s
+        if receipt.status in {"completed", "stale"}:
+            item.payload.pop(_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES, None)
+        return receipt.status

--- a/hephaestus/automation/pipeline/stages/pr_review_threads.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_threads.py
@@ -135,9 +135,9 @@ from ..reply_handoff import (
     IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP,
     PENDING_IMPLEMENTATION_REPLY_HANDOFF as _PENDING_IMPLEMENTATION_REPLY_HANDOFF,
     PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES as _PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES,
+    PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES as _REPLY_VISIBILITY_RETRIES,
     implementation_reply_handoff,
     pr_is_current_open_head,
-    retry_pending_implementation_reply_handoff,
 )
 from ..scope_retraction import scope_retraction_paths_for_threads
 from ..work_item import ItemKind
@@ -210,6 +210,8 @@ REVIEW_CHECKOUT_WAIT = "REVIEW_CHECKOUT_WAIT"
 HOST_VERIFICATION_WAIT = "HOST_VERIFICATION_WAIT"
 VALIDATE_WAIT = "VALIDATE_WAIT"
 POST = "POST"
+POST_APPLY = "POST_APPLY"
+RECOVERY_REPLY_WAIT = "RECOVERY_REPLY_WAIT"
 ADDRESS_WAIT = "ADDRESS_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
 EVAL = "EVAL"
@@ -236,6 +238,8 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     HOST_VERIFICATION_WAIT: "_host_verification_wait",
     VALIDATE_WAIT: "_validate_wait",
     POST: "_post",
+    POST_APPLY: "_post_apply",
+    RECOVERY_REPLY_WAIT: "_recovery_reply_wait",
     ADDRESS_WAIT: "_address",
     PUSH_WAIT: "_push_wait",
     EVAL: "_eval",
@@ -243,6 +247,12 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     COMPACT_WRITER_WAIT: "_compact_writer_wait",
     CLEANUP_REVIEW_WORKTREE_WAIT: "_cleanup_review_worktree_wait",
 }
+
+_PENDING_GITHUB_REQUEST = "_pending_github_request"
+_PR_REVIEW_RECEIPT = "_pr_review_reconciliation_receipt"
+_PR_REVIEW_RECEIPT_ERROR = "_pr_review_reconciliation_error"
+_REPLY_HANDOFF_RECEIPT = "_reply_handoff_receipt"
+_REPLY_HANDOFF_RECEIPT_ERROR = "_reply_handoff_receipt_error"
 
 
 def _issue_number(item: WorkItem) -> int:
@@ -713,7 +723,7 @@ if _typing.TYPE_CHECKING:
             raise NotImplementedError
 
         @staticmethod
-        def _retry_pending_implementation_reply_handoff(item: WorkItem, ctx: StageContext) -> str:
+        def _consume_reply_handoff_receipt(item: WorkItem) -> str:
             raise NotImplementedError
 
 else:
@@ -761,11 +771,14 @@ __all__ = [
     'COMPACT_REVIEWER_WAIT', 'COMPACT_WRITER_WAIT', 'DIRECT_PUSH_REMOTE_CHANGED_RESTART_CAP',
     'DIRECT_PUSH_RETRY_CAP', 'ENTER', 'EVAL', 'GIT_JOB_TIMEOUT_S',
     'HOST_VERIFICATION_DIAGNOSTIC_MAX', 'HOST_VERIFICATION_TIMEOUT_S', 'HOST_VERIFICATION_WAIT',
-    'IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP', 'POST', 'PUSH_WAIT', 'REVIEW_CHECKOUT_RETRY_CAP',
+    'IMPLEMENTATION_REPLY_HANDOFF_RETRY_CAP', 'POST', 'PUSH_WAIT', 'RECOVERY_REPLY_WAIT',
+    'REVIEW_CHECKOUT_RETRY_CAP',
     'REVIEW_CHECKOUT_WAIT', 'REVIEW_ERROR_RETRY_CAP', 'REVIEW_WAIT', 'STATE_SKIP', 'VALIDATE_WAIT',
     'VALID_SEVERITIES', '_COMMENT_VALIDATION_ONLY', '_HOST_VERIFICATION_PENDING',
     '_JSON_RESPONSE_BLOCK_RE', '_PENDING_IMPLEMENTATION_REPLY_HANDOFF',
-    '_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES', '_ROUND_PAYLOAD_KEYS', '_STEP_HANDLER_NAMES',
+    '_PENDING_IMPLEMENTATION_REPLY_HANDOFF_RETRIES',
+    '_REPLY_HANDOFF_RECEIPT', '_REPLY_HANDOFF_RECEIPT_ERROR', '_REPLY_VISIBILITY_RETRIES',
+    '_ROUND_PAYLOAD_KEYS', '_STEP_HANDLER_NAMES',
     'AgentJob', 'Any', 'BuildTestJob', 'Callable', 'CompactJob', 'Continue', 'Disposition',
     'GitJob', 'ItemKind', 'JobRequest', 'JobResult', 'PrReviewStage', 'ReviewAudit', 'Stage',
     'StageContext', 'StageOutcome', 'StepResult', 'WorkItem', '_HostVerificationSpec',
@@ -784,6 +797,6 @@ __all__ = [
     'implementation_reply_handoff', 'implementer_claude_timeout', 'implementer_model',
     'is_full_commit_sha', 'json', 'logger', 'logging', 'parse_addressed_replies',
     'parse_review_audit', 'pr_is_current_open_head', 'pr_reviewer_claude_timeout', 're',
-    'retry_pending_implementation_reply_handoff', 'reviewer_model',
+    'reviewer_model',
     'scope_retraction_paths_for_threads', 'secrets', 'stage_model', 'write_skip_label']
 # fmt: on

--- a/hephaestus/automation/pipeline/stages/pr_review_threads.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_threads.py
@@ -248,9 +248,6 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     CLEANUP_REVIEW_WORKTREE_WAIT: "_cleanup_review_worktree_wait",
 }
 
-_PENDING_GITHUB_REQUEST = "_pending_github_request"
-_PR_REVIEW_RECEIPT = "_pr_review_reconciliation_receipt"
-_PR_REVIEW_RECEIPT_ERROR = "_pr_review_reconciliation_error"
 _REPLY_HANDOFF_RECEIPT = "_reply_handoff_receipt"
 _REPLY_HANDOFF_RECEIPT_ERROR = "_reply_handoff_receipt_error"
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1,8 +1,8 @@
-"""Worker pool: the only place agent, build/test, git, and session work runs.
+"""Worker pool: the only place agent, build/test, git, GitHub, and session work runs.
 
 The coordinator submits frozen jobs and drains ``(handle, result)`` tuples from
 the completion queue. Workers never touch WorkItems or stage queues and never
-perform GitHub API mutations (enforced by test_pipeline_architecture.py).
+touch coordinator state. Closed GitHub jobs use a separately injected runner.
 """
 
 from __future__ import annotations
@@ -35,6 +35,7 @@ from hephaestus.agents.runtime import resolve_agent, resume_agent_session, run_a
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
 from hephaestus.automation.learn import compact_agent_session
 from hephaestus.automation.models import DEFAULT_STATE_DIR
+from hephaestus.automation.pipeline.github_jobs import GitHubJob, GitHubJobRunner
 from hephaestus.automation.pipeline.jobs import (
     WORKTREE_MATERIALIZED_KEY,
     AgentJob,
@@ -1329,6 +1330,7 @@ class WorkerPool:
         completion_q: CompletionQueue,
         lock_dir: Path | None = None,
         gh_extra_path_root: Path | None = None,
+        github_job_runner: GitHubJobRunner | None = None,
     ) -> None:
         """Initialize the pool.
 
@@ -1343,6 +1345,7 @@ class WorkerPool:
                 automation state dir — see :func:`_repo_lock_path`).
             gh_extra_path_root: Explicit CLI-provided root that may supply
                 only ``bin/gh`` for checkout synchronization.
+            github_job_runner: Closed worker-side GitHub operation runner.
 
         """
         self._executor = ThreadPoolExecutor(
@@ -1357,10 +1360,11 @@ class WorkerPool:
         self._repo_locks_guard = threading.Lock()
         self._lock_dir = lock_dir
         self._gh_extra_path_root = gh_extra_path_root
+        self._github_job_runner = github_job_runner
 
     @contextmanager
     def _repo_lock(self, repo: str) -> Iterator[None]:
-        """Acquire a per-repo git lock and evict its cache entry when idle."""
+        """Serialize in-process worker operations for one repository."""
         with self._repo_locks_guard:
             entry = self._repo_locks.get(repo)
             if entry is None:
@@ -1397,7 +1401,7 @@ class WorkerPool:
 
     def submit(
         self,
-        job: AgentJob | BuildTestJob | GitJob | CompactJob,
+        job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob,
         on_done_state: str | StageName,
         *,
         claim_key: str = "",
@@ -1508,7 +1512,7 @@ class WorkerPool:
 
     def _run(
         self,
-        job: AgentJob | BuildTestJob | GitJob | CompactJob,
+        job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob,
         claim_key: str = "",
         claim_stage: str = "",
     ) -> JobResult:
@@ -1548,6 +1552,8 @@ class WorkerPool:
                     result = self._run_build_test(job)
                 elif isinstance(job, GitJob):
                     result = self._run_git(job)
+                elif isinstance(job, GitHubJob):
+                    result = self._run_github(job)
                 elif isinstance(job, CompactJob):
                     result = self._run_compact(job)
                 else:
@@ -1587,6 +1593,14 @@ class WorkerPool:
             stderr_tail=result.stderr_tail[-_TAIL:] if result.stderr_tail else "",
             worker_id=worker_id,
         )
+
+    def _run_github(self, job: GitHubJob) -> JobResult:
+        """Execute one closed GitHub operation exactly once per submission."""
+        if self._github_job_runner is None:
+            raise RuntimeError("GitHubJob submitted without a GitHubJobRunner")
+        with self._repo_lock(job.repo):
+            receipt = self._github_job_runner.run(job)
+        return JobResult(ok=True, value=receipt)
 
     def _run_agent(self, job: AgentJob) -> JobResult:
         """Run an agent job (Claude or other runtime).

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -232,7 +232,12 @@ class PipelineGitHub(
     PipelineGitHubReviews,
     PipelineGitHubMutations,
 ):
-    """Stable coordinator façade over transport, queries, reviews, and mutations."""
+    """Stable GitHub façade with explicit single-owner semantics.
+
+    Coordinator contexts may cache an instance on the coordinator thread.
+    Worker jobs construct a separate instance for each request; sharing an
+    instance between threads is unsupported.
+    """
 
     def mark_pr_implementation_go(self, pr_number: int) -> None:
         """Apply and read back exclusive ``state:implementation-go``."""

--- a/hephaestus/automation/pipeline_github_jobs.py
+++ b/hephaestus/automation/pipeline_github_jobs.py
@@ -1,0 +1,403 @@
+"""Production dispatcher for closed worker-owned GitHub operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, assert_never
+
+from hephaestus.automation.pipeline.github_jobs import (
+    AppendReplyJournalRequest,
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    GitHubJob,
+    GitHubReceipt,
+    MergeWaitCycleCompleted,
+    PrReviewReconciled,
+    ReconcilePrReviewRequest,
+    RecoverReplyJournalRequest,
+    ReplyJournalAppended,
+    ReplyJournalRecovered,
+    RunMergeWaitCycleRequest,
+)
+from hephaestus.automation.pipeline.reply_handoff import (
+    attempt_reply_handoff,
+    journaled_implementation_reply_handoff,
+)
+from hephaestus.automation.pipeline_github import PipelineGitHub
+
+
+@dataclass(frozen=True)
+class PipelineGitHubJobRunner:
+    """Dispatch closed requests through a fresh repository-scoped accessor."""
+
+    org: str
+    dry_run: bool
+
+    def run(self, job: GitHubJob) -> GitHubReceipt:
+        """Execute one request without sharing a coordinator/client instance."""
+        github = PipelineGitHub(
+            self.org,
+            repo=job.repo,
+            dry_run=self.dry_run,
+            repo_root=job.repo_root,
+        )
+        match job.request:
+            case RecoverReplyJournalRequest():
+                threads = job.request.threads.thaw()
+                if not isinstance(threads, list):  # constructor guard; keeps narrowing explicit
+                    raise ValueError("recovery threads must be a list")
+                handoff = journaled_implementation_reply_handoff(
+                    github.issue_comments(job.request.issue_number),
+                    pr_number=job.request.pr_number,
+                    threads=threads,
+                )
+                return ReplyJournalRecovered(
+                    request=job.request,
+                    handoff=FrozenJson.snapshot(handoff) if handoff is not None else None,
+                )
+            case AppendReplyJournalRequest():
+                github.append_issue_comment(
+                    job.request.issue_number,
+                    job.request.marker,
+                    job.request.body,
+                )
+                return ReplyJournalAppended(request=job.request)
+            case DeliverReplyHandoffRequest():
+                return attempt_reply_handoff(job.request, github)
+            case ReconcilePrReviewRequest():
+                return self._reconcile_pr_review(job.request, github)
+            case RunMergeWaitCycleRequest():
+                return self._run_merge_wait_cycle(job.request, github)
+            case unknown:
+                return assert_never(unknown)
+
+    @staticmethod
+    def _reconcile_pr_review(  # noqa: C901
+        request: ReconcilePrReviewRequest,
+        github: Any,
+    ) -> PrReviewReconciled:
+        """Run fresh receipt reconciliation, publication, and late-thread readback."""
+        from hephaestus.automation.pipeline.stages.pr_review_threads import (
+            _durable_thread_id,
+            _is_postable_finding,
+            _normalize_remediation_threads,
+            _validation_pr_metadata_fingerprint,
+            _validation_receipt_fingerprints,
+            _without_duplicate_live_findings,
+        )
+        from hephaestus.automation.prompts.pr_review import BLOCKING_SEVERITIES
+
+        def receipt(
+            action: str,
+            *,
+            posted: Any = (),
+            unresolved: Any = (),
+            remediation: Any = (),
+        ) -> PrReviewReconciled:
+            return PrReviewReconciled(
+                request=request,
+                action=action,  # type: ignore[arg-type]
+                posted_receipts=FrozenJson.snapshot(list(posted)),
+                unresolved_threads=FrozenJson.snapshot(list(unresolved)),
+                remediation_threads=FrozenJson.snapshot(list(remediation)),
+            )
+
+        live_for_reconciliation = github.list_unresolved_review_threads(request.pr_number)
+        validation_receipts = github.reviewer_validation_receipts(
+            request.pr_number,
+            reviewed_head_sha=request.reviewed_head_sha,
+            threads=live_for_reconciliation,
+        )
+        pr_context = github.pr_review_context(request.pr_number)
+        live_fingerprints = _validation_receipt_fingerprints(validation_receipts)
+        if live_fingerprints is None:
+            return receipt("audit_failure")
+        validated_fingerprints = (
+            request.validated_receipt_fingerprints.thaw()
+            if request.validated_receipt_fingerprints is not None
+            else None
+        )
+        live_metadata = _validation_pr_metadata_fingerprint(
+            pr_context,
+            request.reviewed_head_sha,
+        )
+        metadata_guard_expected = request.validated_receipt_fingerprints is not None or (
+            request.validated_metadata_fingerprint is not None
+        )
+        if metadata_guard_expected and (
+            live_metadata is None or request.validated_metadata_fingerprint != live_metadata
+        ):
+            return receipt("revalidate")
+        if validated_fingerprints is not None and validated_fingerprints != live_fingerprints:
+            return receipt("revalidate")
+
+        if validation_receipts:
+            expected_ids = {_durable_thread_id(entry) for entry in validation_receipts}
+            feedback = request.feedback.thaw()
+            if not isinstance(feedback, dict) or None in expected_ids:
+                return receipt("audit_failure")
+            feedback_ids = set(feedback)
+            resolved_ids = set(request.resolved_thread_ids)
+            if (
+                resolved_ids & feedback_ids
+                or resolved_ids | feedback_ids != expected_ids
+                or not all(isinstance(value, str) and value.strip() for value in feedback.values())
+            ):
+                return receipt("audit_failure")
+            reconciliation = github.reconcile_reviewer_validated_threads(
+                request.pr_number,
+                reviewed_head_sha=request.reviewed_head_sha,
+                receipts=validation_receipts,
+                resolved_thread_ids=resolved_ids,
+                feedback=feedback,
+            )
+            completed_ids = set(reconciliation.resolved_thread_ids) | set(
+                reconciliation.feedback_thread_ids
+            )
+            if not completed_ids.issubset(expected_ids):
+                return receipt("audit_failure")
+            if reconciliation.blocked_thread_ids:
+                return receipt("fresh_review")
+
+        live_before_post = github.list_unresolved_review_threads(request.pr_number)
+        live_by_id = {
+            thread_id: thread
+            for thread in live_before_post
+            if (thread_id := _durable_thread_id(thread)) is not None
+        }
+        raw_findings = request.findings.thaw()
+        if not isinstance(raw_findings, list) or not all(
+            isinstance(finding, dict) for finding in raw_findings
+        ):
+            return receipt("audit_failure")
+        findings = _without_duplicate_live_findings(raw_findings, live_by_id)
+        findings = [
+            finding
+            for finding in findings
+            if str(finding.get("severity") or "").strip().lower() in BLOCKING_SEVERITIES
+        ]
+        if any(not _is_postable_finding(finding) for finding in findings):
+            return receipt("audit_failure")
+        posted_receipts = (
+            list(
+                github.post_review_threads(
+                    request.pr_number,
+                    findings,
+                    expected_head_sha=request.reviewed_head_sha,
+                    review_diff=request.review_diff,
+                )
+            )
+            if findings
+            else []
+        )
+        if len(posted_receipts) != len(findings):
+            return receipt("audit_failure")
+        live_threads = github.list_unresolved_review_threads(request.pr_number)
+        remediation_threads = _normalize_remediation_threads(live_threads)
+        if len(remediation_threads) != len(live_threads):
+            return receipt("audit_failure")
+        return receipt(
+            "apply",
+            posted=posted_receipts,
+            unresolved=live_threads,
+            remediation=remediation_threads,
+        )
+
+    @staticmethod
+    def _run_merge_wait_cycle(  # noqa: C901
+        request: RunMergeWaitCycleRequest,
+        github: Any,
+    ) -> MergeWaitCycleCompleted:
+        """Run admission, readiness, one conditional merge, and reconciliation."""
+        requestable = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE"})
+        retryable = frozenset({"BEHIND", "BLOCKED", "UNKNOWN"})
+        conflicting = frozenset({"CONFLICTING", "DIRTY"})
+
+        def complete(
+            outcome: str,
+            *,
+            attempted: bool = False,
+            fingerprint: tuple[str, ...] | None = None,
+            can_retry: bool = False,
+        ) -> MergeWaitCycleCompleted:
+            return MergeWaitCycleCompleted(
+                request=request,
+                outcome=outcome,
+                attempted=attempted,
+                readiness_fingerprint=fingerprint,
+                retryable=can_retry,
+            )
+
+        def terminal(state: object) -> str | None:
+            if not isinstance(state, dict):
+                return None
+            lifecycle = str(state.get("state") or "").upper()
+            if lifecycle == "MERGED" or state.get("mergedAt"):
+                return "merged"
+            if lifecycle == "CLOSED":
+                return "closed"
+            return None
+
+        def admit() -> tuple[dict[str, object], str] | str:
+            try:
+                state = github.gh_pr_state(request.pr_number)
+            except Exception:
+                return "pr_state_unavailable"
+            terminal_outcome = terminal(state)
+            if terminal_outcome is not None:
+                return terminal_outcome
+            if state is None:
+                return "pr_state_unavailable"
+            if not isinstance(state, dict):
+                return "pr_state_unverified"
+            if state.get("autoMergeRequest") is not None:
+                return "auto_merge_already_armed"
+            if state.get("state") != "OPEN" or "autoMergeRequest" not in state:
+                return "pr_state_unverified"
+            if state.get("baseRefName") != "main":
+                return "non_main_base"
+            try:
+                has_go, has_no_go = github.pr_has_implementation_state_label(request.pr_number)
+            except Exception:
+                return "implementation_state_unavailable"
+            if not has_go or has_no_go:
+                return "not_implementation_go"
+            head = str(state.get("headRefOid") or "")
+            if not head:
+                return "missing_pr_head"
+            if head != request.reviewed_head_sha:
+                return "reviewed_head_drift"
+            return state, head
+
+        def conversation_safety(base_branch: str) -> str | None:
+            try:
+                threads = github.list_unresolved_review_threads(request.pr_number)
+            except Exception:
+                return "review_threads_unavailable"
+            if threads:
+                return "unresolved_review_threads"
+            try:
+                protected = github.base_branch_requires_conversation_resolution(
+                    request.pr_number,
+                    base_branch,
+                )
+            except Exception:
+                return "conversation_resolution_unavailable"
+            return None if protected else "conversation_resolution_required"
+
+        def readiness_outcome(
+            state: object,
+            *,
+            park_if_ready: bool,
+        ) -> tuple[str | None, tuple[str, ...] | None]:
+            terminal_outcome = terminal(state)
+            if terminal_outcome is not None:
+                return terminal_outcome, None
+            if state is None or not isinstance(state, dict):
+                return "merge_readiness_unavailable", None
+            if state.get("autoMergeRequest") is not None:
+                return "auto_merge_already_armed", None
+            readiness_head = state.get("headRefOid")
+            if not isinstance(readiness_head, str) or not readiness_head:
+                return "merge_readiness_unavailable", None
+            status = str(state.get("mergeStateStatus") or "").upper()
+            mergeable = str(state.get("mergeable") or "").upper()
+            fingerprint = (
+                readiness_head,
+                str(request.proof_generation),
+                mergeable,
+                status,
+            )
+            if readiness_head != request.reviewed_head_sha:
+                return "readiness_wait", fingerprint
+            if status in requestable and mergeable == "MERGEABLE":
+                if park_if_ready or request.declined_readiness_fingerprint == fingerprint:
+                    return "readiness_wait", fingerprint
+                return None, fingerprint
+            if status in conflicting or mergeable == "CONFLICTING":
+                return "merge_conflicting", fingerprint
+            if status not in retryable and mergeable != "UNKNOWN":
+                return "merge_readiness_unknown", fingerprint
+            return "readiness_wait", fingerprint
+
+        admitted = admit()
+        if isinstance(admitted, str):
+            return complete(admitted)
+        state, _ = admitted
+        base_branch = state.get("baseRefName")
+        if not isinstance(base_branch, str) or not base_branch:
+            return complete("pr_state_unverified")
+        unsafe = conversation_safety(base_branch)
+        if unsafe is not None:
+            return complete(unsafe)
+        try:
+            readiness = github.gh_pr_merge_readiness(request.pr_number)
+        except Exception:
+            return complete("merge_readiness_unavailable")
+        readiness_status, fingerprint = readiness_outcome(readiness, park_if_ready=False)
+        if readiness_status is not None:
+            return complete(readiness_status, fingerprint=fingerprint)
+
+        # Read all authority-bearing facts again immediately before the PUT.
+        admitted = admit()
+        if isinstance(admitted, str):
+            return complete(admitted)
+        state, _ = admitted
+        base_branch = state.get("baseRefName")
+        if not isinstance(base_branch, str) or not base_branch:
+            return complete("pr_state_unverified")
+        unsafe = conversation_safety(base_branch)
+        if unsafe is not None:
+            return complete(unsafe)
+
+        try:
+            result = github.merge_pr_if_head(
+                request.pr_number,
+                request.reviewed_head_sha,
+            )
+        except Exception:
+            return complete("merge_request_transport_error", attempted=True, can_retry=True)
+        if result.dry_run:
+            return complete("conditional_merge_dry_run", attempted=True)
+        if result.malformed:
+            return complete("merge_result_malformed", attempted=True)
+        if result.transport_error or result.status is None:
+            admitted = admit()
+            if isinstance(admitted, str):
+                return complete(admitted, attempted=True)
+            return complete("merge_not_ready", attempted=True, can_retry=True)
+        if result.status == 200:
+            if result.body is None or result.body.get("merged") is not True:
+                return complete("merge_not_merged", attempted=True)
+            try:
+                final_state = github.gh_pr_state(request.pr_number)
+            except Exception:
+                return complete("merge_reconciliation_unavailable", attempted=True)
+            return complete(terminal(final_state) or "merge_not_merged", attempted=True)
+        if result.status == 409:
+            admitted = admit()
+            if isinstance(admitted, str):
+                return complete(admitted, attempted=True)
+            return complete("merge_409_without_head_drift", attempted=True)
+        if result.status == 405:
+            try:
+                readiness = github.gh_pr_merge_readiness(request.pr_number)
+            except Exception:
+                return complete("merge_readiness_unavailable", attempted=True)
+            terminal_outcome = terminal(readiness)
+            if terminal_outcome is not None:
+                return complete(terminal_outcome, attempted=True)
+            if not isinstance(readiness, dict):
+                return complete("merge_readiness_unavailable", attempted=True)
+            if readiness.get("autoMergeRequest") is not None:
+                return complete("auto_merge_already_armed", attempted=True)
+            admitted = admit()
+            if isinstance(admitted, str):
+                return complete(admitted, attempted=True)
+            readiness_status, fingerprint = readiness_outcome(readiness, park_if_ready=True)
+            return complete(
+                readiness_status or "readiness_wait",
+                attempted=True,
+                fingerprint=fingerprint,
+            )
+        return complete(f"merge_http_{result.status}", attempted=True)

--- a/hephaestus/automation/pipeline_github_jobs.py
+++ b/hephaestus/automation/pipeline_github_jobs.py
@@ -70,6 +70,7 @@ class PipelineGitHubJobRunner:
                 return self._run_merge_wait_cycle(job.request, github)
             case unknown:
                 return assert_never(unknown)
+        raise AssertionError("unreachable closed GitHub request dispatch")
 
     @staticmethod
     def _reconcile_pr_review(  # noqa: C901

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from hephaestus.automation.pipeline.github_jobs import GitHubJob, GitHubJobRunner
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
@@ -50,6 +51,8 @@ class FakeWorkerPool:
         shutdown: threading.Event | None = None,
         completion_q: CompletionQueue | None = None,
         lock_dir: Path | None = None,
+        gh_extra_path_root: Path | None = None,
+        github_job_runner: GitHubJobRunner | None = None,
     ) -> None:
         """Initialize the fake pool.
 
@@ -58,6 +61,8 @@ class FakeWorkerPool:
             shutdown: Accepted for signature parity with WorkerPool; unused.
             completion_q: Queue to drain results to (created if omitted).
             lock_dir: Accepted for signature parity with WorkerPool; unused.
+            gh_extra_path_root: Accepted for signature parity; unused.
+            github_job_runner: Scriptable executor for closed GitHub jobs.
 
         """
         self.size = size
@@ -69,6 +74,7 @@ class FakeWorkerPool:
         self.submitted_claims: list[tuple[str, str]] = []
         self.shutdown_calls = 0
         self._scripted: deque[JobResult | Exception] = deque()
+        self.github_job_runner = github_job_runner
 
     def script(self, *outcomes: JobResult | Exception) -> None:
         """FIFO-enqueue scripted outcomes for subsequent :meth:`submit` calls."""
@@ -84,8 +90,8 @@ class FakeWorkerPool:
 
     def submit(
         self,
-        job: AgentJob | BuildTestJob | GitJob | CompactJob,
-        on_done_state: StageName,
+        job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob,
+        on_done_state: str | StageName,
         *,
         claim_key: str = "",
         claim_stage: str = "",
@@ -105,9 +111,17 @@ class FakeWorkerPool:
         handle = JobHandle(job=job, on_done_state=on_done_state)
         self.submitted.append(handle)
         self.submitted_claims.append((claim_key, claim_stage))
-        outcome: JobResult | Exception = (
-            self._scripted.popleft() if self._scripted else self._default_result(job)
-        )
+        if self._scripted:
+            outcome: JobResult | Exception = self._scripted.popleft()
+        elif isinstance(job, GitHubJob):
+            if self.github_job_runner is None:
+                raise AssertionError("GitHubJob requires a scripted runner")
+            try:
+                outcome = JobResult(ok=True, value=self.github_job_runner.run(job))
+            except Exception as error:
+                outcome = error
+        else:
+            outcome = self._default_result(job)
         if isinstance(outcome, Exception):
             outcome = JobResult(
                 ok=False,
@@ -117,7 +131,9 @@ class FakeWorkerPool:
         return handle
 
     @staticmethod
-    def _default_result(job: AgentJob | BuildTestJob | GitJob | CompactJob) -> JobResult:
+    def _default_result(
+        job: AgentJob | BuildTestJob | GitJob | CompactJob,
+    ) -> JobResult:
         """Synthesize a per-job-type ok result when nothing is scripted."""
         if isinstance(job, AgentJob):
             return JobResult(ok=True, value="fake agent output")

--- a/tests/unit/automation/pipeline/stages/test_stage_cross.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_cross.py
@@ -67,7 +67,7 @@ def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int
                 )
                 item.state = result.on_done_state
                 continue
-            pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+            pool.submit(result.job, result.on_done_state)
             _handle, job_result = pool.completion_q.get_nowait()
             stage.on_job_done(item, job_result, ctx)
             item.state = result.on_done_state

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,7 +11,23 @@ from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation.pipeline.github_jobs import (
+    AppendReplyJournalRequest,
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    GitHubJob,
+    RecoverReplyJournalRequest,
+    ReplyHandoffAttempted,
+    ReplyJournalAppended,
+    ReplyJournalRecovered,
+)
 from hephaestus.automation.pipeline.jobs import AgentJob, BuildTestJob, GitJob, JobResult
+from hephaestus.automation.pipeline.reply_handoff import (
+    attempt_reply_handoff,
+    implementation_reply_handoff,
+    implementation_reply_handoff_journal_entry,
+    journaled_implementation_reply_handoff,
+)
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import (
     Continue,
@@ -50,7 +67,7 @@ def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int
             item.state = result.next_state
             continue
         if isinstance(result, JobRequest):
-            pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+            pool.submit(result.job, result.on_done_state)
             _handle, job_result = pool.completion_q.get_nowait()
             assert not job_result.interrupted  # on_job_done contract precondition
             stage.on_job_done(item, job_result, ctx)
@@ -58,6 +75,55 @@ def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int
             continue
         return result
     raise AssertionError("stage driver did not terminate")
+
+
+def _drive_github_jobs(
+    stage: ImplementationStage,
+    item: Any,
+    ctx: Any,
+    *,
+    max_steps: int = 10,
+) -> Any:
+    """Execute typed GitHub jobs only after a stage has dispatched them."""
+    for _ in range(max_steps):
+        result = stage.step(item, ctx)
+        if isinstance(result, Continue):
+            item.state = result.next_state
+            continue
+        if not isinstance(result, JobRequest) or not isinstance(result.job, GitHubJob):
+            return result
+        request = result.job.request
+        try:
+            if isinstance(request, RecoverReplyJournalRequest):
+                threads = request.threads.thaw()
+                assert isinstance(threads, list)
+                handoff = journaled_implementation_reply_handoff(
+                    ctx.github.issue_comments(request.issue_number),
+                    pr_number=request.pr_number,
+                    threads=threads,
+                )
+                receipt: object = ReplyJournalRecovered(
+                    request=request,
+                    handoff=FrozenJson.snapshot(handoff) if handoff is not None else None,
+                )
+            elif isinstance(request, AppendReplyJournalRequest):
+                ctx.github.append_issue_comment(
+                    request.issue_number,
+                    request.marker,
+                    request.body,
+                )
+                receipt = ReplyJournalAppended(request=request)
+            elif isinstance(request, DeliverReplyHandoffRequest):
+                receipt = attempt_reply_handoff(request, ctx.github)
+                assert isinstance(receipt, ReplyHandoffAttempted)
+            else:  # pragma: no cover - the implementation stage has exactly three operations
+                raise AssertionError(f"unexpected request: {request!r}")
+            job_result = JobResult(ok=True, value=receipt)
+        except Exception as error:
+            job_result = JobResult(ok=False, error=f"{type(error).__name__}: {error}")
+        stage.on_job_done(item, job_result, ctx)
+        item.state = result.on_done_state
+    raise AssertionError("typed GitHub stage driver did not terminate")
 
 
 class TestComposedPromptBuilders:
@@ -1668,7 +1734,7 @@ class TestCommitPushAndPrCreate:
         )
 
         item.state = "PR_CREATE"
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
 
@@ -1752,7 +1818,7 @@ class TestCommitPushAndPrCreate:
         )
 
         item.state = "PR_CREATE"
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert ("post_implementation_thread_replies", (1001, ("thread-1",))) in github.mutation_log
@@ -1814,7 +1880,7 @@ class TestCommitPushAndPrCreate:
         )
 
         item.state = "PR_CREATE"
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
         )
         assert item.payload["retry_delay_s"] == 1.0
@@ -1822,7 +1888,7 @@ class TestCommitPushAndPrCreate:
             name == "post_implementation_thread_replies" for name, _ in github.mutation_log
         )
 
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert ("post_implementation_thread_replies", (1001, ("thread-1",))) in github.mutation_log
@@ -1883,7 +1949,7 @@ class TestCommitPushAndPrCreate:
         )
         item.state = "PR_CREATE"
 
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.RETRY, "implementation_reply_handoff_retry"
         )
         assert "pending_implementation_reply_handoff" in item.payload
@@ -1891,7 +1957,7 @@ class TestCommitPushAndPrCreate:
             name == "post_implementation_thread_replies" for name, _ in github.mutation_log
         )
 
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert (
@@ -1973,13 +2039,13 @@ class TestCommitPushAndPrCreate:
         )
         item.state = "PR_CREATE"
 
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
         )
         assert item.payload["retry_delay_s"] == 1.0
         assert "pending_implementation_reply_handoff_retries" not in item.payload
 
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert (
@@ -2047,6 +2113,11 @@ class TestCommitPushAndPrCreate:
             JobResult(ok=True, value={"pushed": True, "head_sha": "b" * 40}),
             ctx,
         )
+        publisher.state = "PR_CREATE"
+        assert _drive_github_jobs(stage, publisher, ctx) == StageOutcome(
+            Disposition.RETRY,
+            "implementation_reply_handoff_retry",
+        )
 
         resumed = make_work_item(issue=1, pr=1001, state="IMPLEMENT_WAIT")
         # The normal restarted read sees the writer's new head and may see a
@@ -2073,15 +2144,7 @@ class TestCommitPushAndPrCreate:
             }
         )
 
-        assert stage.step(resumed, ctx) == Continue(next_state="PR_CREATE")
-        assert "pending_implementation_reply_handoff" in resumed.payload
-        assert "remediation_output" not in resumed.payload
-
-        resumed.state = "PR_CREATE"
-        assert stage.step(resumed, ctx) == StageOutcome(
-            Disposition.RETRY, "implementation_reply_handoff_retry"
-        )
-        assert stage.step(resumed, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, resumed, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert (
@@ -2108,7 +2171,7 @@ class TestCommitPushAndPrCreate:
             }
         )
 
-        stale_result = stage.step(stale, ctx)
+        stale_result = _drive_github_jobs(stage, stale, ctx)
 
         assert isinstance(stale_result, JobRequest)
         assert stale_result.job.descr == "address_review"
@@ -2166,13 +2229,17 @@ class TestCommitPushAndPrCreate:
             ctx,
         )
 
-        assert github.journal_calls == 1
+        assert github.journal_calls == 0
         assert "pending_implementation_reply_handoff" in item.payload
         assert "pending_implementation_reply_handoff_journal" in item.payload
         assert item.attempts.get("implement", 0) == 0
 
         item.state = "PR_CREATE"
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_journal_retry"
+        )
+        assert github.journal_calls == 1
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert github.journal_calls == 2
@@ -2228,7 +2295,7 @@ class TestCommitPushAndPrCreate:
         assert "pending_implementation_reply_handoff" in item.payload
 
         item.state = "PR_CREATE"
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _drive_github_jobs(stage, item, ctx) == StageOutcome(
             Disposition.ADVANCE, "PR #1001 ready for review"
         )
         assert github._thread_replies["thread-1"][-1]["body"] == (
@@ -2738,3 +2805,73 @@ class TestFullWalks:
         assert outcome.disposition == Disposition.FINISH_FAIL
         assert outcome.note == "implement_exhausted"
         assert github.mutation_log == []  # exhaustion here owns no labels
+
+    def test_reply_journal_append_dispatches_without_inline_github_calls(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The coordinator step only freezes and dispatches the journal append."""
+
+        class InlineGitHubForbidden:
+            def append_issue_comment(self, *_args: object, **_kwargs: object) -> None:
+                raise AssertionError("GitHub append ran inline")
+
+            def gh_pr_state(self, *_args: object, **_kwargs: object) -> object:
+                raise AssertionError("GitHub state read ran inline")
+
+            def post_implementation_thread_replies(
+                self, *_args: object, **_kwargs: object
+            ) -> object:
+                raise AssertionError("GitHub reply mutation ran inline")
+
+        threads = [
+            {
+                "id": "thread-1",
+                "comments": [{"id": "comment-1", "body": "fix it"}],
+            }
+        ]
+        handoff = implementation_reply_handoff(
+            "a" * 40,
+            threads,
+            {"thread-1": "[Response] fixed"},
+            "b" * 32,
+        )
+        assert handoff is not None
+        journal = implementation_reply_handoff_journal_entry(7, handoff)
+        assert journal is not None
+        marker, body = journal
+        item = make_work_item(issue=3, pr=7, state="REPLY_JOURNAL_APPEND_WAIT")
+        item.payload.update(
+            {
+                "pending_implementation_reply_handoff": handoff,
+                "pending_implementation_reply_handoff_journal": {
+                    "marker": marker,
+                    "body": body,
+                },
+            }
+        )
+        stage = ImplementationStage()
+        ctx = make_ctx(github=InlineGitHubForbidden())
+
+        started = time.monotonic()
+        result = stage.step(item, ctx)
+        elapsed = time.monotonic() - started
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitHubJob)
+        assert result.job.request == AppendReplyJournalRequest(
+            issue_number=3,
+            marker=marker,
+            body=body,
+        )
+        assert elapsed < 0.25
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value=ReplyJournalAppended(request=result.job.request)),
+            ctx,
+        )
+        assert "pending_implementation_reply_handoff_journal" not in item.payload
+        assert item.payload["pending_implementation_reply_handoff"] == handoff
+
+        item.state = result.on_done_state
+        assert stage.step(item, ctx) == Continue(next_state="REPLY_HANDOFF_WAIT")

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import pytest
 
+from hephaestus.automation.pipeline.github_jobs import GitHubJob, RunMergeWaitCycleRequest
+from hephaestus.automation.pipeline.jobs import JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName
-from hephaestus.automation.pipeline.stages import ConditionalMergeResult, Continue, StageOutcome
+from hephaestus.automation.pipeline.stages import (
+    ConditionalMergeResult,
+    Continue,
+    JobRequest,
+    StageOutcome,
+)
 from hephaestus.automation.pipeline.stages.merge_wait import MergeWaitStage
+from hephaestus.automation.pipeline_github_jobs import PipelineGitHubJobRunner
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
 MERGE = "MERGE"
@@ -99,6 +108,61 @@ def _reviewed_item(make_work_item: Any, *, head: str = "a" * 40) -> Any:
     )
 
 
+def _complete_merge_cycle(stage: MergeWaitStage, item: Any, ctx: Any) -> Any:
+    """Execute a dispatched merge cycle at the worker boundary, then apply it."""
+    request = stage.step(item, ctx)
+    if not isinstance(request, JobRequest) or not isinstance(request.job, GitHubJob):
+        return request
+    assert isinstance(request.job.request, RunMergeWaitCycleRequest)
+    try:
+        receipt = PipelineGitHubJobRunner._run_merge_wait_cycle(
+            request.job.request,
+            ctx.github,
+        )
+        result = JobResult(ok=True, value=receipt)
+    except Exception as error:
+        result = JobResult(ok=False, error=f"{type(error).__name__}: {error}")
+    stage.on_job_done(item, result, ctx)
+    item.state = request.on_done_state
+    applied = stage.step(item, ctx)
+    if isinstance(applied, StageOutcome) and applied.disposition is Disposition.RETRY:
+        item.state = MERGE
+    return applied
+
+
+def test_merge_cycle_dispatches_without_inline_github_calls(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """MERGE freezes its exact proof before any admission or mutation call."""
+
+    class InlineGitHubForbidden(FakeStageGitHub):
+        def __getattribute__(self, name: str) -> object:
+            if name in {
+                "gh_pr_state",
+                "pr_has_implementation_state_label",
+                "list_unresolved_review_threads",
+                "base_branch_requires_conversation_resolution",
+                "gh_pr_merge_readiness",
+                "merge_pr_if_head",
+            }:
+                raise AssertionError(f"GitHub call ran inline: {name}")
+            return super().__getattribute__(name)
+
+    item = _reviewed_item(make_work_item)
+    stage = MergeWaitStage()
+    ctx = make_ctx(github=InlineGitHubForbidden())
+
+    started = time.monotonic()
+    result = stage.step(item, ctx)
+    elapsed = time.monotonic() - started
+
+    assert isinstance(result, JobRequest)
+    assert isinstance(result.job, GitHubJob)
+    assert isinstance(result.job.request, RunMergeWaitCycleRequest)
+    assert result.job.request.reviewed_head_sha == "a" * 40
+    assert elapsed < 0.25
+
+
 def test_conditional_merge_succeeds_only_after_lifecycle_confirms_merged(
     make_ctx: Any, make_work_item: Any
 ) -> None:
@@ -107,7 +171,7 @@ def test_conditional_merge_succeeds_only_after_lifecycle_confirms_merged(
     ctx = make_ctx(github=github)
     ctx.config.enable_learn = False
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), ctx)
+    result = _complete_merge_cycle(MergeWaitStage(), _reviewed_item(make_work_item), ctx)
 
     assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -130,7 +194,7 @@ def test_mergeable_requestable_readiness_merges_successfully(
     ctx.config.enable_learn = False
     item = _reviewed_item(make_work_item)
 
-    result = MergeWaitStage().step(item, ctx)
+    result = _complete_merge_cycle(MergeWaitStage(), item, ctx)
 
     assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -154,7 +218,7 @@ def test_optional_failure_unstable_readiness_attempts_conditional_merge(
     ctx.config.enable_learn = False
     item = _reviewed_item(make_work_item)
 
-    result = MergeWaitStage().step(item, ctx)
+    result = _complete_merge_cycle(MergeWaitStage(), item, ctx)
 
     assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -184,13 +248,13 @@ def test_blocked_readiness_waits_before_the_first_conditional_merge(
     ctx.config.enable_learn = False
     item = _reviewed_item(make_work_item)
 
-    first = MergeWaitStage().step(item, ctx)
+    first = _complete_merge_cycle(MergeWaitStage(), item, ctx)
 
     assert first == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
     assert item.payload["retry_delay_s"] == 5.0
     assert github.merge_attempts == []
 
-    second = MergeWaitStage().step(item, ctx)
+    second = _complete_merge_cycle(MergeWaitStage(), item, ctx)
 
     assert second == StageOutcome(Disposition.FINISH_PASS, "merged")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -210,9 +274,11 @@ def test_readiness_wake_rechecks_the_head_before_a_conditional_merge(
     stage = MergeWaitStage()
     ctx = make_ctx(github=github)
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
 
-    result = stage.step(item, ctx)
+    result = _complete_merge_cycle(stage, item, ctx)
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
     assert github.merge_attempts == []
@@ -246,8 +312,10 @@ def test_readiness_wake_fails_closed_when_a_thread_appears_while_ci_is_pending(
     stage = MergeWaitStage()
     ctx = make_ctx(github=github)
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
-    assert stage.step(item, ctx) == StageOutcome(
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
         Disposition.FINISH_FAIL,
         "unresolved_review_threads",
     )
@@ -282,8 +350,10 @@ def test_readiness_wake_fails_closed_when_conversation_protection_is_removed(
     stage = MergeWaitStage()
     ctx = make_ctx(github=github)
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
-    assert stage.step(item, ctx) == StageOutcome(
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
         Disposition.FINISH_FAIL,
         "conversation_resolution_required",
     )
@@ -328,12 +398,12 @@ def test_minute_scale_readiness_wait_merges_once_when_github_becomes_ready(
     stage = MergeWaitStage()
 
     while now[0] < 10 * 60:
-        result = stage.step(item, ctx)
+        result = _complete_merge_cycle(stage, item, ctx)
         assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
         assert github.merge_attempts == []
         now[0] += item.payload["retry_delay_s"]
 
-    result = stage.step(item, ctx)
+    result = _complete_merge_cycle(stage, item, ctx)
 
     assert now[0] >= 10 * 60
     assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
@@ -353,7 +423,7 @@ def test_open_thread_immediately_before_merge_fails_back_without_put(
     github = LateThreadGitHub(states=[_open_pr()])
 
     item = _reviewed_item(make_work_item)
-    result = MergeWaitStage().step(item, make_ctx(github=github))
+    result = _complete_merge_cycle(MergeWaitStage(), item, make_ctx(github=github))
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "unresolved_review_threads")
     assert github.merge_attempts == []
@@ -368,7 +438,9 @@ def test_missing_conversation_resolution_policy_blocks_merge_put(
     """A branch without server-enforced conversation resolution cannot merge."""
     github = _ConditionalGitHub(conversation_resolution=conversation_resolution)
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "conversation_resolution_required")
     assert github.merge_attempts == []
@@ -389,7 +461,9 @@ def test_missing_admin_enforcement_policy_blocks_merge_put(
 
     github = NoAdminEnforcementGitHub()
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "conversation_resolution_required")
     assert github.merge_attempts == []
@@ -410,7 +484,9 @@ def test_unreadable_conversation_resolution_policy_blocks_merge_put(
 
     github = UnreadablePolicyGitHub()
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "conversation_resolution_unavailable")
     assert github.merge_attempts == []
@@ -453,7 +529,7 @@ def test_server_policy_rejects_thread_that_appears_after_local_thread_read(
     github = ServerRejectsLateThreadGitHub()
     item = _reviewed_item(make_work_item)
 
-    result = MergeWaitStage().step(item, make_ctx(github=github))
+    result = _complete_merge_cycle(MergeWaitStage(), item, make_ctx(github=github))
 
     assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
     assert item.payload["retry_delay_s"] == 5.0
@@ -466,7 +542,9 @@ def test_external_arm_blocks_conditional_merge_without_any_mutation(
     """An arm observed at final admission belongs to an external actor."""
     github = _ConditionalGitHub(states=[_open_pr(auto_merge_request={"enabledAt": "elsewhere"})])
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
     assert github.merge_attempts == []
@@ -479,7 +557,9 @@ def test_stale_proof_fails_back_without_revoking_a_label(
     """A stale process owns no later label and must only request fresh review."""
     github = _ConditionalGitHub(states=[_open_pr("b" * 40)])
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
     assert github.merge_attempts == []
@@ -517,7 +597,7 @@ def test_already_merged_retry_never_attempts_a_second_merge(
     ctx = make_ctx(github=github)
     ctx.config.enable_learn = False
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), ctx)
+    result = _complete_merge_cycle(MergeWaitStage(), _reviewed_item(make_work_item), ctx)
 
     assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
     assert github.merge_attempts == []
@@ -529,7 +609,9 @@ def test_already_merged_retry_preserves_post_merge_learning(
     """A retry that discovers a merge keeps the existing exactly-once learn path."""
     github = _ConditionalGitHub(states=[{"state": "MERGED"}])
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == Continue(next_state="LEARN_WAIT")
     assert github.merge_attempts == []
@@ -554,7 +636,7 @@ def test_ambiguous_transport_reconciles_a_merged_pr_without_duplicate_put(
     ctx = make_ctx(github=github)
     ctx.config.enable_learn = False
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), ctx)
+    result = _complete_merge_cycle(MergeWaitStage(), _reviewed_item(make_work_item), ctx)
 
     assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -577,7 +659,9 @@ def test_ambiguous_transport_head_drift_fails_back_without_label_mutation(
         ],
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -602,7 +686,9 @@ def test_ambiguous_transport_retries_only_after_delayed_same_head_read(
     )
     item = _reviewed_item(make_work_item)
 
-    result = MergeWaitStage().step(item, make_ctx(github=github, budget_fn=lambda _route: 2))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), item, make_ctx(github=github, budget_fn=lambda _route: 2)
+    )
 
     assert result == StageOutcome(Disposition.RETRY, "merge_not_ready")
     assert item.attempts["merge"] == 1
@@ -628,7 +714,9 @@ def test_ambiguous_transport_with_unreadable_reconciliation_is_terminal(
         ],
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "pr_state_unavailable")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -642,7 +730,7 @@ def test_restarted_merge_without_process_local_proof_fails_back_without_put(
     github = _ConditionalGitHub(states=[_open_pr()])
     item = make_work_item(stage=StageName.MERGE_WAIT, pr=12, state=MERGE)
 
-    result = MergeWaitStage().step(item, make_ctx(github=github))
+    result = _complete_merge_cycle(MergeWaitStage(), item, make_ctx(github=github))
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_missing")
     assert github.merge_attempts == []
@@ -666,7 +754,9 @@ def test_409_head_drift_fails_back_without_label_mutation(
         ],
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "reviewed_head_drift")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -696,7 +786,9 @@ def test_405_reenters_readiness_wait_without_a_second_conditional_put(
     )
     item = _reviewed_item(make_work_item)
 
-    result = MergeWaitStage().step(item, make_ctx(github=github, budget_fn=lambda _route: 2))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), item, make_ctx(github=github, budget_fn=lambda _route: 2)
+    )
 
     assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
     assert item.payload["retry_delay_s"] == 5.0
@@ -730,14 +822,14 @@ def test_persistent_405_unchanged_readiness_does_not_duplicate_the_put(
     stage = MergeWaitStage()
     ctx = make_ctx(github=github, budget_fn=lambda _route: 2)
 
-    first = stage.step(item, ctx)
+    first = _complete_merge_cycle(stage, item, ctx)
 
     assert first == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
     assert item.payload["retry_delay_s"] == 5.0
     assert item.attempts["merge"] == 1
     assert github.merge_attempts == [(12, "a" * 40)]
 
-    second = stage.step(item, ctx)
+    second = _complete_merge_cycle(stage, item, ctx)
 
     assert second == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
     assert item.payload["retry_delay_s"] == 10.0
@@ -786,21 +878,29 @@ def test_persistent_405_has_hooks_retries_only_after_readiness_changes(
     ctx = make_ctx(github=github, budget_fn=lambda _route: 2)
     ctx.config.enable_learn = False
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
     assert item.attempts["merge"] == 1
     assert github.merge_attempts == [(12, "a" * 40)]
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
     assert item.attempts["merge"] == 1
     assert github.merge_attempts == [(12, "a" * 40)]
 
     # A second unchanged HAS_HOOKS wake must remain non-mutating. This makes
     # the regression independent of the one-step in-call 405 reconciliation.
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
     assert item.attempts["merge"] == 1
     assert github.merge_attempts == [(12, "a" * 40)]
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.FINISH_PASS, "merged"
+    )
     assert item.attempts["merge"] == 2
     assert github.merge_attempts == [(12, "a" * 40), (12, "a" * 40)]
 
@@ -844,11 +944,15 @@ def test_fresh_same_head_proof_retries_a_prior_unstable_decline(
     ctx = make_ctx(github=github, budget_fn=lambda _route: 2)
     ctx.config.enable_learn = False
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.RETRY, "merge_readiness_wait"
+    )
 
     item.payload["reviewed_pr_proof_generation"] = 1
 
-    assert stage.step(item, ctx) == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert _complete_merge_cycle(stage, item, ctx) == StageOutcome(
+        Disposition.FINISH_PASS, "merged"
+    )
     assert github.merge_attempts == [(12, "a" * 40), (12, "a" * 40)]
 
 
@@ -878,7 +982,9 @@ def test_405_conflicting_or_dirty_readiness_is_terminal(
         ],
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_conflicting")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -902,7 +1008,9 @@ def test_409_reconciliation_external_arm_blocks_without_label_mutation(
         ],
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.BLOCKED, "auto_merge_already_armed")
     assert github.merge_attempts == [(12, "a" * 40)]
@@ -916,11 +1024,11 @@ def test_label_loss_or_non_main_base_prevents_the_conditional_request(
     label_lost = _ConditionalGitHub(labels=(False, False), states=[_open_pr()])
     wrong_base = _ConditionalGitHub(states=[_open_pr(base="release")])
 
-    assert MergeWaitStage().step(
-        _reviewed_item(make_work_item), make_ctx(github=label_lost)
+    assert _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=label_lost)
     ) == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
-    assert MergeWaitStage().step(
-        _reviewed_item(make_work_item), make_ctx(github=wrong_base)
+    assert _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=wrong_base)
     ) == StageOutcome(Disposition.FINISH_FAIL, "non_main_base")
     assert label_lost.merge_attempts == []
     assert wrong_base.merge_attempts == []
@@ -932,7 +1040,9 @@ def test_contradictory_implementation_labels_prevent_the_conditional_request(
     """A contradictory durable state is not an exclusive implementation approval."""
     github = _ConditionalGitHub(labels=(True, True), states=[_open_pr()])
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
     assert github.merge_attempts == []
@@ -947,7 +1057,7 @@ def test_review_prose_cannot_replace_a_missing_implementation_go_label(
     item = _reviewed_item(make_work_item)
     item.payload["review_feedback"] = "Verdict: GO"
 
-    result = MergeWaitStage().step(item, make_ctx(github=github))
+    result = _complete_merge_cycle(MergeWaitStage(), item, make_ctx(github=github))
 
     assert result == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
     assert github.merge_attempts == []
@@ -968,7 +1078,9 @@ def test_200_without_merged_true_is_terminal(make_ctx: Any, make_work_item: Any)
         ]
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_not_merged")
 
@@ -998,12 +1110,12 @@ def test_readiness_wait_allows_one_full_ci_restart_with_a_bounded_deadline(
     )
 
     for _ in range(33):
-        result = stage.step(item, ctx)
+        result = _complete_merge_cycle(stage, item, ctx)
         assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
         assert github.merge_attempts == []
         now[0] += item.payload["retry_delay_s"]
 
-    result = stage.step(item, ctx)
+    result = _complete_merge_cycle(stage, item, ctx)
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_readiness_timeout")
     assert github.merge_attempts == []
@@ -1033,9 +1145,8 @@ def test_requestable_readiness_honors_an_existing_matching_deadline_without_puts
         }
     )
 
-    result = MergeWaitStage().step(
-        item,
-        make_ctx(github=github, now_fn=lambda: now),
+    result = _complete_merge_cycle(
+        MergeWaitStage(), item, make_ctx(github=github, now_fn=lambda: now)
     )
 
     assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_readiness_timeout")
@@ -1066,9 +1177,8 @@ def test_readiness_wait_resets_its_deadline_for_a_fresh_reviewed_head(
         }
     )
 
-    result = MergeWaitStage().step(
-        item,
-        make_ctx(github=github, now_fn=lambda: 100.0),
+    result = _complete_merge_cycle(
+        MergeWaitStage(), item, make_ctx(github=github, now_fn=lambda: 100.0)
     )
 
     assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
@@ -1100,9 +1210,8 @@ def test_readiness_wait_resets_for_a_fresh_proof_of_the_same_head(
         }
     )
 
-    result = MergeWaitStage().step(
-        item,
-        make_ctx(github=github, now_fn=lambda: 100.0),
+    result = _complete_merge_cycle(
+        MergeWaitStage(), item, make_ctx(github=github, now_fn=lambda: 100.0)
     )
 
     assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
@@ -1124,7 +1233,9 @@ def test_unknown_mergeability_waits_without_a_conditional_put(
         }
     )
 
-    result = MergeWaitStage().step(_reviewed_item(make_work_item), make_ctx(github=github))
+    result = _complete_merge_cycle(
+        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+    )
 
     assert result == StageOutcome(Disposition.RETRY, "merge_readiness_wait")
     assert github.merge_attempts == []

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -145,7 +145,7 @@ def test_merge_cycle_dispatches_without_inline_github_calls(
                 "gh_pr_merge_readiness",
                 "merge_pr_if_head",
             }:
-                raise AssertionError(f"GitHub call ran inline: {name}")
+                raise AttributeError(f"GitHub call ran inline: {name}")
             return super().__getattribute__(name)
 
     item = _reviewed_item(make_work_item)

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -1565,7 +1565,7 @@ class TestReviewFlowWithFakePool:
 
         pool = FakeWorkerPool()
         pool.script(JobResult(ok=True, value=_verdict("GO")))
-        handle = pool.submit(request.job, request.on_done_state)  # type: ignore[arg-type]
+        handle = pool.submit(request.job, request.on_done_state)
         done_handle, done_result = pool.completion_q.get_nowait()
         assert done_handle is handle
         assert not done_result.interrupted  # on_job_done contract precondition
@@ -1612,7 +1612,7 @@ class TestReviewFlowWithFakePool:
                 item.state = result.next_state
                 continue
             if isinstance(result, JobRequest):
-                pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+                pool.submit(result.job, result.on_done_state)
                 _handle, job_result = pool.completion_q.get_nowait()
                 assert not job_result.interrupted
                 stage.on_job_done(item, job_result, ctx)

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -1119,7 +1119,7 @@ class TestPlanningFlowWithFakePool:
                 item.state = result.next_state
                 continue
             if isinstance(result, JobRequest):
-                pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+                pool.submit(result.job, result.on_done_state)
                 _handle, job_result = pool.completion_q.get_nowait()
                 assert not job_result.interrupted
                 stage.on_job_done(item, job_result, ctx)

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -7,6 +7,7 @@ import json
 import sys
 import tarfile
 import threading
+import time
 from collections import deque
 from contextlib import nullcontext
 from pathlib import Path
@@ -16,6 +17,13 @@ from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation.pipeline.github_jobs import (
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    GitHubJob,
+    PrReviewReconciled,
+    ReconcilePrReviewRequest,
+)
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
@@ -57,6 +65,7 @@ from hephaestus.automation.pipeline.stages.pr_review import (
 )
 from hephaestus.automation.pipeline.work_item import ItemKind
 from hephaestus.automation.pipeline.worker_pool import WorkerPool
+from hephaestus.automation.pipeline_github_jobs import PipelineGitHubJobRunner
 from hephaestus.automation.review_audit import ReviewAudit, parse_review_audit
 from hephaestus.automation.review_journal import IssueComment
 from hephaestus.automation.state_labels import STATE_SKIP
@@ -86,13 +95,122 @@ def _invalid_audit() -> ReviewAudit:
     )
 
 
+def test_pr_review_post_dispatches_without_inline_github_calls(
+    make_ctx: Any,
+    make_work_item: Any,
+) -> None:
+    """POST freezes one reconciliation request within a small dispatch bound."""
+
+    class InlineGitHubForbidden:
+        def list_unresolved_review_threads(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub thread read ran inline")
+
+        def reviewer_validation_receipts(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub receipt read ran inline")
+
+        def pr_review_context(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub metadata read ran inline")
+
+        def reconcile_reviewer_validated_threads(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub reconciliation ran inline")
+
+        def post_review_threads(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub review publication ran inline")
+
+    item = make_work_item(issue=3, pr=7, state="POST")
+    item.payload.update(
+        {
+            "reviewed_pr_head_sha": "a" * 40,
+            "review_audit": _valid_audit(),
+            "review_threads": [],
+            "pr_diff": "diff --git a/a.py b/a.py",
+        }
+    )
+    stage = PrReviewStage()
+    ctx = make_ctx(github=InlineGitHubForbidden())
+
+    started = time.monotonic()
+    result = stage.step(item, ctx)
+    elapsed = time.monotonic() - started
+
+    assert isinstance(result, JobRequest)
+    assert isinstance(result.job, GitHubJob)
+    assert isinstance(result.job.request, ReconcilePrReviewRequest)
+    assert result.job.request.reviewed_head_sha == "a" * 40
+    assert result.job.request.findings.thaw() == []
+    assert elapsed < 0.25
+
+    stage.on_job_done(
+        item,
+        JobResult(
+            ok=True,
+            value=PrReviewReconciled(
+                request=result.job.request,
+                action="apply",
+                posted_receipts=FrozenJson.snapshot([]),
+                unresolved_threads=FrozenJson.snapshot([]),
+                remediation_threads=FrozenJson.snapshot([]),
+            ),
+        ),
+        ctx,
+    )
+    assert item.state == "POST"
+    item.state = result.on_done_state
+    assert stage.step(item, ctx) == Continue(next_state="EVAL")
+
+
+def test_pr_review_recovery_handoff_dispatches_without_inline_github_calls(
+    make_ctx: Any,
+    make_work_item: Any,
+) -> None:
+    """Recovery freezes the exact handoff before any GitHub state read or reply."""
+
+    class InlineGitHubForbidden:
+        def gh_pr_state(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub head read ran inline")
+
+        def post_implementation_thread_replies(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("GitHub reply post ran inline")
+
+    item = make_work_item(issue=3, pr=7, state="EVAL")
+    item.payload["pending_implementation_reply_handoff"] = {
+        "head_sha": "a" * 40,
+        "batch_nonce": "b" * 32,
+        "threads": [
+            {
+                "id": "thread-1",
+                "path": "a.py",
+                "line": 1,
+                "side": "RIGHT",
+                "body": "fix",
+                "comments": [{"id": "comment-1", "body": "fix"}],
+            }
+        ],
+        "replies": {"thread-1": "Fixed."},
+    }
+    stage = PrReviewStage()
+    ctx = make_ctx(github=InlineGitHubForbidden())
+
+    assert stage.step(item, ctx) == Continue(next_state="RECOVERY_REPLY_WAIT")
+    item.state = "RECOVERY_REPLY_WAIT"
+    started = time.monotonic()
+    result = stage.step(item, ctx)
+    elapsed = time.monotonic() - started
+
+    assert isinstance(result, JobRequest)
+    assert isinstance(result.job, GitHubJob)
+    assert isinstance(result.job.request, DeliverReplyHandoffRequest)
+    assert result.job.request.handoff.thaw() == item.payload["pending_implementation_reply_handoff"]
+    assert elapsed < 0.25
+
+
 def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int = 80) -> Any:
     """Drive a stage through the canonical FakeWorkerPool until an outcome."""
     entry = stage.on_enter(item, ctx)
     if entry is not None:
         return entry
     for _ in range(max_steps):
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
         if isinstance(result, Continue):
             item.state = result.next_state
             continue
@@ -117,7 +235,7 @@ def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int
                 )
                 item.state = result.on_done_state
                 continue
-            pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+            pool.submit(result.job, result.on_done_state)
             _handle, job_result = pool.completion_q.get_nowait()
             assert not job_result.interrupted  # on_job_done contract precondition
             stage.on_job_done(item, job_result, ctx)
@@ -125,6 +243,34 @@ def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int
             continue
         return result
     raise AssertionError("stage driver did not terminate")
+
+
+def _complete_github_job(stage: PrReviewStage, item: Any, ctx: Any) -> Any:
+    """Run one PR-review GitHub request only after its stage dispatch."""
+    request = stage.step(item, ctx)
+    if request == Continue(next_state="RECOVERY_REPLY_WAIT"):
+        item.state = "RECOVERY_REPLY_WAIT"
+        request = stage.step(item, ctx)
+    if not isinstance(request, JobRequest) or not isinstance(request.job, GitHubJob):
+        return request
+    try:
+        if isinstance(request.job.request, ReconcilePrReviewRequest):
+            receipt: object = PipelineGitHubJobRunner._reconcile_pr_review(
+                request.job.request,
+                ctx.github,
+            )
+        elif isinstance(request.job.request, DeliverReplyHandoffRequest):
+            from hephaestus.automation.pipeline.reply_handoff import attempt_reply_handoff
+
+            receipt = attempt_reply_handoff(request.job.request, ctx.github)
+        else:  # pragma: no cover - PR review owns two GitHub operations
+            raise AssertionError(f"unexpected request: {request.job.request!r}")
+        result = JobResult(ok=True, value=receipt)
+    except Exception as error:
+        result = JobResult(ok=False, error=f"{type(error).__name__}: {error}")
+    stage.on_job_done(item, result, ctx)
+    item.state = request.on_done_state
+    return stage.step(item, ctx)
 
 
 def _dispatch_review(stage: Any, item: Any, ctx: Any) -> JobRequest:
@@ -335,7 +481,7 @@ class TestPrReviewStageOnEnter:
         item.state = REVIEW_CHECKOUT_WAIT
         item.payload["review_checkout_ready"] = True
         item.payload["review_checkout_expected_head"] = "a" * 40
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert result == Continue(next_state="VALIDATE_WAIT")
         assert "review_audit" not in item.payload
@@ -482,7 +628,7 @@ class TestPrReviewStageOnEnter:
             }
         )
 
-        result = PrReviewStage().step(item, ctx)
+        result = _complete_github_job(PrReviewStage(), item, ctx)
 
         assert result == Continue(next_state="EVAL")
         assert 1001 not in github.reviews
@@ -544,7 +690,7 @@ class TestPrReviewStageStep:
         item.worktree = "/tmp/repo/review-worktree"
         item.branch = "review-branch"
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob)
@@ -1060,7 +1206,7 @@ class TestPrReviewStageStep:
         item.state = "VALIDATE_WAIT"
         stage.on_job_done(item, JobResult(ok=True, value='{"unaddressed": []}'), ctx)
         item.state = "POST"
-        post = stage.step(item, ctx)
+        post = _complete_github_job(stage, item, ctx)
         assert post == Continue(next_state="ADDRESS_WAIT")
         assert github.reviews[1001][0]["comments"] == item.payload["review_threads"]
 
@@ -1123,7 +1269,7 @@ class TestPrReviewStageStep:
             }
         )
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert isinstance(result, JobRequest)
         for key in (
@@ -2096,7 +2242,7 @@ class TestPrReviewStageStep:
         item.payload["review_threads"] = [dict(t) for t in item.payload["review_audit"].findings]
         item.payload["reviewed_pr_head_sha"] = "a" * 40
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert isinstance(result, Continue)
         assert result.next_state == "ADDRESS_WAIT"
@@ -2119,8 +2265,9 @@ class TestPrReviewStageStep:
             raw_feedback="Reviewer prose is untrusted.",
             valid=True,
         )
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert isinstance(result, Continue)
         assert result.next_state == "EVAL"
@@ -2148,8 +2295,9 @@ class TestPrReviewStageStep:
             raw_feedback="",
             valid=True,
         )
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
 
-        post_result = stage.step(item, ctx)
+        post_result = _complete_github_job(stage, item, ctx)
 
         assert post_result == Continue(next_state="ADDRESS_WAIT")
         assert 1001 not in github.reviews
@@ -2206,7 +2354,7 @@ class TestPrReviewStageStep:
         stage.on_job_done(item, JobResult(ok=True, value=audit), ctx)
         item.state = "POST"
         item.payload["reviewed_pr_head_sha"] = "a" * 40
-        assert stage.step(item, ctx) == Continue(next_state="ADDRESS_WAIT")
+        assert _complete_github_job(stage, item, ctx) == Continue(next_state="ADDRESS_WAIT")
         item.state = "ADDRESS_WAIT"
         result = stage.step(item, ctx)
 
@@ -2745,7 +2893,9 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=PartialGitHub(unresolved=[(2, 0)])))
+        result = _complete_github_job(
+            PrReviewStage(), item, make_ctx(github=PartialGitHub(unresolved=[(2, 0)]))
+        )
 
         assert result == Continue(next_state="REVIEW_WAIT")
         assert item.payload.get("review_audit_failure") is not True
@@ -2791,8 +2941,10 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        assert PrReviewStage().step(
-            item, make_ctx(github=BlockedReconciliationGitHub(unresolved=[(2, 0)]))
+        assert _complete_github_job(
+            PrReviewStage(),
+            item,
+            make_ctx(github=BlockedReconciliationGitHub(unresolved=[(2, 0)])),
         ) == Continue(next_state="REVIEW_WAIT")
 
     def test_unaddressed_external_bot_thread_routes_to_remediation(
@@ -2826,7 +2978,9 @@ class TestReviewThreadLifecycle:
         )
 
         stage = PrReviewStage()
-        assert stage.step(item, make_ctx(github=BotGitHub())) == Continue(next_state="ADDRESS_WAIT")
+        assert _complete_github_job(stage, item, make_ctx(github=BotGitHub())) == Continue(
+            next_state="ADDRESS_WAIT"
+        )
         assert item.payload["remediation_threads"] == [
             {
                 "thread_id": "bot-1",
@@ -2873,7 +3027,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        assert stage.step(item, make_ctx(github=RestartGitHub())) == Continue(
+        assert _complete_github_job(stage, item, make_ctx(github=RestartGitHub())) == Continue(
             next_state="ADDRESS_WAIT"
         )
         assert item.payload["remediation_threads"] == [
@@ -2976,7 +3130,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert result == Continue(next_state="ADDRESS_WAIT")
         assert len(github.posted_batches) == 1
@@ -3008,7 +3162,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="ADDRESS_WAIT")
         assert not any(name == "mark_pr_implementation_go" for name, _ in github.mutation_log)
@@ -3039,7 +3193,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="ADDRESS_WAIT")
         assert github.calls == []
@@ -3087,7 +3241,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="EVAL")
         assert github.posted_batches == []
@@ -3184,7 +3338,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="EVAL")
         assert github.posted == []
@@ -3253,7 +3407,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="ADDRESS_WAIT")
         assert github.posted == []
@@ -3319,7 +3473,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert result == Continue(next_state="VALIDATE_WAIT")
         assert github.reconciliation_calls == []
@@ -3382,7 +3536,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert result == Continue(next_state="VALIDATE_WAIT")
         assert github.reconciliation_calls == []
@@ -3459,7 +3613,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         if pr_state["headRefOid"] != "a" * 40:
             assert result == Continue(next_state="ADDRESS_WAIT")
@@ -3494,7 +3648,7 @@ class TestReviewThreadLifecycle:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="ADDRESS_WAIT")
         assert item.payload["remediation_threads"] == [
@@ -5322,10 +5476,14 @@ class TestRealCommitGate:
         )
 
         assert "pending_implementation_reply_handoff" in item.payload
-        assert github.reply_attempts == 1
+        assert github.reply_attempts == 0
 
         item.state = "EVAL"
-        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert _complete_github_job(stage, item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_retry"
+        )
+        assert github.reply_attempts == 1
+        assert _complete_github_job(stage, item, ctx) == Continue(next_state="REVIEW_WAIT")
         assert github.reply_attempts == 2
         assert "pending_implementation_reply_handoff" not in item.payload
         assert item.payload["push_no_commit"] is False
@@ -5352,7 +5510,7 @@ class TestRealCommitGate:
             "replies": {"thread-1": "Fixed the guard."},
         }
 
-        assert stage.step(item, make_ctx(github=github)) == StageOutcome(
+        assert _complete_github_job(stage, item, make_ctx(github=github)) == StageOutcome(
             Disposition.FINISH_FAIL, "implementation_reply_handoff_invalid"
         )
         assert github.mutation_log == []
@@ -5367,7 +5525,6 @@ class TestRealCommitGate:
                 super().__init__()
                 self._states = deque(
                     [
-                        {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None},
                         {"state": "OPEN", "headRefOid": "b" * 40, "autoMergeRequest": None},
                         {"state": "OPEN", "headRefOid": "a" * 40, "autoMergeRequest": None},
                     ]
@@ -5426,13 +5583,13 @@ class TestRealCommitGate:
         )
 
         item.state = "EVAL"
-        assert stage.step(item, ctx) == StageOutcome(
+        assert _complete_github_job(stage, item, ctx) == StageOutcome(
             Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
         )
         assert item.payload["retry_delay_s"] == 1.0
         assert github.reply_attempts == 0
 
-        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert _complete_github_job(stage, item, ctx) == Continue(next_state="REVIEW_WAIT")
         assert github.reply_attempts == 1
         assert "pending_implementation_reply_handoff" not in item.payload
 
@@ -5499,10 +5656,10 @@ class TestRealCommitGate:
 
         item.state = "EVAL"
         for _ in range(2):
-            assert stage.step(item, ctx) == StageOutcome(
+            assert _complete_github_job(stage, item, ctx) == StageOutcome(
                 Disposition.RETRY, "implementation_reply_handoff_visibility_wait"
             )
-        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert _complete_github_job(stage, item, ctx) == Continue(next_state="REVIEW_WAIT")
         assert github.reply_attempts == 0
         assert "pending_implementation_reply_handoff" not in item.payload
         assert github.mutation_log == []
@@ -5556,9 +5713,9 @@ class TestRealCommitGate:
             ctx,
         )
 
-        assert "pending_implementation_reply_handoff" not in item.payload
         item.state = "EVAL"
-        assert stage.step(item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert _complete_github_job(stage, item, ctx) == Continue(next_state="REVIEW_WAIT")
+        assert "pending_implementation_reply_handoff" not in item.payload
 
     def test_mixed_stale_and_transport_reply_batch_retries_only_ambiguous_thread(
         self, make_ctx: Any, make_work_item: Any
@@ -5625,18 +5782,15 @@ class TestRealCommitGate:
             ctx,
         )
 
+        item.state = "EVAL"
+        assert _complete_github_job(stage, item, ctx) == StageOutcome(
+            Disposition.RETRY, "implementation_reply_handoff_retry"
+        )
         handoff = item.payload["pending_implementation_reply_handoff"]
         assert [snapshot["id"] for snapshot in handoff["threads"]] == ["ambiguous-thread"]
         assert handoff["replies"] == {"ambiguous-thread": "Fixed ambiguous thread."}
 
-        item.state = "EVAL"
-        assert stage.step(item, ctx) == StageOutcome(
-            Disposition.RETRY, "implementation_reply_handoff_retry"
-        )
-        assert ctx.github.reply_batches == [
-            ("ambiguous-thread", "stale-thread"),
-            ("ambiguous-thread",),
-        ]
+        assert ctx.github.reply_batches == [("ambiguous-thread", "stale-thread")]
 
     def test_first_no_commit_retries_address_with_directive(
         self, make_ctx: Any, make_work_item: Any
@@ -5815,8 +5969,9 @@ class TestAuditPublication:
             ' "detail": "still missing"}],'
             ' "wont_fix": [{"thread_id": "t2", "reason": "documented"}]}'
         )
+        item.payload["reviewed_pr_head_sha"] = "a" * 40
 
-        result = stage.step(item, ctx)
+        result = _complete_github_job(stage, item, ctx)
 
         assert isinstance(result, Continue)
         assert github.mutation_log == [("gh_pr_review_post", (1001, "COMMENT"))]
@@ -5883,7 +6038,7 @@ class TestAuditPublication:
             }
         )
 
-        result = PrReviewStage().step(item, make_ctx(github=github))
+        result = _complete_github_job(PrReviewStage(), item, make_ctx(github=github))
 
         assert result == Continue(next_state="EVAL")
         assert github.received_diff == item.payload["pr_diff"]

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -26,12 +26,14 @@ class _RecordingWorkerPool:
         completion_q: Any,
         lock_dir: Path | None = None,
         gh_extra_path_root: Path | None = None,
+        github_job_runner: Any = None,
     ) -> None:
         del lock_dir
         self.size = size
         self.shutdown_event = shutdown
         self.completion_q = completion_q
         self.gh_extra_path_root = gh_extra_path_root
+        self.github_job_runner = github_job_runner
 
 
 def _config(
@@ -69,6 +71,7 @@ def test_coordinator_uses_one_capacity_for_all_queues_and_worker_pool(
     assert coordinator.pool.size == capacity
     assert coordinator.pool.completion_q is coordinator.completion_q
     assert coordinator.pool.gh_extra_path_root is None
+    assert coordinator.pool.github_job_runner is not None
 
 
 def test_coordinator_passes_extra_gh_root_to_worker_pool(

--- a/tests/unit/automation/pipeline/test_backpressure_transitions.py
+++ b/tests/unit/automation/pipeline/test_backpressure_transitions.py
@@ -12,7 +12,15 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
-from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
+from hephaestus.automation.pipeline.github_jobs import GitHubJob
+from hephaestus.automation.pipeline.jobs import (
+    AgentJob,
+    BuildTestJob,
+    CompactJob,
+    GitJob,
+    JobHandle,
+    JobResult,
+)
 from hephaestus.automation.pipeline.queues import StageQueue
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.stages.base import JobRequest
@@ -100,12 +108,17 @@ class _AlwaysJob:
 class _PendingPool(FakeWorkerPool):
     """Record submissions while deliberately withholding completions."""
 
-    def submit(self, job: Any, on_done_state: StageName, **kwargs: Any) -> Any:
-        from hephaestus.automation.pipeline.jobs import JobHandle
-
+    def submit(
+        self,
+        job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob,
+        on_done_state: str | StageName,
+        *,
+        claim_key: str = "",
+        claim_stage: str = "",
+    ) -> JobHandle:
         handle = JobHandle(job=job, on_done_state=on_done_state)
         self.submitted.append(handle)
-        self.submitted_claims.append((kwargs.get("claim_key", ""), kwargs.get("claim_stage", "")))
+        self.submitted_claims.append((claim_key, claim_stage))
         return handle
 
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -27,6 +27,11 @@ from hephaestus.automation.pipeline.coordinator import (
     Coordinator,
     PipelineConfig,
 )
+from hephaestus.automation.pipeline.github_jobs import (
+    AppendReplyJournalRequest,
+    GitHubJob,
+    ReplyJournalAppended,
+)
 from hephaestus.automation.pipeline.jobs import (
     WORKTREE_MATERIALIZED_KEY,
     AgentJob,
@@ -87,6 +92,15 @@ class StubStage:
         self.calls.append(("job_done", result.ok))
 
 
+def _github_append_job(tmp_path: Path) -> tuple[GitHubJob, AppendReplyJournalRequest]:
+    """Build one valid typed GitHub job for coordinator completion tests."""
+    marker = (
+        f"<!-- hephaestus-implementation-reply-handoff:pr=7:head={'a' * 40}:batch={'b' * 32} -->"
+    )
+    request = AppendReplyJournalRequest(3, marker, f'{marker}\n<!-- {{"format":1}} -->')
+    return GitHubJob("repo-a", tmp_path.resolve(), request, "append"), request
+
+
 def make_coordinator(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -131,6 +145,69 @@ def _issue_item(
     issue: int = 1, stage: StageName = StageName.PLANNING, repo: str = "repo-a"
 ) -> WorkItem:
     return WorkItem(repo=repo, kind=ItemKind.ISSUE, issue=issue, stage=stage, state="ENTER")
+
+
+def test_github_receipt_applies_before_on_done_state_and_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The coordinator calls receipt application while the submitting state is intact."""
+    coordinator, _pool, _github = make_coordinator(tmp_path, monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    class ReceiptStage(StubStage):
+        def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+            del result, ctx
+            calls.append(("on_job_done", item.state))
+
+        def step(self, item: WorkItem, ctx: Any) -> StageOutcome:
+            del ctx
+            calls.append(("step", item.state))
+            return StageOutcome(Disposition.FINISH_FAIL, "receipt_applied")
+
+    coordinator.stages[StageName.PR_REVIEW] = ReceiptStage()
+    item = _issue_item(3, StageName.PR_REVIEW)
+    item.state = "POST"
+    job, request = _github_append_job(tmp_path)
+    handle = JobHandle(job=job, on_done_state="POST_APPLY")
+    coordinator.in_flight[handle] = item
+    coordinator.inflight_per_repo[item.repo] = 1
+
+    coordinator._handle_completion(
+        handle,
+        JobResult(ok=True, value=ReplyJournalAppended(request=request)),
+    )
+
+    assert calls == [("on_job_done", "POST"), ("step", "POST_APPLY")]
+
+
+def test_interrupted_github_job_never_applies_a_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An interrupted operation remains resumable in its submitting state."""
+    coordinator, _pool, _github = make_coordinator(tmp_path, monkeypatch)
+    stage = StubStage()
+    coordinator.stages[StageName.PR_REVIEW] = stage
+    item = _issue_item(3, StageName.PR_REVIEW)
+    item.state = "POST"
+    job, _request = _github_append_job(tmp_path)
+    handle = JobHandle(job=job, on_done_state="POST_APPLY")
+    coordinator.in_flight[handle] = item
+    coordinator.inflight_per_repo[item.repo] = 1
+
+    coordinator._handle_completion(
+        handle,
+        JobResult(ok=False, interrupted=True, error="shutdown"),
+    )
+
+    assert not any(name == "job_done" for name, _value in stage.calls)
+    assert item.state == "POST"
+    assert item.result == ItemResult(
+        passed=False,
+        reason="resumable at pr_review",
+        final_stage=StageName.PR_REVIEW,
+    )
 
 
 class TestQuiescence:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -134,11 +134,13 @@ class TestWiring:
                 shutdown: Any,
                 completion_q: Any,
                 gh_extra_path_root: Path | None = None,
+                github_job_runner: Any = None,
             ) -> None:
                 created["size"] = size
                 created["shutdown"] = shutdown
                 created["completion_q"] = completion_q
                 created["gh_extra_path_root"] = gh_extra_path_root
+                created["github_job_runner"] = github_job_runner
 
         monkeypatch.setattr("hephaestus.automation.pipeline.worker_pool.WorkerPool", SpyPool)
         gh_root = tmp_path / "custom-gh"
@@ -156,6 +158,7 @@ class TestWiring:
         assert created["shutdown"] is coordinator.shutdown
         assert created["completion_q"] is coordinator.completion_q
         assert created["gh_extra_path_root"] == gh_root
+        assert created["github_job_runner"] is not None
 
     def test_run_pipeline_wires_accessor_and_runs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -605,7 +608,9 @@ class TestSubmitEdges:
 
         coordinator._submit(_item(), JobRequest(_agent_job(), on_done_state="V"))
 
-        assert pool.submitted[0].job.timeout_s == 1234
+        submitted = pool.submitted[0].job
+        assert isinstance(submitted, AgentJob)
+        assert submitted.timeout_s == 1234
 
     def test_git_job_bypasses_rate_gate(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_github_jobs.py
+++ b/tests/unit/automation/pipeline/test_github_jobs.py
@@ -1,0 +1,310 @@
+"""Contracts for the pipeline's closed GitHub worker boundary."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from hephaestus.automation.pipeline.github_jobs import (
+    AppendReplyJournalRequest,
+    DeliverReplyHandoffRequest,
+    FrozenJson,
+    GitHubJob,
+    MergeWaitCycleCompleted,
+    PrReviewReconciled,
+    ReconcilePrReviewRequest,
+    RecoverReplyJournalRequest,
+    ReplyHandoffAttempted,
+    ReplyJournalAppended,
+    ReplyJournalRecovered,
+    RunMergeWaitCycleRequest,
+)
+from hephaestus.automation.pipeline.reply_handoff import (
+    implementation_reply_handoff,
+    implementation_reply_handoff_journal_entry,
+)
+from hephaestus.automation.review_journal import IssueComment
+
+
+def test_frozen_json_is_detached_from_sources_and_thawed_values() -> None:
+    """Mutable GitHub data cannot cross or mutate the worker boundary."""
+    try:
+        module = importlib.import_module("hephaestus.automation.pipeline.github_jobs")
+    except ModuleNotFoundError:
+        pytest.fail("the typed GitHub worker boundary does not exist", pytrace=False)
+
+    frozen_json = module.FrozenJson
+    source: list[dict[str, Any]] = [{"id": "thread-1", "comments": [{"body": "original"}]}]
+
+    snapshot = frozen_json.snapshot(source)
+    source[0]["comments"][0]["body"] = "source changed"
+    first_thaw = cast(list[dict[str, Any]], snapshot.thaw())
+    first_thaw[0]["comments"][0]["body"] = "thaw changed"
+
+    assert snapshot.thaw() == [{"comments": [{"body": "original"}], "id": "thread-1"}]
+
+
+def test_runner_dispatches_append_with_a_fresh_accessor_per_job(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker requests never share the coordinator or another job's client."""
+    try:
+        module = importlib.import_module("hephaestus.automation.pipeline_github_jobs")
+    except ModuleNotFoundError:
+        pytest.fail("the production typed GitHub runner does not exist", pytrace=False)
+
+    clients: list[object] = []
+    appends: list[tuple[int, str, str]] = []
+
+    class FakePipelineGitHub:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            clients.append(self)
+
+        def append_issue_comment(self, issue: int, marker: str, body: str) -> None:
+            appends.append((issue, marker, body))
+
+    monkeypatch.setattr(module, "PipelineGitHub", FakePipelineGitHub)
+    marker = (
+        f"<!-- hephaestus-implementation-reply-handoff:pr=7:head={'a' * 40}:batch={'b' * 32} -->"
+    )
+    request = AppendReplyJournalRequest(
+        issue_number=3,
+        marker=marker,
+        body=f'{marker}\n<!-- {{"format":1}} -->',
+    )
+    job = GitHubJob(
+        repo="example",
+        repo_root=tmp_path.resolve(),
+        request=request,
+        descr="append journal",
+    )
+    runner = module.PipelineGitHubJobRunner(org="example-org", dry_run=False)
+
+    first = runner.run(job)
+    second = runner.run(job)
+
+    assert first == ReplyJournalAppended(request=request)
+    assert second == ReplyJournalAppended(request=request)
+    assert len(clients) == 2
+    assert clients[0] is not clients[1]
+    assert appends == [(3, marker, request.body), (3, marker, request.body)]
+
+
+def test_runner_recovers_version_one_journal_and_delivers_exact_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Recovery keeps the v1 payload and delivery's exact head/nonce/subset."""
+    module = importlib.import_module("hephaestus.automation.pipeline_github_jobs")
+    threads = [{"id": "thread-1", "comments": [{"id": "comment-1", "body": "fix it"}]}]
+    handoff = implementation_reply_handoff(
+        "a" * 40,
+        threads,
+        {"thread-1": "fixed"},
+        "b" * 32,
+    )
+    assert handoff is not None
+    journal = implementation_reply_handoff_journal_entry(7, handoff)
+    assert journal is not None
+    _marker, journal_body = journal
+    delivery_calls: list[tuple[object, ...]] = []
+
+    class FakePipelineGitHub:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def issue_comments(self, issue: int) -> list[IssueComment]:
+            assert issue == 3
+            return [IssueComment(body=journal_body, viewer_did_author=True)]
+
+        def gh_pr_state(self, pr: int) -> dict[str, object]:
+            assert pr == 7
+            return {"state": "OPEN", "autoMergeRequest": None, "headRefOid": "a" * 40}
+
+        def post_implementation_thread_replies(
+            self,
+            pr: int,
+            *,
+            expected_head_sha: str,
+            threads: list[dict[str, object]],
+            replies: dict[str, str],
+            batch_nonce: str,
+        ) -> object:
+            delivery_calls.append((pr, expected_head_sha, threads, replies, batch_nonce))
+            return SimpleNamespace(
+                replied_thread_ids=("thread-1",),
+                receipts=({"id": "thread-1"},),
+                retryable_thread_ids=(),
+                retryable=False,
+                visibility_lag=False,
+            )
+
+    monkeypatch.setattr(module, "PipelineGitHub", FakePipelineGitHub)
+    runner = module.PipelineGitHubJobRunner(org="example-org", dry_run=False)
+    recovery_request = RecoverReplyJournalRequest(
+        issue_number=3,
+        pr_number=7,
+        threads=FrozenJson.snapshot(threads),
+    )
+    recovery_job = GitHubJob(
+        repo="example",
+        repo_root=tmp_path.resolve(),
+        request=recovery_request,
+        descr="recover journal",
+    )
+
+    recovered = runner.run(recovery_job)
+    assert recovered == ReplyJournalRecovered(
+        request=recovery_request,
+        handoff=FrozenJson.snapshot(handoff),
+    )
+    assert recovered.handoff is not None
+    delivery_request = DeliverReplyHandoffRequest(
+        issue_number=3,
+        pr_number=7,
+        handoff=recovered.handoff,
+        visibility_retries=0,
+    )
+    delivered = runner.run(
+        GitHubJob(
+            repo="example",
+            repo_root=tmp_path.resolve(),
+            request=delivery_request,
+            descr="deliver replies",
+        )
+    )
+
+    assert delivered == ReplyHandoffAttempted(
+        request=delivery_request,
+        status="completed",
+        remaining_handoff=None,
+        visibility_retries=0,
+        retry_delay_s=None,
+    )
+    assert delivery_calls == [(7, "a" * 40, threads, {"thread-1": "fixed"}, "b" * 32)]
+
+
+def test_pr_reconciliation_reads_back_late_threads_before_apply(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A late thread is returned to the stage and therefore cannot permit GO."""
+    module = importlib.import_module("hephaestus.automation.pipeline_github_jobs")
+    finding = {
+        "path": "a.py",
+        "line": 3,
+        "side": "RIGHT",
+        "severity": "major",
+        "body": "guard None",
+    }
+    posted = {
+        **finding,
+        "id": "posted-thread",
+        "comments": [{"id": "posted-comment", "body": "guard None"}],
+    }
+    late = {
+        "id": "late-thread",
+        "path": "b.py",
+        "line": 4,
+        "side": "RIGHT",
+        "severity": "major",
+        "body": "late race",
+        "comments": [{"id": "late-comment", "body": "late race"}],
+    }
+
+    class FakePipelineGitHub:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.reads = 0
+
+        def list_unresolved_review_threads(self, _pr: int) -> list[dict[str, object]]:
+            self.reads += 1
+            return [] if self.reads < 3 else [posted, late]
+
+        def reviewer_validation_receipts(self, *_args: object, **_kwargs: object) -> list[object]:
+            return []
+
+        def pr_review_context(self, _pr: int) -> dict[str, str]:
+            return {
+                "pr_head_sha": "a" * 40,
+                "pr_title": "fix: example",
+                "pr_description": "body",
+            }
+
+        def post_review_threads(self, *_args: object, **_kwargs: object) -> list[dict[str, object]]:
+            return [posted]
+
+    monkeypatch.setattr(module, "PipelineGitHub", FakePipelineGitHub)
+    request = ReconcilePrReviewRequest(
+        pr_number=7,
+        reviewed_head_sha="a" * 40,
+        validated_receipt_fingerprints=None,
+        validated_metadata_fingerprint=None,
+        resolved_thread_ids=(),
+        feedback=FrozenJson.snapshot({}),
+        findings=FrozenJson.snapshot([finding]),
+        review_diff="diff",
+    )
+    job = GitHubJob(
+        repo="example",
+        repo_root=tmp_path.resolve(),
+        request=request,
+        descr="reconcile review",
+    )
+
+    receipt = module.PipelineGitHubJobRunner("org", False).run(job)
+
+    assert isinstance(receipt, PrReviewReconciled)
+    assert receipt.action == "apply"
+    unresolved = cast(list[dict[str, object]], receipt.unresolved_threads.thaw())
+    remediation = cast(list[dict[str, object]], receipt.remediation_threads.thaw())
+    assert [thread["id"] for thread in unresolved] == [
+        "posted-thread",
+        "late-thread",
+    ]
+    assert len(remediation) == 2
+
+
+def test_runner_dispatches_merge_cycle_as_a_typed_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The fifth closed operation is dispatched without a callable escape hatch."""
+    module = importlib.import_module("hephaestus.automation.pipeline_github_jobs")
+    state_reads: list[int] = []
+
+    class FakePipelineGitHub:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def gh_pr_state(self, pr: int) -> dict[str, object]:
+            state_reads.append(pr)
+            return {"state": "MERGED", "mergedAt": "2026-08-04T00:00:00Z"}
+
+    monkeypatch.setattr(module, "PipelineGitHub", FakePipelineGitHub)
+    request = RunMergeWaitCycleRequest(
+        pr_number=7,
+        reviewed_head_sha="a" * 40,
+        proof_generation=2,
+        declined_readiness_fingerprint=None,
+    )
+
+    receipt = module.PipelineGitHubJobRunner("org", False).run(
+        GitHubJob(
+            repo="example",
+            repo_root=tmp_path.resolve(),
+            request=request,
+            descr="merge wait cycle",
+        )
+    )
+
+    assert receipt == MergeWaitCycleCompleted(
+        request=request,
+        outcome="merged",
+        attempted=False,
+    )
+    assert state_reads == [7]

--- a/tests/unit/automation/pipeline/test_pipeline_architecture.py
+++ b/tests/unit/automation/pipeline/test_pipeline_architecture.py
@@ -1,12 +1,11 @@
-"""Architecture invariant: worker code performs zero GitHub API mutations.
+"""Architecture invariants for coordinator and closed GitHub worker access.
 
 Models tests/unit/automation/test_ci_driver_architecture.py. Enforces via AST
 walk that pipeline/* modules never import or call github_api mutator functions,
 with an explicit allowlist for documented interim offenders awaiting refactor.
-Worker-side modules (worker_pool.py, jobs.py) are held to a stricter bar: they
-may not import ``hephaestus.automation.github_api`` or
-``hephaestus.automation.pr_manager`` AT ALL, in any form — this also catches
-non-obvious mutators such as ``skip_epics``, ``gh_call``, and ``run``.
+The generic worker modules remain implementation-neutral. GitHub worker I/O is
+admitted only through frozen closed requests and the sole production runner,
+which constructs a fresh repository-scoped accessor for every job.
 
 Caveat: this is a static, import/attribute-level guard. Subprocess-level ``gh``
 calls (e.g. building a ``["gh", ...]`` argv and running it directly) are OUT OF
@@ -19,10 +18,26 @@ PipelineGitHub mapping tests.
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
+from dataclasses import fields, is_dataclass
 from pathlib import Path
+from typing import Any, get_args, get_origin, get_type_hints
 
 import hephaestus
 import hephaestus.automation.github_api as github_api
+from hephaestus.automation.pipeline.github_jobs import (
+    AppendReplyJournalRequest,
+    DeliverReplyHandoffRequest,
+    GitHubJob,
+    MergeWaitCycleCompleted,
+    PrReviewReconciled,
+    ReconcilePrReviewRequest,
+    RecoverReplyJournalRequest,
+    ReplyHandoffAttempted,
+    ReplyJournalAppended,
+    ReplyJournalRecovered,
+    RunMergeWaitCycleRequest,
+)
 
 _PIPELINE = Path(hephaestus.__file__).parent / "automation" / "pipeline"
 _AUTOMATION = _PIPELINE.parent
@@ -104,11 +119,11 @@ def _forbidden_module_imports(path: Path) -> set[str]:
     return hits
 
 
-def test_no_worker_module_imports_github_mutators() -> None:
+def test_pipeline_modules_do_not_import_github_api_mutators_directly() -> None:
     """Ensure pipeline modules (recursively) do not import/call github_api mutators.
 
-    Workers execute on thread pool with no coordinator access; all GitHub
-    state changes must go through the coordinator to maintain consistency.
+    Stage code uses the neutral StageGitHub contract; worker GitHub operations
+    live in the repository-scoped production dispatcher outside this package.
     Subprocess-level ``gh`` invocations are out of scope for this AST guard.
     """
     violations = []
@@ -119,7 +134,7 @@ def test_no_worker_module_imports_github_mutators() -> None:
         if offenders:
             violations.append(f"{py.name}: {sorted(offenders)}")
 
-    assert not violations, "worker code must not call github_api mutators:\n" + "\n".join(
+    assert not violations, "pipeline code must not call github_api mutators:\n" + "\n".join(
         violations
     )
 
@@ -142,6 +157,70 @@ def test_worker_side_modules_never_import_github_api_or_pr_manager() -> None:
     assert not violations, (
         "worker-side modules must not import github_api/pr_manager:\n" + "\n".join(violations)
     )
+
+
+def test_github_worker_boundary_is_closed_frozen_and_non_callable() -> None:
+    """Requests cannot smuggle coordinator state, callables, or mutable kwargs."""
+    request_types = (
+        RecoverReplyJournalRequest,
+        AppendReplyJournalRequest,
+        DeliverReplyHandoffRequest,
+        ReconcilePrReviewRequest,
+        RunMergeWaitCycleRequest,
+    )
+    receipt_types = (
+        ReplyJournalRecovered,
+        ReplyJournalAppended,
+        ReplyHandoffAttempted,
+        PrReviewReconciled,
+        MergeWaitCycleCompleted,
+    )
+    assert {field.name for field in fields(GitHubJob)} == {
+        "repo",
+        "repo_root",
+        "request",
+        "descr",
+    }
+    assert vars(GitHubJob)["__dataclass_params__"].frozen
+    forbidden_origins = {list, dict, set, Callable}
+    for request_type in request_types:
+        assert is_dataclass(request_type)
+        assert vars(request_type)["__dataclass_params__"].frozen
+        for annotation in get_type_hints(request_type).values():
+            candidates = (annotation, *get_args(annotation))
+            assert Any not in candidates
+            assert not any(get_origin(candidate) in forbidden_origins for candidate in candidates)
+            assert not any(
+                getattr(candidate, "__name__", "") in {"WorkItem", "StageContext", "Queue"}
+                for candidate in candidates
+            )
+    for receipt_type in receipt_types:
+        assert is_dataclass(receipt_type)
+        assert vars(receipt_type)["__dataclass_params__"].frozen
+
+
+def test_worker_pool_does_not_import_the_github_implementation() -> None:
+    """The generic dispatcher depends only on the typed runner protocol."""
+    tree = ast.parse((_PIPELINE / "worker_pool.py").read_text(encoding="utf-8"))
+    imported = {node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)}
+    assert not any(
+        module.endswith("pipeline_github") or module.endswith("pipeline_github_jobs")
+        for module in imported
+    )
+
+
+def test_worker_runner_is_the_only_worker_module_constructing_pipeline_github() -> None:
+    """Every closed job gets its accessor at the sole production gateway."""
+    runner = _AUTOMATION / "pipeline_github_jobs.py"
+    tree = ast.parse(runner.read_text(encoding="utf-8"), filename=str(runner))
+    constructors = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "PipelineGitHub"
+    ]
+    assert len(constructors) == 1
 
 
 def test_mutator_set_is_non_empty() -> None:

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -20,9 +20,15 @@ from hephaestus.automation.pipeline.coordinator import (
     Coordinator,
     PipelineConfig,
 )
+from hephaestus.automation.pipeline.github_jobs import (
+    GitHubJob,
+    MergeWaitCycleCompleted,
+    RunMergeWaitCycleRequest,
+)
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.stages.base import ConditionalMergeResult
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline_github_jobs import PipelineGitHubJobRunner
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -221,6 +227,15 @@ class TestRetryDelayConsumption:
         github = NotReadyGitHub()
         coordinator.github = github
         coordinator._ctx_cache.clear()
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+
+        class Runner:
+            def run(self, job: GitHubJob) -> MergeWaitCycleCompleted:
+                assert isinstance(job.request, RunMergeWaitCycleRequest)
+                return PipelineGitHubJobRunner._run_merge_wait_cycle(job.request, github)
+
+        pool.github_job_runner = Runner()
         coordinator.config.budget_overrides["merge"] = 2
         item = WorkItem(
             repo="repo-a",
@@ -240,12 +255,14 @@ class TestRetryDelayConsumption:
         )
 
         coordinator._run_item(item)
+        coordinator._drain_completions()
 
         assert github.puts == 0
         assert len(coordinator.timers) == 1
         clock.now += 2.0
         coordinator._wake_timers()
         coordinator._drain_queues()
+        coordinator._drain_completions()
 
         assert github.puts == 0
         assert item.result is not None
@@ -292,6 +309,15 @@ class TestRetryDelayConsumption:
         github = AmbiguousGitHub()
         coordinator.github = github
         coordinator._ctx_cache.clear()
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+
+        class Runner:
+            def run(self, job: GitHubJob) -> MergeWaitCycleCompleted:
+                assert isinstance(job.request, RunMergeWaitCycleRequest)
+                return PipelineGitHubJobRunner._run_merge_wait_cycle(job.request, github)
+
+        pool.github_job_runner = Runner()
         coordinator.config.budget_overrides["merge"] = 2
         item = WorkItem(
             repo="repo-a",
@@ -304,6 +330,7 @@ class TestRetryDelayConsumption:
         )
 
         coordinator._run_item(item)
+        coordinator._drain_completions()
 
         assert github.puts == 1
         assert item.attempts["merge"] == 1
@@ -311,6 +338,7 @@ class TestRetryDelayConsumption:
         clock.now += 2.0
         coordinator._wake_timers()
         coordinator._drain_queues()
+        coordinator._drain_completions()
 
         assert github.puts == 2
         assert item.attempts["merge"] == 2

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -23,6 +23,11 @@ import pytest
 from hephaestus.automation import git_utils, subprocess_registry
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.automation.models import DEFAULT_STATE_DIR
+from hephaestus.automation.pipeline.github_jobs import (
+    AppendReplyJournalRequest,
+    GitHubJob,
+    ReplyJournalAppended,
+)
 from hephaestus.automation.pipeline.jobs import (
     WORKTREE_MATERIALIZED_KEY,
     AgentJob,
@@ -135,6 +140,193 @@ def test_shutdown_can_reap_without_marking_interrupted(
     pool.shutdown(mark_interrupted=False)
 
     assert not shutdown_event.is_set()
+
+
+def test_github_job_dispatches_once_through_injected_typed_runner(
+    shutdown_event: threading.Event,
+    completion_q: CompletionQueue,
+    tmp_path: Path,
+) -> None:
+    """GitHub jobs have one typed dispatch and no generic worker replay."""
+    marker = (
+        f"<!-- hephaestus-implementation-reply-handoff:pr=7:head={'a' * 40}:batch={'b' * 32} -->"
+    )
+    request = AppendReplyJournalRequest(
+        issue_number=3,
+        marker=marker,
+        body=f'{marker}\n<!-- {{"format":1}} -->',
+    )
+    job = GitHubJob(
+        repo="example",
+        repo_root=tmp_path.resolve(),
+        request=request,
+        descr="append journal",
+    )
+    calls: list[GitHubJob] = []
+
+    class Runner:
+        def run(self, submitted: GitHubJob) -> ReplyJournalAppended:
+            calls.append(submitted)
+            return ReplyJournalAppended(request=submitted.request)  # type: ignore[arg-type]
+
+    pool = WorkerPool(
+        size=1,
+        shutdown=shutdown_event,
+        completion_q=completion_q,
+        lock_dir=tmp_path / "locks",
+        github_job_runner=Runner(),
+    )
+    try:
+        result = pool._run(job)
+    finally:
+        pool.shutdown(mark_interrupted=False)
+
+    assert result.ok
+    assert result.value == ReplyJournalAppended(request=request)
+    assert calls == [job]
+
+
+def test_same_repo_github_jobs_are_serialized(
+    shutdown_event: threading.Event,
+    completion_q: CompletionQueue,
+    tmp_path: Path,
+) -> None:
+    """The explicit StageGitHub contract permits one in-flight job per repo."""
+    marker = (
+        f"<!-- hephaestus-implementation-reply-handoff:pr=7:head={'a' * 40}:batch={'b' * 32} -->"
+    )
+    request = AppendReplyJournalRequest(3, marker, f'{marker}\n<!-- {{"format":1}} -->')
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    active = 0
+    max_active = 0
+    guard = threading.Lock()
+
+    class Runner:
+        def run(self, submitted: GitHubJob) -> ReplyJournalAppended:
+            nonlocal active, max_active
+            with guard:
+                active += 1
+                max_active = max(max_active, active)
+                entered = first_entered if not first_entered.is_set() else second_entered
+                entered.set()
+            if entered is first_entered:
+                assert release_first.wait(timeout=2)
+            with guard:
+                active -= 1
+            return ReplyJournalAppended(request=submitted.request)  # type: ignore[arg-type]
+
+    pool = WorkerPool(
+        size=2,
+        shutdown=shutdown_event,
+        completion_q=completion_q,
+        lock_dir=tmp_path / "locks",
+        github_job_runner=Runner(),
+    )
+    jobs = [
+        GitHubJob("same-repo", tmp_path.resolve(), request, f"append-{index}") for index in range(2)
+    ]
+    try:
+        for job in jobs:
+            pool.submit(job, "done")
+        assert first_entered.wait(timeout=2)
+        assert not second_entered.wait(timeout=0.05)
+        release_first.set()
+        assert second_entered.wait(timeout=2)
+        completion_q.get(timeout=2)
+        completion_q.get(timeout=2)
+    finally:
+        release_first.set()
+        pool.shutdown(mark_interrupted=False)
+
+    assert max_active == 1
+
+
+def test_different_repo_github_jobs_may_run_concurrently(
+    shutdown_event: threading.Event,
+    completion_q: CompletionQueue,
+    tmp_path: Path,
+) -> None:
+    """Independent repositories do not share the worker-operation lock."""
+    marker = (
+        f"<!-- hephaestus-implementation-reply-handoff:pr=7:head={'a' * 40}:batch={'b' * 32} -->"
+    )
+    request = AppendReplyJournalRequest(3, marker, f'{marker}\n<!-- {{"format":1}} -->')
+    both_entered = threading.Event()
+    release = threading.Event()
+    active = 0
+    max_active = 0
+    guard = threading.Lock()
+
+    class Runner:
+        def run(self, submitted: GitHubJob) -> ReplyJournalAppended:
+            nonlocal active, max_active
+            with guard:
+                active += 1
+                max_active = max(max_active, active)
+                if active == 2:
+                    both_entered.set()
+            assert release.wait(timeout=2)
+            with guard:
+                active -= 1
+            return ReplyJournalAppended(request=submitted.request)  # type: ignore[arg-type]
+
+    pool = WorkerPool(
+        size=2,
+        shutdown=shutdown_event,
+        completion_q=completion_q,
+        lock_dir=tmp_path / "locks",
+        github_job_runner=Runner(),
+    )
+    try:
+        pool.submit(GitHubJob("repo-a", tmp_path.resolve(), request, "append-a"), "done")
+        pool.submit(GitHubJob("repo-b", tmp_path.resolve(), request, "append-b"), "done")
+        assert both_entered.wait(timeout=2)
+        release.set()
+        completion_q.get(timeout=2)
+        completion_q.get(timeout=2)
+    finally:
+        release.set()
+        pool.shutdown(mark_interrupted=False)
+
+    assert max_active == 2
+
+
+def test_failing_github_job_is_not_replayed_by_worker_pool(
+    shutdown_event: threading.Event,
+    completion_q: CompletionQueue,
+    tmp_path: Path,
+) -> None:
+    """Mutation ambiguity remains stage-owned and receives one failed result."""
+    marker = (
+        f"<!-- hephaestus-implementation-reply-handoff:pr=7:head={'a' * 40}:batch={'b' * 32} -->"
+    )
+    request = AppendReplyJournalRequest(3, marker, f'{marker}\n<!-- {{"format":1}} -->')
+    calls = 0
+
+    class Runner:
+        def run(self, submitted: GitHubJob) -> ReplyJournalAppended:
+            nonlocal calls
+            del submitted
+            calls += 1
+            raise OSError("ambiguous transport")
+
+    pool = WorkerPool(
+        size=1,
+        shutdown=shutdown_event,
+        completion_q=completion_q,
+        lock_dir=tmp_path / "locks",
+        github_job_runner=Runner(),
+    )
+    try:
+        result = pool._run(GitHubJob("repo", tmp_path.resolve(), request, "append"))
+    finally:
+        pool.shutdown(mark_interrupted=False)
+
+    assert not result.ok
+    assert "ambiguous transport" in (result.error or "")
+    assert calls == 1
 
 
 class TestWorkerPoolSubmitComplete:


### PR DESCRIPTION
Summary:
- move reply journal/reply delivery, PR-review reconciliation, and merge-wait admission behind typed worker jobs
- preserve exact-head, journal, receipt, late-thread, conditional-merge, and v1 recovery contracts
- add immutable request/receipt, concurrency, zero-inline-I/O, and dispatch-bound regression coverage

Verification:
- 7139 passed, 11 skipped, 5 deselected
- coverage 83.72%
- Ruff, formatting, MyPy, and diff checks pass

Closes #2633
