### PR TITLE
fix(automation): admit nested Codex worktrees and fail closed on tool errors

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -990,10 +990,9 @@ _CODEX_NESTED_SANDBOX_DIAGNOSTIC = (
     "automation loop outside the enclosing API sandbox; the child sandbox "
     "permissions were not broadened."
 )
-_CODEX_FATAL_TOOL_ITEM_TYPES = frozenset(
-    {"error", "file_change", "mcp_tool_call", "collab_tool_call"}
-)
 _CODEX_FAILED_TOOL_STATUSES = frozenset({"failed", "declined"})
+_CODEX_APP_SERVER_STREAM_LAG_PREFIX = "in-process app-server event stream lagged; dropped "
+_CODEX_APP_SERVER_STREAM_LAG_SUFFIX = " events"
 
 
 def _codex_json_objects(text: str) -> Iterable[dict[str, Any]]:
@@ -1023,6 +1022,19 @@ def _codex_error_message(value: object) -> str | None:
     return None
 
 
+def _is_codex_app_server_stream_lag(message: str) -> bool:
+    """Return whether *message* is Codex's nonfatal app-server lag notice."""
+    if not (
+        message.startswith(_CODEX_APP_SERVER_STREAM_LAG_PREFIX)
+        and message.endswith(_CODEX_APP_SERVER_STREAM_LAG_SUFFIX)
+    ):
+        return False
+    dropped_count = message[
+        len(_CODEX_APP_SERVER_STREAM_LAG_PREFIX) : -len(_CODEX_APP_SERVER_STREAM_LAG_SUFFIX)
+    ]
+    return dropped_count.isascii() and dropped_count.isdigit()
+
+
 def _codex_structured_failure(event: dict[str, Any]) -> str | None:
     """Return a failure description for a fatal Codex JSONL event."""
     event_type = event.get("type")
@@ -1048,9 +1060,13 @@ def _codex_structured_failure(event: dict[str, Any]) -> str | None:
             return output.strip()
         return None
     if item_type == "error":
-        return _codex_error_message(item) or "Codex error item"
-    if item_type in _CODEX_FATAL_TOOL_ITEM_TYPES and status in _CODEX_FAILED_TOOL_STATUSES:
-        return _codex_error_message(item) or f"{item_type} status={status}"
+        message = _codex_error_message(item)
+        if message is not None and _is_codex_app_server_stream_lag(message):
+            return None
+        return message or "Codex error item"
+    if status in _CODEX_FAILED_TOOL_STATUSES:
+        item_label = item_type if isinstance(item_type, str) else "item"
+        return _codex_error_message(item) or f"{item_label} status={status}"
     return None
 
 

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -106,6 +106,10 @@ class AgentRunResult:
     session_id: str | None = None
 
 
+class AgentExecutionError(RuntimeError):
+    """An agent CLI reported a fatal provider, sandbox, or tool failure."""
+
+
 class AgentCapability(StrEnum):
     """Provider capability names used by the provider-neutral parity contract."""
 
