### PR TITLE
chore: Fail closed when dependency-audit evidence is missing or unscored

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ zero totals, and zero requested/processed counts.
 | `hephaestus-check-tier-labels` | Enforce tier label consistency across all project Markdown files |
 | `hephaestus-check-type-aliases` | Detect type alias shadowing patterns in Python code |
 | `hephaestus-check-unlinked-todo` | Enforce that every TODO/FIXME/HACK marker references a tracking issue |
-| `hephaestus-filter-audit` | Filter pip-audit JSON output to fail only on HIGH/CRITICAL severity vulnerabilities |
+| `hephaestus-filter-audit` | Validate pip-audit evidence and fail on HIGH, CRITICAL, or unscored advisories |
 | `hephaestus-mypy-each-file` | Run mypy on each file individually to avoid duplicate-module-name errors |
 | `hephaestus-validate-agents` | YAML frontmatter extraction and validation for agent markdown files |
 | `hephaestus-validate-links` | Markdown validation utilities for HomericIntelligence projects |

--- a/hephaestus/validation/audit.py
+++ b/hephaestus/validation/audit.py
@@ -246,6 +246,10 @@ def _validate_audit_result(data: object) -> dict[str, Any]:
     if not isinstance(dependencies, list):
         raise ValueError("dependencies must be a list")
 
+    fixes = data.get("fixes")
+    if not isinstance(fixes, list):
+        raise ValueError("fixes must be a list")
+
     for dependency_index, dependency in enumerate(dependencies):
         _validate_audit_dependency(dependency, dependency_index)
 

--- a/hephaestus/validation/audit.py
+++ b/hephaestus/validation/audit.py
@@ -1,8 +1,9 @@
-"""Filter pip-audit JSON output to fail only on HIGH/CRITICAL severity vulnerabilities.
+"""Filter pip-audit JSON output using a fail-closed severity policy.
 
 Reads pip-audit JSON from stdin, classifies vulnerabilities by CVSS v3 base score,
-and exits non-zero only for HIGH (7.0+) or CRITICAL (9.0+) findings. Lower-severity
-findings are reported as warnings. Supports an ignore list via ``.pip-audit-ignore.txt``.
+and exits non-zero for HIGH (7.0+), CRITICAL (9.0+), or unscored findings. Lower-
+severity findings are reported as warnings. Supports an ignore list via
+``.pip-audit-ignore.txt``.
 
 Usage::
 
@@ -200,12 +201,63 @@ def severity_label(score: float | None) -> str:
 AuditEntry = tuple[str, str, str, str]  # (package, version, vuln_id, label)
 
 
+def _validate_audit_vulnerability(vulnerability: object, path: str) -> None:
+    """Validate one vulnerability record and its optional severity list."""
+    if not isinstance(vulnerability, dict):
+        raise ValueError(f"{path} must be an object")
+
+    vulnerability_id = vulnerability.get("id")
+    if not isinstance(vulnerability_id, str) or not vulnerability_id.strip():
+        raise ValueError(f"{path}.id must be a nonempty string")
+
+    severity = vulnerability.get("severity", [])
+    if not isinstance(severity, list):
+        raise ValueError(f"{path}.severity must be a list")
+    if any(not isinstance(entry, dict) for entry in severity):
+        raise ValueError(f"{path}.severity entries must be objects")
+
+
+def _validate_audit_dependency(dependency: object, index: int) -> None:
+    """Validate one dependency record and all of its vulnerabilities."""
+    path = f"dependencies[{index}]"
+    if not isinstance(dependency, dict):
+        raise ValueError(f"{path} must be an object")
+
+    for field in ("name", "version"):
+        value = dependency.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{path}.{field} must be a nonempty string")
+
+    vulnerabilities = dependency.get("vulns")
+    if not isinstance(vulnerabilities, list):
+        raise ValueError(f"{path}.vulns must be a list")
+
+    for vulnerability_index, vulnerability in enumerate(vulnerabilities):
+        vuln_path = f"{path}.vulns[{vulnerability_index}]"
+        _validate_audit_vulnerability(vulnerability, vuln_path)
+
+
+def _validate_audit_result(data: object) -> dict[str, Any]:
+    """Validate the pip-audit result shape consumed by this filter."""
+    if not isinstance(data, dict):
+        raise ValueError("expected a top-level object")
+
+    dependencies = data.get("dependencies")
+    if not isinstance(dependencies, list):
+        raise ValueError("dependencies must be a list")
+
+    for dependency_index, dependency in enumerate(dependencies):
+        _validate_audit_dependency(dependency, dependency_index)
+
+    return cast(dict[str, Any], data)
+
+
 def filter_audit_results(
-    data: dict[str, Any],
+    data: object,
     ignore_ids: frozenset[str] = frozenset(),
     threshold: float = HIGH_THRESHOLD,
 ) -> tuple[list[AuditEntry], list[AuditEntry]]:
