### PR TITLE
chore: Distinguish plan absence from GitHub read failure throughout plan discovery

### DIFF
--- a/hephaestus/automation/_interfaces.py
+++ b/hephaestus/automation/_interfaces.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from .review_journal import IssueComment, PlanDiscoveryResult
+
 
 @runtime_checkable
 class PRDiscoveryProtocol(Protocol):
@@ -115,9 +117,8 @@ class WorktreeManagerProtocol(Protocol):
 class PlannerStateProtocol(Protocol):
     """Structural contract for the planner-side state store.
 
-    Full public surface of PlannerStateManager (planner_state.py): filter:79,
-    get_cached_labels:167, prefetch_comments:178, get_cached_comments:209,
-    has_existing_plan:224.
+    Full public surface of PlannerStateManager (state/planner.py): filter,
+    get_cached_labels, prefetch_comments, get_cached_comments, discover_plan.
     """
 
     def filter(self) -> list[int]:
@@ -129,11 +130,11 @@ class PlannerStateProtocol(Protocol):
     def prefetch_comments(self, issue_numbers: list[int]) -> None:
         """Prefetch comments for multiple issues."""
 
-    def get_cached_comments(self, issue_number: int) -> list[dict[str, Any]] | None:
-        """Get cached comments for an issue or None if not prefetched."""
+    def get_cached_comments(self, issue_number: int) -> list[IssueComment] | None:
+        """Return a successfully read cached journal, or None when unavailable."""
 
-    def has_existing_plan(self, issue_number: int) -> bool:
-        """Check if a plan exists for an issue."""
+    def discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Return FOUND, ABSENT, or READ_ERROR for an issue plan lookup."""
 
 
 @runtime_checkable

--- a/hephaestus/automation/_plan_phase.py
+++ b/hephaestus/automation/_plan_phase.py
@@ -9,19 +9,21 @@ implementation plan, and if not, generate one" responsibility.
 from __future__ import annotations
 
 import contextlib
-import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from hephaestus.github.client import gh_call
-
 from ._stage_context import StageMixin
 from .agent_config import plan_stage_timeout
 from .git_utils import run
-from .planner_state import _comments_contain_plan
+from .github_api import fetch_issue_comments_metadata, gh_current_login
+from .review_journal import (
+    PlanDiscoveryResult,
+    discover_plan_from_comments,
+    normalize_issue_comments,
+)
 
 if TYPE_CHECKING:
     from ._stage_context import StageContext
@@ -46,28 +48,16 @@ class PlanPhase(StageMixin):
         """Store the shared :class:`StageContext`."""
         self.ctx = ctx
 
-    def _has_plan(self, issue_number: int) -> bool:
-        """Check if issue has an implementation plan.
-
-        Delegates to :func:`planner_state._comments_contain_plan` so the
-        prefix-anchored check stays in sync with the planner. Substring
-        matching here previously caused the implementer to mistake a
-        ``## 🔍 Plan Review`` comment (which quotes the plan body) for the
-        plan itself — the same bug class fixed in #455/#468/#484 (#715).
-
-        Note: ``_comments_contain_plan`` is a private helper but is the
-        canonical implementation per its own docstring; cross-module reuse
-        here is intentional to avoid a third copy of the same prefix logic.
-        """
+    def _discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Discover an actor-owned plan without converting read failure to absence."""
         try:
