### PR TITLE
fix(automation): honor forced replanning when an issue has an open PR

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -286,6 +286,7 @@ class Coordinator(
         self._stage_config = _StageRunConfig(
             enable_advise=not config.no_advise,
             enable_learn=config.enable_learn,
+            force=config.force,
             agent=config.agent,
             model=config.model,
             planner_model=config.planner_model,

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -242,7 +242,7 @@ def _write_planning_entry_labels(
     forced_initial_plan: bool,
 ) -> bool:
     """Durably establish and confirm the exclusive planning-entry label."""
-    if revision_already_published or forced_initial_plan:
+    if (STATE_PLAN_NO_GO in labels and revision_already_published) or forced_initial_plan:
         if not is_exclusive_plan_state(labels, STATE_NEEDS_PLAN):
             add_labels, remove_labels = enter_planning_transition()
             logger.info(
@@ -422,23 +422,22 @@ def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
     requires_revision = bool(item.payload.get("requires_plan_revision"))
     awaiting_revision_candidate = requires_revision and plan_text is None
     posted_plan = False
-    if plan_text is not None:
-        if requires_revision or lookup.status is PlanDiscoveryStatus.ABSENT:
-            logger.info("planning:%d: publishing plan revision", item.issue)
-            try:
-                publication_outcome = _publish_candidate_plan(
-                    item,
-                    ctx,
-                    requires_revision=requires_revision,
-                )
-            except CommentJournalReadError as exc:
-                return StageOutcome(
-                    Disposition.RETRY,
-                    f"plan journal read failed: {exc}",
-                )
-            if publication_outcome is not None:
-                return publication_outcome
-            posted_plan = True
+    if plan_text is not None and (requires_revision or lookup.status is PlanDiscoveryStatus.ABSENT):
+        logger.info("planning:%d: publishing plan revision", item.issue)
+        try:
+            publication_outcome = _publish_candidate_plan(
+                item,
+                ctx,
+                requires_revision=requires_revision,
+            )
+        except CommentJournalReadError as exc:
+            return StageOutcome(
+                Disposition.RETRY,
+                f"plan journal read failed: {exc}",
+            )
+        if publication_outcome is not None:
+            return publication_outcome
+        posted_plan = True
 
     if not awaiting_revision_candidate and (
         posted_plan or lookup.status is PlanDiscoveryStatus.FOUND

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -62,6 +62,7 @@ from hephaestus.automation.state_labels import (
     STATE_PLAN_BLOCKED,
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
+    apply_plan_state,
     enter_planning_transition,
     is_exclusive_plan_state,
     is_plan_go,
@@ -187,8 +188,10 @@ def _load_planning_journal(
     item: WorkItem,
     ctx: StageContext,
     labels: Sequence[str],
-) -> tuple[list[IssueComment], JournalSnapshot, bool, bool]:
-    """Reconcile GitHub, hydrate the work item, and recover replan intent."""
+    *,
+    force_replan: bool,
+) -> tuple[list[IssueComment], JournalSnapshot, bool, bool, bool]:
+    """Reconcile GitHub and classify durable planning entry state."""
     assert item.issue is not None  # noqa: S101 - on_enter validates the work item first
     comments = reconcile_plan_journal(item.issue, ctx.github)
     snapshot = journal_snapshot(comments)
@@ -200,15 +203,28 @@ def _load_planning_journal(
         and snapshot.current_review_revision == snapshot.revision
         and is_pending_review(snapshot.current_review, revision=snapshot.revision)
     )
-    is_replan_entry = _is_replan_entry(
+    forced_from_plan_go = force_replan and is_exclusive_plan_state(
         labels,
-        revision_already_published=revision_already_published,
+        STATE_PLAN_GO,
+    )
+    forced_initial_plan = forced_from_plan_go and not snapshot.current_plan
+    is_replan_entry = (
+        _is_replan_entry(
+            labels,
+            revision_already_published=revision_already_published,
+        )
+        or (
+            forced_from_plan_go
+            and bool(snapshot.current_plan)
+            and not revision_already_published
+        )
     )
     return (
         comments,
         snapshot,
         is_replan_entry,
         revision_already_published,
+        forced_initial_plan,
     )
 
 
@@ -230,26 +246,48 @@ def _write_planning_entry_labels(
     *,
     is_replan_entry: bool,
     revision_already_published: bool,
+    forced_initial_plan: bool,
 ) -> bool:
-    """Durably establish the mutually-exclusive planning entry label."""
-    if STATE_PLAN_NO_GO in labels and revision_already_published:
-        add, remove = enter_planning_transition()
-        logger.info("planning:%d: entry swap; add %s, remove %s", issue_number, add, remove)
-        ctx.github.edit_labels(issue_number, add=add, remove=remove)
+    """Durably establish and confirm the exclusive planning-entry label."""
+    if revision_already_published or forced_initial_plan:
+        if not is_exclusive_plan_state(labels, STATE_NEEDS_PLAN):
+            add_labels, remove_labels = enter_planning_transition()
+            logger.info(
+                "planning:%d: entry swap; add %s, remove %s",
+                issue_number,
+                add_labels,
+                remove_labels,
+            )
+            ctx.github.edit_labels(issue_number, add=add_labels, remove=remove_labels)
+        expected_state = STATE_NEEDS_PLAN
     elif is_replan_entry:
         # Keep state:plan-no-go authoritative until a revised canonical plan
         # has actually been published. This removes the crash window where a
         # needs-plan label plus stale rejected plan could be mistaken for a
         # fresh initial planning entry.
-        return is_exclusive_plan_state(
-            _require_issue_labels_for_transition(issue_number, ctx), STATE_PLAN_NO_GO
-        )
+        if not is_exclusive_plan_state(labels, STATE_PLAN_NO_GO):
+            label_to_add, remove_labels = apply_plan_state(STATE_PLAN_NO_GO)
+            logger.info(
+                "planning:%d: forced replan; add %s, remove %s",
+                issue_number,
+                label_to_add,
+                remove_labels,
+            )
+            ctx.github.edit_labels(
+                issue_number,
+                add=[label_to_add],
+                remove=remove_labels,
+            )
+        expected_state = STATE_PLAN_NO_GO
     elif STATE_NEEDS_PLAN not in labels:
         logger.info("planning:%d: adding %s label", issue_number, STATE_NEEDS_PLAN)
         ctx.github.add_labels(issue_number, [STATE_NEEDS_PLAN])
+        expected_state = STATE_NEEDS_PLAN
+    else:
+        expected_state = STATE_NEEDS_PLAN
     return is_exclusive_plan_state(
         _require_issue_labels_for_transition(issue_number, ctx),
-        STATE_NEEDS_PLAN,
+        expected_state,
     )
 
 
@@ -388,9 +426,10 @@ def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
         )
 
     plan_text = item.payload.get("plan_text")
+    requires_revision = bool(item.payload.get("requires_plan_revision"))
+    awaiting_revision_candidate = requires_revision and plan_text is None
     posted_plan = False
     if plan_text is not None:
-        requires_revision = bool(item.payload.get("requires_plan_revision"))
         if requires_revision or lookup.status is PlanDiscoveryStatus.ABSENT:
             logger.info("planning:%d: publishing plan revision", item.issue)
             try:
@@ -408,7 +447,9 @@ def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
                 return publication_outcome
             posted_plan = True
 
-    if posted_plan or lookup.status is PlanDiscoveryStatus.FOUND:
+    if not awaiting_revision_candidate and (
+        posted_plan or lookup.status is PlanDiscoveryStatus.FOUND
+    ):
         labels = _require_issue_labels_for_transition(item.issue, ctx)
         if STATE_PLAN_BLOCKED in labels:
             return StageOutcome(
@@ -458,10 +499,12 @@ class PlanningStage(Stage):
 
     - ``state:skip`` -> SKIP (checked BEFORE plan-go; skip wins over
       everything, even a contradictory plan-go, logging a WARNing — #1835)
-    - already at-or-past ``state:plan-go`` -> ADVANCE (zero jobs)
+    - already at-or-past ``state:plan-go`` -> ADVANCE (zero jobs), unless
+      force requests a fresh plan revision
     - freshly closed issue + exact merged closing PR -> FINISH_PASS
     - open issue + historic merged closing PR -> continue planning
-    - open PR -> SKIP (PR already covers implementation)
+    - open PR -> SKIP (PR already covers implementation), unless force
+      requests replanning
     - unlabeled entry -> idempotent bare add of ``state:needs-plan``; entry
       carrying ``state:plan-no-go`` (or a stale ``state:plan-go``) after a
       plan_review fail-back -> ONE atomic ``edit_labels`` swap adding
@@ -472,6 +515,9 @@ class PlanningStage(Stage):
       fast-forward ``item.state`` to VERIFY so a restart mid-stage never
       redoes advise + plan (the base-protocol idempotency promise); the
       ``is_plan_review_go`` label check above stays the primary gate.
+    - forced revisions remain ``state:plan-no-go`` until durable publication;
+      a recovered pending revision resumes verification and plan review
+      without another planner job.
     """
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:  # noqa: C901
@@ -516,9 +562,11 @@ class PlanningStage(Stage):
             ctx.github.ensure_blocked_audit(item.issue)
             return StageOutcome(Disposition.BLOCKED, "plan requires external intervention")
 
+        force_replan = bool(ctx.config.force)
+
         # Fast-forward only from the sole confirmed plan state. A stale sibling
         # makes the label set contradictory and must never authorize work.
-        if is_exclusive_plan_state(labels, STATE_PLAN_GO):
+        if is_exclusive_plan_state(labels, STATE_PLAN_GO) and not force_replan:
             logger.info("planning:%d: already plan-go; advancing", item.issue)
             return StageOutcome(Disposition.ADVANCE, "plan already approved")
 
@@ -526,7 +574,7 @@ class PlanningStage(Stage):
         # merged PR is deliberately not a completion shortcut: only GitHub's
         # current closed issue state may terminalize work at seeding.
         open_pr = ctx.github.find_pr_for_issue(item.issue)
-        if open_pr:
+        if open_pr and not force_replan:
             logger.info("planning:%d: open PR #%d exists; skipping", item.issue, open_pr)
             return StageOutcome(Disposition.SKIP, f"open PR #{open_pr} exists")
 
@@ -544,7 +592,13 @@ class PlanningStage(Stage):
                 snapshot,
                 is_replan_entry,
                 revision_already_published,
-            ) = _load_planning_journal(item, ctx, labels)
+                forced_initial_plan,
+            ) = _load_planning_journal(
+                item,
+                ctx,
+                labels,
+                force_replan=force_replan,
+            )
         except CommentJournalReadError as exc:
             logger.warning(
                 "planning:%d: plan journal reconciliation read failed: %s",
@@ -555,19 +609,23 @@ class PlanningStage(Stage):
                 Disposition.RETRY,
                 f"plan journal read failed: {exc}",
             )
-        if is_replan_entry:
-            item.payload["requires_plan_revision"] = True
         if not _write_planning_entry_labels(
             item.issue,
             ctx,
             labels,
             is_replan_entry=is_replan_entry,
             revision_already_published=revision_already_published,
+            forced_initial_plan=forced_initial_plan,
         ):
             return StageOutcome(
                 Disposition.RETRY,
                 "exclusive planning entry label was not confirmed",
             )
+        if is_replan_entry:
+            item.payload["requires_plan_revision"] = True
+            item.payload.pop("plan_text", None)
+        else:
+            item.payload.pop("requires_plan_revision", None)
 
         history = _planning_history(comments)
         if history:

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -53,6 +53,7 @@ from hephaestus.automation.review_journal import (
     current_revision_context,
     is_pending_review,
     journal_snapshot,
+    parse_plan_review_state,
     render_current_plan,
     render_current_review,
 )
@@ -230,6 +231,24 @@ def _plan_is_ready_for_verify(
     if is_replan_entry:
         return False
     return bool(snapshot.current_plan)
+
+
+def _has_open_pr_planning_authority(labels: Sequence[str], snapshot: JournalSnapshot) -> bool:
+    """Return whether an open PR may bypass planning without a new plan.
+
+    An exclusive ``state:plan-go`` is the ordinary durable authority.  During
+    a crash between a finalized canonical review and its label write, the
+    matching canonical plan/review pair is a self-verifying recovery artifact
+    for this *planning-bypass* decision only; it does not authorize
+    implementation or change the label-state authority elsewhere.
+    """
+    if is_exclusive_plan_state(labels, STATE_PLAN_GO):
+        return True
+    return bool(
+        snapshot.current_plan
+        and snapshot.current_review_revision == snapshot.revision
+        and parse_plan_review_state(snapshot.current_review) == STATE_PLAN_GO
+    )
 
 
 def _write_planning_entry_labels(
@@ -562,13 +581,37 @@ class PlanningStage(Stage):
             logger.info("planning:%d: already plan-go; advancing", item.issue)
             return StageOutcome(Disposition.ADVANCE, "plan already approved")
 
-        # An open PR already in flight makes planning redundant. A historic
+        # An open PR already in flight makes planning redundant only after
+        # durable authority confirms the PR has a finalized plan. A historic
         # merged PR is deliberately not a completion shortcut: only GitHub's
         # current closed issue state may terminalize work at seeding.
         open_pr = ctx.github.find_pr_for_issue(item.issue)
+        planning_journal: tuple[list[IssueComment], JournalSnapshot, bool, bool, bool] | None = None
         if open_pr and not force_replan:
-            logger.info("planning:%d: open PR #%d exists; skipping", item.issue, open_pr)
-            return StageOutcome(Disposition.SKIP, f"open PR #{open_pr} exists")
+            try:
+                planning_journal = _load_planning_journal(
+                    item,
+                    ctx,
+                    labels,
+                    force_replan=False,
+                )
+            except CommentJournalReadError as exc:
+                logger.warning(
+                    "planning:%d: plan journal reconciliation read failed: %s",
+                    item.issue,
+                    exc,
+                )
+                return StageOutcome(
+                    Disposition.RETRY,
+                    f"plan journal read failed: {exc}",
+                )
+            if _has_open_pr_planning_authority(labels, planning_journal[1]):
+                logger.info(
+                    "planning:%d: open PR #%d has planning authority; skipping",
+                    item.issue,
+                    open_pr,
+                )
+                return StageOutcome(Disposition.SKIP, f"open PR #{open_pr} has plan authority")
 
         # Entry label normalization. On the plan_review "nogo" fail-back the
         # issue carries state:plan-no-go and NEITHER sibling (apply_plan_verdict
@@ -579,13 +622,7 @@ class PlanningStage(Stage):
         # (#1857). Swap atomically: add needs-plan, remove both siblings, in
         # ONE gh issue edit. Restores state:plan-no-go ──re-plan──▶ needs-plan.
         try:
-            (
-                comments,
-                snapshot,
-                is_replan_entry,
-                revision_already_published,
-                forced_initial_plan,
-            ) = _load_planning_journal(
+            planning_journal = planning_journal or _load_planning_journal(
                 item,
                 ctx,
                 labels,
@@ -601,6 +638,13 @@ class PlanningStage(Stage):
                 Disposition.RETRY,
                 f"plan journal read failed: {exc}",
             )
+        (
+            comments,
+            snapshot,
+            is_replan_entry,
+            revision_already_published,
+            forced_initial_plan,
+        ) = planning_journal
         if not _write_planning_entry_labels(
             item.issue,
             ctx,

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -211,7 +211,7 @@ def _load_planning_journal(
     is_replan_entry = _is_replan_entry(
         labels,
         revision_already_published=revision_already_published,
-    ) or (forced_from_plan_go and bool(snapshot.current_plan) and not revision_already_published)
+    ) or (forced_from_plan_go and bool(snapshot.current_plan))
     return (
         comments,
         snapshot,

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -208,17 +208,10 @@ def _load_planning_journal(
         STATE_PLAN_GO,
     )
     forced_initial_plan = forced_from_plan_go and not snapshot.current_plan
-    is_replan_entry = (
-        _is_replan_entry(
-            labels,
-            revision_already_published=revision_already_published,
-        )
-        or (
-            forced_from_plan_go
-            and bool(snapshot.current_plan)
-            and not revision_already_published
-        )
-    )
+    is_replan_entry = _is_replan_entry(
+        labels,
+        revision_already_published=revision_already_published,
+    ) or (forced_from_plan_go and bool(snapshot.current_plan) and not revision_already_published)
     return (
         comments,
         snapshot,

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -182,12 +182,32 @@ class TestPlanningStageEnter:
         assert outcome.disposition == Disposition.FINISH_FAIL
         assert github.mutation_log == []
 
-    def test_open_pr_skips(self, make_ctx: Any, make_work_item: Any) -> None:
-        """An open PR for the issue skips planning with zero writes (gate B)."""
+    def test_open_pr_without_plan_authority_enters_planning(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An open PR cannot bypass planning without durable plan authority (#2659)."""
         stage = PlanningStage()
         github = FakeStageGitHub(open_pr=456)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=4)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is None
+        assert github.mutation_log == [("gh_issue_add_labels", (4, (STATE_NEEDS_PLAN,)))]
+
+    def test_open_pr_with_finalized_canonical_plan_skips(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A matching canonical plan and final GO review make an open PR redundant."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(open_pr=456)
+        github.comments[5] = [
+            render_current_plan("Plan v1", revision=1),
+            render_current_review("Approved.\n\nstate:plan-go", revision=1),
+        ]
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=5)
 
         outcome = stage.on_enter(item, ctx)
 

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -303,8 +303,7 @@ class TestPlanningStageEnter:
         assert is_pending_review(snapshot.current_review, revision=2)
 
         history = {
-            (artifact.revision, artifact.kind): artifact.body
-            for artifact in snapshot.history
+            (artifact.revision, artifact.kind): artifact.body for artifact in snapshot.history
         }
         assert set(history) == {(1, "plan"), (1, "review")}
         assert archived_old_plan(history[(1, "plan")]) == "Plan v1"

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -332,6 +332,33 @@ class TestPlanningStageEnter:
         assert final_snapshot.history == ()
         assert final_snapshot.prior_plan_fingerprints == immutable_fingerprints
 
+    def test_force_plan_go_without_canonical_review_requires_new_revision(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """Force cannot treat a reconciliation-created pending review as a revision."""
+        github = FakeStageGitHub(labels=[STATE_PLAN_GO], has_plan=True)
+        github.comments[44] = [render_current_plan("Plan v1", revision=1)]
+        ctx = make_ctx(github=github)
+        ctx.config.force = True
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=44, state="ENTER")
+        stage = PlanningStage()
+
+        assert stage.on_enter(item, ctx) is None
+        assert github.labels[44] == {STATE_PLAN_NO_GO}
+        assert item.payload["requires_plan_revision"] is True
+        assert item.state == "ENTER"
+
+        transition = stage.step(item, ctx)
+        assert isinstance(transition, Continue)
+        item.state = transition.next_state
+
+        planner_request = stage.step(item, ctx)
+        assert isinstance(planner_request, JobRequest)
+        assert planner_request.job.descr == "plan"
+
     def test_force_plan_go_without_canonical_plan_starts_initial_plan(
         self,
         make_ctx: Any,

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -14,6 +14,7 @@ from hephaestus.automation.pipeline.athena_skill_jobs import AthenaSkillJob, Ath
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.plan_review import PlanReviewStage
 from hephaestus.automation.pipeline.stages.planning import (
     PlanningStage,
     build_plan_prompt,
@@ -27,6 +28,10 @@ from hephaestus.automation.protocol import (
 )
 from hephaestus.automation.review_journal import (
     IssueComment,
+    archived_new_plan,
+    archived_old_plan,
+    is_pending_review,
+    journal_snapshot,
     render_current_plan,
     render_current_review,
 )
@@ -190,6 +195,261 @@ class TestPlanningStageEnter:
         assert outcome is not None
         assert outcome.disposition == Disposition.SKIP
         assert github.mutation_log == []
+
+    def test_force_open_pr_replans_archives_and_requests_review(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """Force supersedes an approved plan despite an existing open PR."""
+        github = FakeStageGitHub(
+            labels=[STATE_PLAN_GO],
+            open_pr=456,
+            has_plan=True,
+        )
+        github.comments[39] = [
+            render_current_plan("Plan v1", revision=1),
+            render_current_review("Approved.\n\nstate:plan-go", revision=1),
+        ]
+        ctx = make_ctx(github=github)
+        ctx.config.force = True
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=39, state="ENTER")
+        stage = PlanningStage()
+
+        assert stage.on_enter(item, ctx) is None
+        assert github.labels[39] == {STATE_PLAN_NO_GO}
+
+        transition = stage.step(item, ctx)
+        assert isinstance(transition, Continue)
+        item.state = transition.next_state
+
+        planner_request = stage.step(item, ctx)
+        assert isinstance(planner_request, JobRequest)
+        assert planner_request.job.descr == "plan"
+
+        stage.on_job_done(item, JobResult(ok=True, value="Plan v2"), ctx)
+        item.state = planner_request.on_done_state
+        outcome = stage.step(item, ctx)
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+
+        snapshot = journal_snapshot(github.issue_comments(39))
+        assert snapshot.revision == 2
+        assert snapshot.current_plan == "Plan v2"
+        assert is_pending_review(snapshot.current_review, revision=2)
+
+        item.state = "ENTER"
+        review_stage = PlanReviewStage()
+        assert review_stage.on_enter(item, ctx) is None
+        review_transition = review_stage.step(item, ctx)
+        assert isinstance(review_transition, Continue)
+        item.state = review_transition.next_state
+        review_request = review_stage.step(item, ctx)
+        assert isinstance(review_request, JobRequest)
+        assert isinstance(review_request.job, AgentJob)
+        assert review_request.job.descr == "review"
+        assert review_request.job.prompt_kwargs["plan_text"] == "Plan v2"
+
+    def test_force_restart_after_partial_revision_resumes_review(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """A forced revision resumes from an interrupted journal transaction."""
+
+        class FailReviewArchiveOnce(FakeStageGitHub):
+            failed = False
+
+            def append_issue_comment(
+                self,
+                issue_number: int,
+                marker: str,
+                body: str,
+            ) -> None:
+                if marker.endswith("kind=review -->") and not self.failed:
+                    self.failed = True
+                    raise RuntimeError("injected review archive failure")
+                super().append_issue_comment(issue_number, marker, body)
+
+        github = FailReviewArchiveOnce(
+            labels=[STATE_PLAN_GO],
+            open_pr=456,
+            has_plan=True,
+        )
+        github.comments[40] = [
+            render_current_plan("Plan v1", revision=1),
+            render_current_review("Approved.\n\nstate:plan-go", revision=1),
+        ]
+        ctx = make_ctx(github=github)
+        ctx.config.force = True
+        stage = PlanningStage()
+
+        first = make_work_item(issue=40, state="ENTER")
+        assert stage.on_enter(first, ctx) is None
+        first.state = "VERIFY"
+        first.payload["plan_text"] = "Plan v2"
+        with pytest.raises(RuntimeError, match="injected review archive failure"):
+            stage.step(first, ctx)
+
+        restarted = make_work_item(issue=40, state="ENTER")
+        assert stage.on_enter(restarted, ctx) is None
+        assert restarted.state == "VERIFY"
+        assert github.labels[40] == {STATE_NEEDS_PLAN}
+
+        snapshot = journal_snapshot(github.issue_comments(40))
+        assert snapshot.revision == 2
+        assert snapshot.current_plan == "Plan v2"
+        assert is_pending_review(snapshot.current_review, revision=2)
+
+        history = {
+            (artifact.revision, artifact.kind): artifact.body
+            for artifact in snapshot.history
+        }
+        assert set(history) == {(1, "plan"), (1, "review")}
+        assert archived_old_plan(history[(1, "plan")]) == "Plan v1"
+        assert archived_new_plan(history[(1, "plan")]) == "Plan v2"
+        assert "Approved." in history[(1, "review")]
+        immutable_history = dict(history)
+
+        planning_outcome = stage.step(restarted, ctx)
+        assert isinstance(planning_outcome, StageOutcome)
+        assert planning_outcome.disposition == Disposition.ADVANCE
+
+        restarted.state = "ENTER"
+        review_stage = PlanReviewStage()
+        assert review_stage.on_enter(restarted, ctx) is None
+        review_transition = review_stage.step(restarted, ctx)
+        assert isinstance(review_transition, Continue)
+        restarted.state = review_transition.next_state
+        review_request = review_stage.step(restarted, ctx)
+
+        assert isinstance(review_request, JobRequest)
+        assert isinstance(review_request.job, AgentJob)
+        assert review_request.job.descr == "review"
+        assert review_request.job.prompt_kwargs["plan_text"] == "Plan v2"
+        assert {
+            (artifact.revision, artifact.kind): artifact.body
+            for artifact in journal_snapshot(github.issue_comments(40)).history
+        } == immutable_history
+
+    def test_force_plan_go_without_canonical_plan_starts_initial_plan(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """Force recovers a plan-go issue whose canonical plan is missing."""
+        github = FakeStageGitHub(
+            labels=[STATE_PLAN_GO],
+            open_pr=456,
+            has_plan=False,
+        )
+        ctx = make_ctx(github=github)
+        ctx.config.force = True
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=41, state="ENTER")
+        stage = PlanningStage()
+
+        assert stage.on_enter(item, ctx) is None
+        assert github.labels[41] == {STATE_NEEDS_PLAN}
+        assert "requires_plan_revision" not in item.payload
+
+        transition = stage.step(item, ctx)
+        assert isinstance(transition, Continue)
+        item.state = transition.next_state
+        planner_request = stage.step(item, ctx)
+        assert isinstance(planner_request, JobRequest)
+        assert planner_request.job.descr == "plan"
+
+        stage.on_job_done(item, JobResult(ok=True, value="Initial plan"), ctx)
+        item.state = planner_request.on_done_state
+        outcome = stage.step(item, ctx)
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+
+        snapshot = journal_snapshot(github.issue_comments(41))
+        assert snapshot.revision == 1
+        assert snapshot.current_plan == "Initial plan"
+        assert is_pending_review(snapshot.current_review, revision=1)
+        assert snapshot.history == ()
+
+        item.state = "ENTER"
+        review_stage = PlanReviewStage()
+        assert review_stage.on_enter(item, ctx) is None
+        review_transition = review_stage.step(item, ctx)
+        assert isinstance(review_transition, Continue)
+        item.state = review_transition.next_state
+        review_request = review_stage.step(item, ctx)
+        assert isinstance(review_request, JobRequest)
+        assert review_request.job.descr == "review"
+
+    def test_force_unconfirmed_label_transition_retries_before_planner(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """Force cannot schedule planning until its exclusive label is confirmed."""
+
+        class PartialLabelGitHub(FakeStageGitHub):
+            def edit_labels(
+                self,
+                issue_number: int,
+                *,
+                add: list[str],
+                remove: list[str],
+            ) -> None:
+                self._issue_labels(issue_number).update(add)
+                self._log("edit_labels", issue_number, tuple(add), tuple(remove))
+
+        github = PartialLabelGitHub(labels=[STATE_PLAN_GO], has_plan=True)
+        github.comments[42] = [
+            render_current_plan("Plan v1", revision=1),
+            render_current_review("Approved.\n\nstate:plan-go", revision=1),
+        ]
+        ctx = make_ctx(github=github)
+        ctx.config.force = True
+        item = make_work_item(issue=42, state="ENTER")
+
+        outcome = PlanningStage().on_enter(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert journal_snapshot(github.issue_comments(42)).current_plan == "Plan v1"
+
+    def test_force_planner_failure_retries_without_publishing_old_plan(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """A failed forced planner job cannot verify the stale approved plan."""
+        github = FakeStageGitHub(labels=[STATE_PLAN_GO], has_plan=True)
+        github.comments[43] = [
+            render_current_plan("Plan v1", revision=1),
+            render_current_review("Approved.\n\nstate:plan-go", revision=1),
+        ]
+        ctx = make_ctx(github=github)
+        ctx.config.force = True
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=43, state="ENTER")
+        stage = PlanningStage()
+
+        assert stage.on_enter(item, ctx) is None
+        item.state = "PLAN_WAIT"
+        request = stage.step(item, ctx)
+        assert isinstance(request, JobRequest)
+
+        stage.on_job_done(item, JobResult(ok=False, error="agent timeout"), ctx)
+        item.state = request.on_done_state
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert item.state == "PLAN_WAIT"
+        snapshot = journal_snapshot(github.issue_comments(43))
+        assert snapshot.revision == 1
+        assert snapshot.current_plan == "Plan v1"
+        assert snapshot.history == ()
+        assert github.labels[43] == {STATE_PLAN_NO_GO}
 
     def test_unlabeled_entry_adds_needs_plan(self, make_ctx: Any, make_work_item: Any) -> None:
         """Unlabeled entry durably writes state:needs-plan before proceeding."""

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -28,10 +28,9 @@ from hephaestus.automation.protocol import (
 )
 from hephaestus.automation.review_journal import (
     IssueComment,
-    archived_new_plan,
-    archived_old_plan,
     is_pending_review,
     journal_snapshot,
+    plan_fingerprint,
     render_current_plan,
     render_current_review,
 )
@@ -258,21 +257,28 @@ class TestPlanningStageEnter:
     ) -> None:
         """A forced revision resumes from an interrupted journal transaction."""
 
-        class FailReviewArchiveOnce(FakeStageGitHub):
+        class FailReviewUpsertOnce(FakeStageGitHub):
             failed = False
 
-            def append_issue_comment(
+            def upsert_issue_comment(
                 self,
                 issue_number: int,
                 marker: str,
                 body: str,
+                *,
+                legacy_marker: str | None = None,
             ) -> None:
-                if marker.endswith("kind=review -->") and not self.failed:
+                if marker == PLAN_REVIEW_CANONICAL_MARKER and not self.failed:
                     self.failed = True
-                    raise RuntimeError("injected review archive failure")
-                super().append_issue_comment(issue_number, marker, body)
+                    raise RuntimeError("injected review upsert failure")
+                super().upsert_issue_comment(
+                    issue_number,
+                    marker,
+                    body,
+                    legacy_marker=legacy_marker,
+                )
 
-        github = FailReviewArchiveOnce(
+        github = FailReviewUpsertOnce(
             labels=[STATE_PLAN_GO],
             open_pr=456,
             has_plan=True,
@@ -289,7 +295,7 @@ class TestPlanningStageEnter:
         assert stage.on_enter(first, ctx) is None
         first.state = "VERIFY"
         first.payload["plan_text"] = "Plan v2"
-        with pytest.raises(RuntimeError, match="injected review archive failure"):
+        with pytest.raises(RuntimeError, match="injected review upsert failure"):
             stage.step(first, ctx)
 
         restarted = make_work_item(issue=40, state="ENTER")
@@ -302,14 +308,9 @@ class TestPlanningStageEnter:
         assert snapshot.current_plan == "Plan v2"
         assert is_pending_review(snapshot.current_review, revision=2)
 
-        history = {
-            (artifact.revision, artifact.kind): artifact.body for artifact in snapshot.history
-        }
-        assert set(history) == {(1, "plan"), (1, "review")}
-        assert archived_old_plan(history[(1, "plan")]) == "Plan v1"
-        assert archived_new_plan(history[(1, "plan")]) == "Plan v2"
-        assert "Approved." in history[(1, "review")]
-        immutable_history = dict(history)
+        assert snapshot.history == ()
+        assert snapshot.prior_plan_fingerprints == (plan_fingerprint("Plan v1"),)
+        immutable_fingerprints = snapshot.prior_plan_fingerprints
 
         planning_outcome = stage.step(restarted, ctx)
         assert isinstance(planning_outcome, StageOutcome)
@@ -327,10 +328,9 @@ class TestPlanningStageEnter:
         assert isinstance(review_request.job, AgentJob)
         assert review_request.job.descr == "review"
         assert review_request.job.prompt_kwargs["plan_text"] == "Plan v2"
-        assert {
-            (artifact.revision, artifact.kind): artifact.body
-            for artifact in journal_snapshot(github.issue_comments(40)).history
-        } == immutable_history
+        final_snapshot = journal_snapshot(github.issue_comments(40))
+        assert final_snapshot.history == ()
+        assert final_snapshot.prior_plan_fingerprints == immutable_fingerprints
 
     def test_force_plan_go_without_canonical_plan_starts_initial_plan(
         self,

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -3556,10 +3556,12 @@ class TestPipelineScopeWiring:
         coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
 
         entries = coordinator._seed_direct_scope("repo-a")
+        ctx = coordinator._ctx_for_repo("repo-a")
 
         assert len(entries) == 1
         assert entries[0].stage is StageName.PLANNING
         assert "force re-plan" in entries[0].reason
+        assert ctx.config.force is True
 
     def test_force_leaves_pre_scope_stage_untouched(self, tmp_path: Path) -> None:
         """--force must NOT pull a PRE-scope stage forward into the scope.


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2659.

## Changes
See the PR diff for the full change set.

## Testing
`uv run pytest tests -q --tb=short` — passed

## Closes
Closes #2659

Generated by Hephaestus automation

Closes #2662
