### PR TITLE
chore: Make version bumping operate on the authoritative tag or become compute-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,27 @@ jobs:
           uv run python -m build
           ls -1 dist/
 
+      - name: Verify canonical and installed versions
+        shell: bash
+        env:
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${TAG#v}"
+          VERIFY_ENV="build/version-verify"
+          WHEEL="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          if [ -z "${WHEEL}" ]; then
+            echo "::error::No built wheel found for version verification"
+            exit 1
+          fi
+
+          uv venv "${VERIFY_ENV}"
+          uv pip install --python "${VERIFY_ENV}/bin/python" "${WHEEL}"
+          "${VERIFY_ENV}/bin/hephaestus-check-version-consistency" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --expected-version "${TAG_VERSION}" \
+            --verbose
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
         with:

--- a/README.md
+++ b/README.md
@@ -470,9 +470,9 @@ zero totals, and zero requested/processed counts.
 
 | Command | Description |
 |---|---|
-| `hephaestus-bump-version` | Version consistency checks and atomic version bumping |
-| `hephaestus-check-package-versions` | Check package version consistency across config files |
-| `hephaestus-check-version-consistency` | Version consistency checks across config files |
+| `hephaestus-bump-version` | Compute the next tag-derived semantic version without changing files or tags |
+| `hephaestus-check-package-versions` | Check optional package and documentation version references against the canonical tag |
+| `hephaestus-check-version-consistency` | Verify an expected version matches the canonical tag and installed distribution |
 
 ### Examples
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,6 +21,7 @@ workflow_dispatch (Auto Tag Release)
          └─ build-and-publish job (after test + type-check succeed)
               ├─ verify tag == package version
               ├─ build wheel + sdist
+              ├─ verify tag == installed wheel version
               ├─ publish to PyPI (trusted publishing)
               └─ create GitHub Release with auto-generated notes
 ```
@@ -41,6 +42,18 @@ Before triggering the workflow, ensure:
 The package version itself does **not** need to be edited in any file: this project uses
 hatch-vcs dynamic versioning, so the package version is derived from the git tag the
 `auto-tag` workflow pushes. There is no `[project].version` field to bump.
+
+To preview the next version locally without changing files or tags:
+
+```bash
+hephaestus-bump-version patch
+```
+
+This command is compute-only. Create the authoritative signed tag through
+**Actions → Auto Tag Release → Run workflow**; do not copy the proposal into
+`VERSION`, `pyproject.toml`, or `hephaestus/__init__.py`. The release workflow
+then verifies the requested tag against hatch-vcs and a freshly installed wheel
+before publication.
 
 ## Manual Tag + Release (escape hatch)
 

--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -9,14 +9,21 @@ requested version.
 
 Provides three operations:
 
-1. ``check_version_consistency`` — verify an expected version against the
-   canonical git tag and installed distribution.
+1. ``check_version_consistency`` — verify that a canonical git tag can be
+   resolved, preserving the historical status-code API.
+
+   ``_verify_requested_version`` is the stricter check used by release
+   automation to compare an expected version with both the canonical tag and
+   installed distribution.
 
 2. ``check_package_version_consistency`` — broader multi-source scan of
    ``__init__.py`` ``__version__`` and optional skill markdown files.
 
-3. ``bump_version`` — compute the next semver string by incrementing a chosen
-   part (major/minor/patch) without changing repository state.
+3. ``preview_version`` — compute the next semver string by incrementing a
+   chosen part (major/minor/patch) without changing repository state.
+
+4. ``bump_version`` — preserve the historical integer status-code API while
+   performing the same compute-only preview.
 
 Usage:
     hephaestus-check-version-consistency [--repo-root PATH] --expected-version VERSION [--verbose]
@@ -198,12 +205,33 @@ def _find_aspirational_versions(
 # ---------------------------------------------------------------------------
 
 
-def check_version_consistency(
+def check_version_consistency(repo_root: Path, verbose: bool = False) -> int:
+    """Verify that the canonical git-derived version can be resolved.
+
+    Args:
+        repo_root: Root directory of the repository.
+        verbose: If True, print the canonical version when it resolves.
+
+    Returns:
+        0 when a canonical version can be resolved.
+
+    """
+    canonical_version = _get_canonical_version(repo_root)
+    if verbose:
+        print(f"Canonical version (git tag): {canonical_version}")
+    return 0
+
+
+def _verify_requested_version(
     repo_root: Path,
     requested_version: str,
     verbose: bool = False,
 ) -> int:
-    """Verify the canonical tag and installed distribution equal a request.
+    """Verify an expected version against the tag and installed distribution.
+
+    This strict, release-oriented check is separate from the historical
+    ``check_version_consistency`` API so existing library callers retain their
+    status-code and argument semantics.
 
     Args:
         repo_root: Root directory of the repository.
@@ -334,7 +362,7 @@ def check_package_version_consistency(
     """
     canonical = _get_canonical_version(repo_root)
     if verbose:
-        print(f"Canonical version (git tag / metadata): {canonical}")
+        print(f"Canonical version (git tag): {canonical}")
 
     all_errors: list[str] = []
     all_errors.extend(_check_init_version_errors(package_init, canonical, verbose))
@@ -357,30 +385,8 @@ def check_package_version_consistency(
     return 0
 
 
-def bump_version(
-    repo_root: Path,
-    part: str,
-    verbose: bool = False,
-) -> str:
-    """Compute the next version from the authoritative tag without changing state.
-
-    The authoritative version is set by the signed Git tag created by the
-    explicitly dispatched release workflow. This function only previews the
-    next semantic version.
-
-    Args:
-        repo_root: Root directory of the repository.
-        part: Which part to increment — ``"major"``, ``"minor"``, or ``"patch"``.
-        verbose: If True, print additional details.
-
-    Returns:
-        The proposed ``X.Y.Z`` version.
-
-    Raises:
-        ValueError: If ``part`` is not a supported semantic-version component.
-        SystemExit: If no authoritative Git tag can be determined.
-
-    """
+def _calculate_next_version(repo_root: Path, part: str) -> tuple[str, str]:
+    """Return the current and next versions without changing repository state."""
     current_str = _get_canonical_version(repo_root)
     current = parse_version(current_str)
 
@@ -393,10 +399,63 @@ def bump_version(
     else:
         raise ValueError(f"invalid part {part!r}: must be 'major', 'minor', or 'patch'")
 
-    requested = ".".join(str(component) for component in new)
+    return current_str, ".".join(str(component) for component in new)
+
+
+def preview_version(repo_root: Path, part: str, verbose: bool = False) -> str:
+    """Compute the next semantic version without changing repository state.
+
+    Args:
+        repo_root: Root directory of the repository.
+        part: Which version part to increment — ``major``, ``minor``, or ``patch``.
+        verbose: If True, print the current and proposed versions.
+
+    Returns:
+        The proposed ``X.Y.Z`` version.
+
+    Raises:
+        ValueError: If ``part`` is not a supported semantic-version component.
+        SystemExit: If no authoritative Git tag can be determined.
+
+    """
+    current_str, requested = _calculate_next_version(repo_root, part)
     if verbose:
         print(f"Computed next version: {current_str} -> {requested}")
     return requested
+
+
+def bump_version(
+    repo_root: Path,
+    part: str,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Preview a version bump while preserving the legacy status-code API.
+
+    Version changes are now compute-only. ``dry_run`` remains accepted for
+    callers of the historical API and is intentionally a no-op because every
+    invocation leaves files and tags untouched.
+
+    Args:
+        repo_root: Root directory of the repository.
+        part: Which part to increment — ``major``, ``minor``, or ``patch``.
+        dry_run: Retained for compatibility; no writes occur regardless of its value.
+        verbose: If True, print the current and proposed versions.
+
+    Returns:
+        0 on success, 1 when the requested part or current version is invalid.
+
+    """
+    del dry_run  # Retained solely for source compatibility; previews never write.
+    try:
+        current_str, requested = _calculate_next_version(repo_root, part)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if verbose:
+        print(f"Computed next version: {current_str} -> {requested}")
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -429,7 +488,7 @@ def check_version_consistency_main() -> int:
     args = parser.parse_args()
     root = resolve_repo_root(args)
     if args.json:
-        exit_code = check_version_consistency(
+        exit_code = _verify_requested_version(
             root, requested_version=args.expected_version, verbose=False
         )
         payload = {
@@ -440,7 +499,7 @@ def check_version_consistency_main() -> int:
         }
         print(format_output(payload, "json"))
         return exit_code
-    return check_version_consistency(
+    return _verify_requested_version(
         root, requested_version=args.expected_version, verbose=args.verbose
     )
 
@@ -522,6 +581,11 @@ def bump_version_main() -> int:
         help="Which version part to bump",
     )
     parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Deprecated compatibility flag; version previews are always compute-only",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -529,7 +593,7 @@ def bump_version_main() -> int:
     )
     args = parser.parse_args()
     root = resolve_repo_root(args)
-    requested = bump_version(root, part=args.part, verbose=False)
+    requested = preview_version(root, part=args.part, verbose=args.verbose and not args.json)
     if args.json:
         print(
             format_output(

--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -1,26 +1,27 @@
 #!/usr/bin/env python3
 
-"""Version consistency checks and atomic version bumping.
+"""Version consistency checks and tag-derived version previews.
 
 The project uses hatch-vcs dynamic versioning: the **canonical version is
 derived from git tags**, not stored in any file. These checks therefore compare
-secondary version declarations against the git-derived canonical version.
+the authoritative tag and installed distribution against an explicitly
+requested version.
 
 Provides three operations:
 
-1. ``check_version_consistency`` — verify that a canonical git-derived version
-   can be resolved.
+1. ``check_version_consistency`` — verify an expected version against the
+   canonical git tag and installed distribution.
 
 2. ``check_package_version_consistency`` — broader multi-source scan of
    ``__init__.py`` ``__version__`` and optional skill markdown files.
 
-3. ``bump_version`` — compute the next semver string by incrementing a chosen part
-   (major/minor/patch), then delegate writes to :class:`~hephaestus.version.manager.VersionManager`.
+3. ``bump_version`` — compute the next semver string by incrementing a chosen
+   part (major/minor/patch) without changing repository state.
 
 Usage:
-    hephaestus-check-version-consistency [--repo-root PATH] [--verbose]
+    hephaestus-check-version-consistency [--repo-root PATH] --expected-version VERSION [--verbose]
     hephaestus-check-package-versions [--repo-root PATH] [--scan-skills] [--verbose]
-    hephaestus-bump-version {major,minor,patch} [--repo-root PATH] [--dry-run] [--verbose]
+    hephaestus-bump-version {major,minor,patch} [--repo-root PATH] [--verbose]
 """
 
 import re
@@ -29,16 +30,11 @@ import sys
 from importlib.metadata import PackageNotFoundError, version as _dist_version
 from pathlib import Path
 
-from hephaestus.cli.utils import (
-    create_validation_parser,
-    emit_json_status,
-    format_output,
-    resolve_repo_root,
-)
-from hephaestus.version.manager import VersionManager, parse_version
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
+from hephaestus.version.manager import parse_version
 from hephaestus.version.parsing import parse_version_tuple
 
-# PyPI distribution name used for the importlib.metadata fallback.
+# PyPI distribution name used for installed-artifact verification.
 _DIST_NAME = "HomericIntelligence-Hephaestus"
 
 # ---------------------------------------------------------------------------
@@ -99,26 +95,25 @@ def _version_from_git_tag(repo_root: Path) -> str | None:
 
 
 def _version_from_metadata() -> str | None:
-    """Return the installed distribution's base version (no dev/local suffix), or None.
+    """Return the exact installed distribution version, or ``None``.
 
     Returns:
-        A ``"X.Y.Z"`` string, or ``None`` if the package is not installed.
+        The installed distribution version, including any development or
+        local suffix, or ``None`` if the package is not installed.
 
     """
     try:
-        raw = _dist_version(_DIST_NAME)
+        return _dist_version(_DIST_NAME)
     except PackageNotFoundError:
         return None
-    match = re.match(r"^\d+\.\d+\.\d+", raw)
-    return match.group(0) if match else None
 
 
 def _get_canonical_version(repo_root: Path) -> str:
-    """Return the canonical project version.
+    """Return the authoritative version from the latest reachable tag.
 
-    Under hatch-vcs dynamic versioning the canonical version is derived from git
-    tags. This prefers the latest ``v*`` git tag and falls back to the installed
-    distribution metadata.
+    Under hatch-vcs dynamic versioning the canonical version is derived from a
+    ``vX.Y.Z`` Git tag. Installed metadata is a separate verification source,
+    not a fallback authority.
 
     Args:
         repo_root: Repository root directory.
@@ -130,12 +125,10 @@ def _get_canonical_version(repo_root: Path) -> str:
         SystemExit: With code 1 if no canonical version can be determined.
 
     """
-    version = _version_from_git_tag(repo_root) or _version_from_metadata()
+    version = _version_from_git_tag(repo_root)
     if version is None:
         print(
-            "ERROR: could not determine the canonical version.\n"
-            "  This project uses hatch-vcs dynamic versioning; a vX.Y.Z git tag\n"
-            "  or an installed distribution is required.",
+            "ERROR: could not determine the canonical version from a vX.Y.Z Git tag.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -205,20 +198,51 @@ def _find_aspirational_versions(
 # ---------------------------------------------------------------------------
 
 
-def check_version_consistency(repo_root: Path, verbose: bool = False) -> int:
-    """Verify the project can resolve its canonical git-derived version.
+def check_version_consistency(
+    repo_root: Path,
+    requested_version: str,
+    verbose: bool = False,
+) -> int:
+    """Verify the canonical tag and installed distribution equal a request.
 
     Args:
         repo_root: Root directory of the repository.
+        requested_version: Exact ``X.Y.Z`` version expected from both sources.
         verbose: If True, print versions even when they match.
 
     Returns:
-        0 when the canonical version can be resolved.
+        0 when both sources exactly match ``requested_version``, otherwise 1.
 
     """
-    canonical_version = _get_canonical_version(repo_root)
+    try:
+        parse_version(requested_version)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    canonical = _version_from_git_tag(repo_root)
+    installed = _version_from_metadata()
+    errors: list[str] = []
+
+    if canonical != requested_version:
+        errors.append(
+            f"canonical Git tag version is {canonical or '<not found>'}, "
+            f"expected {requested_version}"
+        )
+    if installed != requested_version:
+        errors.append(
+            f"installed distribution version is {installed or '<not found>'}, "
+            f"expected {requested_version}"
+        )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
     if verbose:
-        print(f"Canonical version (git tag / metadata): {canonical_version}")
+        print(f"Canonical tag version: {canonical}")
+        print(f"Installed distribution version: {installed}")
     return 0
 
 
@@ -336,36 +360,29 @@ def check_package_version_consistency(
 def bump_version(
     repo_root: Path,
     part: str,
-    dry_run: bool = False,
     verbose: bool = False,
-) -> int:
-    """Increment the project version by one semver step.
+) -> str:
+    """Compute the next version from the authoritative tag without changing state.
 
-    Reads the current canonical version (latest git tag), computes the new
-    version by incrementing ``part`` (major/minor/patch), and delegates writes of
-    secondary files (``VERSION``, ``__init__.py``) to
-    :class:`~hephaestus.version.manager.VersionManager`.
-
-    Note: under hatch-vcs the authoritative version is set by creating a git tag
-    (``vX.Y.Z``). This helper computes and records the next version in secondary
-    files; the release is finalised by tagging — see ``docs/RELEASING.md``.
+    The authoritative version is set by the signed Git tag created by the
+    explicitly dispatched release workflow. This function only previews the
+    next semantic version.
 
     Args:
         repo_root: Root directory of the repository.
         part: Which part to increment — ``"major"``, ``"minor"``, or ``"patch"``.
-        dry_run: If True, print what would change without writing.
         verbose: If True, print additional details.
 
     Returns:
-        0 on success, 1 on failure.
+        The proposed ``X.Y.Z`` version.
+
+    Raises:
+        ValueError: If ``part`` is not a supported semantic-version component.
+        SystemExit: If no authoritative Git tag can be determined.
 
     """
     current_str = _get_canonical_version(repo_root)
-    try:
-        current = parse_version(current_str)
-    except ValueError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+    current = parse_version(current_str)
 
     if part == "major":
         new = (current[0] + 1, 0, 0)
@@ -374,40 +391,12 @@ def bump_version(
     elif part == "patch":
         new = (current[0], current[1], current[2] + 1)
     else:
-        print(
-            f"ERROR: invalid part '{part}': must be 'major', 'minor', or 'patch'",
-            file=sys.stderr,
-        )
-        return 1
+        raise ValueError(f"invalid part {part!r}: must be 'major', 'minor', or 'patch'")
 
-    new_str = f"{new[0]}.{new[1]}.{new[2]}"
-
-    if dry_run:
-        print(f"Would bump version: {current_str} -> {new_str}")
-        return 0
-
+    requested = ".".join(str(component) for component in new)
     if verbose:
-        print(f"Bumping version: {current_str} -> {new_str}")
-
-    manager = VersionManager(repo_root=repo_root)
-    manager.update(new_str, verbose=verbose)
-
-    # Validate consistency after writing
-    result = check_version_consistency(repo_root, verbose=verbose)
-    if result != 0:
-        print(
-            "ERROR: post-bump consistency check failed; files may be in an inconsistent state.",
-            file=sys.stderr,
-        )
-        return 1
-
-    print(f"Version bumped: {current_str} -> {new_str}")
-    print()
-    print("Next steps (hatch-vcs derives the published version from the git tag):")
-    print(f'  1. git tag -s v{new_str} -m "Release v{new_str}"')
-    print(f"  2. git push origin v{new_str}")
-    print("  See docs/RELEASING.md for the full release workflow.")
-    return 0
+        print(f"Computed next version: {current_str} -> {requested}")
+    return requested
 
 
 # ---------------------------------------------------------------------------
@@ -423,8 +412,13 @@ def check_version_consistency_main() -> int:
 
     """
     parser = create_validation_parser(
-        "Verify the canonical git-derived project version",
-        epilog="Example: %(prog)s --repo-root /path/to/repo --verbose",
+        "Verify an expected version against the canonical tag and installed distribution",
+        epilog=("Example: %(prog)s --repo-root /path/to/repo --expected-version 1.2.3 --verbose"),
+    )
+    parser.add_argument(
+        "--expected-version",
+        required=True,
+        help="Exact X.Y.Z version expected from both the Git tag and installed package",
     )
     parser.add_argument(
         "--verbose",
@@ -435,14 +429,20 @@ def check_version_consistency_main() -> int:
     args = parser.parse_args()
     root = resolve_repo_root(args)
     if args.json:
-        canonical = _version_from_git_tag(root) or _version_from_metadata()
+        exit_code = check_version_consistency(
+            root, requested_version=args.expected_version, verbose=False
+        )
         payload = {
-            "canonical_version": canonical,
-            "consistent": canonical is not None,
+            "expected_version": args.expected_version,
+            "canonical_version": _version_from_git_tag(root),
+            "installed_version": _version_from_metadata(),
+            "consistent": exit_code == 0,
         }
         print(format_output(payload, "json"))
-        return 0 if canonical is not None else 1
-    return check_version_consistency(root, verbose=args.verbose)
+        return exit_code
+    return check_version_consistency(
+        root, requested_version=args.expected_version, verbose=args.verbose
+    )
 
 
 def check_package_versions_main() -> int:
@@ -513,18 +513,13 @@ def bump_version_main() -> int:
 
     """
     parser = create_validation_parser(
-        "Bump project version in pyproject.toml (and secondary files) atomically",
+        "Compute the next tag-derived semantic version without changing files or tags",
         epilog="Example: %(prog)s patch --verbose",
     )
     parser.add_argument(
         "part",
         choices=["major", "minor", "patch"],
         help="Which version part to bump",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print what would change without writing",
     )
     parser.add_argument(
         "--verbose",
@@ -534,13 +529,20 @@ def bump_version_main() -> int:
     )
     args = parser.parse_args()
     root = resolve_repo_root(args)
+    requested = bump_version(root, part=args.part, verbose=False)
     if args.json:
-        exit_code = bump_version(root, part=args.part, dry_run=args.dry_run, verbose=False)
-        emit_json_status(
-            exit_code,
-            message=("dry run complete" if args.dry_run else "version bumped"),
-            part=args.part,
-            dry_run=args.dry_run,
+        print(
+            format_output(
+                {
+                    "requested_version": requested,
+                    "changed": False,
+                    "authoritative_action": "Auto Tag Release workflow",
+                },
+                "json",
+            )
         )
-        return exit_code
-    return bump_version(root, part=args.part, dry_run=args.dry_run, verbose=args.verbose)
+    else:
+        print(f"Computed next version: {requested}")
+        print("No files or tags were changed.")
+        print("Use the explicitly dispatched Auto Tag Release workflow to create the signed tag.")
+    return 0

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import yaml
 
 from hephaestus.ci import WorkflowValidationError, workflows as workflows_module
 from hephaestus.ci.workflows import (
@@ -372,6 +373,24 @@ def test_releasing_doc_has_stranded_tag_recovery_section() -> None:
     doc = (REPO_ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
     assert "### Dispatch failed after tag push" in doc
     assert "gh workflow run release.yml -f tag=vX.Y.Z" in doc
+
+
+def test_release_verifies_installed_wheel_before_publish() -> None:
+    """The release gate verifies the built wheel before publishing it."""
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["build-and-publish"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    verify_index = names.index("Verify canonical and installed versions")
+    publish_index = names.index("Publish to PyPI")
+    assert verify_index < publish_index
+
+    command = steps[verify_index]["run"]
+    assert 'VERIFY_ENV="build/version-verify"' in command
+    assert "hephaestus-check-version-consistency" in command
+    assert "--expected-version" in command
 
 
 class TestCollectWorkflowFiles:

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -16,6 +16,7 @@ from hephaestus.version.consistency import (
     bump_version,
     check_package_version_consistency,
     check_version_consistency,
+    preview_version,
 )
 
 # ---------------------------------------------------------------------------
@@ -38,12 +39,12 @@ def set_canonical(monkeypatch: pytest.MonkeyPatch):
 # ---------------------------------------------------------------------------
 
 
-def test_check_version_consistency_requires_exact_requested_versions(tmp_path, monkeypatch):
+def test_check_requested_version_requires_exact_requested_versions(tmp_path, monkeypatch):
     """Pass when both independent version sources exactly match the request."""
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: "1.2.3")
     monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "1.2.3")
 
-    assert check_version_consistency(tmp_path, "1.2.3") == 0
+    assert consistency._verify_requested_version(tmp_path, "1.2.3") == 0
 
 
 @pytest.mark.parametrize(
@@ -56,40 +57,48 @@ def test_check_version_consistency_requires_exact_requested_versions(tmp_path, m
         ("1.2.3", None),
     ],
 )
-def test_check_version_consistency_rejects_source_mismatch(
+def test_check_requested_version_rejects_source_mismatch(
     tmp_path, monkeypatch, canonical, installed
 ):
     """Reject stale, missing, or development-version sources."""
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: canonical)
     monkeypatch.setattr(consistency, "_version_from_metadata", lambda: installed)
 
-    assert check_version_consistency(tmp_path, "1.2.3") == 1
+    assert consistency._verify_requested_version(tmp_path, "1.2.3") == 1
 
 
-def test_check_version_consistency_rejects_invalid_requested_version(tmp_path, capsys):
+def test_check_requested_version_rejects_invalid_requested_version(tmp_path, capsys):
     """Reject requests that are not exact three-part semantic versions."""
-    assert check_version_consistency(tmp_path, "1.2") == 1
+    assert consistency._verify_requested_version(tmp_path, "1.2") == 1
     assert "Invalid version format" in capsys.readouterr().err
 
 
-def test_check_version_consistency_verbose(tmp_path, monkeypatch, capsys):
+def test_check_requested_version_verbose(tmp_path, monkeypatch, capsys):
     """Verbose mode prints both exact sources when they match."""
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: "0.5.0")
     monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "0.5.0")
 
-    result = check_version_consistency(tmp_path, "0.5.0", verbose=True)
+    result = consistency._verify_requested_version(tmp_path, "0.5.0", verbose=True)
     assert result == 0
     out = capsys.readouterr().out
     assert "Canonical tag version: 0.5.0" in out
     assert "Installed distribution version: 0.5.0" in out
 
 
-def test_check_version_consistency_no_matching_sources(tmp_path, monkeypatch):
+def test_check_requested_version_no_matching_sources(tmp_path, monkeypatch):
     """Return failure when neither source matches the requested version."""
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
     monkeypatch.setattr(consistency, "_version_from_metadata", lambda: None)
 
-    assert check_version_consistency(tmp_path, "1.2.3") == 1
+    assert consistency._verify_requested_version(tmp_path, "1.2.3") == 1
+
+
+def test_check_version_consistency_preserves_legacy_signature(tmp_path, set_canonical, capsys):
+    """The public status check still accepts the historical positional verbose flag."""
+    set_canonical("1.2.3")
+
+    assert check_version_consistency(tmp_path, True) == 0
+    assert "Canonical version (git tag): 1.2.3" in capsys.readouterr().out
 
 
 def test_canonical_requires_git_tag(tmp_path, monkeypatch):
@@ -192,7 +201,8 @@ def test_bump_version_computes_without_mutation(tmp_path, set_canonical, part, e
     """Compute each semantic bump without creating or changing files."""
     set_canonical("1.2.3")
 
-    assert bump_version(tmp_path, part) == expected
+    assert preview_version(tmp_path, part) == expected
+    assert bump_version(tmp_path, part, dry_run=True) == 0
     assert list(tmp_path.iterdir()) == []
 
 
@@ -207,7 +217,8 @@ def test_bump_version_preserves_secondary_version_files(tmp_path, set_canonical)
     pyproject.write_text('[project]\nversion = "legacy"\n')
     before = {path: path.read_bytes() for path in (version_file, init_file, pyproject)}
 
-    assert bump_version(tmp_path, "minor") == "1.3.0"
+    assert preview_version(tmp_path, "minor") == "1.3.0"
+    assert bump_version(tmp_path, "minor") == 0
     assert {path: path.read_bytes() for path in before} == before
 
 
@@ -228,8 +239,7 @@ def test_bump_version_invalid_part(tmp_path, set_canonical):
     """Invalid bump parts fail without changing repository state."""
     set_canonical("1.0.0")
 
-    with pytest.raises(ValueError, match="invalid part"):
-        bump_version(tmp_path, "invalid")
+    assert bump_version(tmp_path, "invalid") == 1
     assert list(tmp_path.iterdir()) == []
 
 
@@ -237,7 +247,7 @@ def test_bump_version_verbose(tmp_path, set_canonical, capsys):
     """Verbose mode reports the computed transition."""
     set_canonical("0.1.0")
 
-    assert bump_version(tmp_path, "patch", verbose=True) == "0.1.1"
+    assert bump_version(tmp_path, "patch", verbose=True) == 0
     assert "Computed next version: 0.1.0 -> 0.1.1" in capsys.readouterr().out
 
 

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -7,6 +7,8 @@ git tags, not a file. Tests inject a canonical version by monkeypatching
 ``_version_from_git_tag`` rather than writing a static ``[project].version``.
 """
 
+import json
+
 import pytest
 
 import hephaestus.version.consistency as consistency
@@ -36,35 +38,68 @@ def set_canonical(monkeypatch: pytest.MonkeyPatch):
 # ---------------------------------------------------------------------------
 
 
-def test_check_version_consistency_resolves_canonical_version(tmp_path, set_canonical):
-    """Pass when the git-derived canonical version can be resolved."""
-    set_canonical("1.2.3")
-    assert check_version_consistency(tmp_path) == 0
+def test_check_version_consistency_requires_exact_requested_versions(tmp_path, monkeypatch):
+    """Pass when both independent version sources exactly match the request."""
+    monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: "1.2.3")
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "1.2.3")
+
+    assert check_version_consistency(tmp_path, "1.2.3") == 0
 
 
-def test_check_version_consistency_verbose(tmp_path, set_canonical, capsys):
-    """Verbose mode prints versions even when consistent."""
-    set_canonical("0.5.0")
-    result = check_version_consistency(tmp_path, verbose=True)
+@pytest.mark.parametrize(
+    ("canonical", "installed"),
+    [
+        ("1.2.2", "1.2.3"),
+        ("1.2.3", "1.2.2"),
+        ("1.2.3", "1.2.3.dev1"),
+        (None, "1.2.3"),
+        ("1.2.3", None),
+    ],
+)
+def test_check_version_consistency_rejects_source_mismatch(
+    tmp_path, monkeypatch, canonical, installed
+):
+    """Reject stale, missing, or development-version sources."""
+    monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: canonical)
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: installed)
+
+    assert check_version_consistency(tmp_path, "1.2.3") == 1
+
+
+def test_check_version_consistency_rejects_invalid_requested_version(tmp_path, capsys):
+    """Reject requests that are not exact three-part semantic versions."""
+    assert check_version_consistency(tmp_path, "1.2") == 1
+    assert "Invalid version format" in capsys.readouterr().err
+
+
+def test_check_version_consistency_verbose(tmp_path, monkeypatch, capsys):
+    """Verbose mode prints both exact sources when they match."""
+    monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: "0.5.0")
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "0.5.0")
+
+    result = check_version_consistency(tmp_path, "0.5.0", verbose=True)
     assert result == 0
     out = capsys.readouterr().out
-    assert "0.5.0" in out
+    assert "Canonical tag version: 0.5.0" in out
+    assert "Installed distribution version: 0.5.0" in out
 
 
-def test_check_version_consistency_no_canonical_source(tmp_path, monkeypatch):
-    """Exit 1 when no canonical version can be determined (no tag, not installed)."""
+def test_check_version_consistency_no_matching_sources(tmp_path, monkeypatch):
+    """Return failure when neither source matches the requested version."""
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
     monkeypatch.setattr(consistency, "_version_from_metadata", lambda: None)
-    with pytest.raises(SystemExit) as exc_info:
-        check_version_consistency(tmp_path)
-    assert exc_info.value.code == 1
+
+    assert check_version_consistency(tmp_path, "1.2.3") == 1
 
 
-def test_canonical_falls_back_to_metadata(tmp_path, monkeypatch):
-    """When no git tag exists, the canonical version falls back to dist metadata."""
+def test_canonical_requires_git_tag(tmp_path, monkeypatch):
+    """Installed metadata cannot replace the authoritative Git tag."""
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
     monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "7.8.9")
-    assert consistency._get_canonical_version(tmp_path) == "7.8.9"
+
+    with pytest.raises(SystemExit) as exc_info:
+        consistency._get_canonical_version(tmp_path)
+    assert exc_info.value.code == 1
 
 
 # ---------------------------------------------------------------------------
@@ -149,76 +184,61 @@ def test_check_package_consistency_scan_skills_ignores_code_blocks(tmp_path, set
 # ---------------------------------------------------------------------------
 
 
-def test_bump_version_patch(tmp_path, set_canonical):
-    """Patch bump computes the next patch version."""
+@pytest.mark.parametrize(
+    ("part", "expected"),
+    [("patch", "1.2.4"), ("minor", "1.3.0"), ("major", "2.0.0")],
+)
+def test_bump_version_computes_without_mutation(tmp_path, set_canonical, part, expected):
+    """Compute each semantic bump without creating or changing files."""
     set_canonical("1.2.3")
-    result = bump_version(tmp_path, "patch", verbose=False)
-    assert result == 0
-    assert "1.2.4" in (tmp_path / "VERSION").read_text()
+
+    assert bump_version(tmp_path, part) == expected
+    assert list(tmp_path.iterdir()) == []
 
 
-def test_bump_version_minor(tmp_path, set_canonical):
-    """Minor bump increments minor and resets patch to 0."""
+def test_bump_version_preserves_secondary_version_files(tmp_path, set_canonical):
+    """A preview leaves legacy version files byte-for-byte unchanged."""
     set_canonical("1.2.3")
-    result = bump_version(tmp_path, "minor", verbose=False)
-    assert result == 0
-    assert "1.3.0" in (tmp_path / "VERSION").read_text()
+    version_file = tmp_path / "VERSION"
+    init_file = tmp_path / "__init__.py"
+    pyproject = tmp_path / "pyproject.toml"
+    version_file.write_text("legacy\n")
+    init_file.write_text('__version__ = "legacy"\n')
+    pyproject.write_text('[project]\nversion = "legacy"\n')
+    before = {path: path.read_bytes() for path in (version_file, init_file, pyproject)}
+
+    assert bump_version(tmp_path, "minor") == "1.3.0"
+    assert {path: path.read_bytes() for path in before} == before
 
 
-def test_bump_version_major(tmp_path, set_canonical):
-    """Major bump increments major and resets minor and patch to 0."""
-    set_canonical("1.2.3")
-    result = bump_version(tmp_path, "major", verbose=False)
-    assert result == 0
-    assert "2.0.0" in (tmp_path / "VERSION").read_text()
-
-
-def test_bump_version_dry_run(tmp_path, set_canonical):
-    """Dry run does not write a VERSION file."""
-    set_canonical("1.0.0")
-    result = bump_version(tmp_path, "patch", dry_run=True, verbose=False)
-    assert result == 0
-    assert not (tmp_path / "VERSION").exists()
-
-
-def test_bump_version_dry_run_output(tmp_path, set_canonical, capsys):
-    """Dry run prints the proposed version change."""
-    set_canonical("2.3.4")
-    bump_version(tmp_path, "minor", dry_run=True, verbose=False)
-    assert "2.4.0" in capsys.readouterr().out
-
-
-def test_bump_version_invalid_part(tmp_path, set_canonical, capsys):
-    """Invalid part argument returns exit code 1."""
-    set_canonical("1.0.0")
-    result = bump_version(tmp_path, "invalid", verbose=False)
-    assert result == 1
-    assert "invalid" in capsys.readouterr().err.lower()
-
-
-def test_bump_version_no_canonical_source(tmp_path, monkeypatch):
-    """No determinable canonical version causes SystemExit(1)."""
+def test_bump_version_failure_preserves_repository_files(tmp_path, monkeypatch):
+    """Failure to resolve the tag leaves existing repository files unchanged."""
+    sentinel = tmp_path / "VERSION"
+    sentinel.write_text("unchanged\n")
     monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
-    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: None)
-    with pytest.raises(SystemExit) as exc_info:
+
+    with pytest.raises(SystemExit):
         bump_version(tmp_path, "patch")
-    assert exc_info.value.code == 1
+
+    assert sentinel.read_text() == "unchanged\n"
+    assert list(tmp_path.iterdir()) == [sentinel]
+
+
+def test_bump_version_invalid_part(tmp_path, set_canonical):
+    """Invalid bump parts fail without changing repository state."""
+    set_canonical("1.0.0")
+
+    with pytest.raises(ValueError, match="invalid part"):
+        bump_version(tmp_path, "invalid")
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_bump_version_verbose(tmp_path, set_canonical, capsys):
-    """Verbose mode prints the bump message."""
+    """Verbose mode reports the computed transition."""
     set_canonical("0.1.0")
-    bump_version(tmp_path, "patch", verbose=True)
-    assert "0.1.1" in capsys.readouterr().out
 
-
-def test_bump_version_next_steps_mention_git_tag(tmp_path, set_canonical, capsys):
-    """The post-bump guidance points at git tagging, not editing pyproject.toml."""
-    set_canonical("1.0.0")
-    bump_version(tmp_path, "patch", verbose=False)
-    out = capsys.readouterr().out
-    assert "git tag" in out
-    assert "v1.0.1" in out
+    assert bump_version(tmp_path, "patch", verbose=True) == "0.1.1"
+    assert "Computed next version: 0.1.0 -> 0.1.1" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------
@@ -231,11 +251,47 @@ def test_check_version_consistency_main_pass(tmp_path, set_canonical, monkeypatc
     from hephaestus.version.consistency import check_version_consistency_main
 
     set_canonical("1.0.0")
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "1.0.0")
     monkeypatch.setattr(
         "sys.argv",
-        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
+        [
+            "hephaestus-check-version-consistency",
+            "--repo-root",
+            str(tmp_path),
+            "--expected-version",
+            "1.0.0",
+        ],
     )
     assert check_version_consistency_main() == 0
+
+
+def test_check_version_consistency_main_json_reports_exact_sources(
+    tmp_path, set_canonical, monkeypatch, capsys
+):
+    """JSON consistency output includes both exact verification sources."""
+    from hephaestus.version.consistency import check_version_consistency_main
+
+    set_canonical("1.0.0")
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "1.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hephaestus-check-version-consistency",
+            "--repo-root",
+            str(tmp_path),
+            "--expected-version",
+            "1.0.0",
+            "--json",
+        ],
+    )
+
+    assert check_version_consistency_main() == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "expected_version": "1.0.0",
+        "canonical_version": "1.0.0",
+        "installed_version": "1.0.0",
+        "consistent": True,
+    }
 
 
 def test_check_package_versions_main_pass(tmp_path, set_canonical, monkeypatch):
@@ -250,30 +306,35 @@ def test_check_package_versions_main_pass(tmp_path, set_canonical, monkeypatch):
     assert check_package_versions_main() == 0
 
 
-def test_bump_version_main_dry_run(tmp_path, set_canonical, monkeypatch, capsys):
-    """CLI --dry-run flag prints the proposed change without writing."""
+def test_bump_version_main_compute_only(tmp_path, set_canonical, monkeypatch, capsys):
+    """CLI prints the proposed change without writing repository files."""
     from hephaestus.version.consistency import bump_version_main
 
     set_canonical("3.0.0")
     monkeypatch.setattr(
         "sys.argv",
-        ["hephaestus-bump-version", "minor", "--repo-root", str(tmp_path), "--dry-run"],
+        ["hephaestus-bump-version", "minor", "--repo-root", str(tmp_path)],
     )
     result = bump_version_main()
     assert result == 0
-    assert "3.1.0" in capsys.readouterr().out
-    assert not (tmp_path / "VERSION").exists()
+    assert "Computed next version: 3.1.0" in capsys.readouterr().out
+    assert list(tmp_path.iterdir()) == []
 
 
-def test_bump_version_main_patch(tmp_path, set_canonical, monkeypatch):
-    """CLI patch bump computes and records the next patch version."""
+def test_bump_version_main_json_reports_compute_only(tmp_path, set_canonical, monkeypatch, capsys):
+    """JSON output identifies the proposal and confirms no mutation occurred."""
     from hephaestus.version.consistency import bump_version_main
 
     set_canonical("0.5.2")
     monkeypatch.setattr(
         "sys.argv",
-        ["hephaestus-bump-version", "patch", "--repo-root", str(tmp_path)],
+        ["hephaestus-bump-version", "patch", "--repo-root", str(tmp_path), "--json"],
     )
-    result = bump_version_main()
-    assert result == 0
-    assert "0.5.3" in (tmp_path / "VERSION").read_text()
+    assert bump_version_main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "requested_version": "0.5.3",
+        "changed": False,
+        "authoritative_action": "Auto Tag Release workflow",
+    }
+    assert list(tmp_path.iterdir()) == []

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -12,10 +12,9 @@ import json
 import pytest
 
 import hephaestus.version.consistency as consistency
+from hephaestus.version import bump_version, check_version_consistency
 from hephaestus.version.consistency import (
-    bump_version,
     check_package_version_consistency,
-    check_version_consistency,
     preview_version,
 )
 
@@ -94,8 +93,11 @@ def test_check_requested_version_no_matching_sources(tmp_path, monkeypatch):
 
 
 def test_check_version_consistency_preserves_legacy_signature(tmp_path, set_canonical, capsys):
-    """The public status check still accepts the historical positional verbose flag."""
+    """The exported status check accepts both historical calling forms."""
     set_canonical("1.2.3")
+
+    assert check_version_consistency(tmp_path) == 0
+    assert capsys.readouterr().out == ""
 
     assert check_version_consistency(tmp_path, True) == 0
     assert "Canonical version (git tag): 1.2.3" in capsys.readouterr().out
@@ -197,8 +199,8 @@ def test_check_package_consistency_scan_skills_ignores_code_blocks(tmp_path, set
     ("part", "expected"),
     [("patch", "1.2.4"), ("minor", "1.3.0"), ("major", "2.0.0")],
 )
-def test_bump_version_computes_without_mutation(tmp_path, set_canonical, part, expected):
-    """Compute each semantic bump without creating or changing files."""
+def test_public_bump_version_computes_without_mutation(tmp_path, set_canonical, part, expected):
+    """The exported legacy wrapper returns success without changing files."""
     set_canonical("1.2.3")
 
     assert preview_version(tmp_path, part) == expected


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2373.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2373

Generated by Hephaestus automation