-            result = gh_call(
-                ["issue", "view", str(issue_number), "--comments", "--json", "comments"]
+            comments = normalize_issue_comments(
+                fetch_issue_comments_metadata(issue_number),
+                viewer_login=gh_current_login() or "",
             )
-            data = json.loads(result.stdout)
-            comments = data.get("comments", [])
-            return _comments_contain_plan(comments)
-        except (subprocess.SubprocessError, RuntimeError, json.JSONDecodeError, OSError):
-            return False
+        except Exception as exc:
+            return PlanDiscoveryResult.read_error(exc)
+        return discover_plan_from_comments(comments)
 
     def _generate(self, issue_number: int) -> None:
         """Generate plan for an issue using hephaestus-plan-issues.

--- a/hephaestus/automation/github_api/issues.py
+++ b/hephaestus/automation/github_api/issues.py
@@ -272,9 +272,12 @@ def _fetch_issue_comments_paginated(
                 f"Issue #{issue_number} comment journal exceeds "
                 f"{MAX_ISSUE_JOURNAL_COMMENTS} entries; manual recovery is required"
             )
-        for comment in page:
+        for index, comment in enumerate(page):
             if not isinstance(comment, dict):
-                continue
+                raise RuntimeError(
+                    f"Failed to fetch complete comment journal for #{issue_number}: "
+                    f"comment {index} was not an object"
+                )
             normalized = dict(comment)
             if normalized.get("databaseId") is None and normalized.get("id") is not None:
                 normalized["databaseId"] = normalized["id"]

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -58,7 +58,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 
 from hephaestus.agents.runtime import DEFAULT_AGENT, agent_supports_model_reasoning_effort
 from hephaestus.agents.workspace import SourceLane, WorkspaceBinding
-from hephaestus.automation.review_journal import IssueComment
+from hephaestus.automation.review_journal import IssueComment, PlanDiscoveryResult
 from hephaestus.automation.state_labels import STATE_SKIP
 
 from ..athena_skill_jobs import AthenaSkillJob, AthenaSkillRequest, AthenaSkillResult
@@ -208,8 +208,8 @@ class StageGitHub(Protocol):
         """Return title/body/head metadata; checkout later derives the review diff."""
         ...
 
-    def has_existing_plan(self, issue_number: int) -> bool:
-        """Return True when a canonical plan artifact exists for the issue."""
+    def discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Return the tri-state actor-owned plan-discovery outcome."""
         ...
 
     def issue_comments(self, issue_number: int) -> list[IssueComment]:
@@ -516,7 +516,7 @@ class StageContext:
     coordinator (#1817) maps onto the ``github_api`` mutators, while its
     read surface mirrors the existing helper names (``gh_issue_json``,
     ``find_merged_closing_pr``, ``find_pr_for_issue``,
-    ``has_existing_plan``). Stages never import ``github_api`` directly —
+    ``discover_plan``). Stages never import ``github_api`` directly —
     enforced by ``tests/unit/automation/pipeline/test_pipeline_architecture``.
     """
 

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -46,8 +46,10 @@ from hephaestus.automation.prompts._shared import fence_content
 from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.protocol import PLAN_REVIEW_CANONICAL_MARKER, PLAN_REVIEW_PREFIX
 from hephaestus.automation.review_journal import (
+    CommentJournalReadError,
     IssueComment,
     JournalSnapshot,
+    PlanDiscoveryStatus,
     current_revision_context,
     is_pending_review,
     journal_snapshot,
@@ -211,15 +213,14 @@ def _load_planning_journal(
 
 
 def _plan_is_ready_for_verify(
-    issue_number: int,
-    ctx: StageContext,
+    snapshot: JournalSnapshot,
     *,
     is_replan_entry: bool,
 ) -> bool:
     """Return whether restart may verify the canonical plan without another agent."""
     if is_replan_entry:
         return False
-    return ctx.github.has_existing_plan(issue_number)
+    return bool(snapshot.current_plan)
 
 
 def _write_planning_entry_labels(
@@ -379,23 +380,35 @@ def _publish_candidate_plan(
 def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
     """Publish or recover the candidate plan, then authorize advancement by label."""
     assert item.issue is not None  # noqa: S101 - stage validates the issue
+    lookup = ctx.github.discover_plan(item.issue)
+    if lookup.status is PlanDiscoveryStatus.READ_ERROR:
+        return StageOutcome(
+            Disposition.RETRY,
+            f"plan discovery failed: {lookup.error}",
+        )
+
     plan_text = item.payload.get("plan_text")
     posted_plan = False
     if plan_text is not None:
         requires_revision = bool(item.payload.get("requires_plan_revision"))
-        has_existing_plan = ctx.github.has_existing_plan(item.issue)
-        if requires_revision or not has_existing_plan:
+        if requires_revision or lookup.status is PlanDiscoveryStatus.ABSENT:
             logger.info("planning:%d: publishing plan revision", item.issue)
-            publication_outcome = _publish_candidate_plan(
-                item,
-                ctx,
-                requires_revision=requires_revision,
-            )
+            try:
+                publication_outcome = _publish_candidate_plan(
+                    item,
+                    ctx,
+                    requires_revision=requires_revision,
+                )
+            except CommentJournalReadError as exc:
+                return StageOutcome(
+                    Disposition.RETRY,
+                    f"plan journal read failed: {exc}",
+                )
             if publication_outcome is not None:
                 return publication_outcome
             posted_plan = True
 
-    if posted_plan or ctx.github.has_existing_plan(item.issue):
+    if posted_plan or lookup.status is PlanDiscoveryStatus.FOUND:
         labels = _require_issue_labels_for_transition(item.issue, ctx)
         if STATE_PLAN_BLOCKED in labels:
             return StageOutcome(
@@ -441,7 +454,7 @@ class PlanningStage(Stage):
       ``PLAN_WAIT`` and RETRY within the ``plan`` budget, then FINISH_FAIL.
 
     on_enter idempotency guards (re-housed from ``Planner._pr_coverage_skip``
-    and ``Planner._has_existing_plan``, all ordered at-or-past checks):
+    and the planner's tri-state plan discovery, all ordered at-or-past checks):
 
     - ``state:skip`` -> SKIP (checked BEFORE plan-go; skip wins over
       everything, even a contradictory plan-go, logging a WARNing — #1835)
@@ -453,15 +466,15 @@ class PlanningStage(Stage):
       carrying ``state:plan-no-go`` (or a stale ``state:plan-go``) after a
       plan_review fail-back -> ONE atomic ``edit_labels`` swap adding
       ``state:needs-plan`` and removing both siblings, so the labels-first
-      ``has_existing_plan`` gate can pass once a fresh plan comment is posted
+      plan-discovery gate can pass once a fresh plan comment is posted
       and the mutually-exclusive-label invariant holds (#1857)
-    - plan comment already exists (``ctx.github.has_existing_plan``) ->
+    - plan comment already exists (``ctx.github.discover_plan`` returns FOUND) ->
       fast-forward ``item.state`` to VERIFY so a restart mid-stage never
       redoes advise + plan (the base-protocol idempotency promise); the
       ``is_plan_review_go`` label check above stays the primary gate.
     """
 
-    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:  # noqa: C901
         """Refresh labels and perform idempotent fast-forward checks.
 
         Args:
@@ -522,15 +535,26 @@ class PlanningStage(Stage):
         # ADDS no-go, removing needs-plan/plan-go). A bare add of needs-plan
         # would leave state:plan-no-go in place — violating the
         # mutually-exclusive invariant AND keeping the labels-first
-        # has_existing_plan gate stuck-False so VERIFY can never ADVANCE
+        # plan-discovery gate stuck-False so VERIFY can never ADVANCE
         # (#1857). Swap atomically: add needs-plan, remove both siblings, in
         # ONE gh issue edit. Restores state:plan-no-go ──re-plan──▶ needs-plan.
-        (
-            comments,
-            _snapshot,
-            is_replan_entry,
-            revision_already_published,
-        ) = _load_planning_journal(item, ctx, labels)
+        try:
+            (
+                comments,
+                snapshot,
+                is_replan_entry,
+                revision_already_published,
+            ) = _load_planning_journal(item, ctx, labels)
+        except CommentJournalReadError as exc:
+            logger.warning(
+                "planning:%d: plan journal reconciliation read failed: %s",
+                item.issue,
+                exc,
+            )
+            return StageOutcome(
+                Disposition.RETRY,
+                f"plan journal read failed: {exc}",
+            )
         if is_replan_entry:
             item.payload["requires_plan_revision"] = True
         if not _write_planning_entry_labels(
@@ -549,14 +573,10 @@ class PlanningStage(Stage):
         if history:
             item.payload["issue_history"] = history
 
-        # Restart fast-forward: a plan comment already exists (real has-plan
-        # semantics via ctx.github), so re-entry must not redo advise + plan.
+        # Restart fast-forward: journal reconciliation already found a current
+        # plan, so re-entry must not redo advise + plan.
         # Jump straight to VERIFY; idempotent on repeated on_enter calls.
-        if _plan_is_ready_for_verify(
-            item.issue,
-            ctx,
-            is_replan_entry=is_replan_entry,
-        ):
+        if _plan_is_ready_for_verify(snapshot, is_replan_entry=is_replan_entry):
             logger.info(
                 "planning:%d: plan comment already exists; fast-forward to VERIFY", item.issue
             )

--- a/hephaestus/automation/pipeline_github_contract.py
+++ b/hephaestus/automation/pipeline_github_contract.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
         def _owner_name(self) -> tuple[str, str]:
             pass
 
+        def _viewer_login(self) -> str:
+            pass
+
         def _comment_owned_by_viewer(self, comment: dict[str, Any]) -> bool:
             pass
 

--- a/hephaestus/automation/pipeline_github_queries.py
+++ b/hephaestus/automation/pipeline_github_queries.py
@@ -2,35 +2,17 @@
 # ruff: noqa: F403, F405
 from .pipeline_github_contract import _PipelineGitHubHost
 from .pipeline_github_transport import *
+from .review_journal import (
+    CommentJournalReadError,
+    IssueComment,
+    PlanDiscoveryResult,
+    discover_plan_from_comments,
+    normalize_issue_comments,
+)
 
 
 class PipelineGitHubQueries(_PipelineGitHubHost):
     """Own read-only issue, PR, plan, and review-state queries."""
-
-    def _comments_have_plan(self, comments: Any) -> bool:
-        """Return whether an actor-owned canonical plan artifact is present.
-
-        Comment markers locate data; they never establish state.  Requiring
-        GitHub's ownership proof prevents a foreign comment from impersonating
-        the pipeline's canonical plan and influencing stage orchestration.
-        """
-        if not isinstance(comments, list):
-            return False
-        for comment in comments:
-            if not isinstance(comment, dict):
-                continue
-            if not self._comment_owned_by_viewer(comment):
-                continue
-            body = comment.get("body")
-            if not isinstance(body, str):
-                continue
-            stripped = body.lstrip()
-            first_line = stripped.splitlines()[0] if stripped else ""
-            if first_line in {PLAN_REVIEW_CANONICAL_MARKER, PLAN_REVIEW_PREFIX}:
-                continue
-            if first_line in {PLAN_CANONICAL_MARKER, PLAN_COMMENT_MARKER}:
-                return True
-        return False
 
     def _open_prs_for_branch(self, branch_name: str) -> list[tuple[int, str]]:
         """Return open PRs on ``branch_name`` without altering auto-merge."""
@@ -292,27 +274,18 @@ class PipelineGitHubQueries(_PipelineGitHubHost):
         )
 
     def issue_comments(self, issue_number: int) -> list[IssueComment]:
-        """Return structured issue comments in GitHub creation order."""
-        comments = self._repo_issue_comments(issue_number)
-        return [
-            IssueComment(
-                body=str(comment.get("body", "")),
-                author_login=str(
-                    (comment.get("user") or comment.get("author") or {}).get("login", "")
-                ),
-                author_association=str(
-                    comment.get("author_association") or comment.get("authorAssociation") or ""
-                ),
-                created_at=str(comment.get("created_at") or comment.get("createdAt") or ""),
-                updated_at=str(comment.get("updated_at") or comment.get("updatedAt") or ""),
-                viewer_did_author=self._comment_owned_by_viewer(comment),
-                database_id=(
-                    int(comment["databaseId"]) if comment.get("databaseId") is not None else None
-                ),
-                url=str(comment.get("html_url") or comment.get("url") or ""),
+        """Return a complete, ownership-verified issue-comment journal."""
+        try:
+            return normalize_issue_comments(
+                self._repo_issue_comments(issue_number),
+                viewer_login=self._viewer_login(),
             )
-            for comment in comments
-        ]
+        except CommentJournalReadError:
+            raise
+        except Exception as exc:
+            raise CommentJournalReadError(
+                f"failed to read issue #{issue_number} comments: {exc}"
+            ) from exc
 
     def ensure_blocked_audit(self, issue_number: int) -> None:
         """Repair an interrupted BLOCKED explanation without touching its label."""
@@ -422,25 +395,13 @@ class PipelineGitHubQueries(_PipelineGitHubHost):
             "pr_base_branch": base_branch,
         }
 
-    def has_existing_plan(self, issue_number: int) -> bool:
-        """Return whether the canonical plan artifact exists.
-
-        This is an artifact-presence query, not an approval gate. Plan approval
-        is read exclusively from GitHub labels by stage entry checks.
-        """
+    def discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Discover the actor-owned canonical plan without inventing absence."""
         try:
-            result = (
-                self._gh(
-                    ["issue", "view", str(issue_number), "--json", "comments"],
-                    check=False,
-                )
-                if self._repo_slug is not None
-                else gh_call(["issue", "view", str(issue_number), "--json", "comments"])
-            )
-            data = json.loads(result.stdout or "{}")
-        except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
-            return False
-        return isinstance(data, dict) and self._comments_have_plan(data.get("comments"))
+            return discover_plan_from_comments(self.issue_comments(issue_number))
+        except CommentJournalReadError as exc:
+            logger.warning("Issue #%s: plan discovery failed: %s", issue_number, exc)
+            return PlanDiscoveryResult.read_error(exc)
 
     def get_pr_head_branch(self, pr_number: int) -> str | None:
         """Return the PR's head branch (``_review_utils.get_pr_head_branch``)."""

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -59,10 +59,15 @@ from .models import PlanReviewerOptions, WorkerResult
 from .prompts import get_plan_review_prompt
 from .protocol import PLAN_REVIEW_CANONICAL_MARKER
 from .review_journal import (
+    CommentJournalReadError,
     IssueComment,
+    PlanDiscoveryResult,
+    PlanDiscoveryStatus,
     blocked_audit_recovery_body,
     comment_revision,
+    discover_plan_from_comments,
     is_plan_comment,
+    normalize_issue_comments,
     parse_plan_review_state,
     render_current_review,
 )
@@ -125,7 +130,7 @@ class PlanReviewer:
         # Per-instance cache for ``_fetch_issue_comments`` (#A3-009, #560).
         # Initialised here rather than lazily so mypy sees the type and the
         # ThreadPoolExecutor invariant is unambiguous.
-        self._comments_cache: dict[int, list[dict[str, Any]]] = {}
+        self._comments_cache: dict[int, list[IssueComment]] = {}
 
     def run(self) -> dict[int, WorkerResult]:
         """Run the plan reviewer on all issues.
@@ -179,7 +184,7 @@ class PlanReviewer:
         self._print_summary(results)
         return results
 
-    def _review_issue(self, issue_number: int, slot_id: int) -> WorkerResult:
+    def _review_issue(self, issue_number: int, slot_id: int) -> WorkerResult:  # noqa: C901
         """Review the plan for a single issue.
 
         Args:
@@ -233,14 +238,27 @@ class PlanReviewer:
                         issue_number=issue_number, success=True, already_reviewed=True
                     )
 
-                # Skip if no plan exists
-                plan_text = self._get_latest_plan(issue_number)
-                if plan_text is None:
+                plan_lookup = self._get_latest_plan(issue_number)
+                if plan_lookup.status is PlanDiscoveryStatus.READ_ERROR:
+                    return WorkerResult(
+                        issue_number=issue_number,
+                        success=False,
+                        error=f"Failed to discover plan: {plan_lookup.error}",
+                    )
+                if plan_lookup.status is PlanDiscoveryStatus.ABSENT:
                     logger.info(
                         "Issue %s: no plan comment found, skipping", issue_ref(issue_number)
                     )
                     return WorkerResult(
                         issue_number=issue_number, success=True, already_reviewed=True
+                    )
+
+                plan_text = plan_lookup.plan_text
+                if plan_text is None:
+                    return WorkerResult(
+                        issue_number=issue_number,
+                        success=False,
+                        error="plan discovery returned FOUND without plan text",
                     )
 
                 # Fetch issue details for context
@@ -299,7 +317,7 @@ class PlanReviewer:
                     error=str(e)[:80],
                 )
 
-    def _fetch_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+    def _fetch_issue_comments(self, issue_number: int) -> list[IssueComment]:
         """Fetch the complete bounded issue journal, caching it per instance.
 
         Both ``_latest_review_is_final`` and ``_get_latest_plan`` call this
@@ -310,32 +328,34 @@ class PlanReviewer:
             issue_number: GitHub issue number.
 
         Returns:
-            Chronological comment dictionaries with normalized ownership.
+            Chronological comments with validated author metadata and derived
+            ownership.
 
         Raises:
-            RuntimeError: GitHub cannot provide the complete bounded journal or
+            CommentJournalReadError: GitHub cannot provide a complete journal or
                 the authenticated actor identity cannot be established.
 
         """
         if issue_number in self._comments_cache:
             return self._comments_cache[issue_number]
 
-        comments = fetch_issue_comments_metadata(issue_number, **self._repo_kwargs())
-        viewer_login = (gh_current_login() or "").lower()
-        if not viewer_login:
-            raise RuntimeError("cannot verify GitHub comment ownership: viewer login unavailable")
-        for comment in comments:
-            if "viewerDidAuthor" in comment:
-                continue
-            author = comment.get("user") or comment.get("author") or {}
-            login = author.get("login") if isinstance(author, dict) else ""
-            comment["viewerDidAuthor"] = bool(login) and str(login).lower() == viewer_login
+        try:
+            comments = normalize_issue_comments(
+                fetch_issue_comments_metadata(issue_number, **self._repo_kwargs()),
+                viewer_login=gh_current_login() or "",
+            )
+        except CommentJournalReadError:
+            raise
+        except Exception as exc:
+            raise CommentJournalReadError(
+                f"failed to read issue #{issue_number} comments: {exc}"
+            ) from exc
 
         self._comments_cache[issue_number] = comments
         return comments
 
