### PR TITLE
chore: Enforce Claude read-only mode instead of relying on CLI defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -648,8 +648,16 @@ allowlists, cwd/worktree scoping, subprocess timeouts, prompt fencing for
 untrusted GitHub content, secure logs, and GitHub branch protection plus the
 required CI/CD checks.
 
+`--allowedTools` pre-approves tools but is not by itself a tool-availability
+boundary. `run_claude_text(..., sandbox="read-only")` additionally fixes the
+built-in surface with `--tools Read,Glob,Grep`, disables ambient discovery with
+`--bare` and strict MCP mode without a supplied config, and fails when the
+installed CLI rejects the required policy. This remains a model-tool
+restriction, not an OS-level sandbox.
+
 | Call site | Tools | Scope / controls |
 | --- | --- | --- |
+| `agents/runtime.py:run_claude_text` | `Read,Glob,Grep` | One-shot `agent_stage` read-only execution uses `--bare`, a fixed `--tools`/`--allowedTools` scope, `dontAsk`, and strict MCP mode without a supplied config; incompatible CLIs fail the invocation instead of falling back. |
 | `audit_reviewer.py:run_audit_coordinator` | `Read,Glob,Grep` | Repo-root audit analysis; no write tools; direct-runner parity uses `sandbox="read-only"`. |
 | `comment_difficulty.py:_run_classifier_session` | `Read,Glob,Grep` | Worktree comment classification; no write tools; result is parsed JSON only. |
 | `pr_review_core.py:_invoke_and_parse_review_session` | `Read,Glob,Grep,Bash,Skill,Agent,WebFetch` | Worktree PR analysis invokes the normal read-only `$athena:pr-review` workflow when available (or its inline fallback); the agent does not post reviews or mutate CI/CD. |

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -53,6 +53,7 @@ CODEX_HAIKU_MODEL = "gpt-5.4-mini"
 CODEX_DEFAULT_MODEL = CODEX_OPUS_MODEL
 CODEX_DEFAULT_REASONING_EFFORT = CODEX_OPUS_REASONING_EFFORT
 CODEX_PARENT_CONTEXT_ENV_VARS = ("CODEX_THREAD_ID",)
+CLAUDE_READ_ONLY_TOOLS = "Read,Glob,Grep"
 PI_PROVIDER_ENV = "HEPH_PI_PROVIDER"
 PI_MODEL_ENV = "HEPH_PI_MODEL"
 PI_MODEL_CONFIG_RELATIVE_PATH = Path(".pi") / "agent" / "models.json"
@@ -750,11 +751,28 @@ def run_claude_text(
     sandbox: str = "workspace-write",
     allowed_tools: str = "Read,Write,Edit,Glob,Grep,Bash",
 ) -> subprocess.CompletedProcess[str]:
-    """Run Claude Code non-interactively and return a text completed process."""
+    """Run Claude Code with an explicit tool policy for read-only calls."""
     cmd = ["claude", "--print", "--output-format", "text"]
     if model:
         cmd.extend(["--model", model])
