### PR TITLE
ci: podman-by-default — containerized CI

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -722,8 +722,8 @@ jobs:
             hephaestus-ci:local bash -c '
             uv venv /tmp/hephaestus-wheel-smoke
             uv pip install --python /tmp/hephaestus-wheel-smoke/bin/python dist/homericintelligence_hephaestus-*.whl --force-reinstall
-            /tmp/hephaestus-wheel-smoke/bin/python -c "import hephaestus; print(\'Package version:\', hephaestus.__version__)"
-            /tmp/hephaestus-wheel-smoke/bin/python -c "from hephaestus import slugify, retry_with_backoff, setup_logging; print(\'OK\')"
+            /tmp/hephaestus-wheel-smoke/bin/python -c "import hephaestus; print(\"Package version:\", hephaestus.__version__)"
+            /tmp/hephaestus-wheel-smoke/bin/python -c "from hephaestus import slugify, retry_with_backoff, setup_logging; print(\"OK\")"
           '
 
   security-dependency-scan:
@@ -934,13 +934,13 @@ jobs:
           # Use check-jsonschema's bundled `vendor.github-workflows` schema so
           # the job is network-free and fail-fast. No schemastore.org probe and
           # no advisory `::warning::` outage fallback (Bucket F anti-pattern).
-          mapfile -t wf_files < <(find .github/workflows -name "*.yml")
-          if [ "${#wf_files[@]}" -eq 0 ]; then
-            echo "No workflow files to validate"
-            exit 0
-          fi
           podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
-            hephaestus-ci:local bash -c '
+            hephaestus-ci:local bash -ceu '
+            mapfile -t wf_files < <(find .github/workflows -name "*.yml")
+            if [ "${#wf_files[@]}" -eq 0 ]; then
+              echo "No workflow files to validate"
+              exit 0
+            fi
             uvx check-jsonschema \
               --builtin-schema vendor.github-workflows \
               "${wf_files[@]}"

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -157,10 +157,16 @@ jobs:
       # job (issue #1173) so that the WHOLE hook suite is a required status
       # check — previously pre-commit was advisory, which let an unformatted
       # file land on main via #959 and break pre-commit for every later PR.
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
       - name: Cache pre-commit environments
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
@@ -180,13 +186,15 @@ jobs:
           restore-keys: |
             mypy-${{ runner.os }}-
 
-      - name: Run pre-commit (all hooks)
+      - name: Run pre-commit (all hooks, in container)
         run: |
-          uv sync --all-groups --all-extras --locked
-          uv run pre-commit run --all-files --show-diff-on-failure
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local uv run pre-commit run --all-files --show-diff-on-failure
 
-      - name: Validate documentation links
-        run: uv run hephaestus-validate-links docs --repo-root .
+      - name: Validate documentation links (in container)
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run hephaestus-validate-links docs --repo-root .
 
       - name: Upload pre-commit diff
         if: failure()
@@ -209,12 +217,20 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
-      - name: Check uv.lock is in sync with pyproject.toml
-        run: uv lock --check
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
+      - name: Check uv.lock is in sync with pyproject.toml (in container)
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv lock --check
 
   justfile-check:
     name: justfile-check
@@ -501,25 +517,37 @@ jobs:
       - name: Install Pi CLI
         uses: ./.github/actions/setup-pi-cli
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Install locked project environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Run unit tests
+
+      - name: Run unit tests (in container)
         run: |
-          uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers -m "not nightly" \
-            --cov=hephaestus --cov-report=term-missing --cov-report=xml
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local bash -c '
+            uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers -m "not nightly" \
+              --cov=hephaestus --cov-report=term-missing --cov-report=xml
+          '
 
-      - name: Check unit test structure
+      - name: Check unit test structure (in container)
         # Use the strict CLI (also flags loose test_*.py files at tests/unit/ root).
-        run: uv run hephaestus-check-test-structure
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run hephaestus-check-test-structure
 
-      - name: Check per-module coverage floors
-        run: uv run hephaestus-check-coverage --coverage-file coverage.xml --config coverage.toml
+      - name: Check per-module coverage floors (in container)
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run hephaestus-check-coverage
+          --coverage-file coverage.xml --config coverage.toml
 
   integration-tests:
     name: integration-tests
@@ -538,20 +566,28 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Install locked project environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Run integration tests
-        # uv sync installed every [project.scripts] binary into .venv/bin, so
-        # the CLI entry-point checks must never skip here (#2173).
+
+      - name: Run integration tests (in container)
+        # The baked image installs every [project.scripts] binary into the venv,
+        # so the CLI entry-point checks must never skip here (#2173).
         env:
           HEPHAESTUS_REQUIRE_CLI: "1"
-        run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          -e HEPHAESTUS_REQUIRE_CLI
+          hephaestus-ci:local uv run pytest tests/integration
+          --override-ini="addopts=" -v --strict-markers -m "not nightly"
 
   installed-cli-tests:
     # Installed-artifact lane (#2173): build the wheel, install it into a
@@ -577,30 +613,45 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Build wheel
-        run: uv build --wheel
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Install wheel into fresh venv
+      - name: Build wheel (in container)
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv build --wheel
+
+      - name: Install wheel into fresh venv (in container)
         # [automation] extra: most console scripts live under
         # hephaestus.automation.*. pytest runs the suite; pyyaml is
         # imported by tests/conftest.py.
         run: |