@@ -979,10 +983,21 @@ def _codex_base_cmd(
     return cmd
 
 
-def _parse_codex_json_events(text: str) -> tuple[str | None, str]:
-    """Extract session id and final text from Codex JSONL output."""
-    session_id: str | None = None
-    messages: list[str] = []
+_CODEX_NESTED_SANDBOX_MARKER = "sandbox_apply: Operation not permitted"
+_CODEX_NESTED_SANDBOX_DIAGNOSTIC = (
+    "codex_nested_sandbox_unsupported: Codex could not initialize its child "
+    "sandbox (sandbox_apply: Operation not permitted). Run the outer Hephaestus "
+    "automation loop outside the enclosing API sandbox; the child sandbox "
+    "permissions were not broadened."
+)
+_CODEX_FATAL_TOOL_ITEM_TYPES = frozenset(
+    {"error", "file_change", "mcp_tool_call", "collab_tool_call"}
+)
+_CODEX_FAILED_TOOL_STATUSES = frozenset({"failed", "declined"})
+
+
+def _codex_json_objects(text: str) -> Iterable[dict[str, Any]]:
+    """Yield JSON objects from Codex JSONL while ignoring non-object lines."""
     for line in text.splitlines():
         if not line.strip():
             continue
@@ -990,8 +1005,76 @@ def _parse_codex_json_events(text: str) -> tuple[str | None, str]:
             event: Any = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if not isinstance(event, dict):
+        if isinstance(event, dict):
+            yield event
+
+
+def _codex_error_message(value: object) -> str | None:
+    """Extract a short message from a structured Codex failure payload."""
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if not isinstance(value, dict):
+        return None
+    for key in ("message", "error", "detail", "reason"):
+        nested_message = _codex_error_message(value.get(key))
+        if nested_message is not None:
+            return nested_message
+    return None
+
+
+def _codex_structured_failure(event: dict[str, Any]) -> str | None:
+    """Return a failure description for a fatal Codex JSONL event."""
+    event_type = event.get("type")
+    if event_type == "error":
+        return _codex_error_message(event) or "unrecoverable Codex error"
+    if event_type == "turn.failed":
+        return _codex_error_message(event.get("error")) or "Codex turn failed"
+    if event_type != "item.completed":
+        return None
+
+    item = event.get("item")
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    status = item.get("status")
+    if item_type == "command_execution":
+        output = item.get("aggregated_output")
+        if (
+            status in _CODEX_FAILED_TOOL_STATUSES
+            and isinstance(output, str)
+            and _CODEX_NESTED_SANDBOX_MARKER.casefold() in output.casefold()
+        ):
+            return output.strip()
+        return None
+    if item_type == "error":
+        return _codex_error_message(item) or "Codex error item"
+    if item_type in _CODEX_FATAL_TOOL_ITEM_TYPES and status in _CODEX_FAILED_TOOL_STATUSES:
+        return _codex_error_message(item) or f"{item_type} status={status}"
+    return None
+
+
+def _codex_failure_diagnostic(stdout: str, stderr: str) -> str | None:
+    """Return a bounded fatal Codex diagnostic from structured failure channels."""
+    marker = _CODEX_NESTED_SANDBOX_MARKER.casefold()
+    if marker in stderr.casefold():
+        return _CODEX_NESTED_SANDBOX_DIAGNOSTIC
+
+    for event in _codex_json_objects(stdout):
+        failure = _codex_structured_failure(event)
+        if failure is None:
             continue
+        if marker in failure.casefold():
+            return _CODEX_NESTED_SANDBOX_DIAGNOSTIC
+        return f"codex_tool_or_provider_failure: {failure[:300]}"
+    return None
+
+
+def _parse_codex_json_events(text: str) -> tuple[str | None, str]:
+    """Extract session id and final text from Codex JSONL output."""
+    session_id: str | None = None
+    messages: list[str] = []
+    for event in _codex_json_objects(text):
         if event.get("type") == "session_meta":
             payload = event.get("payload")
             if isinstance(payload, dict) and isinstance(payload.get("id"), str):
@@ -1150,10 +1233,21 @@ def _run_codex_command(
                 output_path=Path(output_file.name),
                 process_tracker=process_tracker,
             )
+        except subprocess.CalledProcessError as exc:
+            diagnostic = _codex_failure_diagnostic(
+                _coerce_timeout_output(exc.stdout),
+                _coerce_timeout_output(exc.stderr),
+            )
+            if diagnostic is not None:
+                raise AgentExecutionError(diagnostic) from exc
+            raise
         except subprocess.TimeoutExpired as e:
             last_message = Path(output_file.name).read_text(encoding="utf-8").strip()
             stdout_text = _coerce_timeout_output(e.stdout)
             stderr_text = _coerce_timeout_output(e.stderr)
+            diagnostic = _codex_failure_diagnostic(stdout_text, stderr_text)
+            if diagnostic is not None:
+                raise AgentExecutionError(diagnostic) from e
             if not last_message:
                 raise
             session_id, _ = _parse_codex_json_events(stdout_text)
@@ -1164,6 +1258,9 @@ def _run_codex_command(
             )
         last_message = Path(output_file.name).read_text(encoding="utf-8")
 
+    diagnostic = _codex_failure_diagnostic(stdout_text, stderr_text)
+    if diagnostic is not None:
+        raise AgentExecutionError(diagnostic)
     session_id, event_message = _parse_codex_json_events(stdout_text)
     stdout = (last_message or event_message or stdout_text or "").strip()
     return AgentRunResult(stdout=stdout, stderr=stderr_text, session_id=session_id)

--- a/hephaestus/automation/pipeline/stages/pr_review_verification.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_verification.py
@@ -67,6 +67,20 @@ _NONHERMETIC_HOST_UNIT_TEST_PATHS = frozenset(
 # diff header, never from reviewer or GitHub prose.
 _PATH_HOST_VERIFICATION_SPECS: tuple[_HostVerificationSpec, ...] = (
     _HostVerificationSpec(
+        changed_path="tests/unit/automation/pipeline/test_worker_pool.py",
+        argv=(
+            "uv",
+            "run",
+            "pytest",
+            "-o",
+            "addopts=",
+            "tests/unit/automation/pipeline/test_worker_pool.py::TestAgentErrorHandling::test_codex_event_failure_is_explicit_agent_error",
+            "-q",
+            "--tb=short",
+        ),
+        descr="review_worker_pool_agent_execution_error",
+    ),
+    _HostVerificationSpec(
         changed_path="tests/performance/test_worker_pool_load.py",
         argv=(
             "uv",

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -31,7 +31,12 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TypeGuard, cast
 
-from hephaestus.agents.runtime import resolve_agent, resume_agent_session, run_agent_session
+from hephaestus.agents.runtime import (
+    AgentExecutionError,
+    resolve_agent,
+    resume_agent_session,
+    run_agent_session,
+)
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
 from hephaestus.automation.learn import compact_agent_session
 from hephaestus.automation.models import DEFAULT_STATE_DIR
@@ -133,6 +138,20 @@ _HOST_VERIFICATION_CPU_MAX_S = 240
 _HOST_VERIFICATION_PROCESS_HEADROOM = 64
 _HOST_VERIFICATION_POLL_S = 0.05
 _HOST_VERIFICATION_SETUP_TIMEOUT_S = 30
+
+
+def _agent_exception_result(exc: Exception) -> JobResult:
+    """Map provider-declared and unexpected agent exceptions to job results."""
+    if isinstance(exc, AgentExecutionError):
+        return JobResult(
+            ok=False,
+            error=f"agent_error: {exc!s}"[:_ERR_MAX],
+        )
+    logger.exception("Agent job raised, returning error result")
+    return JobResult(
+        ok=False,
+        error=f"{type(exc).__name__}: {exc!s}"[:_ERR_MAX],
+    )
 
 
 class _HostVerificationBoundaryError(RuntimeError):
@@ -1717,11 +1736,7 @@ class WorkerPool:
                 stderr_tail=(exc.stderr or "")[-_TAIL:],
             )
         except Exception as exc:
-            logger.exception("Agent job raised, returning error result")
-            return JobResult(
-                ok=False,
-                error=f"{type(exc).__name__}: {exc!s}"[:_ERR_MAX],
-            )
+            return _agent_exception_result(exc)
 
     @staticmethod
     def _run_compact(job: CompactJob) -> JobResult:

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -509,6 +509,17 @@ def test_run_codex_session_rejects_nested_sandbox_tool_failure_with_no_edits(
             },
             "collab_tool_call status=failed",
         ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "web_search_call",
+                    "status": "failed",
+                },
+            },
+            "web_search_call status=failed",
+        ),
     ],
 )
 def test_run_codex_session_rejects_structured_fatal_events(
@@ -657,6 +668,63 @@ def test_run_codex_session_allows_recovered_command_failure(tmp_path: Path) -> N
         )
 
     assert result.stdout == "Implemented the fix after correcting the test."
