### PR TITLE
fix(agents): allow Codex skills-budget notice

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -993,6 +993,8 @@ _CODEX_NESTED_SANDBOX_DIAGNOSTIC = (
 _CODEX_FAILED_TOOL_STATUSES = frozenset({"failed", "declined"})
 _CODEX_APP_SERVER_STREAM_LAG_PREFIX = "in-process app-server event stream lagged; dropped "
 _CODEX_APP_SERVER_STREAM_LAG_SUFFIX = " events"
+_CODEX_SKILLS_BUDGET_PREFIX = "Skill descriptions were shortened to fit the "
+_CODEX_SKILLS_BUDGET_MARKER = "% skills context budget."
 
 
 def _codex_json_objects(text: str) -> Iterable[dict[str, Any]]:
@@ -1035,6 +1037,21 @@ def _is_codex_app_server_stream_lag(message: str) -> bool:
     return dropped_count.isascii() and dropped_count.isdigit()
 
 
+def _is_codex_nonfatal_error_item(message: str) -> bool:
+    """Return whether Codex encodes a known informational notice as an error item."""
+    if _is_codex_app_server_stream_lag(message):
+        return True
+    if not message.startswith(_CODEX_SKILLS_BUDGET_PREFIX):
+        return False
+    percentage, marker, _guidance = message[len(_CODEX_SKILLS_BUDGET_PREFIX) :].partition(
+        _CODEX_SKILLS_BUDGET_MARKER
+    )
+    percentage_parts = percentage.split(".", maxsplit=1)
+    return bool(
+        marker and all(part and part.isascii() and part.isdigit() for part in percentage_parts)
+    )
+
+
 def _codex_structured_failure(event: dict[str, Any]) -> str | None:
     """Return a failure description for a fatal Codex JSONL event."""
     event_type = event.get("type")
@@ -1061,7 +1078,7 @@ def _codex_structured_failure(event: dict[str, Any]) -> str | None:
         return None
     if item_type == "error":
         message = _codex_error_message(item)
-        if message is not None and _is_codex_app_server_stream_lag(message):
+        if message is not None and _is_codex_nonfatal_error_item(message):
             return None
         return message or "Codex error item"
     if status in _CODEX_FAILED_TOOL_STATUSES:

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -479,6 +479,31 @@ def test_run_codex_session_rejects_nested_sandbox_tool_failure_with_no_edits(
                 "type": "item.completed",
                 "item": {
                     "id": "item_1",
+                    "type": "error",
+                    "message": "Skill descriptions failed to load: invalid context budget",
+                },
+            },
+            "Skill descriptions failed to load: invalid context budget",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "error",
+                    "message": (
+                        "Skill descriptions were shortened to fit the invalid% skills context "
+                        "budget."
+                    ),
+                },
+            },
+            "Skill descriptions were shortened to fit the invalid% skills context budget",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
                     "type": "file_change",
                     "status": "failed",
                     "changes": [],
@@ -725,6 +750,65 @@ def test_run_codex_session_allows_app_server_stream_lag_after_successful_edits(
         )
 
     assert result.stdout == "Implemented and verified the fix."
+
+
+@pytest.mark.parametrize(
+    "notice",
+    [
+        (
+            "Skill descriptions were shortened to fit the 2% skills context budget. "
+            "Codex can still see every skill, but some descriptions are shorter. "
+            "Disable unused skills or plugins to leave more room for the rest."
+        ),
+        (
+            "Skill descriptions were shortened to fit the 7.5% skills context budget. "
+            "Some descriptions use compact summaries."
+        ),
+    ],
+)
+def test_run_codex_session_allows_skills_budget_notice_after_successful_turn(
+    tmp_path: Path,
+    notice: str,
+) -> None:
+    """Skills-budget percentage and guidance changes do not discard final output."""
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "codex-session"}),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "item_1",
+                            "type": "error",
+                            "message": notice,
+                        },
+                    }
+                ),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=stdout,
+            final_message='{"grade":"A","summary":"Reviewed.","comments":[]}',
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        result = agent_runtime.run_codex_session(
+            "review",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="read-only",
+        )
+
+    assert result.stdout == '{"grade":"A","summary":"Reviewed.","comments":[]}'
 
 
 def test_codex_approval_args_uses_config_override_for_current_cli() -> None:


### PR DESCRIPTION
## Summary

- Recognize Codex's skills-context budget notice by its stable semantic structure rather than one exact sentence.
- Accept integer or decimal budget percentages and changing follow-up guidance.
- Preserve fail-closed handling for malformed lookalikes, unrelated provider errors, `turn.failed`, failed tool items, and nested-sandbox failures.
- Add end-to-end runtime regressions proving successful final review output survives valid notices while near-miss errors remain fatal.

## Validation

- `tests/unit/agents/test_runtime.py`: 118 passed.
- Focused valid-notice/fatal-boundary selection: 10 passed.
- Ruff check and format: passed.
- mypy: passed.
- Full pre-push gate: 7,158 passed, 11 skipped, 5 deselected; 83.77% coverage.

Closes #2640