-          uv venv build/cli-venv
-          WHEEL=(dist/*.whl)
-          uv pip install --python build/cli-venv/bin/python "${WHEEL[0]}[automation]" pytest pyyaml
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local bash -c '
+            uv venv build/cli-venv
+            WHEEL=(dist/*.whl)
+            uv pip install --python build/cli-venv/bin/python "${WHEEL[0]}[automation]" pytest pyyaml
+          '
 
-      - name: Run CLI entry-point tests against installed binaries
+      - name: Run CLI entry-point tests against installed binaries (in container)
         env:
           HEPHAESTUS_REQUIRE_CLI: "1"
         run: |
-          export PATH="$PWD/build/cli-venv/bin:$PATH"
-          build/cli-venv/bin/pytest tests/integration/test_cli_entry_points.py \
-            --override-ini="addopts=" -v --strict-markers
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            -e HEPHAESTUS_REQUIRE_CLI \
+            hephaestus-ci:local bash -c '
+            export PATH="$PWD/build/cli-venv/bin:$PATH"
+            build/cli-venv/bin/pytest tests/integration/test_cli_entry_points.py \
+              --override-ini="addopts=" -v --strict-markers
+          '
 
   shell-tests:
     name: shell-tests
@@ -648,23 +699,32 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Install locked build environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Build wheel and sdist
-        run: uv run python -m build --no-isolation
 
-      - name: Smoke-test installed wheel
+      - name: Build wheel and sdist (in container)
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run python -m build --no-isolation
+
+      - name: Smoke-test installed wheel (in container)
         run: |
-          uv venv /tmp/hephaestus-wheel-smoke
-          uv pip install --python /tmp/hephaestus-wheel-smoke/bin/python dist/homericintelligence_hephaestus-*.whl --force-reinstall
-          /tmp/hephaestus-wheel-smoke/bin/python -c "import hephaestus; print('Package version:', hephaestus.__version__)"
-          /tmp/hephaestus-wheel-smoke/bin/python -c "from hephaestus import slugify, retry_with_backoff, setup_logging; print('OK')"
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local bash -c '
+            uv venv /tmp/hephaestus-wheel-smoke
+            uv pip install --python /tmp/hephaestus-wheel-smoke/bin/python dist/homericintelligence_hephaestus-*.whl --force-reinstall
+            /tmp/hephaestus-wheel-smoke/bin/python -c "import hephaestus; print(\'Package version:\', hephaestus.__version__)"
+            /tmp/hephaestus-wheel-smoke/bin/python -c "from hephaestus import slugify, retry_with_backoff, setup_logging; print(\'OK\')"
+          '
 
   security-dependency-scan:
     name: security/dependency-scan
@@ -678,17 +738,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Install locked dependency audit environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Run pip-audit
+
+      - name: Run pip-audit (in container)
         id: pip-audit
-        run: uv run pip-audit
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run pip-audit
 
       - name: Post pip-audit summary
         if: always()
@@ -750,14 +816,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Run bandit (SAST)
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
+
+      - name: Run bandit (SAST, in container)
         id: bandit
-        run: uv run bandit -c pyproject.toml -r hephaestus scripts --severity-level medium
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run bandit -c pyproject.toml -r hephaestus scripts
+          --severity-level medium
 
       - name: Post bandit summary
         if: always()
@@ -788,10 +863,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
       - name: Run zizmor (workflow SAST)
         id: zizmor
@@ -799,7 +880,10 @@ jobs:
         # Online audits (e.g. known-vulnerable-actions) run weekly in
         # security.yml. Keep these flags identical to the zizmor pre-commit
         # hook (drift-guarded by tests/unit/ci/test_zizmor_config.py).
-        run: uv run zizmor --no-online-audits --min-severity medium .github/workflows/
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv run zizmor --no-online-audits --min-severity medium
+          .github/workflows/
 
       - name: Post zizmor summary
         if: always()
@@ -833,12 +917,18 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Validate GitHub workflow schemas
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
+
+      - name: Validate GitHub workflow schemas (in container)
         run: |
           set -euo pipefail
           # Use check-jsonschema's bundled `vendor.github-workflows` schema so
@@ -849,9 +939,12 @@ jobs:
             echo "No workflow files to validate"
             exit 0
           fi
-          uvx check-jsonschema \
-            --builtin-schema vendor.github-workflows \
-            "${wf_files[@]}"
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local bash -c '
+            uvx check-jsonschema \
+              --builtin-schema vendor.github-workflows \
+              "${wf_files[@]}"
+          '
 
   deps-version-sync:
     name: deps/version-sync
@@ -871,21 +964,25 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
 
-      - name: Install locked project environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Check version single-source-of-truth
+
+      - name: Check version single-source-of-truth (in container)
         run: |
           set -euo pipefail
 
           # Diagnostics (informational only).
-          PKG_VERSION=$(uv run python -c "import hephaestus; print(hephaestus.__version__)")
-          echo "Installed __version__: $PKG_VERSION"
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local uv run python -c "import hephaestus; print('Installed __version__:', hephaestus.__version__)"
 
           # ENFORCEMENT: the tested checker asserts there is no
           # static [project].version, that version is in [project].dynamic,
@@ -897,10 +994,13 @@ jobs:
           # the module form is immune to sys.path[0]/CWD-dependent __file__
           # resolution, so the checker's get_repo_root() anchors to the
           # installed package and reads the checked-out pyproject.toml.
-          uv run python -m hephaestus.scripts_lib.check_version_single_source
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            hephaestus-ci:local uv run python -m hephaestus.scripts_lib.check_version_single_source
 
-      - name: Check uv.lock is in sync with pyproject.toml
-        run: uv lock --check
+      - name: Check uv.lock is in sync with pyproject.toml (in container)
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          hephaestus-ci:local uv lock --check
 
   license-scan:
     name: license-scan
@@ -915,21 +1015,28 @@ jobs:
           persist-credentials: false
           fetch-depth: 0  # hatch-vcs needs full history to compute the version
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-hephaestus-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-hephaestus-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
       # Install the package + all runtime extras. ``[all]`` is required so
       # distributed_requirements() can read every runtime extra's Requires-Dist.
-      - name: Install locked project environment
-        run: uv sync --all-groups --all-extras --locked
 
-      - name: Run license scan
+      - name: Run license scan (in container)
         id: license-scan
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: uv run python scripts/check_license_compatibility.py
+        run: >
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000
+          -e GITHUB_EVENT_NAME
+          hephaestus-ci:local uv run python scripts/check_license_compatibility.py
 
       - name: Post license-scan summary
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,17 +37,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5.2.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: hephaestus-podman-${{ runner.os }}-${{ hashFiles('ci/Containerfile', 'uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            hephaestus-podman-${{ runner.os }}-
 
-      - name: Install locked dependency audit environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Run pip-audit
+      - name: Run pip-audit (in container)
         id: pip-audit
-        run: uv run pip-audit
+        run: podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 hephaestus-ci:local uv run pip-audit
 
       - name: Post pip-audit summary
         if: always()
@@ -78,22 +81,29 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5.2.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: hephaestus-podman-${{ runner.os }}-${{ hashFiles('ci/Containerfile', 'uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            hephaestus-podman-${{ runner.os }}-
 
-      - name: Run bandit (SAST)
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
+
+      - name: Run bandit (SAST, in container)
         id: bandit
-        run: uv run bandit -c pyproject.toml -r hephaestus scripts --severity-level medium
+        run: podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 hephaestus-ci:local uv run bandit -c pyproject.toml -r hephaestus scripts --severity-level medium
 
-      - name: Run bandit LOW-severity baseline check
+      - name: Run bandit LOW-severity baseline check (in container)
         id: bandit-low
         run: |
           mkdir -p build
-          uv run bandit -c pyproject.toml -r hephaestus scripts \
-            --severity-level low --exit-zero -f json -o build/bandit_low.json
-          uv run python hephaestus/ci/bandit_baseline_check.py build/bandit_low.json hephaestus/ci/bandit_low_baseline.json
+          podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 hephaestus-ci:local bash -c '
+            uv run bandit -c pyproject.toml -r hephaestus scripts --severity-level low --exit-zero -f json -o /workspace/build/bandit_low.json
+            uv run python /workspace/hephaestus/ci/bandit_baseline_check.py /workspace/build/bandit_low.json /workspace/hephaestus/ci/bandit_low_baseline.json
+          '
 
       - name: Post bandit summary
         if: always()
@@ -127,16 +137,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5.2.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: hephaestus-podman-${{ runner.os }}-${{ hashFiles('ci/Containerfile', 'uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            hephaestus-podman-${{ runner.os }}-
 
-      - name: Run zizmor (workflow SAST with online audits)
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
+
+      - name: Run zizmor (workflow SAST with online audits, in container)
         id: zizmor
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run zizmor --min-severity medium .github/workflows/
+        run: podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 hephaestus-ci:local uv run zizmor --min-severity medium .github/workflows/
 
       - name: Post zizmor summary
         if: always()
@@ -168,19 +184,22 @@ jobs:
           fetch-depth: 0  # hatch-vcs needs full history to compute the version
           persist-credentials: false
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5.2.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: hephaestus-podman-${{ runner.os }}-${{ hashFiles('ci/Containerfile', 'uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            hephaestus-podman-${{ runner.os }}-
 
-      - name: Install locked project environment
-        run: uv sync --all-groups --all-extras --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t hephaestus-ci:local .
 
-      - name: Run license scan
+      - name: Run license scan (in container)
         id: license-scan
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: uv run python scripts/check_license_compatibility.py
+        run: podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 hephaestus-ci:local uv run python scripts/check_license_compatibility.py
 
       - name: Post license-scan summary
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -152,7 +152,7 @@ jobs:
         id: zizmor
         env:
           GH_TOKEN: ${{ github.token }}
-        run: podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 hephaestus-ci:local uv run zizmor --min-severity medium .github/workflows/
+        run: podman run --rm --tmpfs /tmp:rw,size=4g,mode=1777 -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 -e GH_TOKEN hephaestus-ci:local uv run zizmor --min-severity medium .github/workflows/
 
       - name: Post zizmor summary
         if: always()

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,0 +1,169 @@
+# Containerfile for hephaestus-ci — CI image for shared HomericIntelligence tooling.
+#
+# This image provides:
+# - Python 3.13 environment (matches requires-python >=3.13,<3.14)
+# - uv with the locked project environment (all groups + extras) pre-installed
+# - pre-commit hook environments baked in (largest speedup)
+# - Non-root user 'ci' for rootless Podman compatibility
+#
+# Toolchain: uv (Odysseus ADR-017). Pattern mirrors Scylla ci/Containerfile.
+#
+# Build (OCI-compliant — works with both podman and docker):
+#   podman build -f ci/Containerfile -t hephaestus-ci:local .
+#   docker build -f ci/Containerfile -t hephaestus-ci:local .
+#
+# Run:
+#   podman run --rm -v .:/workspace:Z hephaestus-ci:local uv run pytest tests/unit
+#   podman run --rm -v .:/workspace:Z hephaestus-ci:local uv run pre-commit run --all-files
+
+# ============================================================================
+# Stage 0: uv binary — installed from a pinned GitHub release so the checksum
+# is reproducible and the build resolves identically under both podman/buildah
+# and docker (no cross-registry COPY of a third-party image). The ghcr.io
+# astral-sh/uv image's version-tag scheme does not track uv CLI versions
+# (0.11.21 does not exist there), so we pin the release tarball instead.
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && echo "90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb  /tmp/uv.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
+    && rm /tmp/uv.tar.gz
+
+# ============================================================================
+# Stage: node — pinned Node 22 runtime for the Pi coding-agent CLI used by the
+# pi_smoke tests (native CI installs it via the setup-pi-cli action).
+# ============================================================================
+FROM node:22-bookworm-slim AS node
+
+# Pre-install the Pi CLI here so the runtime stage can copy the whole /usr/local
+# prefix in one consistent tree (copying node/npm/npx individually breaks npm's
+# internal relative requires).
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.2 && \
+    pi --version
+
+# ============================================================================
+# Stage 1: Builder — install uv and the locked project environment
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Build the project virtualenv in a fixed, copyable location.
+    UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv \
+    # Bytecode-compile on install for faster cold starts.
+    UV_COMPILE_BYTECODE=1 \
+    # Copy (not hardlink) from the cache so the venv is self-contained for the
+    # runtime-stage COPY --from=builder.
+    UV_LINK_MODE=copy \
+    PATH="/opt/hephaestus-venv/bin:$PATH"
+
+# Install build dependencies + git (required by pre-commit hooks)
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gcc \
+    g++ \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (pinned release — keep the version and sha256 in sync with
+# astral-sh/setup-uv in .github/workflows/*.yml when bumping).
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+# Layer 1: Dependency files + the package source the hatchling build needs.
+# The package tree is copied so `uv sync` can install the project itself,
+# mirroring `uv sync --all-groups --all-extras --locked` in CI. Layer stays
+# cached when only the lock/config files change; uv's own cache absorbs the
+# dependency downloads, so source-only edits rebuild this layer quickly.
+WORKDIR /opt/hephaestus-build
+COPY uv.lock pyproject.toml .pre-commit-config.yaml README.md ./
+COPY hephaestus/ hephaestus/
+
+# Layer 2: Install the locked dependency set (all groups + extras) plus the
+# project itself into the venv, exactly as CI does.
+# hatch-vcs derives the package version from git tags, so init a synthetic
+# repo with a base tag first; pre-commit install-hooks also needs a git repo.
+# The synthetic .git is removed at the end of this stage.
+RUN git init . && \
+    git -c user.email=ci@localhost -c user.name=ci commit --allow-empty --quiet -m base && \
+    git tag 0.0.0 && \
+    uv sync --all-groups --all-extras --locked
+
+# Layer 3: Install pre-commit hook environments.
+# Baking this in means 'pre-commit run --all-files' starts immediately,
+# without downloading hook repos or creating virtualenvs at CI time.
+RUN uv run pre-commit install-hooks && \
+    rm -rf .git
+
+# ============================================================================
+# Stage 2: Runtime — minimal image without build tools
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+
+LABEL org.opencontainers.image.title="hephaestus-ci"
+LABEL org.opencontainers.image.description="CI container for Hephaestus — validation, testing, security scans"
+LABEL org.opencontainers.image.vendor="Hephaestus"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Hephaestus"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv \
+    UV_LINK_MODE=copy \
+    PATH="/opt/hephaestus-venv/bin:$PATH"
+
+# Runtime-only system packages (no build tools)
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    jq \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (gh) — pinned release; native runners ship it preinstalled and the
+# automation pipeline's _trusted_gh_executable() requires it.
+RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_amd64.deb -o /tmp/gh.deb \
+    && echo "7c7fa3bb890db0934baf65910d97b8c0fa437b2e590f7f7daf6bdf82c5c486d7  /tmp/gh.deb" | sha256sum --check \
+    && apt-get install -y /tmp/gh.deb \
+    && rm -f /tmp/gh.deb
+
+# Node 22 + npm + the Pi coding-agent CLI (same pin as setup-pi-cli), copied
+# as one consistent /usr/local tree from the node stage.
+COPY --from=node /usr/local/ /usr/local/
+
+# Copy the uv binaries and the pre-installed project virtualenv from builder.
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --from=builder /opt/hephaestus-venv /opt/hephaestus-venv
+
+# Copy pre-commit hook cache from builder (baked-in hook envs)
+COPY --from=builder /root/.cache/pre-commit /root/.cache/pre-commit
+
+# Create non-root user for rootless Podman compatibility
+# UID 1000 is the default first user on most Linux systems, matching typical
+# developer UIDs for smooth volume mount permissions without --userns=keep-id
+RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci
+
+# Copy pre-commit cache to ci user's home (pre-commit uses $HOME/.cache)
+RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
+    chown -R ci:ci /home/ci/.cache
+
+# Make the baked venv writable by the ci user: when the repo is bind-mounted at
+# /workspace, uv detects the project path changed and re-points the editable
+# install at the mounted source, so scripts and tests exercise the working tree.
+RUN chown -R ci:ci /opt/hephaestus-venv
+
+# Working directory is the mounted repo root at runtime
+WORKDIR /workspace
+
+# No ENTRYPOINT — commands are provided externally by CI or run_ci_local.sh
+# Example: podman run --rm -v .:/workspace:Z hephaestus-ci:local uv run pytest
+
+USER ci

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -24,8 +24,23 @@
 # (0.11.21 does not exist there), so we pin the release tarball instead.
 # ============================================================================
 ARG TARGETARCH
+ARG DEBIAN_SNAPSHOT=20260701T000000Z
 
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+# All Python stages inherit immutable Debian package indexes. The base image is
+# digest-pinned, and the dated snapshot fixes both package candidates and their
+# signed artifacts so rebuilding does not resolve today's Debian repository.
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS python-snapshot
+
+ARG DEBIAN_SNAPSHOT
+
+RUN . /etc/os-release \
+    && rm -f /etc/apt/sources.list /etc/apt/sources.list.d/* \
+    && printf '%s\n' \
+        "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ ${VERSION_CODENAME} main" \
+        "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ ${VERSION_CODENAME}-security main" \
+        > /etc/apt/sources.list.d/debian-snapshot.list
+
+FROM python-snapshot AS uv
 
 ARG TARGETARCH
 
@@ -56,7 +71,7 @@ RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.2 && \
 # ============================================================================
 # Stage 1: Builder — install uv and the locked project environment
 # ============================================================================
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+FROM python-snapshot AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \
@@ -70,9 +85,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     UV_LINK_MODE=copy \
     PATH="/opt/hephaestus-venv/bin:$PATH"
 
-# Install build dependencies + git (required by pre-commit hooks)
-# apt-get upgrade picks up any security patches released after the base image was pinned
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# Install build dependencies + git (required by pre-commit hooks) from the
+# immutable Debian snapshot configured by python-snapshot.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
@@ -113,7 +128,7 @@ RUN uv run pre-commit install-hooks && \
 # ============================================================================
 # Stage 2: Runtime — minimal image without build tools
 # ============================================================================
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+FROM python-snapshot
 
 ARG TARGETARCH
 
@@ -129,9 +144,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     UV_LINK_MODE=copy \
     PATH="/opt/hephaestus-venv/bin:$PATH"
 
-# Runtime-only system packages (no build tools)
-# apt-get upgrade picks up any security patches released after the base image was pinned
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+# Runtime-only system packages (no build tools), resolved from the same
+# immutable snapshot as the builder stage.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
@@ -171,10 +186,12 @@ RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci
 RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
     chown -R ci:ci /home/ci/.cache
 
-# Make the baked venv writable by the ci user: when the repo is bind-mounted at
-# /workspace, uv detects the project path changed and re-points the editable
-# install at the mounted source, so scripts and tests exercise the working tree.
-RUN chown -R ci:ci /opt/hephaestus-venv
+# Make the baked venv writable in each container's private image layer. Podman
+# maps the ci user through keep-id, while Docker runs as the invoking host UID,
+# which may be any numeric ID. uv must be able to refresh the editable install
+# for /workspace under either engine without changing bind-mounted ownership.
+RUN chown -R ci:ci /opt/hephaestus-venv && \
+    chmod -R a+rwX /opt/hephaestus-venv
 
 # Working directory is the mounted repo root at runtime
 WORKDIR /workspace

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -23,12 +23,21 @@
 # astral-sh/uv image's version-tag scheme does not track uv CLI versions
 # (0.11.21 does not exist there), so we pin the release tarball instead.
 # ============================================================================
+ARG TARGETARCH
+
 FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+
+ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
-    && echo "90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb  /tmp/uv.tar.gz" | sha256sum --check \
+    && case "$TARGETARCH" in \
+        amd64) uv_asset="uv-x86_64-unknown-linux-gnu"; uv_sha256="90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb" ;; \
+        arm64) uv_asset="uv-aarch64-unknown-linux-gnu"; uv_sha256="769d373e146692c639b5fbaae33b331c297a32e03d30448772051902df52bbf4" ;; \
+        *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/astral-sh/uv/releases/download/0.12.1/${uv_asset}.tar.gz" -o /tmp/uv.tar.gz \
+    && echo "${uv_sha256}  /tmp/uv.tar.gz" | sha256sum --check \
     && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
     && rm /tmp/uv.tar.gz
 
@@ -36,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 # Stage: node — pinned Node 22 runtime for the Pi coding-agent CLI used by the
 # pi_smoke tests (native CI installs it via the setup-pi-cli action).
 # ============================================================================
-FROM node:22-bookworm-slim AS node
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS node
 
 # Pre-install the Pi CLI here so the runtime stage can copy the whole /usr/local
 # prefix in one consistent tree (copying node/npm/npx individually breaks npm's
@@ -106,6 +115,8 @@ RUN uv run pre-commit install-hooks && \
 # ============================================================================
 FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
 
+ARG TARGETARCH
+
 LABEL org.opencontainers.image.title="hephaestus-ci"
 LABEL org.opencontainers.image.description="CI container for Hephaestus — validation, testing, security scans"
 LABEL org.opencontainers.image.vendor="Hephaestus"
@@ -130,8 +141,13 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 
 # GitHub CLI (gh) — pinned release; native runners ship it preinstalled and the
 # automation pipeline's _trusted_gh_executable() requires it.
-RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_amd64.deb -o /tmp/gh.deb \
-    && echo "7c7fa3bb890db0934baf65910d97b8c0fa437b2e590f7f7daf6bdf82c5c486d7  /tmp/gh.deb" | sha256sum --check \
+RUN case "$TARGETARCH" in \
+        amd64) gh_arch="amd64"; gh_sha256="7c7fa3bb890db0934baf65910d97b8c0fa437b2e590f7f7daf6bdf82c5c486d7" ;; \
+        arm64) gh_arch="arm64"; gh_sha256="0ba7a76739c865d82ebde24667d875d9b8caa55db47c7597c24accdd4defd2bb" ;; \
+        *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_${gh_arch}.deb" -o /tmp/gh.deb \
+    && echo "${gh_sha256}  /tmp/gh.deb" | sha256sum --check \
     && apt-get install -y /tmp/gh.deb \
     && rm -f /tmp/gh.deb
 

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -186,12 +186,10 @@ RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci
 RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
     chown -R ci:ci /home/ci/.cache
 
-# Make the baked venv writable in each container's private image layer. Podman
-# maps the ci user through keep-id, while Docker runs as the invoking host UID,
-# which may be any numeric ID. uv must be able to refresh the editable install
-# for /workspace under either engine without changing bind-mounted ownership.
-RUN chown -R ci:ci /opt/hephaestus-venv && \
-    chmod -R a+rwX /opt/hephaestus-venv
+# Podman maps the ci user through keep-id and may refresh the editable install.
+# Docker's arbitrary host UID uses the baked environment without syncing and
+# imports project code from /workspace; the environment need not be world-writable.
+RUN chown -R ci:ci /opt/hephaestus-venv
 
 # Working directory is the mounted repo root at runtime
 WORKDIR /workspace

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,14 +1,14 @@
 # Migration Guide
 
-> **Release status:** The latest released version is **0.10.1** (tag-driven
+> **Release status:** The latest released version is **0.10.2** (tag-driven
 > via hatch-vcs). **1.0 has not been released yet** — the section below is
 > forthcoming 1.0 migration guidance. The package remains on the 0.x release
 > line until a signed `v1.0.0` tag is published.
 
-## Current main (unreleased; post-v0.10.1)
+## Current main (unreleased; post-v0.10.2)
 
 The 15-minute operational readiness wait described below is part of the released
-0.10.1 behavior.
+0.10.2 behavior.
 
 Before a request, `merge_wait` may wait up to 15 minutes for operational GitHub
 readiness without spending a merge attempt; readiness is not authorization, and the

--- a/justfile
+++ b/justfile
@@ -105,3 +105,45 @@ clean-all: clean
     find . -type d -name __pycache__ -not -path './.venv/*' -exec rm -rf {} +
     find . -type d -name '*.egg-info' -not -path './.venv/*' -exec rm -rf {} +
     find . -type f \( -name '*.pyc' -o -name '*.pyo' \) -not -path './.venv/*' -delete
+
+# === Containerized CI (podman by default) ===
+
+# Build the CI container image (podman first, docker fallback)
+ci-build:
+    podman build -f ci/Containerfile -t hephaestus-ci:local . || docker build -f ci/Containerfile -t hephaestus-ci:local .
+
+# Run CI lint (pre-commit + doc links) in container
+ci-lint:
+    ./scripts/run_ci_local.sh lint
+
+# Run CI unit tests in container
+ci-unit:
+    ./scripts/run_ci_local.sh unit
+
+# Run CI integration tests in container
+ci-integration:
+    ./scripts/run_ci_local.sh integration
+
+# Run CI installed-CLI tests in container
+ci-cli:
+    ./scripts/run_ci_local.sh cli
+
+# Run CI package build in container
+ci-build-package:
+    ./scripts/run_ci_local.sh build
+
+# Run CI security scans (audit, sast, workflow-scan) in container
+ci-security:
+    ./scripts/run_ci_local.sh audit
+    ./scripts/run_ci_local.sh sast
+    ./scripts/run_ci_local.sh workflow-scan
+
+# Run CI schema/version/license checks in container
+ci-consistency:
+    ./scripts/run_ci_local.sh schema
+    ./scripts/run_ci_local.sh version
+    ./scripts/run_ci_local.sh license
+
+# Run all CI checks in container
+ci-all:
+    ./scripts/run_ci_local.sh all

--- a/justfile
+++ b/justfile
@@ -132,11 +132,12 @@ ci-cli:
 ci-build-package:
     ./scripts/run_ci_local.sh build
 
-# Run CI security scans (audit, sast, workflow-scan) in container
+# Run CI security scans (audit, sast, workflow-scan, secrets)
 ci-security:
     ./scripts/run_ci_local.sh audit
     ./scripts/run_ci_local.sh sast
     ./scripts/run_ci_local.sh workflow-scan
+    ./scripts/run_ci_local.sh secrets
 
 # Run CI schema/version/license checks in container
 ci-consistency:
@@ -144,6 +145,6 @@ ci-consistency:
     ./scripts/run_ci_local.sh version
     ./scripts/run_ci_local.sh license
 
-# Run all CI checks in container
+# Run all locally executable CI checks
 ci-all:
     ./scripts/run_ci_local.sh all

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,6 +43,11 @@ through installed `hephaestus-*` console scripts.
 - **`shell/lib/install_helpers.sh`** — Sourceable helper library (colors,
   counters, check helpers) shared by the installer scripts.
 
+### Local CI
+
+- **`run_ci_local.sh`** — Run the CI checks or a named subset in the local
+  Podman/Docker image built with `just ci-build`.
+
 ### Disaster recovery
 
 - **`backup_state.py`** — Backup, restore, and verify tier-3 operational

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,8 +45,10 @@ through installed `hephaestus-*` console scripts.
 
 ### Local CI
 
-- **`run_ci_local.sh`** — Run the CI checks or a named subset in the local
-  Podman/Docker image built with `just ci-build`.
+- **`run_ci_local.sh`** — Run the locally executable CI checks or a named
+  subset. Project-toolchain commands use the Podman/Docker image built with
+  `just ci-build`; the full route also requires host `just`, `shellcheck`, and
+  `bats`, matching their GitHub Actions jobs.
 
 ### Disaster recovery
 

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+# Run the Hephaestus CI suite locally inside a container.
+#
+# Mirrors what GitHub Actions runs, using the same CI container image.
+# Supports both Podman (rootless, no SU — preferred) and Docker.
+#
+# Usage:
+#   ./scripts/run_ci_local.sh              # Run all CI checks
+#   ./scripts/run_ci_local.sh lint         # pre-commit + doc-link validation
+#   ./scripts/run_ci_local.sh unit         # unit tests + structure/coverage checks
+#   ./scripts/run_ci_local.sh integration  # integration tests
+#   ./scripts/run_ci_local.sh cli          # installed-CLI entry-point tests
+#   ./scripts/run_ci_local.sh build        # sdist + wheel build
+#   ./scripts/run_ci_local.sh audit        # pip-audit dependency scan
+#   ./scripts/run_ci_local.sh sast         # bandit static analysis
+#   ./scripts/run_ci_local.sh workflow-scan # zizmor workflow security scan
+#   ./scripts/run_ci_local.sh schema       # workflow YAML schema validation
+#   ./scripts/run_ci_local.sh version      # version-single-source + uv.lock check
+#   ./scripts/run_ci_local.sh license      # license compatibility scan
+#
+# Container engine: auto-detected (podman first, docker fallback).
+# Override: CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh
+#
+# Image: built locally from ci/Containerfile — run `just ci-build` first.
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUBSET="${1:-all}"
+
+LOCAL_IMAGE="hephaestus-ci:local"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[CI]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[CI]${NC} $*"; }
+log_error() { echo -e "${RED}[CI]${NC} $*" >&2; }
+log_step()  { echo -e "\n${BLUE}==>${NC} $*"; }
+
+# ============================================================================
+# Container engine detection
+# ============================================================================
+
+detect_engine() {
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+        if ! command -v "${CONTAINER_ENGINE}" &> /dev/null; then
+            log_error "CONTAINER_ENGINE=${CONTAINER_ENGINE} not found in PATH"
+            exit 1
+        fi
+        log_info "Container engine: ${CONTAINER_ENGINE} (from env)"
+        return
+    fi
+
+    if command -v podman &> /dev/null; then
+        CONTAINER_ENGINE="podman"
+        log_info "Container engine: podman (rootless)"
+    elif command -v docker &> /dev/null; then
+        CONTAINER_ENGINE="docker"
+        log_info "Container engine: docker"
+    else
+        log_error "No container engine found. Install podman (recommended) or docker."
+        log_error "  Podman: https://podman.io/getting-started/installation"
+        exit 1
+    fi
+    export CONTAINER_ENGINE
+}
+
+# ============================================================================
+# Image resolution
+# ============================================================================
+
+resolve_image() {
+    if "${CONTAINER_ENGINE}" image exists "${LOCAL_IMAGE}" 2>/dev/null || \
+       "${CONTAINER_ENGINE}" images -q "${LOCAL_IMAGE}" 2>/dev/null | grep -q .; then
+        CI_IMAGE="${LOCAL_IMAGE}"
+        log_info "Using local CI image: ${CI_IMAGE}"
+    else
+        log_error "Local image '${LOCAL_IMAGE}' not found."
+        log_error "Build it first: just ci-build"
+        log_error "  (podman build -f ci/Containerfile -t ${LOCAL_IMAGE} .)"
+        exit 1
+    fi
+    export CI_IMAGE
+}
+
+# ============================================================================
+# Run a command inside the CI container
+# ============================================================================
+# Volume mounts:
+#   /workspace  — the full repo (rw, :Z for SELinux/Podman)
+# --userns=keep-id:uid=1000,gid=1000 — run as the image's non-root 'ci' user
+# while mapping it to the invoking host UID, so mounted-file ownership works on
+# both dev hosts (uid 1000) and GitHub runners (uid 1001).
+# --tmpfs /tmp — pytest tmp_path and the Pi smoke runtime use a real POSIX-ACL
+# filesystem (tmpfs), which their verification requires; the default overlay
+# filesystem of the container is not ACL-verifiable.
+
+run_in_container() {
+    local cmd=("$@")
+    local engine_flags=()
+
+    if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+        engine_flags+=(--userns=keep-id:uid=1000,gid=1000)
+    fi
+
+    "${CONTAINER_ENGINE}" run --rm \
+        "${engine_flags[@]}" \
+        --tmpfs /tmp:rw,size=4g,mode=1777 \
+        --volume "${PROJECT_ROOT}:/workspace:Z" \
+        --workdir /workspace \
+        "${CI_IMAGE}" \
+        "${cmd[@]}"
+}
+
+# ============================================================================
+# CI steps
+# ============================================================================
+
+run_lint() {
+    log_step "Lint (pre-commit + doc-link validation)"
+    run_in_container uv run pre-commit run --all-files --show-diff-on-failure
+    run_in_container uv run hephaestus-validate-links docs --repo-root .
+}
+
+run_unit() {
+    log_step "Unit tests + structure/coverage checks"
+    run_in_container bash -c '\
+        uv run pytest tests/unit --override-ini="addopts=" -v --strict-markers -m "not nightly" \
+            --cov=hephaestus --cov-report=xml --cov-report=term-missing && \
+        uv run hephaestus-check-test-structure && \
+        uv run hephaestus-check-coverage --coverage-file coverage.xml --config coverage.toml'
+}
+
+run_integration() {
+    log_step "Integration tests"
+    run_in_container uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"
+}
+
+run_cli() {
+    log_step "Installed-CLI entry-point tests"
+    run_in_container bash -c '\
+        uv build --wheel && \
+        uv venv build/cli-venv && \
+        WHEEL=(dist/*.whl) && \
+        uv pip install --python build/cli-venv/bin/python "${WHEEL[0]}[automation]" pytest pyyaml && \
+        export PATH="$PWD/build/cli-venv/bin:$PATH" && \
+        HEPHAESTUS_REQUIRE_CLI=1 build/cli-venv/bin/pytest tests/integration/test_cli_entry_points.py \
+            --override-ini="addopts=" -v --strict-markers'
+}
+
+run_build() {
+    log_step "Package build (sdist + wheel)"
+    run_in_container uv run python -m build --no-isolation
+}
+
+run_audit() {
+    log_step "Dependency scan (pip-audit)"
+    run_in_container uv run pip-audit
+}
+
+run_sast() {
+    log_step "Static analysis (bandit)"
+    run_in_container uv run bandit -c pyproject.toml -r hephaestus scripts --severity-level medium
+}
+
+run_workflow_scan() {
+    log_step "Workflow security scan (zizmor)"
+    run_in_container uv run zizmor --no-online-audits --min-severity medium .github/workflows/
+}
+
+run_schema() {
+    log_step "Workflow YAML schema validation"
+    run_in_container uvx check-jsonschema \
+        --builtin-schema vendor.github-workflows \
+        .github/workflows/*.yml
+}
+
+run_version() {
+    log_step "Version single-source-of-truth + uv.lock check"
+    run_in_container uv run python -m hephaestus.scripts_lib.check_version_single_source
+    run_in_container uv lock --check
+}
+
+run_license() {
+    log_step "License compatibility scan"
+    run_in_container uv run python scripts/check_license_compatibility.py
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+FAILED=()
+
+run_step() {
+    local name="$1"
+    local fn="$2"
+    if ! "${fn}"; then
+        FAILED+=("${name}")
+        log_error "${name} FAILED"
+    fi
+}
+
+detect_engine
+resolve_image
+
+log_info "CI subset: ${SUBSET}"
+log_info "Project root: ${PROJECT_ROOT}"
+
+case "${SUBSET}" in
+    lint)
+        run_step "lint" run_lint
+        ;;
+    unit)
+        run_step "unit" run_unit
+        ;;
+    integration)
+        run_step "integration" run_integration
+        ;;
+    cli)
+        run_step "cli" run_cli
+        ;;
+    build)
+        run_step "build" run_build
+        ;;
+    audit)
+        run_step "audit" run_audit
+        ;;
+    sast)
+        run_step "sast" run_sast
+        ;;
+    workflow-scan)
+        run_step "workflow-scan" run_workflow_scan
+        ;;
+    schema)
+        run_step "schema" run_schema
+        ;;
+    version)
+        run_step "version" run_version
+        ;;
+    license)
+        run_step "license" run_license
+        ;;
+    all)
+        run_step "lint" run_lint
+        run_step "unit" run_unit
+        run_step "integration" run_integration
+        run_step "cli" run_cli
+        run_step "build" run_build
+        run_step "audit" run_audit
+        run_step "sast" run_sast
+        run_step "workflow-scan" run_workflow_scan
+        run_step "schema" run_schema
+        run_step "version" run_version
+        run_step "license" run_license
+        ;;
+    *)
+        log_error "Unknown subset: ${SUBSET}"
+        log_error "Valid values: all, lint, unit, integration, cli, build, audit, sast, workflow-scan, schema, version, license"
+        exit 1
+        ;;
+esac
+
+echo ""
+if [ "${#FAILED[@]}" -eq 0 ]; then
+    log_info "All CI checks passed."
+else
+    log_error "Failed: ${FAILED[*]}"
+    exit 1
+fi

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -117,12 +117,11 @@ run_in_container() {
     if [ "${CONTAINER_ENGINE}" = "podman" ]; then
         engine_flags+=("--userns=keep-id:uid=1000,gid=1000")
     else
-        # Docker gives each invocation a private writable image layer. The
-        # image makes this baked environment writable by arbitrary UIDs so uv
-        # can refresh the editable install while bind-mounted artifacts remain
-        # owned by the invoking host user.
+        # Docker runs as the invoking host UID so bind-mounted artifacts retain
+        # host ownership. Arbitrary UIDs cannot update the ci-owned baked venv,
+        # so keep it read-only and import project code from the mounted checkout.
         engine_flags+=(--user "$(id -u):$(id -g)" --env HOME=/tmp \
-            --env UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv)
+            --env UV_NO_SYNC=1 --env PYTHONPATH=/workspace)
     fi
 
     "${CONTAINER_ENGINE}" run --rm \

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -117,7 +117,12 @@ run_in_container() {
     if [ "${CONTAINER_ENGINE}" = "podman" ]; then
         engine_flags+=("--userns=keep-id:uid=1000,gid=1000")
     else
-        engine_flags+=(--user "$(id -u):$(id -g)" --env HOME=/tmp)
+        # Docker gives each invocation a private writable image layer. The
+        # image makes this baked environment writable by arbitrary UIDs so uv
+        # can refresh the editable install while bind-mounted artifacts remain
+        # owned by the invoking host user.
+        engine_flags+=(--user "$(id -u):$(id -g)" --env HOME=/tmp \
+            --env UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv)
     fi
 
     "${CONTAINER_ENGINE}" run --rm \
@@ -203,6 +208,12 @@ run_version() {
 run_license() {
     log_step "License compatibility scan"
     run_in_container uv run python scripts/check_license_compatibility.py
+}
+
+run_license_blocking() {
+    log_step "License compatibility scan (blocking PR mode)"
+    run_in_container env GITHUB_EVENT_NAME=pull_request \
+        uv run python scripts/check_license_compatibility.py
 }
 
 run_symlinks() {
@@ -341,7 +352,7 @@ case "${SUBSET}" in
         run_step "workflow-scan" run_workflow_scan
         run_step "schema" run_schema
         run_step "version" run_version
-        run_step "license" run_license
+        run_step "license" run_license_blocking
         run_step "symlinks" run_symlinks
         run_step "justfile" run_justfile
         run_step "shellcheck" run_shellcheck
@@ -357,7 +368,11 @@ esac
 
 echo ""
 if [ "${#FAILED[@]}" -eq 0 ]; then
-    log_info "All local CI checks passed."
+    if [ "${SUBSET}" = "all" ]; then
+        log_info "All locally executable CI checks passed."
+    else
+        log_info "Local CI subset '${SUBSET}' passed."
+    fi
 else
     log_error "Failed: ${FAILED[*]}"
     exit 1

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Run the Hephaestus CI suite locally inside a container.
+# Run the locally executable Hephaestus CI checks.
 #
-# Mirrors what GitHub Actions runs, using the same CI container image.
+# Project toolchain commands use the same CI container image as GitHub Actions.
 # Supports both Podman (rootless, no SU — preferred) and Docker.
 #
 # Usage:
-#   ./scripts/run_ci_local.sh              # Run all CI checks
+#   ./scripts/run_ci_local.sh              # Run all local CI checks
 #   ./scripts/run_ci_local.sh lint         # pre-commit + doc-link validation
 #   ./scripts/run_ci_local.sh unit         # unit tests + structure/coverage checks
 #   ./scripts/run_ci_local.sh integration  # integration tests
@@ -17,6 +17,11 @@
 #   ./scripts/run_ci_local.sh schema       # workflow YAML schema validation
 #   ./scripts/run_ci_local.sh version      # version-single-source + uv.lock check
 #   ./scripts/run_ci_local.sh license      # license compatibility scan
+#   ./scripts/run_ci_local.sh symlinks     # repository symlink validation
+#   ./scripts/run_ci_local.sh justfile     # justfile evaluation and recipe listing
+#   ./scripts/run_ci_local.sh shellcheck   # shell static analysis
+#   ./scripts/run_ci_local.sh shell-tests  # Bats shell test suite
+#   ./scripts/run_ci_local.sh secrets      # Gitleaks repository scan
 #
 # Container engine: auto-detected (podman first, docker fallback).
 # Override: CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh
@@ -34,6 +39,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SUBSET="${1:-all}"
 
 LOCAL_IMAGE="hephaestus-ci:local"
+GITLEAKS_IMAGE="ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -109,7 +115,9 @@ run_in_container() {
     local engine_flags=()
 
     if [ "${CONTAINER_ENGINE}" = "podman" ]; then
-        engine_flags+=(--userns=keep-id:uid=1000,gid=1000)
+        engine_flags+=("--userns=keep-id:uid=1000,gid=1000")
+    else
+        engine_flags+=(--user "$(id -u):$(id -g)" --env HOME=/tmp)
     fi
 
     "${CONTAINER_ENGINE}" run --rm \
@@ -127,7 +135,7 @@ run_in_container() {
 
 run_lint() {
     log_step "Lint (pre-commit + doc-link validation)"
-    run_in_container uv run pre-commit run --all-files --show-diff-on-failure
+    run_in_container uv run pre-commit run --all-files --show-diff-on-failure || return 1
     run_in_container uv run hephaestus-validate-links docs --repo-root .
 }
 
@@ -142,11 +150,13 @@ run_unit() {
 
 run_integration() {
     log_step "Integration tests"
-    run_in_container uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"
+    run_in_container bash -c '\
+        HEPHAESTUS_REQUIRE_CLI=1 uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers -m "not nightly"'
 }
 
 run_cli() {
     log_step "Installed-CLI entry-point tests"
+    # shellcheck disable=SC2016 # $PWD and WHEEL expand in the container shell.
     run_in_container bash -c '\
         uv build --wheel && \
         uv venv build/cli-venv && \
@@ -186,13 +196,65 @@ run_schema() {
 
 run_version() {
     log_step "Version single-source-of-truth + uv.lock check"
-    run_in_container uv run python -m hephaestus.scripts_lib.check_version_single_source
+    run_in_container uv run python -m hephaestus.scripts_lib.check_version_single_source || return 1
     run_in_container uv lock --check
 }
 
 run_license() {
     log_step "License compatibility scan"
     run_in_container uv run python scripts/check_license_compatibility.py
+}
+
+run_symlinks() {
+    log_step "Repository symlink validation"
+    run_in_container bash scripts/check-symlinks.sh
+}
+
+run_justfile() {
+    log_step "Justfile evaluation"
+    command -v just >/dev/null || {
+        log_error "just is required for the justfile check"
+        return 1
+    }
+    just --evaluate >/dev/null || return 1
+    just --list >/dev/null
+}
+
+run_shellcheck() {
+    log_step "ShellCheck"
+    command -v shellcheck >/dev/null || {
+        log_error "shellcheck is required for shell static analysis"
+        return 1
+    }
+    shopt -s nullglob globstar
+    local files=(scripts/**/*.sh scripts/**/*.sbatch)
+    if [ "${#files[@]}" -eq 0 ]; then
+        log_info "No shell scripts found — nothing to lint."
+        return 0
+    fi
+    shellcheck --severity=error "${files[@]}"
+}
+
+run_shell_tests() {
+    log_step "Bats shell tests"
+    command -v bats >/dev/null || {
+        log_error "bats is required for shell tests"
+        return 1
+    }
+    bats --recursive tests/shell
+}
+
+run_secrets() {
+    log_step "Gitleaks repository scan"
+    local args=(detect --source=. --verbose --exit-code=1)
+    if [ -f .gitleaks.toml ]; then
+        args+=(--config=.gitleaks.toml)
+    fi
+    "${CONTAINER_ENGINE}" run --rm \
+        --volume "${PROJECT_ROOT}:/repo:Z" \
+        --workdir /repo \
+        "${GITLEAKS_IMAGE}" \
+        "${args[@]}"
 }
 
 # ============================================================================
