### PR TITLE
chore: Fail closed when coverage reports cannot be securely parsed

### DIFF
--- a/hephaestus/validation/coverage.py
+++ b/hephaestus/validation/coverage.py
@@ -94,40 +94,81 @@ def get_module_threshold(path: str, config: dict[str, Any]) -> float:
     return cast(float, config.get("coverage", {}).get("minimum", 80.0))
 
 
-def parse_coverage_report(coverage_file: Path) -> float | None:
+class CoverageReportError(RuntimeError):
+    """Base error raised when a coverage report cannot be validated."""
+
+    error_code = "coverage_report_error"
+
+
+class CoverageParserUnavailableError(CoverageReportError):
+    """Raised when the secure XML parser is unavailable."""
+
+    error_code = "parser_unavailable"
+
+
+class CoverageReportParseError(CoverageReportError):
+    """Raised when a coverage report cannot be securely parsed."""
+
+    error_code = "report_unparseable"
+
+
+class CoverageDataAbsentError(CoverageReportError):
+    """Raised when a parsed report contains no aggregate coverage data."""
+
+    error_code = "coverage_data_absent"
+
+
+def _parse_coverage_xml(coverage_file: Path) -> Any:
+    """Securely parse a Cobertura XML report and return its root element."""
+    if not coverage_file.exists():
+        raise FileNotFoundError(f"Coverage file not found: {coverage_file}")
+
+    try:
+        import defusedxml.ElementTree as ElementTree
+    except ImportError as error:
+        raise CoverageParserUnavailableError(
+            "Secure XML parser unavailable. Install it with: "
+            "pip install HomericIntelligence-Hephaestus[xml]"
+        ) from error
+
+    try:
+        return ElementTree.parse(str(coverage_file)).getroot()
+    except Exception as error:
+        raise CoverageReportParseError(
+            f"Could not securely parse coverage report {coverage_file}: {error}"
+        ) from error
+
+
+def parse_coverage_report(coverage_file: Path) -> float:
     """Parse a Cobertura XML coverage report and extract total coverage.
 
     Args:
         coverage_file: Path to ``coverage.xml`` file.
 
     Returns:
-        Coverage percentage (0-100), or None if file not found or invalid.
+        Coverage percentage (0-100).
+
+    Raises:
+        FileNotFoundError: If the coverage report does not exist.
+        CoverageParserUnavailableError: If ``defusedxml`` is unavailable.
+        CoverageReportParseError: If the report cannot be parsed or has an
+            invalid line-rate value.
+        CoverageDataAbsentError: If the report has no root line-rate data.
 
     """