-    """Filter pip-audit JSON results by severity.
+    """Filter validated pip-audit results using a fail-closed severity policy.
 
     Args:
         data: Parsed pip-audit JSON output.
@@ -216,22 +268,30 @@ def filter_audit_results(
         Tuple of ``(blocking, suppressed)`` where each is a list of
         ``(package, version, vuln_id, severity_label)`` tuples.
 
+    Raises:
+        ValueError: If data is not a complete scanner-result structure.
+
     """
+    validated = _validate_audit_result(data)
     blocking: list[AuditEntry] = []
     suppressed: list[AuditEntry] = []
 
-    for dep in data.get("dependencies", []):
-        name = dep.get("name", "?")
-        version = dep.get("version", "?")
-        for vuln in dep.get("vulns", []):
-            vuln_id = vuln.get("id", "?")
-            if vuln_id in ignore_ids:
+    for dependency in validated["dependencies"]:
+        name = dependency["name"]
+        version = dependency["version"]
+        for vulnerability in dependency["vulns"]:
+            vulnerability_id = vulnerability["id"]
+            if vulnerability_id in ignore_ids:
                 continue
-            severity_list = vuln.get("severity", [])
-            score = extract_cvss_score(severity_list)
-            label = severity_label(score)
-            entry: AuditEntry = (name, version, vuln_id, label)
-            if score is not None and score >= threshold:
+
+            score = extract_cvss_score(vulnerability.get("severity", []))
+            entry: AuditEntry = (
+                name,
+                version,
+                vulnerability_id,
+                severity_label(score),
+            )
+            if score is None or score >= threshold:
                 blocking.append(entry)
             else:
                 suppressed.append(entry)
@@ -240,7 +300,7 @@ def filter_audit_results(
 
 
 def main() -> int:
-    """Parse pip-audit JSON from stdin and exit non-zero on HIGH/CRITICAL findings.
+    """Parse pip-audit JSON and exit non-zero on blocking findings.
 
     Returns:
         Exit code (0 if no blocking vulnerabilities, 1 otherwise).
@@ -249,14 +309,14 @@ def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
 
+    try:
+        data = _parse_audit_input(sys.stdin.read())
+    except ValueError as exc:
+        return _audit_input_error(str(exc), args.json)
+
     ignore_ids = load_ignore_list(args.ignore_file)
     if ignore_ids and not args.json:
         print(f"pip-audit: ignoring {len(ignore_ids)} advisory ID(s)")
-
-    parsed = _parse_audit_input(sys.stdin.read(), args.json)
-    if isinstance(parsed, int):
-        return parsed
-    data = parsed
 
     blocking, suppressed = filter_audit_results(data, ignore_ids)
 
@@ -264,12 +324,12 @@ def main() -> int:
         return _emit_audit_json(blocking, suppressed)
 
     if suppressed:
-        print("pip-audit: suppressed vulnerabilities (LOW/MEDIUM/UNKNOWN — not blocking CI):")
+        print("pip-audit: non-blocking vulnerabilities (below configured threshold):")
         for name, version, vuln_id, label in suppressed:
             print(f"  [{label}] {name}=={version} {vuln_id}")
 
     if blocking:
-        print("pip-audit: BLOCKING vulnerabilities found (HIGH/CRITICAL):")
+        print("pip-audit: BLOCKING vulnerabilities found (HIGH/CRITICAL/UNKNOWN):")
         for name, version, vuln_id, label in blocking:
             print(f"  [{label}] {name}=={version} {vuln_id}")
         return 1
@@ -279,28 +339,23 @@ def main() -> int:
     return 0
 
 
-def _parse_audit_input(raw: str, json_mode: bool) -> dict[str, Any] | int:
-    """Parse pip-audit stdin payload.
+def _audit_input_error(detail: str, json_mode: bool) -> int:
+    """Emit a fail-closed scanner-evidence error in the requested mode."""
+    message = f"invalid pip-audit evidence: {detail}"
+    if json_mode:
+        emit_json_status(1, message=message)
+    else:
+        print(f"filter_audit: {message}", file=sys.stderr)
+    return 1
 
-    Returns the parsed dict, or an integer exit code if the input was empty
-    or failed to parse.
-    """
-    json_start = raw.find("{")
-    if json_start == -1:
-        if json_mode:
-            emit_json_status(0, message="no vulnerabilities found")
-        else:
-            print("pip-audit: no vulnerabilities found", file=sys.stderr)
-        return 0
 
+def _parse_audit_input(raw: str) -> dict[str, Any]:
+    """Decode and validate one complete pip-audit JSON document."""
     try:
-        return cast(dict[str, Any], json.loads(raw[json_start:]))
+        parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
-        if json_mode:
-            emit_json_status(1, message=f"failed to parse pip-audit JSON: {exc}")
-        else:
-            print(f"filter_audit: failed to parse pip-audit JSON: {exc}", file=sys.stderr)
-        return 1
+        raise ValueError(f"failed to parse JSON: {exc}") from exc
+    return _validate_audit_result(parsed)
 
 
 def _emit_audit_json(blocking: list[AuditEntry], suppressed: list[AuditEntry]) -> int:
@@ -322,7 +377,7 @@ def _emit_audit_json(blocking: list[AuditEntry], suppressed: list[AuditEntry]) -
 def _build_parser() -> argparse.ArgumentParser:
     """Build argument parser for the filter-audit CLI."""
     parser = create_validation_parser(
-        "Filter pip-audit JSON to fail only on HIGH/CRITICAL vulnerabilities",
+        "Validate pip-audit JSON and fail on HIGH, CRITICAL, or unscored advisories",
         include_repo_root=False,
         epilog="Usage: pip-audit --format json | %(prog)s",
     )

--- a/tests/unit/validation/test_audit.py
+++ b/tests/unit/validation/test_audit.py
@@ -4,6 +4,8 @@ import io
 import json
 from pathlib import Path
 
+import pytest
+
 from hephaestus.validation.audit import (
     extract_cvss_score,
     filter_audit_results,
@@ -162,7 +164,12 @@ class TestSeverityLabel:
 class TestFilterAuditResults:
     """Tests for filter_audit_results()."""
 
-    def _make_data(self, vulns: list[dict], name: str = "pkg", version: str = "1.0") -> dict:
+    def _make_data(
+        self,
+        vulns: list[dict[str, object]],
+        name: str = "pkg",
+        version: str = "1.0",
+    ) -> dict[str, object]:
         return {"dependencies": [{"name": name, "version": version, "vulns": vulns}]}
 
     def test_high_severity_blocks(self) -> None:
@@ -200,12 +207,59 @@ class TestFilterAuditResults:
         blocking, _suppressed = filter_audit_results(data, threshold=4.0)
         assert len(blocking) == 1
 
-    def test_no_score_is_suppressed(self) -> None:
-        """Vulnerabilities with no CVSS score are suppressed, not blocking."""
-        data = self._make_data([{"id": "CVE-4", "severity": []}])
-        blocking, suppressed = filter_audit_results(data)
-        assert len(blocking) == 0
-        assert len(suppressed) == 1
+    @pytest.mark.parametrize(
+        "vulnerability",
+        [
+            pytest.param({"id": "CVE-4"}, id="missing-severity"),
+            pytest.param({"id": "CVE-4", "severity": []}, id="empty-severity"),
+            pytest.param(
+                {"id": "CVE-4", "severity": [{"score": "unknown"}]},
+                id="unparseable-score",
+            ),
+        ],
+    )
+    def test_unknown_score_is_blocking(self, vulnerability: dict[str, object]) -> None:
+        """Structurally valid advisories without a parseable score block."""
+        blocking, suppressed = filter_audit_results(self._make_data([vulnerability]))
+        assert blocking == [("pkg", "1.0", "CVE-4", "UNKNOWN")]
+        assert suppressed == []
+
+    def test_ignored_unscored_id_is_skipped(self) -> None:
+        """Only the matching reviewed advisory ID bypasses an unscored finding."""
+        data = self._make_data([{"id": "CVE-4"}])
+        blocking, suppressed = filter_audit_results(
+            data,
+            ignore_ids=frozenset({"CVE-4"}),
+        )
+        assert blocking == []
+        assert suppressed == []
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"dependencies": [{}]}, id="empty-dependency"),
+            pytest.param(
+                {"dependencies": [{"name": "pkg", "version": "1.0"}]},
+                id="missing-vulns",
+            ),
+            pytest.param(
+                {
+                    "dependencies": [
+                        {
+                            "name": "pkg",
+                            "version": "1.0",
+                            "vulns": [{}],
+                        }
+                    ]
+                },
+                id="missing-vulnerability-id",
+            ),
+        ],
+    )
+    def test_invalid_nested_result_raises(self, data: object) -> None:
+        """Malformed nested scanner data cannot produce a clean verdict."""
+        with pytest.raises(ValueError, match=r"dependencies\[0\]"):
+            filter_audit_results(data)
 
     def test_cvss_vector_only_high_severity_blocks(self) -> None:
         """Vector-only HIGH/CRITICAL vulnerabilities are blocking."""
@@ -225,17 +279,142 @@ class TestFilterAuditResults:
 class TestMain:
     """Tests for main() CLI entry point."""
 
-    def test_no_json_input(self, monkeypatch) -> None:
-        """No JSON on stdin returns 0."""
-        monkeypatch.setattr("sys.argv", ["filter-audit"])
-        monkeypatch.setattr("sys.stdin", io.StringIO("No known vulnerabilities found"))
-        assert main() == 0
+    @pytest.mark.parametrize("json_mode", [False, True], ids=["human", "json"])
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("No known vulnerabilities found", id="non-json"),
+            pytest.param("{invalid json", id="malformed-json"),
+        ],
+    )
+    def test_invalid_scanner_output_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        raw: str,
+        json_mode: bool,
+    ) -> None:
+        """Missing or unparsable evidence exits nonzero in both output modes."""
+        argv = ["filter-audit", *(["--json"] if json_mode else [])]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr("sys.stdin", io.StringIO(raw))
 
-    def test_invalid_json(self, monkeypatch) -> None:
-        """Invalid JSON returns 1."""
-        monkeypatch.setattr("sys.argv", ["filter-audit"])
-        monkeypatch.setattr("sys.stdin", io.StringIO("{invalid json"))
         assert main() == 1
+        captured = capsys.readouterr()
+        if json_mode:
+            report = json.loads(captured.out)
+            assert report["status"] == "error"
+            assert report["exit_code"] == 1
+        else:
+            assert "invalid pip-audit evidence" in captured.err
+
+    @pytest.mark.parametrize("json_mode", [False, True], ids=["human", "json"])
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param(None, id="null"),
+            pytest.param("scanner output", id="string"),
+            pytest.param(1, id="number"),
+            pytest.param(True, id="boolean"),
+            pytest.param([], id="array"),
+            pytest.param({}, id="missing-dependencies"),
+            pytest.param({"dependencies": {}}, id="dependencies-not-list"),
+        ],
+    )
+    def test_invalid_top_level_shape_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        data: object,
+        json_mode: bool,
+    ) -> None:
+        """Only an object containing a dependencies list is accepted."""
+        argv = ["filter-audit", *(["--json"] if json_mode else [])]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
+
+        assert main() == 1
+        captured = capsys.readouterr()
+        if json_mode:
+            report = json.loads(captured.out)
+            assert report["status"] == "error"
+            assert report["exit_code"] == 1
+        else:
+            assert "invalid pip-audit evidence" in captured.err
+
+    @pytest.mark.parametrize("json_mode", [False, True], ids=["human", "json"])
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"dependencies": [None]}, id="dependency-not-object"),
+            pytest.param({"dependencies": [{}]}, id="empty-dependency"),
+            pytest.param(
+                {"dependencies": [{"name": "pkg", "version": "1.0"}]},
+                id="missing-vulns",
+            ),
+            pytest.param(
+                {"dependencies": [{"name": "pkg", "skip_reason": "not auditable"}]},
+                id="skipped-dependency",
+            ),
+            pytest.param(
+                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": {}}]},
+                id="vulns-not-list",
+            ),
+            pytest.param(
+                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": [None]}]},
+                id="vulnerability-not-object",
+            ),
+            pytest.param(
+                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": [{}]}]},
+                id="missing-vulnerability-id",
+            ),
+            pytest.param(
+                {
+                    "dependencies": [
+                        {
+                            "name": "pkg",
+                            "version": "1.0",
+                            "vulns": [{"id": "CVE-1", "severity": {}}],
+                        }
+                    ]
+                },
+                id="severity-not-list",
+            ),
+            pytest.param(
+                {
+                    "dependencies": [
+                        {
+                            "name": "pkg",
+                            "version": "1.0",
+                            "vulns": [{"id": "CVE-1", "severity": [None]}],
+                        }
+                    ]
+                },
+                id="severity-entry-not-object",
+            ),
+        ],
+    )
+    def test_invalid_nested_shape_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        data: object,
+        json_mode: bool,
+    ) -> None:
+        """Every structurally invalid nested payload uses the shared error path."""
+        argv = ["filter-audit", *(["--json"] if json_mode else [])]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
+
+        assert main() == 1
+        captured = capsys.readouterr()
+        if json_mode:
+            report = json.loads(captured.out)
+            assert report["status"] == "error"
+            assert report["exit_code"] == 1
+        else:
+            assert "invalid pip-audit evidence" in captured.err
 
     def test_clean_audit(self, monkeypatch) -> None:
         """Clean audit with no vulns returns 0."""
@@ -273,3 +452,40 @@ class TestMain:
         monkeypatch.setattr("sys.argv", ["filter-audit"])
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
         assert main() == 0
+
+    @pytest.mark.parametrize("json_mode", [False, True], ids=["human", "json"])
+    def test_unscored_vulnerability_blocks_in_all_output_modes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        json_mode: bool,
+    ) -> None:
+        """Human and JSON output expose the same blocking UNKNOWN verdict."""
+        data = {
+            "dependencies": [
+                {
+                    "name": "pkg",
+                    "version": "1.0",
+                    "vulns": [{"id": "CVE-UNKNOWN"}],
+                }
+            ]
+        }
+        argv = ["filter-audit", *(["--json"] if json_mode else [])]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
+
+        assert main() == 1
+        captured = capsys.readouterr()
+        if json_mode:
+            report = json.loads(captured.out)
+            assert report["exit_code"] == 1
+            assert report["blocking"] == [
+                {
+                    "package": "pkg",
+                    "version": "1.0",
+                    "id": "CVE-UNKNOWN",
+                    "severity": "UNKNOWN",
+                }
+            ]
+        else:
+            assert "[UNKNOWN] pkg==1.0 CVE-UNKNOWN" in captured.out

--- a/tests/unit/validation/test_audit.py
+++ b/tests/unit/validation/test_audit.py
@@ -170,7 +170,7 @@ class TestFilterAuditResults:
         name: str = "pkg",
         version: str = "1.0",
     ) -> dict[str, object]:
-        return {"dependencies": [{"name": name, "version": version, "vulns": vulns}]}
+        return {"dependencies": [{"name": name, "version": version, "vulns": vulns}], "fixes": []}
 
     def test_high_severity_blocks(self) -> None:
         """HIGH severity vulnerabilities are blocking."""
@@ -196,7 +196,7 @@ class TestFilterAuditResults:
 
     def test_no_vulnerabilities(self) -> None:
         """No vulnerabilities returns empty lists."""
-        data = {"dependencies": [{"name": "safe", "version": "1.0", "vulns": []}]}
+        data = {"dependencies": [{"name": "safe", "version": "1.0", "vulns": []}], "fixes": []}
         blocking, suppressed = filter_audit_results(data)
         assert blocking == []
         assert suppressed == []
@@ -237,9 +237,9 @@ class TestFilterAuditResults:
     @pytest.mark.parametrize(
         "data",
         [
-            pytest.param({"dependencies": [{}]}, id="empty-dependency"),
+            pytest.param({"dependencies": [{}], "fixes": []}, id="empty-dependency"),
             pytest.param(
-                {"dependencies": [{"name": "pkg", "version": "1.0"}]},
+                {"dependencies": [{"name": "pkg", "version": "1.0"}], "fixes": []},
                 id="missing-vulns",
             ),
             pytest.param(
@@ -250,7 +250,8 @@ class TestFilterAuditResults:
                             "version": "1.0",
                             "vulns": [{}],
                         }
-                    ]
+                    ],
+                    "fixes": [],
                 },
                 id="missing-vulnerability-id",
             ),
@@ -259,6 +260,18 @@ class TestFilterAuditResults:
     def test_invalid_nested_result_raises(self, data: object) -> None:
         """Malformed nested scanner data cannot produce a clean verdict."""
         with pytest.raises(ValueError, match=r"dependencies\[0\]"):
+            filter_audit_results(data)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"dependencies": []}, id="missing-fixes"),
+            pytest.param({"dependencies": [], "fixes": {}}, id="fixes-not-list"),
+        ],
+    )
+    def test_fixes_list_is_required(self, data: object) -> None:
+        """Incomplete scanner evidence without a fixes list cannot pass."""
+        with pytest.raises(ValueError, match="fixes must be a list"):
             filter_audit_results(data)
 
     def test_cvss_vector_only_high_severity_blocks(self) -> None:
@@ -320,6 +333,8 @@ class TestMain:
             pytest.param([], id="array"),
             pytest.param({}, id="missing-dependencies"),
             pytest.param({"dependencies": {}}, id="dependencies-not-list"),
+            pytest.param({"dependencies": []}, id="missing-fixes"),
+            pytest.param({"dependencies": [], "fixes": {}}, id="fixes-not-list"),
         ],
     )
     def test_invalid_top_level_shape_fails_closed(
@@ -329,7 +344,7 @@ class TestMain:
         data: object,
         json_mode: bool,
     ) -> None:
-        """Only an object containing a dependencies list is accepted."""
+        """Only an object containing dependencies and fixes lists is accepted."""
         argv = ["filter-audit", *(["--json"] if json_mode else [])]
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
@@ -347,26 +362,26 @@ class TestMain:
     @pytest.mark.parametrize(
         "data",
         [
-            pytest.param({"dependencies": [None]}, id="dependency-not-object"),
-            pytest.param({"dependencies": [{}]}, id="empty-dependency"),
+            pytest.param({"dependencies": [None], "fixes": []}, id="dependency-not-object"),
+            pytest.param({"dependencies": [{}], "fixes": []}, id="empty-dependency"),
             pytest.param(
-                {"dependencies": [{"name": "pkg", "version": "1.0"}]},
+                {"dependencies": [{"name": "pkg", "version": "1.0"}], "fixes": []},
                 id="missing-vulns",
             ),
             pytest.param(
-                {"dependencies": [{"name": "pkg", "skip_reason": "not auditable"}]},
+                {"dependencies": [{"name": "pkg", "skip_reason": "not auditable"}], "fixes": []},
                 id="skipped-dependency",
             ),
             pytest.param(
-                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": {}}]},
+                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": {}}], "fixes": []},
                 id="vulns-not-list",
             ),
             pytest.param(
-                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": [None]}]},
+                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": [None]}], "fixes": []},
                 id="vulnerability-not-object",
             ),
             pytest.param(
-                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": [{}]}]},
+                {"dependencies": [{"name": "pkg", "version": "1.0", "vulns": [{}]}], "fixes": []},
                 id="missing-vulnerability-id",
             ),
             pytest.param(
@@ -377,7 +392,8 @@ class TestMain:
                             "version": "1.0",
                             "vulns": [{"id": "CVE-1", "severity": {}}],
                         }
-                    ]
+                    ],
+                    "fixes": [],
                 },
                 id="severity-not-list",
             ),
@@ -389,7 +405,8 @@ class TestMain:
                             "version": "1.0",
                             "vulns": [{"id": "CVE-1", "severity": [None]}],
                         }
-                    ]
+                    ],
+                    "fixes": [],
                 },
                 id="severity-entry-not-object",
             ),
@@ -418,7 +435,7 @@ class TestMain:
 
     def test_clean_audit(self, monkeypatch) -> None:
         """Clean audit with no vulns returns 0."""
-        data = {"dependencies": [{"name": "safe", "version": "1.0", "vulns": []}]}
+        data = {"dependencies": [{"name": "safe", "version": "1.0", "vulns": []}], "fixes": []}
         monkeypatch.setattr("sys.argv", ["filter-audit"])
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
         assert main() == 0
@@ -432,7 +449,8 @@ class TestMain:
                     "version": "1.0",
                     "vulns": [{"id": "CVE-1", "severity": [{"score": 9.5}]}],
                 }
-            ]
+            ],
+            "fixes": [],
         }
         monkeypatch.setattr("sys.argv", ["filter-audit"])
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
@@ -447,7 +465,8 @@ class TestMain:
                     "version": "1.0",
                     "vulns": [{"id": "CVE-2", "severity": [{"score": 3.0}]}],
                 }
-            ]
+            ],
+            "fixes": [],
         }
         monkeypatch.setattr("sys.argv", ["filter-audit"])
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(data)))
@@ -468,7 +487,8 @@ class TestMain:
                     "version": "1.0",
                     "vulns": [{"id": "CVE-UNKNOWN"}],
                 }
-            ]
+            ],
+            "fixes": [],
         }
         argv = ["filter-audit", *(["--json"] if json_mode else [])]
         monkeypatch.setattr("sys.argv", argv)


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2379.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2379

Generated by Hephaestus automation