@@ -250,6 +312,21 @@ case "${SUBSET}" in
     license)
         run_step "license" run_license
         ;;
+    symlinks)
+        run_step "symlinks" run_symlinks
+        ;;
+    justfile)
+        run_step "justfile" run_justfile
+        ;;
+    shellcheck)
+        run_step "shellcheck" run_shellcheck
+        ;;
+    shell-tests)
+        run_step "shell-tests" run_shell_tests
+        ;;
+    secrets)
+        run_step "secrets" run_secrets
+        ;;
     all)
         run_step "lint" run_lint
         run_step "unit" run_unit
@@ -262,17 +339,22 @@ case "${SUBSET}" in
         run_step "schema" run_schema
         run_step "version" run_version
         run_step "license" run_license
+        run_step "symlinks" run_symlinks
+        run_step "justfile" run_justfile
+        run_step "shellcheck" run_shellcheck
+        run_step "shell-tests" run_shell_tests
+        run_step "secrets" run_secrets
         ;;
     *)
         log_error "Unknown subset: ${SUBSET}"
-        log_error "Valid values: all, lint, unit, integration, cli, build, audit, sast, workflow-scan, schema, version, license"
+        log_error "Valid values: all, lint, unit, integration, cli, build, audit, sast, workflow-scan, schema, version, license, symlinks, justfile, shellcheck, shell-tests, secrets"
         exit 1
         ;;
 esac
 
 echo ""
 if [ "${#FAILED[@]}" -eq 0 ]; then