-    def _get_latest_plan(self, issue_number: int) -> str | None:
-        """Return the body of the last comment that is the PLAN.
+    def _get_latest_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Return the tri-state result for the latest actor-owned plan.
 
         Uses :meth:`_fetch_issue_comments` so the API call is shared with
         :meth:`_latest_review_is_final`.
@@ -352,41 +372,17 @@ class PlanReviewer:
             issue_number: GitHub issue number.
 
         Returns:
-            Plan comment body text, or None if no plan comment is found.
+            ``FOUND``, ``ABSENT``, or ``READ_ERROR`` for the complete journal.
 
         """
-        comments = self._fetch_issue_comments(issue_number)
-
-        # Walk in reverse to find the *last* genuine plan comment.
-        for comment in reversed(comments):
-            if not bool(comment.get("viewerDidAuthor")):
-                continue
-            body: str = comment.get("body", "")
-            stripped = body.lstrip()
-            if stripped.startswith(_REVIEW_PREFIX):
-                continue  # never treat a review comment as the plan
-            # Match the single canonical marker ONLY at the start of the body
-            # (anchored), never as a free substring.
-            if is_plan_comment(stripped):
-                logger.debug("Found plan comment for issue #%s", issue_number)
-                return body
-
-        return None
+        try:
+            return discover_plan_from_comments(self._fetch_issue_comments(issue_number))
+        except CommentJournalReadError as exc:
+            return PlanDiscoveryResult.read_error(exc)
 
     def _ensure_blocked_audit(self, issue_number: int) -> None:
         """Repair an interrupted BLOCKED explanation without invoking an agent."""
-        comments = [
-            IssueComment(
-                body=str(comment.get("body", "")),
-                author_login=str(
-                    (comment.get("user") or comment.get("author") or {}).get("login", "")
-                ),
-                viewer_did_author=bool(comment.get("viewerDidAuthor")),
-                created_at=str(comment.get("createdAt") or comment.get("created_at") or ""),
-                updated_at=str(comment.get("updatedAt") or comment.get("updated_at") or ""),
-            )
-            for comment in self._fetch_issue_comments(issue_number)
-        ]
+        comments = self._fetch_issue_comments(issue_number)
         body = blocked_audit_recovery_body(comments)
         if body is None:
             return
@@ -605,11 +601,10 @@ class PlanReviewer:
             raise RuntimeError(f"contradictory plan-state labels: {sorted(active_states)}")
         revision = 1
         for comment in reversed(self._fetch_issue_comments(issue_number)):
-            if not bool(comment.get("viewerDidAuthor")):
+            if not comment.viewer_did_author:
                 continue
-            body = str(comment.get("body", ""))
-            if is_plan_comment(body):
-                revision = comment_revision(body) or 1
+            if is_plan_comment(comment.body):
+                revision = comment_revision(comment.body) or 1
                 break
         comment_body = render_current_review(review_text, revision=revision)
         label_to_add, labels_to_remove = apply_plan_state(state)