-    if sandbox != "read-only":
+
+    if sandbox == "read-only":
+        # --allowedTools only pre-approves tools; --tools fixes the model-visible
+        # built-in surface. Bare mode and strict MCP mode without a supplied
+        # config prevent ambient configuration from adding executable paths.
+        cmd.extend(
+            [
+                "--bare",
+                "--permission-mode",
+                "dontAsk",
+                "--tools",
+                CLAUDE_READ_ONLY_TOOLS,
+                "--allowedTools",
+                CLAUDE_READ_ONLY_TOOLS,
+                "--strict-mcp-config",
+            ]
+        )
+    else:
         cmd.extend(
             [
                 "--permission-mode",

--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -37,7 +37,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--sandbox",
         choices=["read-only", "workspace-write", "danger-full-access"],
         default="workspace-write",
-        help="Sandbox mode for agents that support it",
+        help=(
+            "Execution policy: Codex sandbox mode; Claude read-only applies "
+            "a fixed non-mutating tool surface"
+        ),
     )
     parser.add_argument(
         "--approval",
@@ -145,9 +148,10 @@ def run_direct_agent(
 # Flag values that silently no-op when --agent=claude is selected.
 # - `approval` is not a parameter of run_claude_text at all, so any
 #   non-default value (i.e. != "never") is a no-op.
-# - `sandbox="read-only"` IS honored (run_claude_text:125 gates
-#   --permission-mode on it), so only `danger-full-access` is a no-op.
-# See issue #773.
+# - `sandbox="read-only"` maps to run_claude_text's fixed Claude tool policy;
+#   it is enforced through CLI tool/configuration flags, not an OS sandbox.
+# - `danger-full-access` remains unsupported for Claude.
+# See issues #773 and #2369.
 _CLAUDE_NOOP_VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
     ("approval", "--approval", frozenset({"untrusted", "on-request"})),
     ("sandbox", "--sandbox", frozenset({"danger-full-access"})),

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -2132,8 +2132,10 @@ def test_run_claude_text_builds_stage_command(tmp_path: Path) -> None:
     assert captured["kwargs"]["env"]["CLAUDECODE"] == ""
 
 
-def test_run_claude_text_read_only_omits_write_permissions(tmp_path: Path) -> None:
-    """Read-only stages should not grant Claude write-capable tool permissions."""
+def test_run_claude_text_read_only_uses_explicit_non_mutating_policy(
+    tmp_path: Path,
+) -> None:
+    """Read-only Claude execution must receive a fixed, explicit policy."""
     captured_cmd: list[str] = []
 
     def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -2148,8 +2150,46 @@ def test_run_claude_text_read_only_omits_write_permissions(tmp_path: Path) -> No
             sandbox="read-only",
         )
 
-    assert "--permission-mode" not in captured_cmd
-    assert "--allowedTools" not in captured_cmd
+    assert captured_cmd == [
+        "claude",
+        "--print",
+        "--output-format",
+        "text",
+        "--bare",
+        "--permission-mode",
+        "dontAsk",
+        "--tools",
+        "Read,Glob,Grep",
+        "--allowedTools",
+        "Read,Glob,Grep",
+        "--strict-mcp-config",
+    ]
+
+
+def test_run_claude_text_read_only_cannot_be_broadened_by_caller_tools(
+    tmp_path: Path,
+) -> None:
+    """Caller grants cannot expose write, edit, or shell tools in read-only mode."""
+    captured_cmd: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured_cmd.extend(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        agent_runtime.run_claude_text(
+            "prompt",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="read-only",
+            allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+        )
+
+    tools = set(captured_cmd[captured_cmd.index("--tools") + 1].split(","))
+    allowed = set(captured_cmd[captured_cmd.index("--allowedTools") + 1].split(","))
+    assert tools == {"Read", "Glob", "Grep"}
+    assert allowed == tools
+    assert tools.isdisjoint({"Write", "Edit", "Bash"})
 
 
 def test_resolve_agent_prefers_claude_when_both_are_authenticated() -> None:

--- a/tests/unit/automation/test_agent_stage.py
+++ b/tests/unit/automation/test_agent_stage.py
@@ -234,14 +234,11 @@ def test_main_rejects_danger_full_access_sandbox_with_claude_agent(
     assert "--sandbox=danger-full-access" in capsys.readouterr().err
 
 
-def test_main_allows_read_only_sandbox_with_claude_agent(
+def test_main_allows_enforced_read_only_policy_with_claude_agent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """--sandbox=read-only IS honored by run_claude_text and must NOT be rejected.
-
-    Regression guard for the over-restriction caught in plan review of issue #773.
-    """
+    """Claude accepts the explicitly enforced read-only tool policy."""
 
     def fake_run_claude_text(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(["claude"], 0, stdout="ok", stderr="")
@@ -265,6 +262,32 @@ def test_main_allows_read_only_sandbox_with_claude_agent(
         "read-only",
     ]
     assert agent_stage.main(argv) == 0
+
+
+def test_run_agent_propagates_claude_read_only_policy_rejection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupported enforcement flags must fail the stage without fallback."""
+
+    def fake_run_claude_text(
+        *args: object,
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        assert kwargs["sandbox"] == "read-only"
+        return subprocess.CompletedProcess(
+            ["claude"],
+            2,
+            stdout="error: unsupported read-only policy flag",
+            stderr="",
+        )
+
+    monkeypatch.setattr(agent_stage, "run_claude_text", fake_run_claude_text)
+    monkeypatch.setattr(agent_stage, "resolve_agent", lambda agent: "claude")
+    args = _args(tmp_path, agent="claude")
+    args.sandbox = "read-only"
+
+    assert agent_stage.run_agent(args) == 2
 
 
 def test_main_allows_default_flags_with_claude_agent(


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2369.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2369

Generated by Hephaestus automation
