### PR TITLE
fix(automation): require clean reusable checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Worktrees for parallel development
 /worktree/
 
-# Build artifacts
+# Build and automation scratch artifacts; intermediate files belong here.
 build/
 
 # Auto-generated API reference (pdoc output)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -675,9 +675,14 @@ by its durable state.
 Before it reads a direct `--issues` / `--prs` scope, performs a label mutation,
 or dispatches an agent, repo intake proves its reusable checkout is the
 expected repository, clean, on the remote default branch, and fast-forwarded
-to that branch's fetched head. A missing checkout is cloned and then subjected
-to the same synchronization proof. Any failure is terminal for that scope; it
-never falls through to an ambient or stale checkout.
+to that branch's fetched head. Here, clean means that
+`git status --porcelain --untracked-files=all` reports neither tracked changes
+nor non-ignored untracked files. Every log, build product, and other
+intermediate file created before this check must therefore be covered by the
+repository's `.gitignore`; `build/` is the sanctioned scratch location. A
+missing checkout is cloned and then subjected to the same synchronization
+proof. Any failure is terminal for that scope; it never falls through to an
+ambient or stale checkout.
 
 #### Boundary diagram
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2071,7 +2071,11 @@ class WorkerPool:
         )
 
     def _git_sync_checkout(self, job: GitJob) -> JobResult:
-        """Validate and fast-forward a reusable checkout without discarding local work."""
+        """Validate and fast-forward a clean reusable checkout.
+
+        Generated and intermediate files must be covered by the repository's
+        ignore rules; any other uncommitted path blocks synchronization.
+        """
         expected_repo = str(job.kwargs.get("repo") or "")
         dest = str(job.kwargs.get("dest") or "")
         if not expected_repo or not dest:
@@ -2134,7 +2138,7 @@ class WorkerPool:
                 "core.fsmonitor=false",
                 "status",
                 "--porcelain",
-                "--untracked-files=no",
+                "--untracked-files=all",
             ],
             cwd=checkout,
             timeout=timeout_s,
@@ -2143,7 +2147,7 @@ class WorkerPool:
         if status.stdout.strip():
             return JobResult(
                 ok=False,
-                error=f"checkout has tracked changes: {checkout}: {status.stdout.strip()}",
+                error=f"checkout has uncommitted changes: {checkout}: {status.stdout.strip()}",
             )
         branch_result = git_utils.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
@@ -2197,14 +2201,14 @@ class WorkerPool:
                 "core.fsmonitor=false",
                 "status",
                 "--porcelain",
-                "--untracked-files=no",
+                "--untracked-files=all",
             ],
             cwd=checkout,
             timeout=timeout_s,
             env=_controlled_git_env(),
         )
         if status.stdout.strip():
-            return f"checkout has tracked changes: {checkout}: {status.stdout.strip()}"
+            return f"checkout has uncommitted changes: {checkout}: {status.stdout.strip()}"
         branch_result = git_utils.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
             cwd=checkout,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2134,14 +2134,17 @@ class WorkerPool:
                 "core.fsmonitor=false",
                 "status",
                 "--porcelain",
-                "--untracked-files=all",
+                "--untracked-files=no",
             ],
             cwd=checkout,
             timeout=timeout_s,
             env=_controlled_git_env(),
         )
         if status.stdout.strip():
-            return JobResult(ok=False, error=f"checkout is dirty: {checkout}")
+            return JobResult(
+                ok=False,
+                error=f"checkout has tracked changes: {checkout}: {status.stdout.strip()}",
+            )
         branch_result = git_utils.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
             cwd=checkout,
@@ -2194,14 +2197,14 @@ class WorkerPool:
                 "core.fsmonitor=false",
                 "status",
                 "--porcelain",
-                "--untracked-files=all",
+                "--untracked-files=no",
             ],
             cwd=checkout,
             timeout=timeout_s,
             env=_controlled_git_env(),
         )
         if status.stdout.strip():