--- a/hephaestus/automation/review_journal.py
+++ b/hephaestus/automation/review_journal.py
@@ -209,18 +209,14 @@ def normalize_issue_comments(
             try:
                 database_id = int(raw_database_id)
             except (TypeError, ValueError) as exc:
-                raise CommentJournalReadError(
-                    f"comment {index} database id was invalid"
-                ) from exc
+                raise CommentJournalReadError(f"comment {index} database id was invalid") from exc
 
         normalized.append(
             IssueComment(
                 body=body,
                 author_login=login,
                 author_association=str(
-                    raw.get("author_association")
-                    or raw.get("authorAssociation")
-                    or ""
+                    raw.get("author_association") or raw.get("authorAssociation") or ""
                 ),
                 created_at=str(raw.get("created_at") or raw.get("createdAt") or ""),
                 updated_at=str(raw.get("updated_at") or raw.get("updatedAt") or ""),

--- a/hephaestus/automation/review_journal.py
+++ b/hephaestus/automation/review_journal.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import difflib
 import hashlib
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Final
 
 from hephaestus.automation.protocol import (
@@ -49,6 +50,10 @@ _NEW_PLAN_PAYLOAD = "<!-- hephaestus-plan-history:new-plan -->"
 _TRUSTED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
 
+class CommentJournalReadError(RuntimeError):
+    """A complete, ownership-verifiable GitHub comment read failed."""
+
+
 @dataclass(frozen=True)
 class IssueComment:
     """Issue comment metadata required for ownership and feedback decisions."""
@@ -71,6 +76,38 @@ class IssueComment:
             and self.author_association.upper() in _TRUSTED_ASSOCIATIONS
             and not login.endswith("[bot]")
         )
+
+
+class PlanDiscoveryStatus(StrEnum):
+    """Outcome of discovering an actor-owned canonical plan."""
+
+    FOUND = "found"
+    ABSENT = "absent"
+    READ_ERROR = "read_error"
+
+
+@dataclass(frozen=True, slots=True)
+class PlanDiscoveryResult:
+    """Plan-discovery outcome and its optional payload or diagnostic."""
+
+    status: PlanDiscoveryStatus
+    plan_text: str | None = None
+    error: str | None = None
+
+    @classmethod
+    def found(cls, plan_text: str) -> PlanDiscoveryResult:
+        """Create a successful result containing the canonical plan text."""
+        return cls(PlanDiscoveryStatus.FOUND, plan_text=plan_text)
+
+    @classmethod
+    def absent(cls) -> PlanDiscoveryResult:
+        """Create a successful result proving no actor-owned plan exists."""
+        return cls(PlanDiscoveryStatus.ABSENT)
+
+    @classmethod
+    def read_error(cls, error: object) -> PlanDiscoveryResult:
+        """Create a result describing an incomplete or invalid journal read."""
+        return cls(PlanDiscoveryStatus.READ_ERROR, error=str(error))
 
 
 @dataclass(frozen=True)
@@ -109,7 +146,8 @@ def comment_body(comment: IssueComment | str) -> str:
 def is_plan_comment(body: str) -> bool:
     """Recognize current and legacy canonical plan comments."""
     stripped = body.lstrip()
-    return stripped.startswith(PLAN_CANONICAL_MARKER) or stripped.startswith(PLAN_COMMENT_MARKER)
+    first_line = stripped.splitlines()[0].strip() if stripped else ""
+    return first_line in {PLAN_CANONICAL_MARKER, PLAN_COMMENT_MARKER}
 
 
 def is_plan_review_comment(body: str) -> bool:
@@ -118,6 +156,95 @@ def is_plan_review_comment(body: str) -> bool:
     return stripped.startswith(PLAN_REVIEW_CANONICAL_MARKER) or stripped.startswith(
         PLAN_REVIEW_PREFIX
     )
+
+
+def normalize_issue_comments(
+    comments: Sequence[object],
+    *,
+    viewer_login: str,
+) -> list[IssueComment]:
+    """Validate REST comments and derive ownership from authenticated identity.
+
+    A plan lookup may report ``ABSENT`` only after every comment in the
+    complete journal has been validated.  In particular, ownership is derived
+    from the authenticated viewer login and the comment's author metadata;
+    caller-provided ownership flags are intentionally ignored.
+
+    Args:
+        comments: Raw REST comment payloads in chronological order.
+        viewer_login: Login returned by the authenticated GitHub session.
+
+    Returns:
+        Structured comments with derived ownership metadata.
+
+    Raises:
+        CommentJournalReadError: If the viewer identity or any comment payload
+            is missing required fields or has an invalid shape.
+
+    """
+    actor = viewer_login.strip()
+    if not actor:
+        raise CommentJournalReadError(
+            "cannot verify GitHub comment ownership: viewer login unavailable"
+        )
+
+    normalized: list[IssueComment] = []
+    for index, raw in enumerate(comments):
+        if not isinstance(raw, Mapping):
+            raise CommentJournalReadError(f"comment {index} was not an object")
+
+        body = raw.get("body")
+        author = raw.get("user") or raw.get("author")
+        login = author.get("login") if isinstance(author, Mapping) else None
+        if not isinstance(body, str):
+            raise CommentJournalReadError(f"comment {index} body was not a string")
+        if not isinstance(login, str) or not login.strip():
+            raise CommentJournalReadError(f"comment {index} author login was unavailable")
+
+        database_id: int | None = None
+        raw_database_id = raw.get("databaseId")
+        if raw_database_id is None:
+            raw_database_id = raw.get("id")
+        if raw_database_id is not None:
+            try:
+                database_id = int(raw_database_id)
+            except (TypeError, ValueError) as exc:
+                raise CommentJournalReadError(
+                    f"comment {index} database id was invalid"
+                ) from exc
+
+        normalized.append(
+            IssueComment(
+                body=body,
+                author_login=login,
+                author_association=str(
+                    raw.get("author_association")
+                    or raw.get("authorAssociation")
+                    or ""
+                ),
+                created_at=str(raw.get("created_at") or raw.get("createdAt") or ""),
+                updated_at=str(raw.get("updated_at") or raw.get("updatedAt") or ""),
+                viewer_did_author=login.casefold() == actor.casefold(),
+                database_id=database_id,
+                url=str(raw.get("html_url") or raw.get("url") or ""),
+            )
+        )
+    return normalized
+
+
+def discover_plan_from_comments(
+    comments: Sequence[IssueComment],
+) -> PlanDiscoveryResult:
+    """Select the latest actor-owned plan from a validated complete journal."""
+    for comment in reversed(comments):
+        if not comment.viewer_did_author:
+            continue
+        body = comment.body.lstrip()
+        if is_plan_review_comment(body):
+            continue
+        if is_plan_comment(body):
+            return PlanDiscoveryResult.found(comment.body)
+    return PlanDiscoveryResult.absent()
 
 
 def is_journal_comment(body: str) -> bool:

--- a/hephaestus/automation/state/planner.py
+++ b/hephaestus/automation/state/planner.py
@@ -4,10 +4,10 @@ Owns the cheap, idempotent state queries the planner runs against GitHub:
 
 - ``filter()`` — drop closed issues from the working set (one batched GraphQL
   call per 100 issues via :func:`prefetch_issue_states`).
-- ``prefetch_comments()`` — batch-fetch all issue comments in one aliased
-  GraphQL call and store them in an internal cache (#616).
-- ``has_existing_plan()`` — return ``True`` when an issue already carries the
-  canonical plan-comment marker (uses the cache when available).
+- ``prefetch_comments()`` — fetch and normalize all issue comments into an
+  internal cache (#616).
+- ``discover_plan()`` — return FOUND, ABSENT, or READ_ERROR using the cache
+  when available and a complete REST lookup otherwise.
 
 Extracted from ``planner.py`` (#598) so the coordinator class stays focused
 on the worker-pool driver. No behavior change.
@@ -15,16 +15,27 @@ on the worker-pool driver. No behavior change.
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from ..git_utils import issue_ref
-from ..github_api import _gh_call, prefetch_issue_states, skip_epics
-from ..review_journal import is_plan_comment, is_plan_review_comment
+from ..github_api import (
+    fetch_issue_comments_metadata,
+    gh_current_login,
+    prefetch_issue_states,
+    skip_epics,
+)
+from ..review_journal import (
+    CommentJournalReadError,
+    IssueComment,
+    PlanDiscoveryResult,
+    PlanDiscoveryStatus,
+    discover_plan_from_comments,
+    normalize_issue_comments,
+)
 from ..state_labels import STATE_PLAN_GO, is_epic, is_exclusive_plan_state
 from .review import (
-    fetch_all_issue_comments_graphql,
     fetch_all_issue_labels_graphql,
     fetch_all_issue_titles_graphql,
 )
@@ -35,22 +46,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _comments_contain_plan(comments: list[dict[str, Any]]) -> bool:
-    """Return True if any comment is a plan comment (not a review).
-
-    Matches plan markers only at the START of a comment body, never as a free
-    substring: a ``## 🔍 Plan Review`` comment quotes the plan (so it contains
-    plan headings as substrings) and must NOT count as "has a plan" — that
-    substring confusion caused the reviewer to review its own prior review
-    (#455/#468/#484). Mirrors ``plan_reviewer._get_latest_plan``.
-    """
-    for comment in comments:
-        stripped = comment.get("body", "").lstrip()
-        if is_plan_review_comment(stripped):
-            continue
-        if is_plan_comment(stripped):
-            return True
-    return False
+def _comments_contain_plan(comments: Sequence[IssueComment]) -> bool:
+    """Return whether normalized comments contain an actor-owned plan."""
+    return discover_plan_from_comments(comments).status is PlanDiscoveryStatus.FOUND
 
 
 class PlannerStateManager:
@@ -72,7 +70,8 @@ class PlannerStateManager:
 
         """
         self.options = options
-        self._comments_cache: dict[int, list[dict[str, Any]]] | None = None
+        self._comments_cache: dict[int, list[IssueComment]] | None = None
+        self._comment_read_errors: dict[int, str] = {}
         self._labels_cache: dict[int, list[str]] | None = None
 
     def filter(self) -> list[int]:
@@ -174,38 +173,42 @@ class PlannerStateManager:
             return None
         return self._labels_cache.get(issue_number, [])
 
+    def _read_comments(self, issue_number: int) -> list[IssueComment]:
+        """Read and normalize the complete issue comment journal."""
+        try:
+            return normalize_issue_comments(
+                fetch_issue_comments_metadata(issue_number),
+                viewer_login=gh_current_login() or "",
+            )
+        except CommentJournalReadError:
+            raise
+        except Exception as exc:
+            raise CommentJournalReadError(
+                f"failed to read issue #{issue_number} comments: {exc}"
+            ) from exc
+
     def prefetch_comments(self, issue_numbers: list[int]) -> None:
-        """Batch-fetch comments for all issues in one aliased GraphQL call.
-
-        Stores results in the internal cache so subsequent calls to
-        :meth:`has_existing_plan` and callers of
-        :func:`~hephaestus.automation.review_state.is_plan_review_go`
-        (which accept a pre-fetched ``comments`` list) can avoid per-issue
-        round-trips.
-
-        Calling this method before the worker pool starts converts N
-        sequential ``gh issue view --comments`` calls into a single batched
-        GraphQL request, cutting round-trips from O(N) to O(1) (#616).
+        """Read complete comment journals and retain per-issue failures.
 
         Args:
-            issue_numbers: Issue numbers to pre-fetch.  Typically the list
+            issue_numbers: Issue numbers to prefetch. Typically the list
                 returned by :meth:`filter`.
 
         """
-        if not issue_numbers:
-            self._comments_cache = {}
-            return
-        logger.debug(
-            "Batch-fetching comments for %d issue(s) via aliased GraphQL (#616)",
-            len(issue_numbers),
-        )
-        self._comments_cache = fetch_all_issue_comments_graphql(issue_numbers)
-        logger.debug(
-            "Prefetched comments for %d issue(s)",
-            len(self._comments_cache),
-        )
+        self._comments_cache = {}
+        self._comment_read_errors = {}
+        for issue_number in issue_numbers:
+            try:
+                self._comments_cache[issue_number] = self._read_comments(issue_number)
+            except CommentJournalReadError as exc:
+                self._comment_read_errors[issue_number] = str(exc)
+                logger.warning(
+                    "Failed to prefetch comments for %s: %s",
+                    issue_ref(issue_number),
+                    exc,
+                )
 
-    def get_cached_comments(self, issue_number: int) -> list[dict[str, Any]] | None:
+    def get_cached_comments(self, issue_number: int) -> list[IssueComment] | None:
         """Return cached comments for an issue, or None if cache is unpopulated.
 
         Args:
@@ -218,54 +221,17 @@ class PlannerStateManager:
         """
         if self._comments_cache is None:
             return None
-        return self._comments_cache.get(issue_number, [])
+        return self._comments_cache.get(issue_number)
 
-    def has_existing_plan(self, issue_number: int) -> bool:
-        """Check if an issue already has a plan in comments.
+    def discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Return FOUND, ABSENT, or READ_ERROR for an issue plan lookup."""
+        if issue_number in self._comment_read_errors:
+            return PlanDiscoveryResult.read_error(self._comment_read_errors[issue_number])
 
-        Uses the batched comment cache when :meth:`prefetch_comments` has
-        already been called (#616), falling back to an individual
-        ``gh issue view --comments`` call otherwise.
-
-        Args:
-            issue_number: Issue number to check
-
-        Returns:
-            True if plan exists
-
-        """
-        # Fast path: use cached comments when available (#616).
-        cached = self.get_cached_comments(issue_number)
-        if cached is not None:
-            if _comments_contain_plan(cached):
-                logger.debug("Found existing plan for %s (cached)", issue_ref(issue_number))
-                return True
-            return False
-
-        # Slow path: individual fetch (pre-#616 behaviour, kept as fallback).
-        try:
-            result = _gh_call(
-                [
-                    "issue",
-                    "view",
-                    str(issue_number),
-                    "--comments",
-                    "--json",
-                    "comments",
-                ],
-            )
-
-            data = json.loads(result.stdout)
-            comments = data.get("comments", [])
-
-            if _comments_contain_plan(comments):
-                logger.debug("Found existing plan for %s", issue_ref(issue_number))
-                return True
-
-            return False
-
-        except Exception as e:
-            logger.warning(
-                "Failed to check for existing plan on %s: %s", issue_ref(issue_number), e
-            )
-            return False
+        comments = self.get_cached_comments(issue_number)
+        if comments is None:
+            try:
+                comments = self._read_comments(issue_number)
+            except CommentJournalReadError as exc:
+                return PlanDiscoveryResult.read_error(exc)
+        return discover_plan_from_comments(comments)

--- a/hephaestus/automation/state/review.py
+++ b/hephaestus/automation/state/review.py
@@ -212,7 +212,11 @@ def _fetch_issue_comments_graphql(issue_number: int) -> list[dict[str, Any]]:
 def fetch_all_issue_comments_graphql(
     issue_numbers: list[int],
 ) -> dict[int, list[dict[str, Any]]]:
-    """Batch-fetch comments for multiple issues in one aliased GraphQL call.
+    """Batch-fetch bounded comment context for legacy review-state consumers.
+
+    This helper may return empty lists after a failed or capped GraphQL lookup.
+    Plan discovery must use ``fetch_issue_comments_metadata`` and the tri-state
+    discovery contract instead.
 
     Mirrors the aliased batching pattern used by
     :func:`hephaestus.automation.github_api._fetch_batch_states` for issue
@@ -222,11 +226,9 @@ def fetch_all_issue_comments_graphql(
     reversed to chronological order so downstream "last match wins" semantics
     (e.g. :func:`latest_verdict`) work correctly.
 
-    This function is the shared implementation backing both:
-
-    - :class:`hephaestus.automation.planner_state.PlannerStateManager.has_existing_plan`
-      (plan-detection during the planning phase), and
-    - :func:`is_plan_review_go` (review-gate during the review phase).
+    This function remains the shared implementation for bounded review-state
+    context such as :func:`is_plan_review_go`; it is not an authoritative plan
+    presence source.
 
     Falls back to an empty list per issue on any failure.
 

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -340,7 +340,7 @@ def enter_planning_transition() -> tuple[list[str], list[str]]:
     route). Re-entry must restore ``state:needs-plan`` AND remove the sibling
     rejection/terminal labels in ONE transition, or (a) the mutually-exclusive
     label invariant is transiently violated and (b) the labels-first
-    ``has_existing_plan`` gate stays False forever, so VERIFY can never ADVANCE
+    plan-discovery gate stays False forever, so VERIFY can never ADVANCE
     and the re-plan cycle deadlocks (#1857).
 
     Restores the documented state-machine edge

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -3,7 +3,7 @@
 ``FakeStageGitHub`` extends the canonical pipeline ``FakeGitHub`` (see
 ``tests/unit/automation/pipeline/conftest.py``) with the read surface the
 planning/plan_review stages use (``gh_issue_json``, PR-coverage lookups,
-plan-comment presence), so mutator call sites and the ``mutation_log``
+tri-state plan discovery), so mutator call sites and the ``mutation_log``
 format stay identical to what coordinator tests (#1817) will assert.
 """
 
@@ -33,10 +33,19 @@ from hephaestus.automation.protocol import (
     PLAN_REVIEW_CANONICAL_MARKER,
     PLAN_REVIEW_PREFIX,
 )
-from hephaestus.automation.review_journal import IssueComment, blocked_audit_recovery_body
+from hephaestus.automation.review_journal import (
+    CommentJournalReadError,
+    IssueComment,
+    PlanDiscoveryResult,
+    blocked_audit_recovery_body,
+    render_current_plan,
+    render_current_review,
+    render_pending_review,
+)
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
     STATE_IMPLEMENTATION_NO_GO,
+    STATE_PLAN_NO_GO,
 )
 from tests.unit.automation.pipeline.conftest import FakeGitHub
 
@@ -55,7 +64,7 @@ class FakeStageGitHub(FakeGitHub):
     Reads mirror the real helper names the stages call through
     ``ctx.github``: ``gh_issue_json`` (github_api.issues),
     ``find_merged_closing_pr`` / ``find_pr_for_issue`` /
-    ``close_issue_as_covered`` (_review_utils), and ``has_existing_plan``
+    ``close_issue_as_covered`` (_review_utils), and ``discover_plan``
     (PlannerStateManager).
     """
 
@@ -80,6 +89,8 @@ class FakeStageGitHub(FakeGitHub):
         conversation_resolution: bool = True,
         pr_review_context: dict[str, str] | None = None,
         learn_terminal: bool = False,
+        plan_read_error: str | None = None,
+        journal_read_error: str | None = None,
     ) -> None:
         """Initialize the fake with canned read answers.
 
@@ -91,7 +102,7 @@ class FakeStageGitHub(FakeGitHub):
             merged_pr: Canned answer for find_merged_closing_pr.
             open_pr: Canned answer for find_pr_for_issue.
             pr_issue: Canned answer for find_issue_for_pr.
-            has_plan: Canned answer for has_existing_plan.
+            has_plan: Canned answer for plan discovery.
             pr_head_branch: Canned answer for get_pr_head_branch.
             pr_head_writable: Whether the PR head belongs to the base origin
                 and may receive coordinator-owned address commits.
@@ -125,6 +136,8 @@ class FakeStageGitHub(FakeGitHub):
         self._open_pr = open_pr
         self._pr_issue = pr_issue
         self._has_plan = has_plan
+        self._plan_read_error = plan_read_error
+        self._journal_read_error = journal_read_error
         self._pr_head_branch = pr_head_branch
         self._pr_head_writable = pr_head_writable
         self._pr_impl_state = pr_impl_state
@@ -195,12 +208,30 @@ class FakeStageGitHub(FakeGitHub):
         """Mirror PipelineGitHub.find_issue_for_pr (PR body Closes lookup)."""
         return self._pr_issue
 
-    def has_existing_plan(self, issue_number: int) -> bool:
-        """Mirror PlannerStateManager.has_existing_plan (plan comment check)."""
-        return self._has_plan
+    def discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+        """Return a canned tri-state plan-discovery result."""
+        if self._plan_read_error is not None:
+            return PlanDiscoveryResult.read_error(self._plan_read_error)
+        if self._has_plan:
+            return PlanDiscoveryResult.found(render_current_plan("Fake plan"))
+        return PlanDiscoveryResult.absent()
 
     def issue_comments(self, issue_number: int) -> list[IssueComment]:
         """Return fake issue comments in their append order with ownership metadata."""
+        if self._journal_read_error is not None:
+            raise CommentJournalReadError(self._journal_read_error)
+        comments = self.comments.get(issue_number, [])
+        if not comments and self._has_plan:
+            comments = [render_current_plan("Fake plan")]
+            if STATE_PLAN_NO_GO in self._issue_labels(issue_number):
+                comments.append(
+                    render_current_review(
+                        "Rejected fake plan\n\nstate:plan-no-go",
+                        revision=1,
+                    )
+                )
+            else:
+                comments.append(render_pending_review(revision=1))
         return [
             comment
             if isinstance(comment, IssueComment)
@@ -209,7 +240,7 @@ class FakeStageGitHub(FakeGitHub):
                 author_login="hephaestus[bot]",
                 viewer_did_author=True,
             )
-            for comment in self.comments.get(issue_number, [])
+            for comment in comments
         ]
 
     def ensure_blocked_audit(self, issue_number: int) -> None:
@@ -383,8 +414,8 @@ class FakeStageGitHub(FakeGitHub):
 
         Delegates to the canonical ``gh_issue_upsert_comment`` recorder so
         the mutation_log keeps the canonical format, and flips the
-        ``has_existing_plan`` answer to True — the posted comment IS the
-        durable plan artifact the verify step reads back.
+        plan-discovery answer to FOUND — the posted comment IS the durable
+        plan artifact the verify step reads back.
         """
         self._has_plan = True
         self.upsert_issue_comment(

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+import hephaestus.automation.github_api as github_api_mod
+import hephaestus.automation.pipeline_github as pg
 from hephaestus.automation.pipeline.athena_skill_jobs import AthenaSkillJob, AthenaSkillResult
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
@@ -664,6 +667,70 @@ class TestPlanningStageStep:
         assert result.disposition == Disposition.ADVANCE
         assert github.mutation_log == []  # existing plan: no duplicate upsert
 
+    def test_on_enter_journal_read_error_retries_without_mutation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Reconciliation failure retries before labels or journal writes."""
+        github = FakeStageGitHub(labels=[], journal_read_error="rate limited")
+        item = make_work_item(issue=11, state="ENTER")
+
+        outcome = PlanningStage().on_enter(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(
+            Disposition.RETRY,
+            "plan journal read failed: rate limited",
+        )
+        assert item.state == "ENTER"
+        assert item.attempts.get("plan", 0) == 0
+        assert github.labels[11] == set()
+        assert github.mutation_log == []
+
+    def test_verify_read_error_does_not_publish_or_spend_absence_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An uncertain plan lookup stays in VERIFY without side effects."""
+        github = FakeStageGitHub(
+            labels=[STATE_NEEDS_PLAN],
+            plan_read_error="malformed comment body",
+        )
+        item = make_work_item(issue=12, state="VERIFY")
+        item.payload["plan_text"] = "# Implementation Plan\n\nCandidate"
+
+        outcome = PlanningStage().step(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(
+            Disposition.RETRY,
+            "plan discovery failed: malformed comment body",
+        )
+        assert item.state == "VERIFY"
+        assert item.attempts.get("plan", 0) == 0
+        assert github.mutation_log == []
+
+    def test_production_adapter_malformed_comment_retries_without_mutation(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Malformed REST comments cannot be treated as an absent plan."""
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [{"body": None, "user": {"login": "bot"}}],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
+        item = make_work_item(issue=14, state="VERIFY")
+        item.payload["plan_text"] = "# Implementation Plan\n\nCandidate"
+
+        outcome = PlanningStage().step(item, make_ctx(github=adapter))
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert item.state == "VERIFY"
+        assert item.attempts.get("plan", 0) == 0
+
     def test_verify_posts_plan_comment_then_advances(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -696,13 +763,8 @@ class TestPlanningStageStep:
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """A just-written revised plan is valid even before a new review exists."""
-
-        class StaleNoGoGitHub(FakeStageGitHub):
-            def has_existing_plan(self, issue_number: int) -> bool:
-                return False
-
         stage = PlanningStage()
-        github = StaleNoGoGitHub(labels=[STATE_NEEDS_PLAN], has_plan=False)
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN], has_plan=False)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=24, state="VERIFY")
         item.payload["plan_text"] = "# Implementation Plan\n\nRevised plan."
@@ -926,7 +988,7 @@ class TestPlanningStageStep:
     def test_verify_posts_exactly_once_on_reentry(self, make_ctx: Any, make_work_item: Any) -> None:
         """Re-entering VERIFY never double-posts.
 
-        The upsert is guarded by has_existing_plan (idempotent on re-entry).
+        The upsert is guarded by tri-state plan discovery (idempotent on re-entry).
         """
         stage = PlanningStage()
         github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN], has_plan=False)

--- a/tests/unit/automation/state/test_planner.py
+++ b/tests/unit/automation/state/test_planner.py
@@ -1,19 +1,24 @@
 """Unit tests for ``hephaestus.automation.state.planner``.
 
 Covers the batched comment-prefetch path introduced by #616 and the
-``has_existing_plan`` fallback behaviour.
+tri-state plan-discovery fallback behaviour.
 """
 
 from __future__ import annotations
 
-import json
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from hephaestus.automation.models import PLAN_COMMENT_MARKER, PlannerOptions
+from hephaestus.automation.review_journal import (
+    CommentJournalReadError,
+    IssueComment,
+    PlanDiscoveryStatus,
+)
 from hephaestus.automation.state.planner import PlannerStateManager
+from hephaestus.github.client import GitHubRateLimitError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,6 +41,7 @@ def _default_title_and_skip_patches() -> Any:
             return_value={},
         ),
         patch("hephaestus.automation.state.planner.skip_epics"),
+        patch("hephaestus.automation.state.planner.gh_current_login", return_value="bot"),
     ):
         yield
 
@@ -97,37 +103,46 @@ class TestPrefetchComments:
 
     def test_prefetch_populates_cache(self) -> None:
         mgr = PlannerStateManager(_make_options(issues=[11, 12]))
-        expected = {
-            11: [{"body": _plan_body(), "updatedAt": "2025-01-01", "url": "u1"}],
-            12: [{"body": _other_body(), "updatedAt": "2025-01-01", "url": "u2"}],
-        }
         with patch(
-            "hephaestus.automation.state.planner.fetch_all_issue_comments_graphql",
-            return_value=expected,
+            "hephaestus.automation.state.planner.fetch_issue_comments_metadata",
+            side_effect=lambda issue: [
+                {
+                    "body": _plan_body() if issue == 11 else _other_body(),
+                    "user": {"login": "bot"},
+                }
+            ],
         ):
             mgr.prefetch_comments([11, 12])
-        assert mgr._comments_cache == expected
-        assert mgr.get_cached_comments(11) == expected[11]
-        assert mgr.get_cached_comments(12) == expected[12]
+        assert mgr.discover_plan(11).status is PlanDiscoveryStatus.FOUND
+        assert mgr.discover_plan(12).status is PlanDiscoveryStatus.ABSENT
 
-    def test_get_cached_returns_empty_list_for_missing_key(self) -> None:
+    def test_missing_cache_key_falls_back_instead_of_inventing_absence(self) -> None:
         mgr = PlannerStateManager(_make_options(issues=[20]))
-        with patch(
-            "hephaestus.automation.state.planner.fetch_all_issue_comments_graphql",
-            return_value={},
-        ):
-            mgr.prefetch_comments([20])
-        # Issue 20 not in the returned map → get_cached returns []
-        assert mgr.get_cached_comments(20) == []
+        mgr._comments_cache = {}
+        with patch.object(
+            mgr,
+            "_read_comments",
+            return_value=[
+                IssueComment(
+                    body=_plan_body(),
+                    author_login="bot",
+                    viewer_did_author=True,
+                )
+            ],
+        ) as read:
+            result = mgr.discover_plan(20)
+
+        assert result.status is PlanDiscoveryStatus.FOUND
+        read.assert_called_once_with(20)
 
 
 # ---------------------------------------------------------------------------
-# has_existing_plan — cached path
+# discover_plan — cached path
 # ---------------------------------------------------------------------------
 
 
 class TestHasExistingPlanCached:
-    """has_existing_plan uses the cache when prefetch_comments was called."""
+    """discover_plan uses the cache when prefetch_comments was called."""
 
     @pytest.fixture(autouse=True)
     def _patch_repo(self) -> Any:
@@ -143,32 +158,39 @@ class TestHasExistingPlanCached:
         ):
             yield
 
