### PR TITLE
fix(pipeline): limit reseeding to discovery

### DIFF
--- a/hephaestus/automation/pipeline/coordinator_sources.py
+++ b/hephaestus/automation/pipeline/coordinator_sources.py
@@ -913,13 +913,20 @@ class SourceCoordinator(_CoordinatorHost):
         )
 
     def _reseed_if_converged(self) -> bool:
-        """Re-seed after full drain; False = stop (loops or zero-work exit).
+        """Re-seed repository discovery after full drain; False = stop.
 
         Mirrors the legacy zero-work early-exit (loop_runner
         ``_CONVERGENCE_PHASES``): when the just-finished pass produced zero
         actionable (non-repo, non-finished) work, the run converged — exit
         even if ``--loops`` remain.
+
+        Explicit ``--issues`` or ``--prs`` selections are a finite operator
+        scope, not a discovery source. Their stage queues own all retries and
+        fail-backs, so a completed pass must never recreate their cursors.
         """
+        if self.config.issues or self.config.prs:
+            logger.info("explicit issue/PR selection drained; skipping discovery re-seed")
+            return False
         if self._loops_run >= self.config.loops:
             logger.info("loop budget exhausted (%d/%d)", self._loops_run, self.config.loops)
             return False

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -20,8 +20,8 @@ Per tick (epic #1809 "Coordinator event loop"):
    RESUMABLE and never advance (``on_job_done`` is never called for them);
 4. drain queues DOWNSTREAM-FIRST (finished → merge_wait → ... → repo; finish
    work before admitting new) with admission control;
-5. fully drained: re-seed up to ``--loops`` with a zero-work convergence
-   exit; otherwise block on the completion queue.
+5. fully drained: re-seed discovery up to ``--loops``; explicit
+   ``--issues``/``--prs`` selections drain once; otherwise block or converge.
 
 ``_run_item`` drives ``on_enter``/``step`` until a ``JobRequest`` (park +
 submit) or a ``StageOutcome`` (route via ROUTES). Per-item ``try/except``: a

--- a/tests/unit/automation/pipeline/test_backpressure_seeding.py
+++ b/tests/unit/automation/pipeline/test_backpressure_seeding.py
@@ -116,10 +116,10 @@ def test_direct_issue_seeds_are_source_pulled_and_lossless_at_capacity_one(
     assert max(observed_occupancies) <= 1
 
 
-def test_direct_issue_source_restarts_for_each_configured_loop(
+def test_direct_issue_source_does_not_reseed_after_explicit_scope_drains(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The bounded cursor is recreated, rather than exhausted, on re-seeding."""
+    """Explicit ``--issues`` drain once even when the loop budget remains."""
     events: list[tuple[str, int]] = []
 
     def classify_direct_issue(issue: int, github: Any) -> IssueFacts:
@@ -161,11 +161,42 @@ def test_direct_issue_source_restarts_for_each_configured_loop(
     assert events == [
         ("classify", 101),
         ("complete", 101),
-        ("classify", 101),
-        ("complete", 101),
     ]
-    assert coordinator._loops_run == 2
-    assert len(coordinator.ledger) == 2
+    assert coordinator._loops_run == 1
+    assert len(coordinator.ledger) == 1
+
+
+@pytest.mark.parametrize("issues, prs", [([101], []), ([], [701])])
+def test_reseed_is_disabled_for_any_explicit_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    issues: list[int],
+    prs: list[int],
+) -> None:
+    """An explicit issue or PR selection never starts a discovery pass."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=issues,
+            prs=prs,
+            loops=2,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    coordinator._loops_run = 1
+    coordinator._pass_work_count = 1
+
+    def unexpected_reseed() -> int:
+        raise AssertionError("explicit selections must not be re-seeded")
+
+    monkeypatch.setattr(coordinator, "_seed_pass", unexpected_reseed)
+
+    assert coordinator._reseed_if_converged() is False
+    assert coordinator._loops_run == 1
 
 
 def test_direct_pr_seeds_are_source_pulled_and_lossless_at_capacity_one(


### PR DESCRIPTION
## Summary

- stop the coordinator from recreating explicitly selected issue or PR cursors after a full drain
- preserve `--loops` reseeding for repository and organization discovery scopes
- cover explicit issue and PR selection behavior

## Verification

- `uv run pytest tests/unit/automation/pipeline/test_backpressure_seeding.py -q --no-cov`
- `uv run pytest tests/unit/automation/test_automation_hotspot_architecture.py -q --no-cov`
- `uv run mypy hephaestus/automation/pipeline/coordinator_sources.py hephaestus/automation/pipeline/coordinator_types.py tests/unit/automation/pipeline/test_backpressure_seeding.py`
- `uv run ruff check hephaestus/automation/pipeline/coordinator_sources.py hephaestus/automation/pipeline/coordinator_types.py tests/unit/automation/pipeline/test_backpressure_seeding.py`
- `uv run ruff format --check hephaestus/automation/pipeline/coordinator_sources.py hephaestus/automation/pipeline/coordinator_types.py tests/unit/automation/pipeline/test_backpressure_seeding.py`
- full pre-push suite: 7,156 passed, 11 skipped, 5 deselected; 83.77% coverage

Closes #2638