### PR TITLE
chore(automation): increase stage-step watchdog to 60 seconds

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,11 +257,11 @@ tick does, in order:
  [`_reseed_if_converged`](../hephaestus/automation/pipeline/coordinator.py)).
  Otherwise wait on the completion/signal latch and drain the bounded
  completion queue.
-A defensive step watchdog ([`_STEP_WATCHDOG_S = 15.0`](../hephaestus/automation/pipeline/coordinator.py))
-warns when any `stage.step()` call exceeds ~15 s. 5 s proved too tight in
+A defensive step watchdog ([`_STEP_WATCHDOG_S = 60.0`](../hephaestus/automation/pipeline/coordinator.py))
+warns when any `stage.step()` call exceeds ~60 s. 15 s proved too tight in
 practice: routine repo-stage steps (clone + label reads over the network)
 breached it on nearly every multi-repo run, burying real stalls in noise
-(#2247).
+(#2648).
 
 ### Library → product layer boundary
 

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -949,7 +949,7 @@ class CoordinatorRuntime(_CoordinatorHost):
     def _step_with_watchdog(
         self, stage: Stage, item: WorkItem, ctx: StageContext
     ) -> StageStepResult:
-        """Run one stage.step, warning when it breaches the <~15s contract."""
+        """Run one stage.step, warning when it breaches the <~60s contract."""
         t0 = time.monotonic()
         result = stage.step(item, ctx)
         elapsed = time.monotonic() - t0

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -158,11 +158,11 @@ from hephaestus.prompts import PromptCatalog
 logger = logging.getLogger(__name__)
 
 #: Warn when any stage.step() call exceeds this duration (seconds) — the
-#: stage protocol promises short (<~15s) main-thread steps. 5s proved too
+#: stage protocol promises short (<~60s) main-thread steps. 15s proved too
 #: tight in practice: routine repo-stage steps (clone + label reads over the
 #: network) breached it on nearly every multi-repo run, burying real stalls
-#: in noise (#2247).
-_STEP_WATCHDOG_S = 15.0
+#: in noise (#2648).
+_STEP_WATCHDOG_S = 60.0
 
 #: Grace period for graceful shutdown (drain in-flight jobs up to this long).
 _DEFAULT_GRACE_S = 30.0

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -16,7 +16,6 @@ import pytest
 
 from hephaestus.automation.pipeline import coordinator as coordinator_mod, seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import (
-    _STEP_WATCHDOG_S,
     Coordinator,
     PipelineConfig,
 )
@@ -351,7 +350,33 @@ class TestRetryDelayConsumption:
 
 
 class TestStepWatchdog:
-    """WARN when a stage.step breaches the <~15s protocol contract."""
+    """WARN when a stage.step breaches the <~60s protocol contract."""
+
+    def test_watchdog_allows_step_at_sixty_seconds(
+        self,
+        clocked: tuple[Coordinator, FakeClock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A 60-second step remains within the coordinator contract."""
+        coordinator, clock = clocked
+
+        class WithinContractStage:
+            def on_enter(self, item: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                clock.now += 60.0
+                return StageOutcome(Disposition.SKIP, "within_contract")
+
+            def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.PR_REVIEW] = WithinContractStage()
+
+        with caplog.at_level("WARNING"):
+            coordinator._run_item(_item(11))
+
+        assert not any("stage.step stalled" in record.message for record in caplog.records)
 
     def test_watchdog_warns_on_slow_step(
         self,
@@ -366,7 +391,7 @@ class TestStepWatchdog:
                 return None
 
             def step(self, item: WorkItem, ctx: Any) -> Any:
-                clock.now += _STEP_WATCHDOG_S + 3.0  # simulate a stalled step
+                clock.now += 60.1
                 return StageOutcome(Disposition.SKIP, "slow")
 
             def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:


### PR DESCRIPTION
Summary:
- increase the stage-step cooperative watchdog contract from 15 seconds to 60 seconds
- pin deterministic behavior at exactly 60 seconds and immediately above the threshold
- update architecture documentation and rationale provenance

Tests:
- uv run pytest --override-ini=addopts= tests/unit/automation/pipeline/test_timer_heap.py -q
- uv run pytest --override-ini=addopts= tests/unit/validation/test_markdown.py -q
- uv run ruff check hephaestus/automation/pipeline/coordinator_types.py hephaestus/automation/pipeline/coordinator_runtime.py tests/unit/automation/pipeline/test_timer_heap.py
- uv run mypy hephaestus/automation/pipeline/coordinator_types.py hephaestus/automation/pipeline/coordinator_runtime.py tests/unit/automation/pipeline/test_timer_heap.py
- clean full pre-push suite: 7092 passed, 11 skipped, 5 deselected; coverage 83.94%

Closes #2648