-    def _mgr_with_cache(self, cache: dict[int, list[dict[str, Any]]]) -> PlannerStateManager:
+    def _mgr_with_cache(self, cache: dict[int, list[IssueComment]]) -> PlannerStateManager:
         mgr = PlannerStateManager(_make_options(issues=list(cache.keys())))
-        with patch(
-            "hephaestus.automation.state.planner.fetch_all_issue_comments_graphql",
-            return_value=cache,
-        ):
-            mgr.prefetch_comments(list(cache.keys()))
+        mgr._comments_cache = cache
         return mgr
 
     def test_returns_true_when_plan_marker_in_cache(self) -> None:
-        mgr = self._mgr_with_cache({31: [{"body": _plan_body()}, {"body": _other_body()}]})
-        assert mgr.has_existing_plan(31) is True
+        mgr = self._mgr_with_cache(
+            {
+                31: [
+                    IssueComment(body=_plan_body(), author_login="bot", viewer_did_author=True),
+                    IssueComment(body=_other_body(), author_login="bot", viewer_did_author=True),
+                ]
+            }
+        )
+        assert mgr.discover_plan(31).status is PlanDiscoveryStatus.FOUND
 
     def test_returns_false_when_no_plan_marker_in_cache(self) -> None:
-        mgr = self._mgr_with_cache({32: [{"body": _other_body()}]})
-        assert mgr.has_existing_plan(32) is False
+        mgr = self._mgr_with_cache(
+            {32: [IssueComment(body=_other_body(), author_login="bot", viewer_did_author=True)]}
+        )
+        assert mgr.discover_plan(32).status is PlanDiscoveryStatus.ABSENT
 
     def test_returns_false_when_cache_empty_for_issue(self) -> None:
         mgr = self._mgr_with_cache({33: []})