-            return f"checkout is dirty: {checkout}"
+            return f"checkout has tracked changes: {checkout}: {status.stdout.strip()}"
         branch_result = git_utils.run(
             ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
             cwd=checkout,

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -135,8 +135,7 @@ STATE_LABEL_SPECS: dict[str, dict[str, str]] = {
     STATE_IMPLEMENTATION_GO: {
         "color": "0e8a16",  # green — approved
         "description": (
-            "Exact reviewed head has no unresolved review threads; "
-            "merge-wait still requires the process-local reviewed-head proof."
+            "Reviewed head is clean; merge-wait still requires the reviewed-head proof."
         ),
     },
     STATE_SKIP: {

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -135,7 +135,8 @@ STATE_LABEL_SPECS: dict[str, dict[str, str]] = {
     STATE_IMPLEMENTATION_GO: {
         "color": "0e8a16",  # green — approved
         "description": (
-            "Reviewed head is clean; merge-wait still requires the reviewed-head proof."
+            "Exact head has no unresolved review threads; merge-wait also requires "
+            "its process-local head proof."
         ),
     },
     STATE_SKIP: {

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -3311,7 +3311,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3367,7 +3367,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3411,7 +3411,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3490,12 +3490,32 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert "checkout is dirty" in (result.error or "")
+        assert "checkout has tracked changes" in (result.error or "")
         argvs = [call.args[0] for call in mock_run.call_args_list]
         assert ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"] not in argvs
         assert not any(
             argv[:3] == ["git", "-c", f"core.hooksPath={os.devnull}"] and "merge" in argv
             for argv in argvs
+        )
+
+    def test_checkout_state_allows_untracked_artifacts(self, tmp_path: Path) -> None:
+        """Logs and build output do not block a clean checkout from synchronizing (#2645)."""
+        checkout = tmp_path / "checkout"
+        subprocess.run(
+            ["git", "init", "-b", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+        )
+        (checkout / "output.log").write_text("pipeline output\n")
+        (checkout / "build").mkdir()
+
+        assert (
+            WorkerPool._checkout_state_error(
+                checkout=checkout,
+                default_branch="main",
+                timeout_s=120,
+            )
+            is None
         )
 
     def test_sync_checkout_rejects_dirty_worktree_before_fetching(
@@ -3535,7 +3555,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3543,7 +3563,7 @@ class TestGitOps:
             ),
         ]
         assert result.ok is False
-        assert "dirty" in (result.error or "")
+        assert "tracked changes" in (result.error or "")
 
     def test_sync_checkout_rejects_unexpected_origin(
         self,
@@ -4079,7 +4099,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -4141,7 +4161,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -3311,7 +3311,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=no",
+                    "--untracked-files=all",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3367,7 +3367,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=no",
+                    "--untracked-files=all",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3411,7 +3411,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=no",
+                    "--untracked-files=all",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3490,7 +3490,7 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert "checkout has tracked changes" in (result.error or "")
+        assert "checkout has uncommitted changes" in (result.error or "")
         argvs = [call.args[0] for call in mock_run.call_args_list]
         assert ["git", "rev-list", "--left-right", "--count", "HEAD...origin/main"] not in argvs
         assert not any(
@@ -3498,16 +3498,50 @@ class TestGitOps:
             for argv in argvs
         )
 
-    def test_checkout_state_allows_untracked_artifacts(self, tmp_path: Path) -> None:
-        """Logs and build output do not block a clean checkout from synchronizing (#2645)."""
+    def test_checkout_state_rejects_untracked_files(self, tmp_path: Path) -> None:
+        """Non-ignored intermediate files keep a reusable checkout from synchronizing."""
         checkout = tmp_path / "checkout"
         subprocess.run(
             ["git", "init", "-b", "main", str(checkout)],
             check=True,
             capture_output=True,
         )
+        (checkout / "intermediate.txt").write_text("pipeline output\n")
+
+        assert WorkerPool._checkout_state_error(
+            checkout=checkout,
+            default_branch="main",
+            timeout_s=120,
+        ) == (f"checkout has uncommitted changes: {checkout}: ?? intermediate.txt")
+
+    def test_checkout_state_allows_ignored_intermediate_files(self, tmp_path: Path) -> None:
+        """Ignored build and log output do not make a reusable checkout dirty."""
+        checkout = tmp_path / "checkout"
+        subprocess.run(
+            ["git", "init", "-b", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+        )
+        (checkout / ".gitignore").write_text("build/\n/*.log\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=checkout, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test User",
+                "-c",
+                "user.email=test@example.invalid",
+                "commit",
+                "-m",
+                "test: add ignore rules",
+            ],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+        )
         (checkout / "output.log").write_text("pipeline output\n")
         (checkout / "build").mkdir()
+        (checkout / "build" / "artifact.txt").write_text("generated\n")
 
         assert (
             WorkerPool._checkout_state_error(
@@ -3555,7 +3589,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=no",
+                    "--untracked-files=all",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -3563,7 +3597,7 @@ class TestGitOps:
             ),
         ]
         assert result.ok is False
-        assert "tracked changes" in (result.error or "")
+        assert "uncommitted changes" in (result.error or "")
 
     def test_sync_checkout_rejects_unexpected_origin(
         self,
@@ -4099,7 +4133,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=no",
+                    "--untracked-files=all",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -4161,7 +4195,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=no",
+                    "--untracked-files=all",
                 ],
                 cwd=checkout,
                 timeout=120,

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -71,6 +71,7 @@ class TestLabelVocabulary:
         for spec in STATE_LABEL_SPECS.values():
             assert "color" in spec
             assert "description" in spec
+            assert len(spec["description"]) <= 100
             # Hex colour without leading '#'.
             assert len(spec["color"]) == 6
             int(spec["color"], 16)


### PR DESCRIPTION
## Summary

- require reusable checkouts to have no tracked changes or non-ignored untracked files before synchronization
- document that every intermediate file must be gitignored and keep `build/` as the sanctioned ignored scratch location
- preserve the exact reviewed-head label semantics within GitHub’s 100-character description limit

Closes #2645
Closes #2647

## Validation

- RED: non-ignored `intermediate.txt` was accepted before the implementation change
- `uv run pytest --no-cov tests/unit/automation/pipeline/test_worker_pool.py tests/unit/automation/test_state_labels.py tests/unit/scripts/test_check_build_dir_untracked.py -q` (228 passed)
- `uv run pre-commit run --files .gitignore docs/architecture.md hephaestus/automation/pipeline/worker_pool.py hephaestus/automation/state_labels.py tests/unit/automation/pipeline/test_worker_pool.py tests/unit/automation/test_state_labels.py`
- pre-push: `uv run --all-extras --locked pytest -q` (7,119 selected)