-    if not coverage_file.exists():
-        logger.error("Coverage file not found: %s", coverage_file)
-        return None
-
-    try:
-        import defusedxml.ElementTree as ElementTree
-    except ImportError:
-        logger.warning(
-            "defusedxml not installed. "
-            "Install with: pip install HomericIntelligence-Hephaestus[xml]"
+    root = _parse_coverage_xml(coverage_file)
+    line_rate = root.get("line-rate")
+    if line_rate is None:
+        raise CoverageDataAbsentError(
+            f"Coverage report {coverage_file} contains no root line-rate data"
         )
-        return None
 
     try:
-        tree = ElementTree.parse(str(coverage_file))
-        root = tree.getroot()
-        line_rate = root.get("line-rate")
-        if line_rate is not None:
-            return float(line_rate) * 100.0
-        logger.warning("No line-rate found in %s", coverage_file)
-        return None
-    except Exception as e:
-        logger.error("Error parsing coverage file: %s", e)
-        return None
+        return float(line_rate) * 100.0
+    except (TypeError, ValueError) as error:
+        raise CoverageReportParseError(
+            f"Coverage report {coverage_file} has invalid line-rate data: {line_rate!r}"
+        ) from error
 
 
 def parse_module_coverage(coverage_file: Path) -> dict[str, tuple[float, float]]:
@@ -145,25 +186,11 @@ def parse_module_coverage(coverage_file: Path) -> dict[str, tuple[float, float]]
 
     Raises:
         FileNotFoundError: If coverage file does not exist.
-        RuntimeError: If defusedxml is not available or parsing fails.
+        CoverageParserUnavailableError: If ``defusedxml`` is unavailable.
+        CoverageReportParseError: If parsing fails.
 
     """
-    if not coverage_file.exists():
-        raise FileNotFoundError(f"Coverage file not found: {coverage_file}")
-
-    try:
-        import defusedxml.ElementTree as ElementTree
-    except ImportError as err:
-        raise RuntimeError(
-            "defusedxml not installed. "
-            "Install with: pip install HomericIntelligence-Hephaestus[xml]"
-        ) from err
-
-    try:
-        tree = ElementTree.parse(str(coverage_file))
-        root = tree.getroot()
-    except Exception as e:
-        raise RuntimeError(f"Error parsing coverage file: {e}") from e
+    root = _parse_coverage_xml(coverage_file)
 
     modules: dict[str, tuple[float, float]] = {}
     for class_elem in root.findall(".//class"):
@@ -192,18 +219,15 @@ def check_coverage(threshold: float, path: str, coverage_file: Path) -> bool:
         coverage_file: Path to coverage report.
 
     Returns:
-        True if coverage meets threshold or coverage is not available,
-        False only if coverage parsing succeeds but is below threshold.
+        True if coverage meets the threshold, otherwise False. Missing or
+        unusable reports fail closed and return False.
 
     """
-    coverage = parse_coverage_report(coverage_file)
-
-    if coverage is None:
-        # User-facing CLI report output — intentionally written to stdout.
-        print(f"\nCoverage Report: {path}")
-        print("  Status: Coverage data not available")
-        print("  PASSED - Coverage check skipped")
-        return True
+    try:
+        coverage = parse_coverage_report(coverage_file)
+    except (FileNotFoundError, CoverageReportError) as error:
+        print(f"\nERROR: Coverage check failed for {path}: {error}", file=sys.stderr)
+        return False
 
     # User-facing CLI report output — intentionally written to stdout.
     print(f"\nCoverage Report: {path}")
@@ -237,11 +261,21 @@ def _check_module_floors(
     """
     try:
         module_coverage = parse_module_coverage(args.coverage_file)
-    except (FileNotFoundError, RuntimeError) as e:
+    except (FileNotFoundError, CoverageReportError) as error:
+        error_code = (
+            error.error_code if isinstance(error, CoverageReportError) else "coverage_file_missing"
+        )
+        message = f"Could not parse module coverage: {error}"
         if args.json:
-            emit_json_status(1, message=f"Could not parse module coverage: {e}")
+            emit_json_status(
+                1,
+                message=message,
+                passed=False,
+                coverage=None,
+                error=error_code,
+            )
         else:
-            print(f"\nERROR: Could not parse module coverage: {e}", file=sys.stderr)
+            print(f"\nERROR: {message}", file=sys.stderr)
         return 1
 
     all_modules_pass = True
@@ -282,20 +316,25 @@ def _emit_json_report(args: argparse.Namespace, threshold: float) -> int:
         threshold: Effective coverage threshold to test against.
 
     Returns:
-        0 if coverage passes (or data unavailable), 1 if below threshold.
+        0 if coverage passes, 1 if it is below threshold or cannot be parsed.
 
     """
-    coverage_value = parse_coverage_report(args.coverage_file)
-    if coverage_value is None:
+    try:
+        coverage_value = parse_coverage_report(args.coverage_file)
+    except (FileNotFoundError, CoverageReportError) as error:
+        error_code = (
+            error.error_code if isinstance(error, CoverageReportError) else "coverage_file_missing"
+        )
         report: dict[str, Any] = {
             "path": args.path,
             "threshold": threshold,
             "coverage": None,
-            "passed": True,
-            "message": "Coverage data not available; check skipped",
+            "passed": False,
+            "error": error_code,
+            "message": str(error),
         }
         print(format_output(report, "json"))
-        return 0
+        return 1
     passed = coverage_value >= threshold
     report = {
         "path": args.path,
@@ -367,7 +406,13 @@ def main() -> int:
 
     if not args.coverage_file.exists():
         if args.json:
-            emit_json_status(1, message=f"Coverage file not found: {args.coverage_file}")
+            emit_json_status(
+                1,
+                message=f"Coverage file not found: {args.coverage_file}",
+                passed=False,
+                coverage=None,
+                error="coverage_file_missing",
+            )
             return 1
         # User-facing actionable guidance — intentionally written to stderr so
         # the message appears even when stdout is redirected to a file.

--- a/tests/unit/validation/test_coverage.py
+++ b/tests/unit/validation/test_coverage.py
@@ -1,10 +1,16 @@
 """Tests for hephaestus.validation.coverage."""
 
+import builtins
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from hephaestus.validation.coverage import (
+    CoverageDataAbsentError,
+    CoverageParserUnavailableError,
+    CoverageReportParseError,
     check_coverage,
     get_module_threshold,
     load_coverage_config,
@@ -88,10 +94,10 @@ class TestGetModuleThreshold:
 class TestParseCoverageReport:
     """Tests for parse_coverage_report()."""
 
-    def test_missing_file(self, tmp_path: Path) -> None:
-        """Missing file returns None."""
-        result = parse_coverage_report(tmp_path / "coverage.xml")
-        assert result is None
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """Missing files are distinct from parsed reports with absent data."""
+        with pytest.raises(FileNotFoundError, match="Coverage file not found"):
+            parse_coverage_report(tmp_path / "coverage.xml")
 
     def test_parses_cobertura_xml(self, tmp_path: Path) -> None:
         """Parses line-rate from Cobertura XML."""
@@ -106,21 +112,44 @@ class TestParseCoverageReport:
         assert result is not None
         assert abs(result - 85.0) < 0.01
 
-    def test_no_line_rate(self, tmp_path: Path) -> None:
-        """XML without line-rate returns None."""
+    def test_no_line_rate_raises_absent_data(self, tmp_path: Path) -> None:
+        """A parsed report without line-rate raises the absent-data error."""
         pytest.importorskip("defusedxml")
         coverage_xml = tmp_path / "coverage.xml"
         coverage_xml.write_text('<?xml version="1.0" ?>\n<coverage version="7.4"></coverage>\n')
-        result = parse_coverage_report(coverage_xml)
-        assert result is None
 
-    def test_malformed_xml(self, tmp_path: Path) -> None:
-        """Malformed XML returns None."""
+        with pytest.raises(CoverageDataAbsentError, match="no root line-rate"):
+            parse_coverage_report(coverage_xml)
+
+    def test_malformed_xml_raises_parse_error(self, tmp_path: Path) -> None:
+        """Malformed XML raises the secure parse error."""
         pytest.importorskip("defusedxml")
         coverage_xml = tmp_path / "coverage.xml"
         coverage_xml.write_text("this is not xml")
-        result = parse_coverage_report(coverage_xml)
-        assert result is None
+
+        with pytest.raises(CoverageReportParseError, match="securely parse"):
+            parse_coverage_report(coverage_xml)
+
+    def test_missing_parser_raises_actionable_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unavailable secure parser identifies the required extra."""
+        coverage_xml = tmp_path / "coverage.xml"
+        coverage_xml.write_text('<coverage line-rate="0.90"></coverage>\n')
+        real_import = builtins.__import__
+
+        def guarded_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name.startswith("defusedxml"):
+                raise ImportError("simulated missing defusedxml")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        with pytest.raises(
+            CoverageParserUnavailableError,
+            match=r"HomericIntelligence-Hephaestus\[xml\]",
+        ):
+            parse_coverage_report(coverage_xml)
 
 
 class TestCheckCoverage:
@@ -146,10 +175,10 @@ class TestCheckCoverage:
         result = check_coverage(80.0, "mypackage/", coverage_xml)
         assert result is False
 
-    def test_missing_coverage_file_passes(self, tmp_path: Path) -> None:
-        """Missing coverage file passes gracefully."""
+    def test_missing_coverage_file_fails(self, tmp_path: Path) -> None:
+        """Missing coverage files fail closed."""
         result = check_coverage(80.0, "mypackage/", tmp_path / "missing.xml")
-        assert result is True
+        assert result is False
 
 
 class TestMain:
@@ -218,8 +247,6 @@ class TestMain:
 
     def test_json_missing_coverage_file(self, tmp_path: Path, monkeypatch, capsys) -> None:
         """--json emits an error envelope when the coverage file is missing."""
-        import json
-
         monkeypatch.setattr(
             "sys.argv",
             [
@@ -234,12 +261,13 @@ class TestMain:
         assert main() == 1
         payload = json.loads(capsys.readouterr().out)
         assert payload["status"] == "error"
+        assert payload["passed"] is False
+        assert payload["coverage"] is None
+        assert payload["error"] == "coverage_file_missing"
         assert "not found" in payload["message"]
 
     def test_json_passing(self, tmp_path: Path, monkeypatch, capsys, empty_config: Path) -> None:
         """--json emits a structured payload when coverage passes."""
-        import json
-
         pytest.importorskip("defusedxml")
         coverage_xml = tmp_path / "coverage.xml"
         coverage_xml.write_text(
@@ -268,8 +296,6 @@ class TestMain:
 
     def test_json_failing(self, tmp_path: Path, monkeypatch, capsys, empty_config: Path) -> None:
         """--json returns 1 and reports failure when below threshold."""
-        import json
-
         pytest.importorskip("defusedxml")
         coverage_xml = tmp_path / "coverage.xml"
         coverage_xml.write_text(
@@ -297,9 +323,7 @@ class TestMain:
     def test_json_unparseable_coverage(
         self, tmp_path: Path, monkeypatch, capsys, empty_config: Path
     ) -> None:
-        """--json returns 0 with passed=True when coverage is unparseable."""
-        import json
-
+        """--json fails with actionable context for malformed XML."""
         coverage_xml = tmp_path / "coverage.xml"
         coverage_xml.write_text("not xml at all")
         monkeypatch.setattr(
@@ -317,7 +341,97 @@ class TestMain:
                 str(empty_config),
             ],
         )
-        assert main() == 0
+        assert main() == 1
         payload = json.loads(capsys.readouterr().out)
-        assert payload["passed"] is True
+        assert payload["passed"] is False
         assert payload["coverage"] is None
+        assert payload["error"] == "report_unparseable"
+        assert str(coverage_xml) in payload["message"]
+
+    def test_unparseable_coverage_returns_one(
+        self, tmp_path: Path, monkeypatch, capsys, empty_config: Path
+    ) -> None:
+        """Human-readable mode fails explicitly for malformed XML."""
+        coverage_xml = tmp_path / "coverage.xml"
+        coverage_xml.write_text("not xml at all")
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check-coverage",
+                "--threshold",
+                "80",
+                "--coverage-file",
+                str(coverage_xml),
+                "--config",
+                str(empty_config),
+            ],
+        )
+
+        assert main() == 1
+        assert "Could not securely parse coverage report" in capsys.readouterr().err
+
+    def test_json_missing_parser(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        empty_config: Path,
+    ) -> None:
+        """--json identifies an unavailable secure parser."""
+        coverage_xml = tmp_path / "coverage.xml"
+        coverage_xml.write_text('<coverage line-rate="0.90"></coverage>\n')
+        real_import = builtins.__import__
+
+        def guarded_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name.startswith("defusedxml"):
+                raise ImportError("simulated missing defusedxml")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check-coverage",
+                "--threshold",
+                "80",
+                "--coverage-file",
+                str(coverage_xml),
+                "--json",
+                "--config",
+                str(empty_config),
+            ],
+        )
+
+        assert main() == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is False
+        assert payload["coverage"] is None
+        assert payload["error"] == "parser_unavailable"
+        assert "[xml]" in payload["message"]
+
+    def test_json_missing_coverage_data(
+        self, tmp_path: Path, monkeypatch, capsys, empty_config: Path
+    ) -> None:
+        """--json identifies reports without aggregate line-rate data."""
+        coverage_xml = tmp_path / "coverage.xml"
+        coverage_xml.write_text('<coverage version="7.4"></coverage>\n')
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check-coverage",
+                "--threshold",
+                "80",
+                "--coverage-file",
+                str(coverage_xml),
+                "--json",
+                "--config",
+                str(empty_config),
+            ],
+        )
+
+        assert main() == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is False
+        assert payload["coverage"] is None
+        assert payload["error"] == "coverage_data_absent"
+        assert "line-rate" in payload["message"]


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2375.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2375

Generated by Hephaestus automation
