### PR TITLE
chore: Treat pytest exit code 5 as failed pre-push verification

### DIFF
--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -92,9 +92,6 @@ _UNMERGED_STATUS_CODES: frozenset[str] = frozenset({"DD", "AU", "UD", "UA", "DU"
 # the exact test it claims to fix (root cause of PR #2056's stranding).
 _FAILED_TEST_LINE_RE = re.compile(r"(?:^|\s)(?:FAILED|ERROR)\s+(tests/[\w./-]+\.py(?:::[\w./-]+)*)")
 _AFFECTED_TESTS_TIMEOUT_SECONDS = 900
-# pytest exit code 5 = "no tests ran": the failing test may have been deleted by
-# the fix/rebase itself (exactly the #2056 remedy) — not a gate failure.
-_PYTEST_NO_TESTS_RAN = 5
 
 
 def extract_failing_pytest_node_ids(ci_logs: str) -> list[str]:

--- a/hephaestus/automation/ci_fix_push_guard.py
+++ b/hephaestus/automation/ci_fix_push_guard.py
@@ -68,9 +68,13 @@ _UNMERGED_STATUS_CODES: frozenset[str] = frozenset({"DD", "AU", "UD", "UA", "DU"
 # the exact test it claims to fix (root cause of PR #2056's stranding).
 _FAILED_TEST_LINE_RE = re.compile(r"(?:^|\s)(?:FAILED|ERROR)\s+(tests/[\w./-]+\.py(?:::[\w./-]+)*)")
 _AFFECTED_TESTS_TIMEOUT_SECONDS = 900
-# pytest exit code 5 = "no tests ran": the failing test may have been deleted by
-# the fix/rebase itself (exactly the #2056 remedy) — not a gate failure.
-_PYTEST_NO_TESTS_RAN = 5
+_PYTEST_FAILURE_REASONS: dict[int, str] = {
+    1: "pytest exit code 1: tests failed",
+    2: "pytest exit code 2: test execution interrupted",
+    3: "pytest exit code 3: internal error",
+    4: "pytest exit code 4: command-line usage error",
+    5: "pytest exit code 5: no tests collected",
+}
 
 
 def extract_failing_pytest_node_ids(ci_logs: str) -> list[str]:
@@ -201,13 +205,11 @@ class CIFixPushGuard(_CIFixHost):
             return False
 
     def _affected_tests_pass(self, worktree_path: Path, issue_number: int, ci_logs: str) -> bool:
-        """Re-run the CI-failing tests locally; refuse the push if they still fail (#2122).
+        """Re-run the CI-failing tests locally before allowing a push (#2122).
 
-        Parses the failing pytest node IDs from ``ci_logs`` and re-runs them in
-        the worktree. Node IDs whose file no longer exists are dropped (a rebase
-        can legitimately delete the failing test — exactly the #2056 remedy).
-        Returns True (gate skipped) when no runnable node IDs are found, so a
-        BEHIND/green PR or an unparseable log never deadlocks the push.
+        The gate is skipped before invocation only when the CI logs contain no
+        runnable node IDs after missing files are filtered. Once pytest is
+        invoked, only exit code 0 passes.
 
         Args:
             worktree_path: Worktree the fix branch is checked out in.
@@ -215,8 +217,8 @@ class CIFixPushGuard(_CIFixHost):
             ci_logs: Combined CI failure log text.
 
         Returns:
-            True if the affected tests pass (or the gate does not apply),
-            False if they still fail or the run times out.
+            True if the affected tests pass or the gate does not apply, False
+            for every nonzero pytest result or timeout.
 
         """
         node_ids = [
@@ -243,10 +245,19 @@ class CIFixPushGuard(_CIFixHost):
         except subprocess.TimeoutExpired:
             logger.error("Issue #%s: pre-push test gate timed out; refusing to push", issue_number)
             return False
-        if result.returncode not in (0, _PYTEST_NO_TESTS_RAN):
+        if result.returncode != 0:
+            reason = (
+                f"pytest terminated by signal {-result.returncode}"
+                if result.returncode < 0
+                else _PYTEST_FAILURE_REASONS.get(
+                    result.returncode,
+                    f"pytest exited with unexpected code {result.returncode}",
+                )
+            )
             logger.error(
-                "Issue #%s: affected tests still failing locally; refusing to push: %s",
+                "Issue #%s: pre-push test gate failed (%s); refusing to push: %s",
                 issue_number,
+                reason,
                 (result.stdout or result.stderr or "")[-500:],
             )
             return False

--- a/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
+++ b/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
@@ -188,6 +188,47 @@ class TestRetryWorktreeChanges:
 class TestPushCiFix:
     """The post-agent push path normalizes dirty but resolved tracked changes."""
 
+    def test_no_tests_collected_refuses_push_with_reason(
+        self,
+        orchestrator: CIFixOrchestrator,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        node = "tests/unit/docs/test_x.py"
+        (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / node).write_text("def test_a():\n    pass\n")
+
+        with (
+            patch.object(orchestrator, "_head_advanced", return_value=True),
+            patch.object(orchestrator, "_ci_fix_head_is_pushable", return_value=True),
+            patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
+            patch(
+                "hephaestus.automation.ci_fix_push_guard.subprocess.run",
+                return_value=MagicMock(
+                    returncode=5,
+                    stdout="no tests collected",
+                    stderr="",
+                ),
+            ),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator."
+                "push_current_branch_with_lease_on_divergence"
+            ) as push,
+        ):
+            pushed = orchestrator.push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="abc123",
+                issue_number=2383,
+                pr_number=2400,
+                pr_head_branch="2383-pytest-exit-code",
+                session_id=None,
+                ci_logs=f"FAILED {node}::test_a\n",
+            )
+
+        assert pushed is False
+        assert "pytest exit code 5: no tests collected" in caplog.text
+        push.assert_not_called()
+
     def test_commits_resolved_dirty_tracked_changes_before_push(
         self, orchestrator: CIFixOrchestrator, tmp_path: Path
     ) -> None:
@@ -680,18 +721,62 @@ class TestAffectedTestsPass:
             assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is True
         mock_run.assert_not_called()
 
-    def test_passing_rerun_allows_push(
-        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    @pytest.mark.parametrize(
+        ("returncode", "expected", "failure_reason"),
+        [
+            pytest.param(0, True, None, id="passed"),
+            pytest.param(
+                1,
+                False,
+                "pytest exit code 1: tests failed",
+                id="tests-failed",
+            ),
+            pytest.param(
+                2,
+                False,
+                "pytest exit code 2: test execution interrupted",
+                id="interrupted",
+            ),
+            pytest.param(
+                3,
+                False,
+                "pytest exit code 3: internal error",
+                id="internal-error",
+            ),
+            pytest.param(
+                4,
+                False,
+                "pytest exit code 4: command-line usage error",
+                id="usage-error",
+            ),
+            pytest.param(
+                5,
+                False,
+                "pytest exit code 5: no tests collected",
+                id="no-tests-collected",
+            ),
+        ],
+    )
+    def test_pytest_exit_codes(
+        self,
+        orchestrator: CIFixOrchestrator,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        returncode: int,
+        expected: bool,
+        failure_reason: str | None,
     ) -> None:
         node = "tests/unit/docs/test_x.py"
         (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
         (tmp_path / node).write_text("def test_a():\n    pass\n")
         logs = f"FAILED {node}::test_a\n"
         with patch(
-            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
-            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+            "hephaestus.automation.ci_fix_push_guard.subprocess.run",
+            return_value=MagicMock(returncode=returncode, stdout="", stderr=""),
         ) as mock_run:
-            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is True
+            result = orchestrator._affected_tests_pass(tmp_path, 7, logs)
+
+        assert result is expected
         assert mock_run.call_args.args[0][:5] == [
             "uv",
             "run",
@@ -699,34 +784,26 @@ class TestAffectedTestsPass:
             "-m",
             "pytest",
         ]
-        assert f"{node}::test_a" in mock_run.call_args.args[0]
+        if failure_reason is not None:
+            assert failure_reason in caplog.text
 
-    def test_failing_rerun_refuses_push(
-        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    def test_signal_refuses_push(
+        self,
+        orchestrator: CIFixOrchestrator,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         node = "tests/unit/docs/test_x.py"
         (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
-        (tmp_path / node).write_text("def test_a():\n    assert False\n")
+        (tmp_path / node).write_text("def test_a():\n    pass\n")
         logs = f"FAILED {node}::test_a\n"
         with patch(
-            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
-            return_value=MagicMock(returncode=1, stdout="1 failed", stderr=""),
+            "hephaestus.automation.ci_fix_push_guard.subprocess.run",
+            return_value=MagicMock(returncode=-15, stdout="", stderr=""),
         ):
             assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is False
 
-    def test_no_tests_ran_exit_code_is_treated_as_pass(
-        self, orchestrator: CIFixOrchestrator, tmp_path: Path
-    ) -> None:
-        """Exit code 5 = the failing test was deleted by the fix/rebase (#2056 remedy)."""
-        node = "tests/unit/docs/test_x.py"
-        (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
-        (tmp_path / node).write_text("# test removed by the fix\n")
-        logs = f"FAILED {node}::test_a\n"
-        with patch(
-            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
-            return_value=MagicMock(returncode=5, stdout="no tests ran", stderr=""),
-        ):
-            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is True
+        assert "pytest terminated by signal 15" in caplog.text
 
     def test_timeout_refuses_push(self, orchestrator: CIFixOrchestrator, tmp_path: Path) -> None:
         node = "tests/unit/docs/test_x.py"
@@ -734,7 +811,7 @@ class TestAffectedTestsPass:
         (tmp_path / node).write_text("def test_a():\n    pass\n")
         logs = f"FAILED {node}::test_a\n"
         with patch(
-            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
+            "hephaestus.automation.ci_fix_push_guard.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd="pytest", timeout=900),
         ):
             assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is False


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2383.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2383

Generated by Hephaestus automation