-        assert mgr.has_existing_plan(33) is False
+        assert mgr.discover_plan(33).status is PlanDiscoveryStatus.ABSENT
 
     def test_does_not_call_gh_cli_when_cache_hit(self) -> None:
-        mgr = self._mgr_with_cache({34: [{"body": _plan_body()}]})
-        with patch("hephaestus.automation.state.planner._gh_call") as mock_gh:
-            mgr.has_existing_plan(34)
-        mock_gh.assert_not_called()
+        mgr = self._mgr_with_cache(
+            {34: [IssueComment(body=_plan_body(), author_login="bot", viewer_did_author=True)]}
+        )
+        with patch.object(mgr, "_read_comments") as read:
+            assert mgr.discover_plan(34).status is PlanDiscoveryStatus.FOUND
+        read.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -201,13 +223,10 @@ class TestFilterDropsPlanGoIssues:
                 "hephaestus.automation.state.planner.fetch_all_issue_labels_graphql",
                 return_value=labels,
             ),
-            patch("hephaestus.automation.state.planner._gh_call") as mock_gh,
         ):
             kept = mgr.filter()
 
         assert kept == [11, 12]
-        # No per-issue gh issue view: only the batched label fetch was used.
-        mock_gh.assert_not_called()
 
     def test_force_replans_even_plan_go_issues(self) -> None:
         from hephaestus.automation.state_labels import STATE_PLAN_GO
@@ -369,34 +388,50 @@ class TestFilterAllFilteredWarning:
 
 
 # ---------------------------------------------------------------------------
-# has_existing_plan — fallback (no cache)
+# discover_plan — fallback (no cache)
 # ---------------------------------------------------------------------------
 
 
 class TestHasExistingPlanFallback:
-    """has_existing_plan falls back to individual gh CLI call when no cache."""
-
-    def _gh_comments_payload(self, bodies: list[str]) -> MagicMock:
-        mock = MagicMock()
-        mock.stdout = json.dumps({"comments": [{"body": b} for b in bodies]})
-        return mock
+    """Plan discovery falls back to a complete REST read when no cache exists."""
 
     def test_returns_true_via_gh_cli_when_plan_present(self) -> None:
         mgr = PlannerStateManager(_make_options(issues=[41]))
-        mock_result = self._gh_comments_payload([_other_body(), _plan_body()])
-        with patch("hephaestus.automation.state.planner._gh_call", return_value=mock_result):
-            assert mgr.has_existing_plan(41) is True
+        with patch(
+            "hephaestus.automation.state.planner.fetch_issue_comments_metadata",
+            return_value=[{"body": _plan_body(), "user": {"login": "bot"}}],
+        ):
+            assert mgr.discover_plan(41).status is PlanDiscoveryStatus.FOUND
 
     def test_returns_false_via_gh_cli_when_no_plan(self) -> None:
         mgr = PlannerStateManager(_make_options(issues=[42]))
-        mock_result = self._gh_comments_payload([_other_body()])
-        with patch("hephaestus.automation.state.planner._gh_call", return_value=mock_result):
-            assert mgr.has_existing_plan(42) is False
+        with patch(
+            "hephaestus.automation.state.planner.fetch_issue_comments_metadata",
+            return_value=[{"body": _other_body(), "user": {"login": "bot"}}],
+        ):
+            assert mgr.discover_plan(42).status is PlanDiscoveryStatus.ABSENT
 
-    def test_returns_false_on_gh_call_exception(self) -> None:
+    @pytest.mark.parametrize(
+        "failure",
+        [RuntimeError("network error"), GitHubRateLimitError("rate limited", reset_epoch=123)],
+    )
+    def test_read_failure_is_explicit(self, failure: Exception) -> None:
         mgr = PlannerStateManager(_make_options(issues=[43]))
         with patch(
-            "hephaestus.automation.state.planner._gh_call",
-            side_effect=RuntimeError("network error"),
+            "hephaestus.automation.state.planner.fetch_issue_comments_metadata",
+            side_effect=failure,
         ):