-    log_info "All CI checks passed."
+    log_info "All local CI checks passed."
 else
     log_error "Failed: ${FAILED[*]}"
     exit 1

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -136,7 +136,7 @@ run_in_container() {
 run_lint() {
     log_step "Lint (pre-commit + doc-link validation)"
     run_in_container uv run pre-commit run --all-files --show-diff-on-failure || return 1
-    run_in_container uv run hephaestus-validate-links docs --repo-root .
+    run_in_container uv run hephaestus-validate-links docs --repo-root . || return 1
 }
 
 run_unit() {
@@ -197,7 +197,7 @@ run_schema() {
 run_version() {
     log_step "Version single-source-of-truth + uv.lock check"
     run_in_container uv run python -m hephaestus.scripts_lib.check_version_single_source || return 1
-    run_in_container uv lock --check
+    run_in_container uv lock --check || return 1
 }
 
 run_license() {
@@ -266,7 +266,10 @@ FAILED=()
 run_step() {
     local name="$1"
     local fn="$2"
-    if ! "${fn}"; then
+    local status=0
+
+    "${fn}" || status=$?
+    if [ "${status}" -ne 0 ]; then
         FAILED+=("${name}")
         log_error "${name} FAILED"
     fi

--- a/tests/integration/test_ci_container_permissions.py
+++ b/tests/integration/test_ci_container_permissions.py
@@ -31,8 +31,10 @@ def _local_ci_image_is_available() -> bool:
     not _local_ci_image_is_available(),
     reason="requires Docker with a locally built hephaestus-ci:local image",
 )
-def test_arbitrary_docker_uid_can_sync_uv_and_write_bind_artifact(tmp_path: Path) -> None:
-    """An arbitrary host UID can refresh uv and create a bind-mounted artifact."""
+def test_arbitrary_docker_uid_uses_baked_uv_and_writes_bind_artifact(
+    tmp_path: Path,
+) -> None:
+    """An arbitrary host UID can run uv and create a bind-mounted artifact."""
     assert DOCKER is not None
     artifact_dir = tmp_path / "artifacts"
     artifact_dir.mkdir(mode=0o777)
@@ -48,7 +50,9 @@ def test_arbitrary_docker_uid_can_sync_uv_and_write_bind_artifact(tmp_path: Path
             "--env",
             "HOME=/tmp",
             "--env",
-            "UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv",
+            "UV_NO_SYNC=1",
+            "--env",
+            "PYTHONPATH=/workspace",
             "--tmpfs",
             "/tmp:rw,size=4g,mode=1777",
             "--volume",
@@ -60,7 +64,8 @@ def test_arbitrary_docker_uid_can_sync_uv_and_write_bind_artifact(tmp_path: Path
             CI_IMAGE,
             "bash",
             "-ceu",
-            "uv run --locked python -c 'import hephaestus' && touch /artifacts/created",
+            "test ! -w /opt/hephaestus-venv && "
+            "uv run python -c 'import hephaestus' && touch /artifacts/created",
         ],
         text=True,
         capture_output=True,

--- a/tests/integration/test_ci_container_permissions.py
+++ b/tests/integration/test_ci_container_permissions.py
@@ -1,0 +1,72 @@
+"""Real-container coverage for the local CI Docker permission boundary."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_IMAGE = "hephaestus-ci:local"
+DOCKER = shutil.which("docker")
+
+
+def _local_ci_image_is_available() -> bool:
+    """Return whether a usable Docker daemon has the locally built CI image."""
+    if DOCKER is None:
+        return False
+    result = subprocess.run(
+        [DOCKER, "image", "inspect", CI_IMAGE],
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    return result.returncode == 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not _local_ci_image_is_available(),
+    reason="requires Docker with a locally built hephaestus-ci:local image",
+)
+def test_arbitrary_docker_uid_can_sync_uv_and_write_bind_artifact(tmp_path: Path) -> None:
+    """An arbitrary host UID can refresh uv and create a bind-mounted artifact."""
+    assert DOCKER is not None
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir(mode=0o777)
+    artifact_dir.chmod(0o777)
+
+    result = subprocess.run(
+        [
+            DOCKER,
+            "run",
+            "--rm",
+            "--user",
+            "23456:23457",
+            "--env",
+            "HOME=/tmp",
+            "--env",
+            "UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv",
+            "--tmpfs",
+            "/tmp:rw,size=4g,mode=1777",
+            "--volume",
+            f"{REPO_ROOT}:/workspace",
+            "--volume",
+            f"{artifact_dir}:/artifacts",
+            "--workdir",
+            "/workspace",
+            CI_IMAGE,
+            "bash",
+            "-ceu",
+            "uv run --locked python -c 'import hephaestus' && touch /artifacts/created",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (artifact_dir / "created").is_file()

--- a/tests/integration/test_ci_container_permissions.py
+++ b/tests/integration/test_ci_container_permissions.py
@@ -64,8 +64,12 @@ def test_arbitrary_docker_uid_uses_baked_uv_and_writes_bind_artifact(
             CI_IMAGE,
             "bash",
             "-ceu",
-            "test ! -w /opt/hephaestus-venv && "
-            "uv run python -c 'import hephaestus' && touch /artifacts/created",
+            " ".join(
+                (
+                    "test ! -w /opt/hephaestus-venv &&",
+                    "uv run python -c 'import hephaestus' && touch /artifacts/created",
+                )
+            ),
         ],
         text=True,
         capture_output=True,

--- a/tests/unit/ci/test_bandit_config.py
+++ b/tests/unit/ci/test_bandit_config.py
@@ -27,8 +27,15 @@ def test_bandit_configuration_excludes_generated_and_test_paths() -> None:
     assert {"tests", "build", ".venv"}.issubset(excluded)
 
 
-def test_precommit_uses_uv_bandit() -> None:
-    """The local enforcement path invokes the project-managed Bandit."""
+def test_required_workflow_and_precommit_use_uv_bandit() -> None:
+    """Both required enforcement paths invoke the project-managed Bandit."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/_required.yml").read_text())
+    sast = workflow["jobs"]["security-sast-scan"]
+    run_step = next(
+        step for step in sast["steps"] if step.get("name") == "Run bandit (SAST, in container)"
+    )
+    assert "uv run bandit" in run_step["run"]
+    assert "podman run" in run_step["run"]
     config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text())
     hook = next(
         hook

--- a/tests/unit/ci/test_container_ci_workflows.py
+++ b/tests/unit/ci/test_container_ci_workflows.py
@@ -11,10 +11,20 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _workflow_step(workflow_name: str, job_name: str, step_name: str) -> str:
+def _workflow_step_definition(
+    workflow_name: str, job_name: str, step_name: str
+) -> dict[str, object]:
+    """Return a named workflow step definition."""
     workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / workflow_name).read_text())
     job = workflow["jobs"][job_name]
     step = next(item for item in job["steps"] if item.get("name") == step_name)
+    assert isinstance(step, dict)
+    return step
+
+
+def _workflow_step(workflow_name: str, job_name: str, step_name: str) -> str:
+    """Return the shell source from a named workflow step."""
+    step = _workflow_step_definition(workflow_name, job_name, step_name)
     run = step["run"]
     assert isinstance(run, str)
     return run
@@ -49,8 +59,8 @@ def test_build_smoke_step_is_valid_bash() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_schema_step_passes_workflow_files_into_the_container(tmp_path: Path) -> None:
-    """Schema validation must provide the in-container checker with workflow inputs."""
+def test_schema_step_builds_workflow_file_array_inside_container(tmp_path: Path) -> None:
+    """Schema validation must declare and consume its inputs in the container shell."""
     tools = tmp_path / "tools"
     tools.mkdir()
     _write_executable(
@@ -78,6 +88,12 @@ def test_schema_step_passes_workflow_files_into_the_container(tmp_path: Path) ->
         "_required.yml", "schema-validation", "Validate GitHub workflow schemas (in container)"
     )
 
+    container_marker = "bash -ceu '"
+    host_command, container_command = step.split(container_marker, maxsplit=1)
+    assert "wf_files" not in host_command
+    assert "mapfile -t wf_files" in container_command
+    assert '"${wf_files[@]}"' in container_command
+
     result = _run_step(tmp_path, step, {"PATH": f"{tools}{os.pathsep}{os.environ['PATH']}"})
 
     assert result.returncode == 0, result.stderr
@@ -92,8 +108,9 @@ def test_scheduled_zizmor_step_forwards_its_token_to_the_container(tmp_path: Pat
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         "forwarded=false\n"
-        'for argument in "$@"; do\n'
-        '  [[ "$argument" == GH_TOKEN ]] && forwarded=true\n'
+        'args=("$@")\n'
+        "for ((index = 0; index < ${#args[@]} - 1; index++)); do\n"
+        '  [[ "${args[index]}" == -e && "${args[index + 1]}" == GH_TOKEN ]] && forwarded=true\n'
         "done\n"
         'if "$forwarded"; then\n'
         "  exec uv run zizmor\n"
@@ -105,11 +122,14 @@ def test_scheduled_zizmor_step_forwards_its_token_to_the_container(tmp_path: Pat
         tools / "uv",
         '#!/usr/bin/env bash\nset -euo pipefail\n[[ "${GH_TOKEN:-}" == test-token ]]\n',
     )
-    step = _workflow_step(
+    step_definition = _workflow_step_definition(
         "security.yml",
         "workflow-scan",
         "Run zizmor (workflow SAST with online audits, in container)",
     )
+    assert step_definition["env"] == {"GH_TOKEN": "${{ github.token }}"}
+    step = step_definition["run"]
+    assert isinstance(step, str)
 
     result = _run_step(
         tmp_path,

--- a/tests/unit/ci/test_container_ci_workflows.py
+++ b/tests/unit/ci/test_container_ci_workflows.py
@@ -1,0 +1,120 @@
+"""Executable contracts for container-backed GitHub Actions steps."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _workflow_step(workflow_name: str, job_name: str, step_name: str) -> str:
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / workflow_name).read_text())
+    job = workflow["jobs"][job_name]
+    step = next(item for item in job["steps"] if item.get("name") == step_name)
+    run = step["run"]
+    assert isinstance(run, str)
+    return run
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_step(
+    tmp_path: Path, source: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    step = tmp_path / "step.sh"
+    _write_executable(step, f"#!/usr/bin/env bash\n{source}\n")
+    return subprocess.run(
+        ["bash", str(step)],
+        cwd=REPO_ROOT,
+        env=os.environ | environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_build_smoke_step_is_valid_bash() -> None:
+    """The required build lane must reach its wheel smoke test."""
+    step = _workflow_step("_required.yml", "build", "Smoke-test installed wheel (in container)")
+
+    result = subprocess.run(["bash", "-n", "-c", step], text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_schema_step_passes_workflow_files_into_the_container(tmp_path: Path) -> None:
+    """Schema validation must provide the in-container checker with workflow inputs."""
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    _write_executable(
+        tools / "podman",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'args=("$@")\n'
+        "for ((index = 0; index < ${#args[@]} - 2; index++)); do\n"
+        '  if [[ "${args[index]}" == bash && "${args[index + 1]}" == -c* ]]; then\n'
+        '    exec bash -c "${args[index + 2]}"\n'
+        "  fi\n"
+        "done\n"
+        "exit 64\n",
+    )
+    _write_executable(
+        tools / "uvx",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'for argument in "$@"; do\n'
+        '  [[ "$argument" == .github/workflows/*.yml ]] && exit 0\n'
+        "done\n"
+        "exit 1\n",
+    )
+    step = _workflow_step(
+        "_required.yml", "schema-validation", "Validate GitHub workflow schemas (in container)"
+    )
+
+    result = _run_step(tmp_path, step, {"PATH": f"{tools}{os.pathsep}{os.environ['PATH']}"})
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_scheduled_zizmor_step_forwards_its_token_to_the_container(tmp_path: Path) -> None:
+    """The online scheduled audit must retain its GitHub token past podman."""
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    _write_executable(
+        tools / "podman",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "forwarded=false\n"
+        'for argument in "$@"; do\n'
+        '  [[ "$argument" == GH_TOKEN ]] && forwarded=true\n'
+        "done\n"
+        'if "$forwarded"; then\n'
+        "  exec uv run zizmor\n"
+        "fi\n"
+        "unset GH_TOKEN\n"
+        "exec uv run zizmor\n",
+    )
+    _write_executable(
+        tools / "uv",
+        '#!/usr/bin/env bash\nset -euo pipefail\n[[ "${GH_TOKEN:-}" == test-token ]]\n',
+    )
+    step = _workflow_step(
+        "security.yml",
+        "workflow-scan",
+        "Run zizmor (workflow SAST with online audits, in container)",
+    )
+
+    result = _run_step(
+        tmp_path,
+        step,
+        {"GH_TOKEN": "test-token", "PATH": f"{tools}{os.pathsep}{os.environ['PATH']}"},
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/ci/test_containerfile_contract.py
+++ b/tests/unit/ci/test_containerfile_contract.py
@@ -22,11 +22,15 @@ def test_debian_packages_use_one_immutable_snapshot() -> None:
     ]
     assert repository_lines == [
         "deb [check-valid-until=no] "
-        "http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ "
-        "${VERSION_CODENAME} main",
-        "deb [check-valid-until=no] "
-        "http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ "
-        "${VERSION_CODENAME}-security main",
+        + "http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ "
+        + "${VERSION_CODENAME} main",
+        "".join(
+            (
+                "deb [check-valid-until=no] ",
+                "http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ ",
+                "${VERSION_CODENAME}-security main",
+            )
+        ),
     ]
     assert source.count("[check-valid-until=no]") == 2
     assert "rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*" in source

--- a/tests/unit/ci/test_containerfile_contract.py
+++ b/tests/unit/ci/test_containerfile_contract.py
@@ -1,0 +1,24 @@
+"""Contracts for the portable, reproducible local CI image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTAINERFILE = REPO_ROOT / "ci" / "Containerfile"
+
+
+def test_node_runtime_source_is_digest_pinned() -> None:
+    """Rebuilding the CI image must not silently select a different Node runtime."""
+    lines = CONTAINERFILE.read_text(encoding="utf-8").splitlines()
+    node_stage = next(line for line in lines if line.startswith("FROM node:"))
+
+    assert "@sha256:" in node_stage
+
+
+def test_runtime_tools_follow_the_requested_build_architecture() -> None:
+    """The image must select its executable artifacts for the build platform."""
+    source = CONTAINERFILE.read_text(encoding="utf-8")
+
+    assert "ARG TARGETARCH" in source
+    assert 'case "$TARGETARCH"' in source

--- a/tests/unit/ci/test_containerfile_contract.py
+++ b/tests/unit/ci/test_containerfile_contract.py
@@ -20,5 +20,28 @@ def test_runtime_tools_follow_the_requested_build_architecture() -> None:
     """The image must select its executable artifacts for the build platform."""
     source = CONTAINERFILE.read_text(encoding="utf-8")
 
-    assert "ARG TARGETARCH" in source
-    assert 'case "$TARGETARCH"' in source
+    assert source.count('case "$TARGETARCH" in') == 2
+
+    assert (
+        'amd64) uv_asset="uv-x86_64-unknown-linux-gnu"; '
+        'uv_sha256="90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb"' in source
+    )
+    assert (
+        'arm64) uv_asset="uv-aarch64-unknown-linux-gnu"; '
+        'uv_sha256="769d373e146692c639b5fbaae33b331c297a32e03d30448772051902df52bbf4"' in source
+    )
+    assert "${uv_asset}.tar.gz" in source
+    assert 'echo "${uv_sha256}  /tmp/uv.tar.gz" | sha256sum --check' in source
+
+    assert (
+        'amd64) gh_arch="amd64"; '
+        'gh_sha256="7c7fa3bb890db0934baf65910d97b8c0fa437b2e590f7f7daf6bdf82c5c486d7"' in source
+    )
+    assert (
+        'arm64) gh_arch="arm64"; '
+        'gh_sha256="0ba7a76739c865d82ebde24667d875d9b8caa55db47c7597c24accdd4defd2bb"' in source
+    )
+    assert "linux_${gh_arch}.deb" in source
+    assert 'echo "${gh_sha256}  /tmp/gh.deb" | sha256sum --check' in source
+
+    assert source.count('*) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1') == 2

--- a/tests/unit/ci/test_containerfile_contract.py
+++ b/tests/unit/ci/test_containerfile_contract.py
@@ -2,10 +2,31 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CONTAINERFILE = REPO_ROOT / "ci" / "Containerfile"
+
+
+def test_debian_packages_use_one_immutable_snapshot() -> None:
+    """Every APT-backed stage must resolve packages from fixed repository state."""
+    source = CONTAINERFILE.read_text(encoding="utf-8")
+
+    snapshot = re.search(r"^ARG DEBIAN_SNAPSHOT=(\d{8}T\d{6}Z)$", source, re.MULTILINE)
+    assert snapshot is not None
+    assert "snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/" in source
+    assert "snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/" in source
+    assert source.count("[check-valid-until=no]") == 2
+    assert "rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*" in source
+
+    # A single digest-pinned Python root configures APT before every stage that
+    # installs OS packages; no stage may fall back to the base image's mutable
+    # deb.debian.org sources or upgrade against whatever repository is current.
+    assert source.count("FROM python:3.13-slim@sha256:") == 1
+    assert source.count("FROM python-snapshot") == 3
+    assert "apt-get upgrade" not in source
+    assert "deb.debian.org" not in source
 
 
 def test_node_runtime_source_is_digest_pinned() -> None:
@@ -13,7 +34,17 @@ def test_node_runtime_source_is_digest_pinned() -> None:
     lines = CONTAINERFILE.read_text(encoding="utf-8").splitlines()
     node_stage = next(line for line in lines if line.startswith("FROM node:"))
 
-    assert "@sha256:" in node_stage
+    assert (
+        node_stage == "FROM node:22-bookworm-slim@sha256:"
+        "d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS node"
+    )
+
+
+def test_baked_environment_is_writable_by_runtime_uid() -> None:
+    """Docker's host UID must be able to let uv refresh the baked environment."""
+    source = CONTAINERFILE.read_text(encoding="utf-8")
+
+    assert "chmod -R a+rwX /opt/hephaestus-venv" in source
 
 
 def test_runtime_tools_follow_the_requested_build_architecture() -> None:

--- a/tests/unit/ci/test_containerfile_contract.py
+++ b/tests/unit/ci/test_containerfile_contract.py
@@ -15,18 +15,32 @@ def test_debian_packages_use_one_immutable_snapshot() -> None:
 
     snapshot = re.search(r"^ARG DEBIAN_SNAPSHOT=(\d{8}T\d{6}Z)$", source, re.MULTILINE)
     assert snapshot is not None
-    assert "snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/" in source
-    assert "snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/" in source
+    repository_lines = [
+        line.strip().strip('" \\')
+        for line in source.splitlines()
+        if line.strip().startswith('"deb ')
+    ]
+    assert repository_lines == [
+        "deb [check-valid-until=no] "
+        "http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ "
+        "${VERSION_CODENAME} main",
+        "deb [check-valid-until=no] "
+        "http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ "
+        "${VERSION_CODENAME}-security main",
+    ]
     assert source.count("[check-valid-until=no]") == 2
     assert "rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*" in source
+    assert "deb.debian.org" not in source
 
     # A single digest-pinned Python root configures APT before every stage that
     # installs OS packages; no stage may fall back to the base image's mutable
-    # deb.debian.org sources or upgrade against whatever repository is current.
+    # repositories or upgrade against whatever repository is current.
     assert source.count("FROM python:3.13-slim@sha256:") == 1
     assert source.count("FROM python-snapshot") == 3
-    assert "apt-get upgrade" not in source
-    assert "deb.debian.org" not in source
+    apt_stages = [stage for stage in re.split(r"(?m)(?=^FROM )", source) if "apt-get" in stage]
+    assert len(apt_stages) == 3
+    assert all(stage.startswith("FROM python-snapshot") for stage in apt_stages)
+    assert re.search(r"\bapt-get\b[^&;\n]*\b(?:dist-)?upgrade\b", source) is None
 
 
 def test_node_runtime_source_is_digest_pinned() -> None:
@@ -40,11 +54,11 @@ def test_node_runtime_source_is_digest_pinned() -> None:
     )
 
 
-def test_baked_environment_is_writable_by_runtime_uid() -> None:
-    """Docker's host UID must be able to let uv refresh the baked environment."""
+def test_baked_environment_is_not_made_world_writable() -> None:
+    """Docker must not require weakening the baked environment's permissions."""
     source = CONTAINERFILE.read_text(encoding="utf-8")
 
-    assert "chmod -R a+rwX /opt/hephaestus-venv" in source
+    assert "chmod -R a+rwX /opt/hephaestus-venv" not in source
 
 
 def test_runtime_tools_follow_the_requested_build_architecture() -> None:

--- a/tests/unit/ci/test_run_ci_local.py
+++ b/tests/unit/ci/test_run_ci_local.py
@@ -1,0 +1,100 @@
+"""Behavioral contracts for the local containerized CI runner."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNNER = REPO_ROOT / "scripts" / "run_ci_local.sh"
+
+
+def _fake_engine(tmp_path: Path, *, failing_command: str = "") -> tuple[Path, Path]:
+    """Create a controlled container-engine boundary that records invocations."""
+    engine = tmp_path / "podman"
+    log = tmp_path / "engine.log"
+    failure_clause = (
+        f'  [[ "$*" == *{failing_command!r}* ]] && exit 37\n' if failing_command else ""
+    )
+    engine.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            'if [[ "$1" == "image" && "$2" == "exists" ]]; then exit 0; fi\n'
+            'if [[ "$1" == "images" ]]; then exit 0; fi\n'
+            'if [[ "$1" == "run" ]]; then\n'
+            '  printf "%q " "$@" >> "$FAKE_ENGINE_LOG"\n'
+            '  printf "\\n" >> "$FAKE_ENGINE_LOG"\n' + failure_clause + "fi\n" + "exit 0\n"
+        ),
+        encoding="utf-8",
+    )
+    engine.chmod(0o755)
+    for command in ("just", "shellcheck", "bats"):
+        executable = tmp_path / command
+        executable.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            'printf "%s " "$(basename "$0")" "$@" >> "$FAKE_ENGINE_LOG"\n'
+            'printf "\\n" >> "$FAKE_ENGINE_LOG"\n',
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+    return engine, log
+
+
+def _run_runner(
+    tmp_path: Path, subset: str, *, engine_name: str = "podman", failing_command: str = ""
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the real wrapper with a deterministic successful or failing engine."""
+    engine, log = _fake_engine(tmp_path, failing_command=failing_command)
+    if engine_name != "podman":
+        docker = engine.with_name(engine_name)
+        engine.rename(docker)
+        engine = docker
+    environment = os.environ | {
+        "CONTAINER_ENGINE": engine_name,
+        "FAKE_ENGINE_LOG": str(log),
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", str(RUNNER), subset],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, log.read_text(encoding="utf-8")
+
+
+def test_lint_failure_makes_the_runner_fail(tmp_path: Path) -> None:
+    """A failing first command in a multi-command check must not be masked."""
+    result, _log = _run_runner(tmp_path, "lint", failing_command="uv run pre-commit")
+
+    assert result.returncode != 0
+    assert "Failed: lint" in result.stderr
+
+
+def test_all_runs_every_local_required_gate(tmp_path: Path) -> None:
+    """The advertised all target invokes every required local check."""
+    result, log = _run_runner(tmp_path, "all")
+
+    assert result.returncode == 0, result.stderr
+    for command in (
+        "bash scripts/check-symlinks.sh",
+        "just --evaluate",
+        "shellcheck --severity=error",
+        "bats --recursive tests/shell",
+        "detect --source=. --verbose --exit-code=1",
+        "HEPHAESTUS_REQUIRE_CLI=1",
+    ):
+        assert command in log
+
+
+def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> None:
+    """Docker fallback must not run bind-mounted checks as image-owned UID 1000."""
+    result, log = _run_runner(tmp_path, "unit", engine_name="docker")
+
+    assert result.returncode == 0, result.stderr
+    assert f"--user {os.getuid()}:{os.getgid()}" in log

--- a/tests/unit/ci/test_run_ci_local.py
+++ b/tests/unit/ci/test_run_ci_local.py
@@ -6,6 +6,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RUNNER = REPO_ROOT / "scripts" / "run_ci_local.sh"
 
@@ -44,14 +46,33 @@ def _fake_engine(tmp_path: Path, *, failing_command: str = "") -> tuple[Path, Pa
 
 
 def _run_runner(
-    tmp_path: Path, subset: str, *, engine_name: str = "podman", failing_command: str = ""
+    tmp_path: Path,
+    subset: str,
+    *,
+    engine_name: str = "podman",
+    failing_command: str = "",
+    host_uid: int | None = None,
+    host_gid: int | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str]:
     """Run the real wrapper with a deterministic successful or failing engine."""
     engine, log = _fake_engine(tmp_path, failing_command=failing_command)
     if engine_name != "podman":
         docker = engine.with_name(engine_name)
         engine.rename(docker)
-        engine = docker
+    if host_uid is not None and host_gid is not None:
+        fake_id = tmp_path / "id"
+        fake_id.write_text(
+            (
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                f'[[ "$1" == "-u" ]] && printf "%s\\n" "{host_uid}" && exit 0\n'
+                f'[[ "$1" == "-g" ]] && printf "%s\\n" "{host_gid}" && exit 0\n'
+                'printf "unsupported id argument: %s\\n" "$1" >&2\n'
+                "exit 2\n"
+            ),
+            encoding="utf-8",
+        )
+        fake_id.chmod(0o755)
     environment = os.environ | {
         "CONTAINER_ENGINE": engine_name,
         "FAKE_ENGINE_LOG": str(log),
@@ -68,12 +89,22 @@ def _run_runner(
     return result, log.read_text(encoding="utf-8")
 
 
-def test_lint_failure_makes_the_runner_fail(tmp_path: Path) -> None:
-    """A failing first command in a multi-command check must not be masked."""
-    result, _log = _run_runner(tmp_path, "lint", failing_command="uv run pre-commit")
+@pytest.mark.parametrize(
+    ("failing_command", "failed_step"),
+    [
+        ("uv run pre-commit", "lint"),
+        ("hephaestus.scripts_lib.check_version_single_source", "version"),
+    ],
+)
+def test_all_preserves_failure_from_multi_command_check(
+    tmp_path: Path, failing_command: str, failed_step: str
+) -> None:
+    """The all target must aggregate an inner failure and continue later gates."""
+    result, log = _run_runner(tmp_path, "all", failing_command=failing_command)
 
     assert result.returncode != 0
-    assert "Failed: lint" in result.stderr
+    assert f"Failed: {failed_step}" in result.stderr
+    assert "detect --source=. --verbose --exit-code=1" in log
 
 
 def test_all_runs_every_local_required_gate(tmp_path: Path) -> None:
@@ -92,9 +123,24 @@ def test_all_runs_every_local_required_gate(tmp_path: Path) -> None:
         assert command in log
 
 
-def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> None:
-    """Docker fallback must not run bind-mounted checks as image-owned UID 1000."""
-    result, log = _run_runner(tmp_path, "unit", engine_name="docker")
+def test_integration_requires_installed_cli_entry_points(tmp_path: Path) -> None:
+    """The integration lane must fail rather than skip when a CLI is absent."""
+    result, log = _run_runner(tmp_path, "integration")
 
     assert result.returncode == 0, result.stderr
-    assert f"--user {os.getuid()}:{os.getgid()}" in log
+    assert "HEPHAESTUS_REQUIRE_CLI=1 uv run pytest tests/integration" in log
+
+
+def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> None:
+    """Docker fallback must not run bind-mounted checks as image-owned UID 1000."""
+    result, log = _run_runner(
+        tmp_path,
+        "unit",
+        engine_name="docker",
+        host_uid=23456,
+        host_gid=23457,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--user 23456:23457" in log
+    assert "--env HOME=/tmp" in log

--- a/tests/unit/ci/test_run_ci_local.py
+++ b/tests/unit/ci/test_run_ci_local.py
@@ -12,14 +12,23 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 RUNNER = REPO_ROOT / "scripts" / "run_ci_local.sh"
 
 
-def _fake_engine(tmp_path: Path, *, failing_command: str = "") -> tuple[Path, Path]:
+def _fake_engine(
+    tmp_path: Path, *, failing_command: str = "", license_violation: bool = False
+) -> tuple[Path, Path]:
     """Create a controlled container-engine boundary that records invocations."""
-    engine = tmp_path / "podman"
+    engine_path = tmp_path / "podman"
     log = tmp_path / "engine.log"
     failure_clause = (
         f'  [[ "$*" == *{failing_command!r}* ]] && exit 37\n' if failing_command else ""
     )
-    engine.write_text(
+    license_violation_clause = (
+        '  [[ "$FAKE_LICENSE_VIOLATION" == "1" && "$*" == *'
+        '"env GITHUB_EVENT_NAME=pull_request uv run python '
+        'scripts/check_license_compatibility.py"* ]] && exit 1\n'
+        if license_violation
+        else ""
+    )
+    engine_path.write_text(
         (
             "#!/usr/bin/env bash\n"
             "set -euo pipefail\n"
@@ -27,11 +36,15 @@ def _fake_engine(tmp_path: Path, *, failing_command: str = "") -> tuple[Path, Pa
             'if [[ "$1" == "images" ]]; then exit 0; fi\n'
             'if [[ "$1" == "run" ]]; then\n'
             '  printf "%q " "$@" >> "$FAKE_ENGINE_LOG"\n'
-            '  printf "\\n" >> "$FAKE_ENGINE_LOG"\n' + failure_clause + "fi\n" + "exit 0\n"
+            '  printf "\\n" >> "$FAKE_ENGINE_LOG"\n'
+            + failure_clause
+            + license_violation_clause
+            + "fi\n"
+            + "exit 0\n"
         ),
         encoding="utf-8",
     )
-    engine.chmod(0o755)
+    engine_path.chmod(0o755)
     for command in ("just", "shellcheck", "bats"):
         executable = tmp_path / command
         executable.write_text(
@@ -42,7 +55,7 @@ def _fake_engine(tmp_path: Path, *, failing_command: str = "") -> tuple[Path, Pa
             encoding="utf-8",
         )
         executable.chmod(0o755)
-    return engine, log
+    return engine_path, log
 
 
 def _run_runner(
@@ -51,14 +64,19 @@ def _run_runner(
     *,
     engine_name: str = "podman",
     failing_command: str = "",
+    license_violation: bool = False,
     host_uid: int | None = None,
     host_gid: int | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str]:
     """Run the real wrapper with a deterministic successful or failing engine."""
-    engine, log = _fake_engine(tmp_path, failing_command=failing_command)
+    engine_path, log = _fake_engine(
+        tmp_path,
+        failing_command=failing_command,
+        license_violation=license_violation,
+    )
     if engine_name != "podman":
-        docker = engine.with_name(engine_name)
-        engine.rename(docker)
+        docker = engine_path.with_name(engine_name)
+        engine_path.rename(docker)
     if host_uid is not None and host_gid is not None:
         fake_id = tmp_path / "id"
         fake_id.write_text(
@@ -76,6 +94,7 @@ def _run_runner(
     environment = os.environ | {
         "CONTAINER_ENGINE": engine_name,
         "FAKE_ENGINE_LOG": str(log),
+        "FAKE_LICENSE_VIOLATION": "1" if license_violation else "0",
         "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
     }
     result = subprocess.run(
@@ -112,6 +131,7 @@ def test_all_runs_every_local_required_gate(tmp_path: Path) -> None:
     result, log = _run_runner(tmp_path, "all")
 
     assert result.returncode == 0, result.stderr
+    assert "All locally executable CI checks passed." in result.stdout
     for command in (
         "bash scripts/check-symlinks.sh",
         "just --evaluate",
@@ -119,8 +139,30 @@ def test_all_runs_every_local_required_gate(tmp_path: Path) -> None:
         "bats --recursive tests/shell",
         "detect --source=. --verbose --exit-code=1",
         "HEPHAESTUS_REQUIRE_CLI=1",
+        "env GITHUB_EVENT_NAME=pull_request uv run python scripts/check_license_compatibility.py",
     ):
         assert command in log
+
+
+def test_all_fails_for_an_injected_license_violation(tmp_path: Path) -> None:
+    """The all target must preserve a blocking PR-mode license failure."""
+    result, log = _run_runner(tmp_path, "all", license_violation=True)
+
+    assert result.returncode != 0
+    assert "Failed: license" in result.stderr
+    assert (
+        "env GITHUB_EVENT_NAME=pull_request uv run python "
+        "scripts/check_license_compatibility.py" in log
+    )
+
+
+def test_explicit_license_mode_remains_advisory(tmp_path: Path) -> None:
+    """The standalone license subset retains the scanner's normal invocation."""
+    result, log = _run_runner(tmp_path, "license")
+
+    assert result.returncode == 0, result.stderr
+    assert "uv run python scripts/check_license_compatibility.py" in log
+    assert "GITHUB_EVENT_NAME=pull_request" not in log
 
 
 def test_integration_requires_installed_cli_entry_points(tmp_path: Path) -> None:
@@ -131,8 +173,17 @@ def test_integration_requires_installed_cli_entry_points(tmp_path: Path) -> None
     assert "HEPHAESTUS_REQUIRE_CLI=1 uv run pytest tests/integration" in log
 
 
+def test_subset_success_message_names_only_the_requested_subset(tmp_path: Path) -> None:
+    """A successful subset must not claim that every local CI check ran."""
+    result, _ = _run_runner(tmp_path, "integration")
+
+    assert result.returncode == 0, result.stderr
+    assert "Local CI subset 'integration' passed." in result.stdout
+    assert "All local CI checks passed." not in result.stdout
+
+
 def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> None:
-    """Docker fallback must not run bind-mounted checks as image-owned UID 1000."""
+    """Docker fallback gives an arbitrary UID a writable uv environment."""
     result, log = _run_runner(
         tmp_path,
         "unit",
@@ -144,3 +195,4 @@ def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
     assert "--user 23456:23457" in log
     assert "--env HOME=/tmp" in log
+    assert "--env UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv" in log

--- a/tests/unit/ci/test_run_ci_local.py
+++ b/tests/unit/ci/test_run_ci_local.py
@@ -183,7 +183,7 @@ def test_subset_success_message_names_only_the_requested_subset(tmp_path: Path) 
 
 
 def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> None:
-    """Docker fallback gives an arbitrary UID a writable uv environment."""
+    """Docker uses its baked environment without syncing as an arbitrary UID."""
     result, log = _run_runner(
         tmp_path,
         "unit",
@@ -195,4 +195,6 @@ def test_docker_uses_the_invoking_user_for_writable_mounts(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
     assert "--user 23456:23457" in log
     assert "--env HOME=/tmp" in log
-    assert "--env UV_PROJECT_ENVIRONMENT=/opt/hephaestus-venv" in log
+    assert "--env UV_NO_SYNC=1" in log
+    assert "--env PYTHONPATH=/workspace" in log
+    assert "UV_PROJECT_ENVIRONMENT" not in log


### PR DESCRIPTION
## Podman-by-default CI

Containerize project-toolchain CI so the Python environment, scans, and test lanes use a reproducible CI image instead of the host environment:

- `ci/Containerfile` — digest-pinned, architecture-aware CI image
- `scripts/run_ci_local.sh` — run every locally executable required check; project-toolchain commands use the CI image and GitHub-hosted tools declare their host prerequisites
- Required workflows run project toolchain jobs through Podman on Ubuntu 24.04 runners
- Merge-queue smoke gate preserved

Validation: focused CI-boundary regression tests, the full `tests/unit/ci` suite, and changed-file pre-commit hooks.

Closes #2691

Closes #2691