+
+
+def test_run_codex_session_allows_app_server_stream_lag_after_successful_edits(
+    tmp_path: Path,
+) -> None:
+    """A nonfatal app-server lag notice does not override turn completion."""
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "codex-session"}),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "item_1",
+                            "type": "file_change",
+                            "status": "completed",
+                            "changes": [{"path": "fixed.py", "kind": "update"}],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "item_2",
+                            "type": "error",
+                            "message": (
+                                "in-process app-server event stream lagged; dropped 17 events"
+                            ),
+                        },
+                    }
+                ),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=stdout,
+            final_message="Implemented and verified the fix.",
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        result = agent_runtime.run_codex_session(
+            "implement",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+    assert result.stdout == "Implemented and verified the fix."
 
 
 def test_codex_approval_args_uses_config_override_for_current_cli() -> None:

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -404,6 +404,261 @@ def test_run_codex_session_timeout_without_last_message_still_raises(tmp_path: P
             )
 
 
+def test_run_codex_session_rejects_nested_sandbox_tool_failure_with_no_edits(
+    tmp_path: Path,
+) -> None:
+    """A failed nested-worktree sandbox must not look like a no-edit success."""
+    worktree = tmp_path / "repo" / "build" / ".worktrees" / "issue-2634"
+    git_common_dir = tmp_path / "repo" / ".git"
+    worktree.mkdir(parents=True)
+    git_common_dir.mkdir(parents=True)
+    captured_cmd: list[str] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        captured_cmd.extend(cmd)
+        stdout = "\n".join(
+            [
+                '{"type":"thread.started","thread_id":"codex-session"}',
+                (
+                    '{"type":"item.completed","item":{"id":"item_1",'
+                    '"type":"command_execution","status":"failed","exit_code":-1,'
+                    '"aggregated_output":"sandbox_apply: Operation not permitted"}}'
+                ),
+                '{"type":"turn.completed","usage":{}}',
+            ]
+        )
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=stdout,
+            final_message="No edits were made.",
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch(
+            "hephaestus.agents.runtime._codex_extra_writable_dirs",
+            return_value=[git_common_dir],
+        ),
+        patch("subprocess.Popen", side_effect=fake_popen),
+        pytest.raises(
+            agent_runtime.AgentExecutionError,
+            match="codex_nested_sandbox_unsupported",
+        ),
+    ):
+        agent_runtime.run_codex_session(
+            "implement",
+            cwd=worktree,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+    assert captured_cmd[captured_cmd.index("--cd") + 1] == str(worktree)
+    assert captured_cmd[captured_cmd.index("--sandbox") + 1] == "workspace-write"
+    assert captured_cmd[captured_cmd.index("--add-dir") + 1] == str(git_common_dir)
+    assert "danger-full-access" not in captured_cmd
+
+
+@pytest.mark.parametrize(
+    ("event", "expected_detail"),
+    [
+        ({"type": "error", "message": "provider unavailable"}, "provider unavailable"),
+        (
+            {"type": "turn.failed", "error": {"message": "turn failed"}},
+            "turn failed",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {"id": "item_1", "type": "error", "message": "tool item failed"},
+            },
+            "tool item failed",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "file_change",
+                    "status": "failed",
+                    "changes": [],
+                },
+            },
+            "file_change status=failed",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "mcp_tool_call",
+                    "status": "failed",
+                    "error": {"message": "MCP unavailable"},
+                },
+            },
+            "MCP unavailable",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "collab_tool_call",
+                    "status": "failed",
+                },
+            },
+            "collab_tool_call status=failed",
+        ),
+    ],
+)
+def test_run_codex_session_rejects_structured_fatal_events(
+    tmp_path: Path,
+    event: dict[str, Any],
+    expected_detail: str,
+) -> None:
+    """Terminal provider and non-shell tool events are explicit failures."""
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=json.dumps(event),
+            final_message="No edits were made.",
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+        pytest.raises(
+            agent_runtime.AgentExecutionError,
+            match=f"codex_tool_or_provider_failure: {expected_detail}",
+        ),
+    ):
+        agent_runtime.run_codex_session(
+            "implement",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+
+def test_run_codex_session_rejects_nonzero_nested_sandbox_failure(tmp_path: Path) -> None:
+    """A nonzero Codex process should retain the actionable sandbox diagnosis."""
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout="",
+            proc_stderr="sandbox_apply: Operation not permitted",
+            final_message="No edits were made.",
+            returncode=1,
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+        pytest.raises(
+            agent_runtime.AgentExecutionError,
+            match="codex_nested_sandbox_unsupported",
+        ),
+    ):
+        agent_runtime.run_codex_session(
+            "implement",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+
+def test_run_codex_session_rejects_failure_before_timeout_recovered_no_edits(
+    tmp_path: Path,
+) -> None:
+    """A recovered final message cannot override an earlier fatal tool event."""
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        stdout = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "command_execution",
+                    "status": "failed",
+                    "aggregated_output": "sandbox_apply: Operation not permitted",
+                },
+            }
+        )
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=stdout,
+            final_message="No edits were made.",
+            hang=True,
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch.dict("os.environ", {"HEPH_CODEX_FINAL_MESSAGE_GRACE": "0"}),
+        patch("subprocess.Popen", side_effect=fake_popen),
+        pytest.raises(
+            agent_runtime.AgentExecutionError,
+            match="codex_nested_sandbox_unsupported",
+        ),
+    ):
+        agent_runtime.run_codex_session(
+            "implement",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+
+def test_run_codex_session_allows_recovered_command_failure(tmp_path: Path) -> None:
+    """A task command may fail before the agent successfully completes its work."""
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "item_1",
+                            "type": "command_execution",
+                            "status": "failed",
+                            "exit_code": 1,
+                            "aggregated_output": "one test failed",
+                        },
+                    }
+                ),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=stdout,
+            final_message="Implemented the fix after correcting the test.",
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        result = agent_runtime.run_codex_session(
+            "implement",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+    assert result.stdout == "Implemented the fix after correcting the test."
+
+
 def test_codex_approval_args_uses_config_override_for_current_cli() -> None:
     """Current Codex exposes approval policy through -c config overrides."""
     help_text = """

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1513,6 +1513,41 @@ class TestImplementBudget:
         assert result.disposition == Disposition.RETRY
         assert result.note == "agent_error"
 
+    def test_agent_tool_failure_with_no_diff_never_enters_no_commit_cleanup(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """A failed tool session cannot reach commit, skip, or branch cleanup."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2634, state="IMPLEMENT_WAIT")
+        reservation = {"branch": "2634-auto-impl", "base_sha": "a" * 40}
+        item.payload["_direct_scope_reservation"] = reservation
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error=(
+                    "agent_error: codex_nested_sandbox_unsupported: "
+                    "run the outer loop outside the enclosing API sandbox"
+                ),
+                stdout_tail="No edits were made; no diff exists.",
+            ),
+            ctx,
+        )
+        item.state = "TEST_WAIT"
+
+        outcome = stage.step(item, ctx)
+
+        assert outcome == StageOutcome(Disposition.RETRY, "agent_error")
+        assert item.payload["_direct_scope_reservation"] == reservation
+        assert "no_commits" not in item.payload
+        assert "_direct_scope_local_branch_cleanup" not in item.payload
+        assert github.mutation_log == []
+
     def test_implement_budget_exhaustion_finishes_failed(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1406,6 +1406,19 @@ class TestPrReviewStageStep:
                 ),
             ),
             (
+                "review_worker_pool_agent_execution_error",
+                (
+                    "uv",
+                    "run",
+                    "pytest",
+                    "-o",
+                    "addopts=",
+                    "tests/unit/automation/pipeline/test_worker_pool.py::TestAgentErrorHandling::test_codex_event_failure_is_explicit_agent_error",
+                    "-q",
+                    "--tb=short",
+                ),
+            ),
+            (
                 "review_stalled_consumer_verification",
                 (
                     "uv",

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -20,6 +20,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
+from hephaestus.agents.runtime import AgentExecutionError
 from hephaestus.automation import git_utils, subprocess_registry
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.automation.models import DEFAULT_STATE_DIR
@@ -1498,6 +1499,27 @@ class TestAgentErrorHandling:
         assert result.error == "rc=2"
         assert "partial stdout" in result.stdout_tail
         assert "nonretryable failure detail" in result.stderr_tail
+
+    def test_codex_event_failure_is_explicit_agent_error(self, pool: WorkerPool) -> None:
+        """Structured Codex failures cross the worker boundary as agent errors."""
+        job = _agent_job(agent="codex")
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="codex"),
+            patch(
+                f"{_WP}.run_agent_session",
+                side_effect=AgentExecutionError(
+                    "codex_nested_sandbox_unsupported: run the outer loop "
+                    "outside the enclosing API sandbox"
+                ),
+            ),
+        ):
+            result = pool._run_agent(job)
+
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.startswith("agent_error: codex_nested_sandbox_unsupported")
+        assert "outside the enclosing API sandbox" in result.error
 
     def test_generic_exception_converted_to_error_result(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool_agent_error_boundary.py
+++ b/tests/unit/automation/pipeline/test_worker_pool_agent_error_boundary.py
@@ -1,0 +1,62 @@
+"""Hermetic WorkerPool agent-error boundary regressions.
+
+The primary WorkerPool suite also exercises the host verifier's containment
+primitives, so immutable host validation excludes that module. Keep focused
+provider-boundary checks here so they can produce reviewed-head receipts.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+from hephaestus.agents.runtime import AgentExecutionError
+from hephaestus.automation.pipeline.jobs import AgentJob
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.worker_pool import WorkerPool
+
+_WORKER_POOL_MODULE = "hephaestus.automation.pipeline.worker_pool"
+
+
+def test_codex_agent_execution_error_is_explicit_at_worker_boundary(
+    completion_q: CompletionQueue,
+    tmp_path: Path,
+) -> None:
+    """Provider-declared Codex failures remain explicit agent errors."""
+    pool = WorkerPool(
+        size=1,
+        shutdown=threading.Event(),
+        completion_q=completion_q,
+        lock_dir=tmp_path / "locks",
+    )
+    job = AgentJob(
+        repo="test/repo",
+        issue=2634,
+        agent="codex",
+        model="sol",
+        prompt_builder=lambda: "test prompt",
+        cwd=tmp_path,
+        timeout_s=60,
+        descr="codex agent execution failure",
+    )
+
+    try:
+        with (
+            patch(f"{_WORKER_POOL_MODULE}.resolve_agent", return_value="codex"),
+            patch(
+                f"{_WORKER_POOL_MODULE}.run_agent_session",
+                side_effect=AgentExecutionError(
+                    "codex_nested_sandbox_unsupported: run the outer loop "
+                    "outside the enclosing API sandbox"
+                ),
+            ),
+        ):
+            result = pool._run_agent(job)
+    finally:
+        pool.shutdown(mark_interrupted=False)
+
+    assert result.ok is False
+    assert result.error is not None
+    assert result.error.startswith("agent_error: codex_nested_sandbox_unsupported")
+    assert "outside the enclosing API sandbox" in result.error


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2634.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2634

Generated by Hephaestus automation