-            assert mgr.has_existing_plan(43) is False
+            result = mgr.discover_plan(43)
+
+        assert result.status is PlanDiscoveryStatus.READ_ERROR
+
+    def test_prefetch_failure_is_read_error(self) -> None:
+        mgr = PlannerStateManager(_make_options(issues=[44]))
+        with patch.object(
+            mgr,
+            "_read_comments",
+            side_effect=CommentJournalReadError("rate limited"),
+        ):
+            mgr.prefetch_comments([44])
+
+        assert mgr.discover_plan(44).status is PlanDiscoveryStatus.READ_ERROR

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2668,6 +2668,17 @@ class TestFetchCompleteIssueCommentJournal:
                 repo=("HomericIntelligence", "Hephaestus"),
             )
 
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_comment_ingest_rejects_non_object_page_entry(self, mock_gh_call: Any) -> None:
+        """A malformed page cannot be silently converted into an empty journal."""
+        mock_gh_call.return_value = Mock(stdout=json.dumps([None]))
+
+        with pytest.raises(RuntimeError, match="comment 0 was not an object"):
+            _github_api_module.fetch_issue_comments_metadata(
+                42,
+                repo=("HomericIntelligence", "Hephaestus"),
+            )
+
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("o", "r"))
     @patch("hephaestus.automation.github_api._gh_call", side_effect=RuntimeError("offline"))
     def test_fetch_failure_is_not_confused_with_empty_journal(

--- a/tests/unit/automation/test_interfaces.py
+++ b/tests/unit/automation/test_interfaces.py
@@ -5,6 +5,7 @@ pipeline stage), so it no longer implements ``run()`` and is not asserted here.
 """
 
 from hephaestus.automation.protocol import ReviewerProtocol
+from hephaestus.automation.review_journal import PlanDiscoveryResult
 
 
 class _ConcreteReviewer:
@@ -120,8 +121,8 @@ def test_planner_state_is_not_implementer_state(tmp_path) -> None:
         def get_cached_comments(self, issue_number: int):
             return None
 
-        def has_existing_plan(self, issue_number: int) -> bool:
-            return False
+        def discover_plan(self, issue_number: int) -> PlanDiscoveryResult:
+            return PlanDiscoveryResult.absent()
 
     assert isinstance(_PlannerOnly(), PlannerStateProtocol)
     assert not isinstance(_PlannerOnly(), ImplementerStateProtocol)

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -30,6 +30,7 @@ from hephaestus.automation.protocol import (
 )
 from hephaestus.automation.review_journal import (
     IssueComment,
+    PlanDiscoveryStatus,
     render_current_plan,
     render_current_review,
 )
@@ -38,6 +39,7 @@ from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
     STATE_IMPLEMENTATION_NO_GO,
 )
+from hephaestus.github.client import GitHubRateLimitError
 from hephaestus.utils.file_lock import LockUnavailableError
 
 _BATCH_NONCE = "b" * 32
@@ -2251,6 +2253,12 @@ class TestConditionalMerge:
                 )
             ),
         )
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [{"body": f"{PLAN_COMMENT_MARKER}\nPlan", "user": {"login": "bot"}}],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
         result = adapter.merge_pr_if_head(7, "a" * 40)
 
@@ -2897,14 +2905,15 @@ class TestRepoScoping:
             adapter,
             "_repo_issue_comments",
             lambda issue: [
-                {"body": "plan", "databaseId": 1},
-                {"body": "review", "databaseId": 2},
+                {"body": "plan", "databaseId": 1, "user": {"login": "bot"}},
+                {"body": "review", "databaseId": 2, "user": {"login": "bot"}},
             ],
         )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
         assert adapter.issue_comments(7) == [
-            IssueComment(body="plan", database_id=1),
-            IssueComment(body="review", database_id=2),
+            IssueComment(body="plan", author_login="bot", viewer_did_author=True, database_id=1),
+            IssueComment(body="review", author_login="bot", viewer_did_author=True, database_id=2),
         ]
 
     def test_issue_reads_include_repo_arg(
@@ -3019,58 +3028,38 @@ class TestRepoScoping:
     def test_plan_presence_does_not_backfill_from_review_comment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        calls: list[list[str]] = []
-
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            calls.append(argv)
-            if argv[:2] == ["issue", "view"]:
-                payload = {
-                    "comments": [
-                        {
-                            "body": f"{PLAN_REVIEW_PREFIX}\n\nstate:plan-go",
-                            "viewerDidAuthor": True,
-                        }
-                    ],
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [
+                {
+                    "body": f"{PLAN_REVIEW_PREFIX}\n\nstate:plan-go",
+                    "user": {"login": "bot"},
                 }
-                return SimpleNamespace(stdout=json.dumps(payload))
-            return SimpleNamespace(stdout="")
-
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
-
-        assert not pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
-
-        assert calls == [
-            [
-                "issue",
-                "view",
-                "5",
-                "--json",
-                "comments",
-                "--repo",
-                "org/repo-a",
             ],
-        ]
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
-    def test_repo_scoped_has_existing_plan_detects_plan_comment(
+        assert adapter.discover_plan(5).status is PlanDiscoveryStatus.ABSENT
+
+    def test_repo_scoped_discover_plan_detects_plan_comment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            if argv[:2] == ["issue", "view"]:
-                payload = {
-                    "labels": [],
-                    "comments": [
-                        {
-                            "body": f"{PLAN_COMMENT_MARKER}\n\nDo the thing.",
-                            "viewerDidAuthor": True,
-                        }
-                    ],
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [
+                {
+                    "body": f"{PLAN_COMMENT_MARKER}\n\nDo the thing.",
+                    "user": {"login": "bot"},
                 }
-                return SimpleNamespace(stdout=json.dumps(payload))
-            return SimpleNamespace(stdout="")
+            ],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
-
-        assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
+        assert adapter.discover_plan(5).status is PlanDiscoveryStatus.FOUND
 
     @pytest.mark.parametrize(
         "body",
@@ -3079,79 +3068,83 @@ class TestRepoScoping:
             f"{PLAN_CANONICAL_MARKER} appendix\n{PLAN_COMMENT_MARKER}\nNot canonical.",
         ],
     )
-    def test_repo_scoped_has_existing_plan_rejects_marker_prefixes(
+    def test_repo_scoped_discover_plan_rejects_marker_prefixes(
         self,
         body: str,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Only an exact first-line marker identifies a canonical plan."""
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [{"body": body, "user": {"login": "bot"}}],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            if argv[:2] == ["issue", "view"]:
-                return SimpleNamespace(
-                    stdout=json.dumps(
-                        {
-                            "comments": [
-                                {"body": body, "viewerDidAuthor": True},
-                            ],
-                        }
-                    )
-                )
-            return SimpleNamespace(stdout="")
+        assert adapter.discover_plan(5).status is PlanDiscoveryStatus.ABSENT
 
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
-
-        assert not pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
-
-    def test_repo_scoped_has_existing_plan_ignores_foreign_plan_marker(
+    def test_repo_scoped_discover_plan_ignores_foreign_plan_marker(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Foreign marker text is inert and cannot impersonate the plan artifact."""
-
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            if argv[:2] == ["issue", "view"]:
-                payload = {
-                    "comments": [
-                        {
-                            "body": f"{PLAN_COMMENT_MARKER}\n\nSpoofed plan.",
-                            "viewerDidAuthor": False,
-                        }
-                    ],
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [
+                {
+                    "body": f"{PLAN_COMMENT_MARKER}\n\nSpoofed plan.",
+                    "user": {"login": "other"},
                 }
-                return SimpleNamespace(stdout=json.dumps(payload))
-            return SimpleNamespace(stdout="")
+            ],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+        assert adapter.discover_plan(5).status is PlanDiscoveryStatus.ABSENT
 
-        assert not pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
-
-    def test_repo_scoped_has_existing_plan_ignores_review_state_text(
+    def test_repo_scoped_discover_plan_ignores_review_state_text(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Artifact presence is independent from the authoritative state label."""
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [
+                {
+                    "body": f"{PLAN_COMMENT_MARKER}\n\nOld rejected plan.",
+                    "user": {"login": "bot"},
+                },
+                {
+                    "body": f"{PLAN_REVIEW_PREFIX}\n\nstate:plan-no-go",
+                    "user": {"login": "bot"},
+                },
+            ],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
-        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
-            if argv[:2] == ["issue", "view"]:
-                payload = {
-                    "labels": [],
-                    "comments": [
-                        {
-                            "body": f"{PLAN_COMMENT_MARKER}\n\nOld rejected plan.",
-                            "viewerDidAuthor": True,
-                        },
-                        {
-                            "body": f"{PLAN_REVIEW_PREFIX}\n\nstate:plan-no-go",
-                            "viewerDidAuthor": True,
-                        },
-                    ],
-                }
-                return SimpleNamespace(stdout=json.dumps(payload))
-            return SimpleNamespace(stdout="")
+        assert adapter.discover_plan(5).status is PlanDiscoveryStatus.FOUND
 
-        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+    @pytest.mark.parametrize(
+        "failure",
+        [RuntimeError("gh unavailable"), GitHubRateLimitError("rate limited", reset_epoch=123)],
+    )
+    def test_repo_scoped_discover_plan_maps_read_failure(
+        self,
+        failure: Exception,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Transport and rate-limit failures remain READ_ERROR outcomes."""
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        monkeypatch.setattr(
+            adapter, "_repo_issue_comments", lambda issue: (_ for _ in ()).throw(failure)
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
-        assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
+        assert adapter.discover_plan(5).status is PlanDiscoveryStatus.READ_ERROR
 
     def test_repo_scoped_pr_lookup_raises_on_gh_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -4718,11 +4711,22 @@ class TestReadSurface:
                 )
             ),
         )
+        monkeypatch.setattr(
+            adapter,
+            "_repo_issue_comments",
+            lambda issue: [
+                {
+                    "body": f"{PLAN_COMMENT_MARKER}\nPlan",
+                    "user": {"login": "bot"},
+                }
+            ],
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
 
         assert adapter.find_merged_closing_pr(9) == 1
         assert adapter.find_pr_for_issue(9) == 2
         assert adapter.get_pr_head_branch(9) == "head"
-        assert adapter.has_existing_plan(9) is True
+        assert adapter.discover_plan(9).status is PlanDiscoveryStatus.FOUND
 
     def test_unscoped_pr_lookup_contains_every_same_head_pr(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -8,12 +8,14 @@ import pytest
 
 from hephaestus.automation.models import PlanReviewerOptions
 from hephaestus.automation.plan_reviewer import PlanReviewer
+from hephaestus.automation.review_journal import PlanDiscoveryResult, PlanDiscoveryStatus
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
     STATE_PLAN_BLOCKED,
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
 )
+from hephaestus.github.client import GitHubRateLimitError
 
 
 @pytest.fixture
@@ -31,6 +33,11 @@ def mock_options() -> PlanReviewerOptions:
 def reviewer(mock_options: PlanReviewerOptions) -> PlanReviewer:
     """Create a PlanReviewer instance."""
     return PlanReviewer(mock_options)
+
+
+def _rest_comment(body: str, *, login: str = "bot") -> dict[str, object]:
+    """Build the author metadata required by the strict REST comment reader."""
+    return {"body": body, "user": {"login": login}}
 
 
 @pytest.fixture(autouse=True)
@@ -61,12 +68,13 @@ class TestGetLatestPlan:
         ]
         with patch(
             "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-            return_value=[{"viewerDidAuthor": True, **comment} for comment in comments],
+            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is not None
-        assert "Implementation Plan" in result
+        assert result.status is PlanDiscoveryStatus.FOUND
+        assert result.plan_text is not None
+        assert "Implementation Plan" in result.plan_text
 
     def test_get_latest_plan_returns_last_plan(self, reviewer: PlanReviewer) -> None:
         """_get_latest_plan returns the LAST plan comment when multiple exist."""
@@ -76,12 +84,13 @@ class TestGetLatestPlan:
         ]
         with patch(
             "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-            return_value=[{"viewerDidAuthor": True, **comment} for comment in comments],
+            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is not None
-        assert "Second plan (updated)" in result
+        assert result.status is PlanDiscoveryStatus.FOUND
+        assert result.plan_text is not None
+        assert "Second plan (updated)" in result.plan_text
 
     def test_get_latest_plan_is_not_hidden_by_one_hundred_newer_comments(
         self, reviewer: PlanReviewer
@@ -106,19 +115,20 @@ class TestGetLatestPlan:
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is not None
-        assert "Owned plan" in result
+        assert result.status is PlanDiscoveryStatus.FOUND
+        assert result.plan_text is not None
+        assert "Owned plan" in result.plan_text
 
     def test_get_latest_plan_ignores_foreign_marker_comment(self, reviewer: PlanReviewer) -> None:
         """Only the authenticated actor's canonical plan can be reviewed."""
         comments = [
             {
                 "body": "# Implementation Plan\n\nOwned plan",
-                "viewerDidAuthor": True,
+                "user": {"login": "bot"},
             },
             {
                 "body": "# Implementation Plan\n\nForeign spoof",
-                "viewerDidAuthor": False,
+                "user": {"login": "other"},
             },
         ]
         with patch(
@@ -127,34 +137,38 @@ class TestGetLatestPlan:
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is not None
-        assert "Owned plan" in result
-        assert "Foreign spoof" not in result
+        assert result.status is PlanDiscoveryStatus.FOUND
+        assert result.plan_text is not None
+        assert "Owned plan" in result.plan_text
+        assert "Foreign spoof" not in result.plan_text
 
-    def test_get_latest_plan_returns_none_when_no_plan(self, reviewer: PlanReviewer) -> None:
-        """_get_latest_plan returns None when no plan comment exists."""
+    def test_get_latest_plan_returns_absent_when_no_plan(self, reviewer: PlanReviewer) -> None:
+        """_get_latest_plan reports successful absence when no plan exists."""
         comments = [
             {"body": "Just a regular comment"},
             {"body": "Another comment"},
         ]
         with patch(
             "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-            return_value=[{"viewerDidAuthor": True, **comment} for comment in comments],
+            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is None
+        assert result.status is PlanDiscoveryStatus.ABSENT
 
-    def test_get_latest_plan_propagates_github_error(self, reviewer: PlanReviewer) -> None:
+    def test_get_latest_plan_reports_github_error(self, reviewer: PlanReviewer) -> None:
         """A failed complete-journal read cannot be mistaken for no plan."""
         with (
             patch(
                 "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
                 side_effect=RuntimeError("gh failed"),
             ),
-            pytest.raises(RuntimeError, match="gh failed"),
         ):
-            reviewer._get_latest_plan(123)
+            result = reviewer._get_latest_plan(123)
+
+        assert result.status is PlanDiscoveryStatus.READ_ERROR
+        assert result.error is not None
+        assert "gh failed" in result.error
 
     def test_get_latest_plan_ignores_review_comment(self, reviewer: PlanReviewer) -> None:
         """A review comment that quotes the plan must never be picked as the plan.
@@ -175,14 +189,15 @@ class TestGetLatestPlan:
         ]
         with patch(
             "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-            return_value=[{"viewerDidAuthor": True, **comment} for comment in comments],
+            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is not None
+        assert result.status is PlanDiscoveryStatus.FOUND
+        assert result.plan_text is not None
         # Must be the actual plan, NOT the review comment.
-        assert result.lstrip().startswith("# Implementation Plan")
-        assert "🔍 Plan Review" not in result
+        assert result.plan_text.lstrip().startswith("# Implementation Plan")
+        assert "🔍 Plan Review" not in result.plan_text
 
     def test_get_latest_plan_review_only_issue_returns_none(self, reviewer: PlanReviewer) -> None:
         """An issue with ONLY a review comment (no real plan) → None, not the review."""
@@ -191,11 +206,11 @@ class TestGetLatestPlan:
         ]
         with patch(
             "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-            return_value=[{"viewerDidAuthor": True, **comment} for comment in comments],
+            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
         ):
             result = reviewer._get_latest_plan(123)
 
-        assert result is None
+        assert result.status is PlanDiscoveryStatus.ABSENT
 
 
 class TestPostReviewStateLabels:
@@ -514,11 +529,31 @@ class TestRunClaudeAnalysis:
 class TestReviewIssue:
     """Tests for _review_issue method."""
 
+    @pytest.mark.parametrize(
+        "failure",
+        [RuntimeError("API unavailable"), GitHubRateLimitError("rate limited", reset_epoch=123)],
+    )
+    def test_plan_read_failure_fails_worker(
+        self, reviewer: PlanReviewer, failure: Exception
+    ) -> None:
+        """Transport and rate-limit failures remain nonzero review outcomes."""
+        with (
+            patch.object(reviewer, "_read_plan_state_labels", return_value=[STATE_NEEDS_PLAN]),
+            patch(
+                "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
+                side_effect=failure,
+            ),
+        ):
+            result = reviewer._review_issue(123, 0)
+
+        assert result.success is False
+        assert result.already_reviewed is False
+
     def test_review_skipped_if_no_plan(self, reviewer: PlanReviewer) -> None:
         """When issue has no plan comment, _review_issue returns success with no post."""
         with (
             patch.object(reviewer, "_read_plan_state_labels", return_value=[STATE_NEEDS_PLAN]),
-            patch.object(reviewer, "_get_latest_plan", return_value=None),
+            patch.object(reviewer, "_get_latest_plan", return_value=PlanDiscoveryResult.absent()),
             patch(
                 "hephaestus.automation.plan_reviewer.gh_issue_upsert_owned_comment"
             ) as mock_upsert,
@@ -598,7 +633,9 @@ class TestReviewIssue:
         """The standalone path persists each supported state end to end."""
         with (
             patch.object(
-                reviewer, "_get_latest_plan", return_value="## Implementation Plan\n\nDo stuff"
+                reviewer,
+                "_get_latest_plan",
+                return_value=PlanDiscoveryResult.found("## Implementation Plan\n\nDo stuff"),
             ),
             patch("hephaestus.automation.plan_reviewer.gh_issue_json") as mock_gh_json,
             patch.object(
@@ -637,7 +674,9 @@ class TestReviewIssue:
 
         with (
             patch.object(
-                reviewer, "_get_latest_plan", return_value="## Implementation Plan\n\nDo stuff"
+                reviewer,
+                "_get_latest_plan",
+                return_value=PlanDiscoveryResult.found("## Implementation Plan\n\nDo stuff"),
             ),
             patch("hephaestus.automation.plan_reviewer.gh_issue_json") as mock_gh_json,
             patch.object(
@@ -662,7 +701,9 @@ class TestReviewIssue:
         """Returns failed WorkerResult when Claude analysis returns None."""
         with (
             patch.object(
-                reviewer, "_get_latest_plan", return_value="## Implementation Plan\n\nDo stuff"
+                reviewer,
+                "_get_latest_plan",
+                return_value=PlanDiscoveryResult.found("## Implementation Plan\n\nDo stuff"),
             ),
             patch("hephaestus.automation.plan_reviewer.gh_issue_json") as mock_gh_json,
             patch.object(reviewer, "_run_claude_analysis", return_value=None),
@@ -688,7 +729,7 @@ class TestFetchIssueCommentsCache:
         with (
             patch(
                 "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-                return_value=[{"viewerDidAuthor": True, **comment} for comment in comments],
+            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
             ) as mock_fetch,
             patch.object(
                 reviewer,
@@ -713,7 +754,7 @@ class TestFetchIssueCommentsCache:
             nonlocal call_count
             call_count += 1
             selected = comments_123 if issue_number == 123 else comments_456
-            return [{"viewerDidAuthor": True, **comment} for comment in selected]
+            return [_rest_comment(str(comment["body"])) for comment in selected]
 
         with patch(
             "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
@@ -745,7 +786,7 @@ class TestFetchIssueCommentsCache:
         ):
             comments = reviewer._fetch_issue_comments(1928)
 
-        assert comments[0]["viewerDidAuthor"] is True
+        assert comments[0].viewer_did_author is True
 
 
 class TestMain:
@@ -961,7 +1002,7 @@ class TestPlanReviewerAlreadyReviewedFlag:
         reviewer = self._reviewer()
         with (
             patch.object(reviewer, "_read_plan_state_labels", return_value=[STATE_NEEDS_PLAN]),
-            patch.object(reviewer, "_get_latest_plan", return_value=None),
+            patch.object(reviewer, "_get_latest_plan", return_value=PlanDiscoveryResult.absent()),
         ):
             result = reviewer._review_issue(123, slot_id=0)
 
@@ -973,7 +1014,11 @@ class TestPlanReviewerAlreadyReviewedFlag:
         reviewer = self._reviewer()
         with (
             patch.object(reviewer, "_read_plan_state_labels", return_value=[STATE_NEEDS_PLAN]),
-            patch.object(reviewer, "_get_latest_plan", return_value="# Implementation Plan\nDo it"),
+            patch.object(
+                reviewer,
+                "_get_latest_plan",
+                return_value=PlanDiscoveryResult.found("# Implementation Plan\nDo it"),
+            ),
             patch(
                 "hephaestus.automation.plan_reviewer.gh_issue_json",
                 return_value={"title": "T", "body": "B"},

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -8,7 +8,11 @@ import pytest
 
 from hephaestus.automation.models import PlanReviewerOptions
 from hephaestus.automation.plan_reviewer import PlanReviewer
-from hephaestus.automation.review_journal import PlanDiscoveryResult, PlanDiscoveryStatus
+from hephaestus.automation.review_journal import (
+    IssueComment,
+    PlanDiscoveryResult,
+    PlanDiscoveryStatus,
+)
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
     STATE_PLAN_BLOCKED,
@@ -418,7 +422,7 @@ class TestLatestReviewUsesAuthoritativeLabel:
 
     def test_legacy_go_comment_cannot_grant_approval(self, reviewer: PlanReviewer) -> None:
         reviewer._comments_cache[123] = [
-            {"body": "## 🔍 Plan Review\n\nVerdict: GO"},
+            IssueComment(body="## 🔍 Plan Review\n\nVerdict: GO"),
         ]
         with patch(
             "hephaestus.automation.plan_reviewer.gh_issue_json",
@@ -750,7 +754,7 @@ class TestFetchIssueCommentsCache:
 
         call_count = 0
 
-        def _side_effect(issue_number: int) -> list[dict[str, str | bool]]:
+        def _side_effect(issue_number: int) -> list[dict[str, object]]:
             nonlocal call_count
             call_count += 1
             selected = comments_123 if issue_number == 123 else comments_456

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -729,7 +729,7 @@ class TestFetchIssueCommentsCache:
         with (
             patch(
                 "hephaestus.automation.plan_reviewer.fetch_issue_comments_metadata",
-            return_value=[_rest_comment(str(comment["body"])) for comment in comments],
+                return_value=[_rest_comment(str(comment["body"])) for comment in comments],
             ) as mock_fetch,
             patch.object(
                 reviewer,

--- a/tests/unit/automation/test_review_journal.py
+++ b/tests/unit/automation/test_review_journal.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
+import pytest
+
 from hephaestus.automation.review_journal import (
     HISTORY_MARKER,
     MAX_CURRENT_REVISION_CONTEXT_CHARS,
+    CommentJournalReadError,
     IssueComment,
+    PlanDiscoveryResult,
+    PlanDiscoveryStatus,
     archive_plan_body,
     archive_review_body,
     blocked_audit_recovery_body,
     current_plan_context,
     current_revision_context,
+    discover_plan_from_comments,
     journal_snapshot,
+    normalize_issue_comments,
     render_current_plan,
     render_current_review,
 )
@@ -19,6 +26,45 @@ from hephaestus.automation.review_journal import (
 
 def _owned(body: str) -> IssueComment:
     return IssueComment(body=body, author_login="hephaestus[bot]", viewer_did_author=True)
+
+
+def test_plan_discovery_distinguishes_found_absent_and_read_error() -> None:
+    """The result contract keeps successful absence separate from read failure."""
+    found = discover_plan_from_comments([_owned(render_current_plan("Plan"))])
+    absent = discover_plan_from_comments([])
+    failed = PlanDiscoveryResult.read_error("offline")
+
+    assert found.status is PlanDiscoveryStatus.FOUND
+    assert found.plan_text is not None
+    assert absent.status is PlanDiscoveryStatus.ABSENT
+    assert failed.status is PlanDiscoveryStatus.READ_ERROR
+
+
+def test_normalization_derives_ownership_from_validated_logins() -> None:
+    """Ownership comes from REST author metadata and the authenticated viewer."""
+    comments = normalize_issue_comments(
+        [
+            {"body": render_current_plan("foreign"), "user": {"login": "other"}},
+            {"body": render_current_plan("owned"), "user": {"login": "BOT"}},
+        ],
+        viewer_login="bot",
+    )
+
+    result = discover_plan_from_comments(comments)
+
+    assert result.status is PlanDiscoveryStatus.FOUND
+    assert result.plan_text is not None
+    assert "owned" in result.plan_text
+
+
+@pytest.mark.parametrize("body", [None, 1, {}, []])
+def test_normalization_rejects_non_string_body(body: object) -> None:
+    """Malformed comment bodies cannot become successful plan absence."""
+    with pytest.raises(CommentJournalReadError, match="body was not a string"):
+        normalize_issue_comments(
+            [{"body": body, "user": {"login": "bot"}}],
+            viewer_login="bot",
+        )
 
 
 def test_snapshot_ignores_foreign_marker_spoofing() -> None:

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -87,9 +87,7 @@ def test_plan_phase_discover_plan_found_on_plan_comment(tmp_path: Path) -> None:
     with (
         mock.patch(
             "hephaestus.automation._plan_phase.fetch_issue_comments_metadata",
-            return_value=[
-                {"body": "# Implementation Plan\n\nstep 1", "user": {"login": "bot"}}
-            ],
+            return_value=[{"body": "# Implementation Plan\n\nstep 1", "user": {"login": "bot"}}],
         ),
         mock.patch("hephaestus.automation._plan_phase.gh_current_login", return_value="bot"),
     ):

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -8,7 +8,6 @@ cross-phase dispatch contract that the pipeline stages rely on.
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -22,6 +21,7 @@ from hephaestus.automation._implement_phase import ImplementPhase, _prepend_advi
 from hephaestus.automation._plan_phase import PlanPhase, _phase_env
 from hephaestus.automation._pr_create_phase import PRCreatePhase
 from hephaestus.automation._stage_context import StageContext, StageMixin
+from hephaestus.automation.review_journal import PlanDiscoveryStatus
 
 
 def _make_ctx(tmp_path: Path, **option_overrides: Any) -> StageContext:
@@ -81,27 +81,33 @@ def test_stage_mixin_exposes_runner_and_impl(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_plan_phase_has_plan_true_on_plan_comment(tmp_path: Path) -> None:
-    """_has_plan returns True when a plan comment is present."""
+def test_plan_phase_discover_plan_found_on_plan_comment(tmp_path: Path) -> None:
+    """_discover_plan returns FOUND when an actor-owned plan is present."""
     phase = PlanPhase(_make_ctx(tmp_path))
-    fake = SimpleNamespace(
-        stdout=json.dumps({"comments": [{"body": "# Implementation Plan\n\nstep 1"}]})
-    )
     with (
-        mock.patch("hephaestus.automation._plan_phase.gh_call", return_value=fake),
         mock.patch(
-            "hephaestus.automation._plan_phase._comments_contain_plan", return_value=True
-        ) as mock_check,
+            "hephaestus.automation._plan_phase.fetch_issue_comments_metadata",
+            return_value=[
+                {"body": "# Implementation Plan\n\nstep 1", "user": {"login": "bot"}}
+            ],
+        ),
+        mock.patch("hephaestus.automation._plan_phase.gh_current_login", return_value="bot"),
     ):
-        assert phase._has_plan(7) is True
-    mock_check.assert_called_once()
+        result = phase._discover_plan(7)
+
+    assert result.status is PlanDiscoveryStatus.FOUND
 
 
-def test_plan_phase_has_plan_false_on_subprocess_error(tmp_path: Path) -> None:
-    """_has_plan swallows subprocess/JSON errors and returns False."""
+def test_plan_phase_read_failure_is_explicit(tmp_path: Path) -> None:
+    """_discover_plan reports API failures instead of inventing absence."""
     phase = PlanPhase(_make_ctx(tmp_path))
-    with mock.patch("hephaestus.automation._plan_phase.gh_call", side_effect=OSError("boom")):
-        assert phase._has_plan(7) is False
+    with mock.patch(
+        "hephaestus.automation._plan_phase.fetch_issue_comments_metadata",
+        side_effect=OSError("boom"),
+    ):
+        result = phase._discover_plan(7)
+
+    assert result.status is PlanDiscoveryStatus.READ_ERROR
 
 
 def test_phase_env_keeps_only_repo_root_pythonpath(


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2388.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2388

Generated by Hephaestus automation

Closes #2669
