### PR TITLE
chore: Make workflow validation fail closed for unreadable malformed and empty inputs

### DIFF
--- a/hephaestus/ci/__init__.py
+++ b/hephaestus/ci/__init__.py
@@ -16,6 +16,8 @@ from hephaestus.ci.precommit import (
     write_step_summary,
 )
 from hephaestus.ci.workflows import (
+    WorkflowToolError,
+    WorkflowValidationError,
     check_inventory,
     collect_workflow_files,
     collect_yml_files,
@@ -24,6 +26,8 @@ from hephaestus.ci.workflows import (
 )
 
 __all__ = [
+    "WorkflowToolError",
+    "WorkflowValidationError",
     "build_summary_table",
     "check_inventory",
     "check_threshold",

--- a/hephaestus/ci/workflows.py
+++ b/hephaestus/ci/workflows.py
@@ -353,8 +353,9 @@ def _collect_workflow_files_detailed(paths: list[str]) -> _WorkflowCollectionRes
             files.append(target)
         elif stat.S_ISDIR(mode):
             try:
-                yml_files = sorted(target.glob("*.yml"))
-                yaml_files = sorted(target.glob("*.yaml"))
+                directory_entries = list(target.iterdir())
+                yml_files = sorted(path for path in directory_entries if path.suffix == ".yml")
+                yaml_files = sorted(path for path in directory_entries if path.suffix == ".yaml")
             except OSError as exc:
                 tool_errors.append(
                     WorkflowToolError(

--- a/hephaestus/ci/workflows.py
+++ b/hephaestus/ci/workflows.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import stat
 import sys
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -37,7 +38,7 @@ except ModuleNotFoundError:
 else:
     _yaml = _pyyaml
 
-# Security limit: skip workflow files larger than 1 MB
+# Security limit: reject workflow files larger than 1 MB.
 _MAX_FILE_SIZE = 1_048_576
 
 # Matches a .yml filename (with or without a markdown hyperlink) inside a
@@ -139,6 +140,34 @@ class Violation(NamedTuple):
     composite_action: str
 
 
+class WorkflowToolError(NamedTuple):
+    """A failure that prevented a workflow target from being validated."""
+
+    target: Path
+    code: str
+    message: str
+
+
+class WorkflowValidationError(RuntimeError):
+    """Raised when workflow discovery or validation is incomplete."""
+
+    def __init__(self, errors: list[WorkflowToolError]) -> None:
+        """Initialize the error with every incomplete-validation finding."""
+        self.errors: tuple[WorkflowToolError, ...] = tuple(errors)
+        detail = "; ".join(f"{error.target}: {error.message}" for error in errors)
+        super().__init__(detail)
+
+
+class _WorkflowCollectionResult(NamedTuple):
+    workflow_files: list[Path]
+    tool_errors: list[WorkflowToolError]
+
+
+class _WorkflowCheckResult(NamedTuple):
+    violations: list[Violation]
+    tool_errors: list[WorkflowToolError]
+
+
 def _is_checkout_step(step: object) -> bool:
     """Return True if the step uses ``actions/checkout`` (any version or hash).
 
@@ -210,6 +239,78 @@ def _check_job_steps(workflow_file: Path, job_name: str, steps: list[Any]) -> li
     return violations
 
 
+def _read_workflow_document(
+    workflow_file: Path,
+) -> tuple[Any, WorkflowToolError | None]:
+    """Read and parse a workflow, returning a typed tool failure when needed."""
+    if _yaml is None:
+        return None, WorkflowToolError(
+            workflow_file,
+            "dependency_unavailable",
+            "PyYAML is not installed",
+        )
+
+    try:
+        file_size = workflow_file.stat().st_size
+    except OSError as exc:
+        return None, WorkflowToolError(workflow_file, "stat_error", f"cannot stat file: {exc}")
+
+    if file_size > _MAX_FILE_SIZE:
+        return None, WorkflowToolError(
+            workflow_file,
+            "oversized",
+            f"file exceeds {_MAX_FILE_SIZE} byte limit",
+        )
+
+    try:
+        with workflow_file.open(encoding="utf-8") as fh:
+            data: Any = _yaml.safe_load(fh)
+    except _yaml.YAMLError as exc:
+        return None, WorkflowToolError(workflow_file, "yaml_parse", f"YAML parse error: {exc}")
+    except UnicodeError as exc:
+        return None, WorkflowToolError(workflow_file, "decode_error", f"cannot decode UTF-8: {exc}")
+    except OSError as exc:
+        return None, WorkflowToolError(workflow_file, "read_error", f"cannot read file: {exc}")
+    return data, None
+
+
+def _validate_workflow_detailed(workflow_file: Path) -> _WorkflowCheckResult:
+    """Validate one workflow and retain tool failures for CLI aggregation."""
+    data, tool_error = _read_workflow_document(workflow_file)
+    if tool_error is not None:
+        return _WorkflowCheckResult([], [tool_error])
+
+    if data is None:
+        return _WorkflowCheckResult(
+            [],
+            [WorkflowToolError(workflow_file, "empty_document", "YAML document is empty")],
+        )
+    if not isinstance(data, dict):
+        return _WorkflowCheckResult(
+            [],
+            [
+                WorkflowToolError(
+                    workflow_file,
+                    "invalid_document",
+                    "YAML document root must be a mapping",
+                )
+            ],
+        )
+
+    violations: list[Violation] = []
+    jobs = data.get("jobs")
+    if isinstance(jobs, dict):
+        for job_name, job_data in jobs.items():
+            if not isinstance(job_data, dict):
+                continue
+
+            steps = job_data.get("steps")
+            if isinstance(steps, list):
+                violations.extend(_check_job_steps(workflow_file, str(job_name), steps))
+
+    return _WorkflowCheckResult(violations, [])
+
+
 def validate_workflow(workflow_file: Path) -> list[Violation]:
     """Validate checkout-first ordering for all jobs in a workflow file.
 
@@ -219,47 +320,80 @@ def validate_workflow(workflow_file: Path) -> list[Violation]:
     Returns:
         List of :class:`Violation` objects; empty list means the file passes.
 
+    Raises:
+        WorkflowValidationError: If the file could not be completely validated.
+
     """
-    if _yaml is None:
-        print(f"WARNING: Skipping {workflow_file} (pyyaml not installed)", file=sys.stderr)
-        return []
+    result = _validate_workflow_detailed(workflow_file)
+    if result.tool_errors:
+        raise WorkflowValidationError(result.tool_errors)
+    return result.violations
 
-    if workflow_file.stat().st_size > _MAX_FILE_SIZE:
-        print(
-            f"WARNING: Skipping {workflow_file} (exceeds {_MAX_FILE_SIZE} byte limit)",
-            file=sys.stderr,
-        )
-        return []
 
-    with open(workflow_file, encoding="utf-8") as fh:
+def _collect_workflow_files_detailed(paths: list[str]) -> _WorkflowCollectionResult:
+    """Collect workflow files and retain discovery failures for CLI aggregation."""
+    files: list[Path] = []
+    tool_errors: list[WorkflowToolError] = []
+
+    for raw in paths:
+        target = Path(raw)
         try:
-            data: Any = _yaml.safe_load(fh)
-        except _yaml.YAMLError as exc:
-            print(
-                f"WARNING: Skipping {workflow_file} (YAML parse error: {exc})",
-                file=sys.stderr,
+            mode = target.stat().st_mode
+        except OSError as exc:
+            tool_errors.append(
+                WorkflowToolError(
+                    target,
+                    "target_stat_error",
+                    f"cannot inspect target: {exc}",
+                )
             )
-            return []
-
-    if not isinstance(data, dict):
-        return []
-
-    jobs = data.get("jobs")
-    if not isinstance(jobs, dict):
-        return []
-
-    violations: list[Violation] = []
-    for job_name, job_data in jobs.items():
-        if not isinstance(job_data, dict):
             continue
 
-        steps = job_data.get("steps")
-        if not isinstance(steps, list):
+        if stat.S_ISREG(mode):
+            files.append(target)
+        elif stat.S_ISDIR(mode):
+            try:
+                yml_files = sorted(target.glob("*.yml"))
+                yaml_files = sorted(target.glob("*.yaml"))
+            except OSError as exc:
+                tool_errors.append(
+                    WorkflowToolError(
+                        target,
+                        "directory_read_error",
+                        f"cannot enumerate directory: {exc}",
+                    )
+                )
+            else:
+                files.extend(yml_files)
+                files.extend(yaml_files)
+        else:
+            tool_errors.append(
+                WorkflowToolError(
+                    target,
+                    "unsupported_target",
+                    "target is neither a regular file nor a directory",
+                )
+            )
+
+    seen: set[Path] = set()
+    deduplicated: list[Path] = []
+    for workflow_file in files:
+        try:
+            key = workflow_file.resolve()
+        except (OSError, RuntimeError) as exc:
+            tool_errors.append(
+                WorkflowToolError(
+                    workflow_file,
+                    "target_resolve_error",
+                    f"cannot resolve target: {exc}",
+                )
+            )
             continue
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(workflow_file)
 
-        violations.extend(_check_job_steps(workflow_file, str(job_name), steps))
-
-    return violations
+    return _WorkflowCollectionResult(deduplicated, tool_errors)
 
 
 def collect_workflow_files(paths: list[str]) -> list[Path]:
@@ -272,26 +406,14 @@ def collect_workflow_files(paths: list[str]) -> list[Path]:
     Returns:
         Deduplicated list of :class:`~pathlib.Path` objects for each candidate.
 
-    """
-    files: list[Path] = []
-    for raw in paths:
-        p = Path(raw)
-        if p.is_file():
-            files.append(p)
-        elif p.is_dir():
-            files.extend(sorted(p.glob("*.yml")))
-            files.extend(sorted(p.glob("*.yaml")))
-        else:
-            print(f"WARNING: Path not found: {p}", file=sys.stderr)
+    Raises:
+        WorkflowValidationError: If any requested target cannot be inspected.
 
-    seen: set[Path] = set()
-    result: list[Path] = []
-    for f in files:
-        key = f.resolve()
-        if key not in seen:
-            seen.add(key)
-            result.append(f)
-    return result
+    """
+    result = _collect_workflow_files_detailed(paths)
+    if result.tool_errors:
+        raise WorkflowValidationError(result.tool_errors)
+    return result.workflow_files
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +502,11 @@ def validate_workflow_checkout_main() -> int:
         nargs="*",
         help="Workflow files or directories (default: .github/workflows/)",
     )
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Allow readable requested targets to contain no workflow YAML files",
+    )
     add_json_arg(parser)
     add_version_arg(parser)
     args = parser.parse_args()
@@ -391,43 +518,81 @@ def validate_workflow_checkout_main() -> int:
         repo_root = get_repo_root()
         target_paths = [str(repo_root / ".github" / "workflows")]
 
-    workflow_files = collect_workflow_files(target_paths)
-
-    if not workflow_files:
-        if args.json:
-            emit_json_status(0, message="no workflow files found", files_checked=0)
-            return 0
-        print("No workflow files found to validate.")
-        return 0
-
+    collection = _collect_workflow_files_detailed(target_paths)
+    workflow_files = collection.workflow_files
+    tool_errors = list(collection.tool_errors)
     all_violations: list[Violation] = []
     for wf_file in workflow_files:
-        all_violations.extend(validate_workflow(wf_file))
+        result = _validate_workflow_detailed(wf_file)
+        all_violations.extend(result.violations)
+        tool_errors.extend(result.tool_errors)
+
+    policy_violations: list[dict[str, Any]] = [
+        {
+            "code": "checkout_order",
+            "workflow_file": str(violation.workflow_file),
+            "job_name": violation.job_name,
+            "step_index": violation.step_index,
+            "step_name": violation.step_name,
+            "composite_action": violation.composite_action,
+        }
+        for violation in all_violations
+    ]
+
+    empty_inventory = not workflow_files and not collection.tool_errors
+    if empty_inventory and not args.allow_empty:
+        policy_violations.append(
+            {
+                "code": "empty_inventory",
+                "targets": target_paths,
+                "message": "no workflow files found in requested targets",
+            }
+        )
+
+    exit_code = 1 if tool_errors or policy_violations else 0
 
     if args.json:
-        exit_code = 0 if not all_violations else 1
         emit_json_status(
             exit_code,
-            message=(
-                "all workflows pass checkout-first invariant"
-                if not all_violations
-                else f"found {len(all_violations)} violation(s)"
-            ),
+            message="workflow validation failed" if exit_code else "workflow validation passed",
             files_checked=len(workflow_files),
             violation_count=len(all_violations),
+            policy_violation_count=len(policy_violations),
+            tool_error_count=len(tool_errors),
+            policy_violations=policy_violations,
+            tool_errors=[
+                {
+                    "target": str(error.target),
+                    "code": error.code,
+                    "message": error.message,
+                }
+                for error in tool_errors
+            ],
         )
         return exit_code
 
-    if all_violations:
-        for v in all_violations:
-            print(
-                f"\nERROR: {v.workflow_file} :: job '{v.job_name}' :: step {v.step_index} "
-                f"uses '{v.composite_action}'\n"
-                f"       but actions/checkout is not a preceding step.\n"
-                f"       Composite actions and reusable workflows require checkout first."
-            )
-        print(f"\nFound {len(all_violations)} violation(s) in {len(workflow_files)} file(s).")
+    for error in tool_errors:
+        print(
+            f"TOOL ERROR [{error.code}]: {error.target}: {error.message}",
+            file=sys.stderr,
+        )
+
+    if empty_inventory and not args.allow_empty:
+        print("POLICY VIOLATION [empty_inventory]: no workflow files found to validate.")
+
+    for violation in all_violations:
+        print(
+            f"POLICY VIOLATION [checkout_order]: {violation.workflow_file} :: "
+            f"job '{violation.job_name}' :: step {violation.step_index} "
+            f"uses '{violation.composite_action}' before actions/checkout."
+        )
+
+    if exit_code:
         return 1
+
+    if empty_inventory:
+        print("No workflow files found to validate.")
+        return 0
 
     print(f"OK: {len(workflow_files)} workflow file(s) checked. All pass checkout-first invariant.")
     return 0

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import stat
 import tomllib
@@ -412,14 +413,14 @@ class TestCollectWorkflowFilesFailClosed:
     def test_directory_enumeration_failure_raises(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        real_glob = Path.glob
+        real_scandir = os.scandir
 
-        def fail_glob(path: Path, pattern: str) -> Any:
-            if path == tmp_path:
+        def fail_scandir(path: Any) -> Any:
+            if Path(path) == tmp_path:
                 raise PermissionError("denied")
-            return real_glob(path, pattern)
+            return real_scandir(path)
 
-        monkeypatch.setattr(Path, "glob", fail_glob)
+        monkeypatch.setattr(os, "scandir", fail_scandir)
 
         with pytest.raises(WorkflowValidationError) as caught:
             collect_workflow_files([str(tmp_path)])
@@ -538,18 +539,20 @@ class TestCheckoutValidationToolErrorExitCodes:
         assert exit_code == 1
         assert payload["tool_errors"][0]["code"] == "stat_error"
 
-    def test_directory_read_failure_returns_nonzero(
+    def test_unreadable_directory_returns_nonzero_with_allow_empty(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        real_glob = Path.glob
+        real_scandir = os.scandir
 
-        def fail_glob(path: Path, pattern: str) -> Any:
-            if path == tmp_path:
+        def fail_scandir(path: Any) -> Any:
+            if Path(path) == tmp_path:
                 raise PermissionError("denied")
-            return real_glob(path, pattern)
+            return real_scandir(path)
 
-        monkeypatch.setattr(Path, "glob", fail_glob)
-        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [tmp_path])
+        monkeypatch.setattr(os, "scandir", fail_scandir)
+        exit_code, payload = _run_checkout_cli_json(
+            monkeypatch, capsys, [tmp_path], allow_empty=True
+        )
 
         assert exit_code == 1
         assert payload["tool_errors"][0]["code"] == "directory_read_error"

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import re
+import stat
 import tomllib
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
+from hephaestus.ci import WorkflowValidationError, workflows as workflows_module
 from hephaestus.ci.workflows import (
+    _MAX_FILE_SIZE,
     Violation,
     _is_checkout_step,
     _is_local_reference_step,
@@ -245,10 +251,101 @@ jobs:
         wf = self._write_workflow(tmp_path / "ci.yml", "name: empty\n")
         assert validate_workflow(wf) == []
 
-    def test_large_file_skipped(self, tmp_path: Path) -> None:
+    def test_large_file_raises(self, tmp_path: Path) -> None:
         wf = tmp_path / "big.yml"
-        wf.write_bytes(b"x" * (1_048_576 + 1))
-        assert validate_workflow(wf) == []
+        wf.write_bytes(b"x" * (_MAX_FILE_SIZE + 1))
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(wf)
+
+        assert caught.value.errors[0].code == "oversized"
+
+
+class TestWorkflowToolErrors:
+    """Tests for direct validation failures that must not look clean."""
+
+    def test_missing_pyyaml_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        monkeypatch.setattr(workflows_module, "_yaml", None)
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "dependency_unavailable"
+
+    def test_file_stat_failure_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        real_stat = Path.stat
+
+        def fail_workflow_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+            if path == workflow:
+                raise PermissionError("denied")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fail_workflow_stat)
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "stat_error"
+
+    def test_read_failure_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        real_open = Path.open
+
+        def fail_workflow_open(path: Path, *args: Any, **kwargs: Any) -> Any:
+            if path == workflow:
+                raise PermissionError("denied")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", fail_workflow_open)
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "read_error"
+
+    def test_decode_failure_raises(self, tmp_path: Path) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_bytes(b"name: \xff\n")
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "decode_error"
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("jobs: [\n", encoding="utf-8")
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "yaml_parse"
+
+    def test_empty_document_raises(self, tmp_path: Path) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("", encoding="utf-8")
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "empty_document"
+
+    @pytest.mark.parametrize("contents", ["plain scalar\n", "- item\n"])
+    def test_non_mapping_document_raises(self, tmp_path: Path, contents: str) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text(contents, encoding="utf-8")
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            validate_workflow(workflow)
+
+        assert caught.value.errors[0].code == "invalid_document"
 
 
 class TestPiCliSetup:
@@ -299,10 +396,342 @@ class TestCollectWorkflowFiles:
         result = collect_workflow_files([str(f), str(f)])
         assert len(result) == 1
 
-    def test_missing_path_warns(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        collect_workflow_files([str(tmp_path / "nonexistent.yml")])
+    def test_missing_path_raises(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.yml"
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            collect_workflow_files([str(missing)])
+
+        assert caught.value.errors[0].code == "target_stat_error"
+        assert caught.value.errors[0].target == missing
+
+
+class TestCollectWorkflowFilesFailClosed:
+    """Tests for discovery failures that must stop validation."""
+
+    def test_directory_enumeration_failure_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_glob = Path.glob
+
+        def fail_glob(path: Path, pattern: str) -> Any:
+            if path == tmp_path:
+                raise PermissionError("denied")
+            return real_glob(path, pattern)
+
+        monkeypatch.setattr(Path, "glob", fail_glob)
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            collect_workflow_files([str(tmp_path)])
+
+        assert caught.value.errors[0].code == "directory_read_error"
+
+    def test_unsupported_target_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "socket"
+        real_stat = Path.stat
+
+        def fake_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+            if path == target:
+                return SimpleNamespace(st_mode=stat.S_IFIFO)
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            collect_workflow_files([str(target)])
+
+        assert caught.value.errors[0].code == "unsupported_target"
+
+    def test_target_resolution_failure_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        real_resolve = Path.resolve
+
+        def fail_resolve(path: Path, *args: Any, **kwargs: Any) -> Path:
+            if path == workflow:
+                raise OSError("cannot resolve")
+            return real_resolve(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+        with pytest.raises(WorkflowValidationError) as caught:
+            collect_workflow_files([str(workflow)])
+
+        assert caught.value.errors[0].code == "target_resolve_error"
+
+
+class TestWorkflowPublicApiCompatibility:
+    """Successful public helpers retain their list-returning contracts."""
+
+    def test_reexported_helpers_keep_list_returns_for_valid_inputs(self, tmp_path: Path) -> None:
+        from hephaestus.ci import (
+            collect_workflow_files as exported_collect,
+            validate_workflow as exported_validate,
+        )
+
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+
+        assert exported_collect([str(workflow)]) == [workflow]
+        assert exported_validate(workflow) == []
+
+
+def _run_checkout_cli_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    paths: list[Path],
+    allow_empty: bool = False,
+) -> tuple[int, dict[str, Any]]:
+    """Run the checkout validator with JSON output and decode its response."""
+    argv = ["hephaestus-validate-workflow-checkout", "--json"]
+    if allow_empty:
+        argv.append("--allow-empty")
+    argv.extend(str(path) for path in paths)
+    monkeypatch.setattr("sys.argv", argv)
+    exit_code = workflows_module.validate_workflow_checkout_main()
+    payload = json.loads(capsys.readouterr().out)
+    return exit_code, payload
+
+
+class TestCheckoutValidationToolErrorExitCodes:
+    """Every tool-error category produces a nonzero CLI result."""
+
+    def test_dependency_unavailable_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        monkeypatch.setattr(workflows_module, "_yaml", None)
+
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [workflow])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "dependency_unavailable"
+
+    def test_discovery_stat_failure_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [tmp_path / "missing.yml"])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "target_stat_error"
+
+    def test_workflow_stat_failure_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        real_stat = Path.stat
+
+        def fail_workflow_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+            if path == workflow:
+                raise PermissionError("denied")
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fail_workflow_stat)
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [tmp_path])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "stat_error"
+
+    def test_directory_read_failure_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        real_glob = Path.glob
+
+        def fail_glob(path: Path, pattern: str) -> Any:
+            if path == tmp_path:
+                raise PermissionError("denied")
+            return real_glob(path, pattern)
+
+        monkeypatch.setattr(Path, "glob", fail_glob)
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [tmp_path])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "directory_read_error"
+
+    def test_unsupported_target_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target = tmp_path / "socket"
+        real_stat = Path.stat
+
+        def fake_stat(path: Path, *args: Any, **kwargs: Any) -> Any:
+            if path == target:
+                return SimpleNamespace(st_mode=stat.S_IFIFO)
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [target])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "unsupported_target"
+
+    def test_target_resolution_failure_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        real_resolve = Path.resolve
+
+        def fail_resolve(path: Path, *args: Any, **kwargs: Any) -> Path:
+            if path == workflow:
+                raise OSError("cannot resolve")
+            return real_resolve(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", fail_resolve)
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [workflow])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "target_resolve_error"
+
+    @pytest.mark.parametrize(
+        ("contents", "expected_code"),
+        [
+            pytest.param("x" * (_MAX_FILE_SIZE + 1), "oversized", id="oversized"),
+            pytest.param("jobs: [\n", "yaml_parse", id="yaml_parse"),
+            pytest.param("", "empty_document", id="empty_document"),
+            pytest.param("plain scalar\n", "invalid_document", id="scalar_root"),
+            pytest.param("- item\n", "invalid_document", id="list_root"),
+        ],
+    )
+    def test_document_validation_failures_return_nonzero(
+        self,
+        tmp_path: Path,
+        contents: str,
+        expected_code: str,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        if expected_code == "oversized":
+            workflow.write_bytes(contents.encode("utf-8"))
+        else:
+            workflow.write_text(contents, encoding="utf-8")
+
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [workflow])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == expected_code
+
+    def test_read_failure_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_text("name: CI\n", encoding="utf-8")
+        real_open = Path.open
+
+        def fail_workflow_open(path: Path, *args: Any, **kwargs: Any) -> Any:
+            if path == workflow:
+                raise PermissionError("denied")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", fail_workflow_open)
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [workflow])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "read_error"
+
+    def test_decode_failure_returns_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        workflow = tmp_path / "ci.yml"
+        workflow.write_bytes(b"name: \xff\n")
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [workflow])
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "decode_error"
+
+
+class TestEmptyWorkflowInventory:
+    """Empty discovered inventories are policy failures unless opted out."""
+
+    def test_empty_inventory_fails_by_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [tmp_path])
+
+        assert exit_code == 1
+        assert payload["policy_violations"][0]["code"] == "empty_inventory"
+        assert payload["tool_error_count"] == 0
+
+    def test_allow_empty_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code, payload = _run_checkout_cli_json(
+            monkeypatch, capsys, [tmp_path], allow_empty=True
+        )
+
+        assert exit_code == 0
+        assert payload["policy_violation_count"] == 0
+        assert payload["tool_error_count"] == 0
+
+    def test_allow_empty_does_not_hide_missing_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        missing = tmp_path / "missing.yml"
+        exit_code, payload = _run_checkout_cli_json(
+            monkeypatch, capsys, [missing], allow_empty=True
+        )
+
+        assert exit_code == 1
+        assert payload["tool_errors"][0]["code"] == "target_stat_error"
+
+
+def _write_mixed_failures(tmp_path: Path) -> tuple[Path, Path]:
+    """Create one malformed workflow and one checkout-order violation."""
+    malformed = tmp_path / "malformed.yml"
+    malformed.write_text("jobs: [\n", encoding="utf-8")
+    violating = tmp_path / "violating.yml"
+    violating.write_text(
+        "jobs:\n  build:\n    steps:\n      - uses: ./.github/actions/setup\n",
+        encoding="utf-8",
+    )
+    return malformed, violating
+
+
+class TestCheckoutValidationOutput:
+    """Human and JSON output keep tool and policy failures distinct."""
+
+    def test_json_separates_categories_and_preserves_legacy_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        malformed, violating = _write_mixed_failures(tmp_path)
+        exit_code, payload = _run_checkout_cli_json(monkeypatch, capsys, [malformed, violating])
+
+        assert exit_code == 1
+        assert payload["status"] == "error"
+        assert payload["exit_code"] == 1
+        assert payload["files_checked"] == 2
+        assert payload["violation_count"] == 1
+        assert payload["policy_violation_count"] == 1
+        assert payload["tool_error_count"] == 1
+        assert payload["policy_violations"][0]["code"] == "checkout_order"
+        assert payload["tool_errors"][0]["code"] == "yaml_parse"
+
+    def test_human_output_labels_both_categories(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        malformed, violating = _write_mixed_failures(tmp_path)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-validate-workflow-checkout",
+                str(malformed),
+                str(violating),
+            ],
+        )
+
+        assert workflows_module.validate_workflow_checkout_main() == 1
         captured = capsys.readouterr()
-        assert "WARNING" in captured.err
+        assert "TOOL ERROR [yaml_parse]" in captured.err
+        assert str(malformed) in captured.err
+        assert "POLICY VIOLATION [checkout_order]" in captured.out
+        assert str(violating) in captured.out
 
 
 class TestCLIEntryPoints:


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2382.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2382

Generated by Hephaestus automation
