### PR TITLE
fix(automation): bind immutable PR review base

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -195,7 +195,7 @@ class PrReviewJobs(_PrReviewHost):
         return Continue(next_state=REVIEW_WAIT)
 
     def _adopt_direct_pr_worktree(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Create a synchronized isolated checkout for an existing PR."""
+        """Create an isolated checkout for the checkout-bound PR review barrier."""
         if item.pr is None:  # guarded by step(); keeps type narrowing local
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
         branch = ctx.github.get_pr_head_branch(item.pr) or item.branch
@@ -220,7 +220,9 @@ class PrReviewJobs(_PrReviewHost):
             # A detached reviewer checkout cannot reuse the writer's branch
             # checkout.
             "isolated": True,
-            "sync_to_remote": True,
+            # The checkout barrier below is the sole authority allowed to
+            # materialize remote PR state and bind it to the GitHub snapshot.
+            "sync_to_remote": False,
             "pr_number": item.pr,
             "repo_root": str(ctx.paths.repo_root),
         }
@@ -239,7 +241,7 @@ class PrReviewJobs(_PrReviewHost):
         return JobRequest(job, on_done_state=ADOPT_WORKTREE_WAIT)
 
     def _adopt_worktree_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Advance only from a clean, synchronized direct-PR checkout."""
+        """Advance only from a detached direct-PR checkout for later binding."""
         del ctx
         if item.payload.pop("direct_pr_worktree_error", None):
             self._restore_writer_worktree(item)
@@ -264,6 +266,7 @@ class PrReviewJobs(_PrReviewHost):
         if review_context is None:
             return StageOutcome(Disposition.FINISH_FAIL, "pr_review_context_unavailable")
         expected_head = str(review_context.get("pr_head_sha") or "")
+        expected_base = str(review_context.get("pr_base_sha") or "")
         if not expected_head:
             return StageOutcome(Disposition.FINISH_FAIL, "pr_review_head_unavailable")
         base_branch = str(review_context.get("pr_base_branch") or "main")
@@ -278,6 +281,7 @@ class PrReviewJobs(_PrReviewHost):
                 "worktree_path": str(_worktree_path(item, ctx)),
                 "branch": item.branch,
                 "expected_head_sha": expected_head,
+                "expected_base_sha": expected_base,
                 "base_branch": base_branch,
                 "pr_number": item.pr,
             },

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2645,12 +2645,19 @@ class WorkerPool:
         worktree = Path(str(job.kwargs.get("worktree_path") or ""))
         branch = str(job.kwargs.get("branch") or "")
         expected_head = str(job.kwargs.get("expected_head_sha") or "")
+        expected_base = str(job.kwargs.get("expected_base_sha") or "")
         base_branch = str(job.kwargs.get("base_branch") or "main")
         pr_number = job.kwargs.get("pr_number")
-        if not worktree.is_dir() or not branch or not expected_head or not base_branch:
+        if (
+            not worktree.is_dir()
+            or not branch
+            or not _is_full_commit_sha(expected_head)
+            or not _is_full_commit_sha(expected_base)
+            or not base_branch
+        ):
             return JobResult(
                 ok=False,
-                error="review checkout requires worktree, branch, base branch, and head",
+                error="review checkout requires worktree, branch, exact base/head, and base branch",
             )
         if not git_utils.is_clean_working_tree(worktree, timeout=job.timeout_s):
             return JobResult(ok=True, value={"ready": False, "reason": "dirty"})
@@ -2676,12 +2683,14 @@ class WorkerPool:
             timeout=job.timeout_s,
         )
         base = git_utils.run(
-            ["git", "rev-parse", f"origin/{base_branch}"],
+            ["git", "rev-parse", "FETCH_HEAD"],
             cwd=worktree,
             timeout=job.timeout_s,
         ).stdout.strip()
-        if not base:
+        if not _is_full_commit_sha(base):
             return JobResult(ok=False, error="review checkout base ref unavailable")
+        if base != expected_base:
+            return JobResult(ok=True, value={"ready": False, "reason": "base_drift"})
         diff = git_utils.run(
             ["git", "diff", "--no-ext-diff", "--binary", f"{base}...{head}"],
             cwd=worktree,

--- a/hephaestus/automation/pipeline_github_queries.py
+++ b/hephaestus/automation/pipeline_github_queries.py
@@ -374,13 +374,13 @@ class PipelineGitHubQueries(_PipelineGitHubHost):
         return int(match.group(1))
 
     def pr_review_context(self, pr_number: int) -> dict[str, str] | None:
-        """Read the PR metadata that precedes a checkout-bound review.
+        """Read immutable PR metadata that precedes a checkout-bound review.
 
         A direct ``--prs`` seed must not grant the only review GO/NOGO based
         solely on a PR number.  The diff intentionally does *not* come from
-        ``gh pr diff``: an ABA head race could otherwise pair another commit's
-        mutable remote diff with this head.  The checkout barrier derives the
-        diff locally after it proves this exact head.
+        ``gh pr diff``: an ABA race could otherwise pair another commit's
+        mutable remote diff with this base/head pair.  The checkout barrier
+        derives the diff locally after it proves both exact commits.
         """
         try:
             body_result = self._gh(
@@ -389,7 +389,7 @@ class PipelineGitHubQueries(_PipelineGitHubHost):
                     "view",
                     str(pr_number),
                     "--json",
-                    "title,body,headRefOid,baseRefName",
+                    "title,body,headRefOid,baseRefOid,baseRefName",
                 ]
             )
             body_data = json.loads(body_result.stdout or "{}")
@@ -401,12 +401,15 @@ class PipelineGitHubQueries(_PipelineGitHubHost):
         title = body_data.get("title")
         body = body_data.get("body")
         head = body_data.get("headRefOid")
+        base = body_data.get("baseRefOid")
         base_branch = body_data.get("baseRefName")
         if (
             not isinstance(title, str)
             or not isinstance(body, str)
             or not isinstance(head, str)
             or not head
+            or not isinstance(base, str)
+            or not base
             or not isinstance(base_branch, str)
             or not base_branch
         ):
@@ -415,6 +418,7 @@ class PipelineGitHubQueries(_PipelineGitHubHost):
             "pr_title": github_api.strip_null_bytes(title),
             "pr_description": github_api.strip_null_bytes(body),
             "pr_head_sha": head,
+            "pr_base_sha": base,
             "pr_base_branch": base_branch,
         }
 

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -711,6 +711,7 @@ class TestPrReviewStageStep:
                 "pr_diff": "diff --git a/a.py b/a.py\n+new\n",
                 "pr_description": "Closes #1",
                 "pr_head_sha": "a" * 40,
+                "pr_base_sha": "b" * 40,
                 "pr_base_branch": "main",
             }
         )
@@ -729,6 +730,7 @@ class TestPrReviewStageStep:
             "worktree_path": "/tmp/repo/review-worktree",
             "branch": "review-branch",
             "expected_head_sha": "a" * 40,
+            "expected_base_sha": "b" * 40,
             "base_branch": "main",
             "pr_number": 1001,
         }
@@ -981,7 +983,7 @@ class TestPrReviewStageStep:
             "branch_name": "review-pr",
             "refresh_base": False,
             "isolated": True,
-            "sync_to_remote": True,
+            "sync_to_remote": False,
             "pr_number": 1001,
             "repo_root": str(ctx.paths.repo_root),
         }

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2323,6 +2323,8 @@ class TestGitOps:
                 "worktree_path": str(tmp_path),
                 "branch": "70-existing",
                 "expected_head_sha": "a" * 40,
+                "expected_base_sha": "b" * 40,
+                "base_branch": "main",
                 "pr_number": 70,
             },
         )
@@ -2352,6 +2354,8 @@ class TestGitOps:
                 "worktree_path": str(tmp_path),
                 "branch": "70-existing",
                 "expected_head_sha": "a" * 40,
+                "expected_base_sha": "b" * 40,
+                "base_branch": "main",
                 "pr_number": 70,
             },
         )
@@ -2366,6 +2370,46 @@ class TestGitOps:
         assert result.ok is True
         assert result.value == {"ready": False, "reason": "head_drift"}
         mock_sync.assert_called_once_with(tmp_path, "70-existing", pr_number=70, timeout=60)
+
+    def test_verify_pr_review_checkout_retries_when_remote_base_drifted(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A moved base ref cannot produce review evidence for the captured PR."""
+        job = GitJob(
+            repo="test/repo",
+            op="verify_pr_review_checkout",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path),
+                "branch": "70-existing",
+                "expected_head_sha": "a" * 40,
+                "expected_base_sha": "c" * 40,
+                "base_branch": "main",
+                "pr_number": 70,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True),
+            patch(f"{_WP}.git_utils.sync_worktree_to_remote_branch"),
+            patch(
+                f"{_WP}.git_utils.run",
+                side_effect=[
+                    MagicMock(stdout="a" * 40 + "\n"),
+                    MagicMock(stdout=""),
+                    MagicMock(stdout="b" * 40 + "\n"),
+                    MagicMock(stdout="checkout diff for stale base"),
+                    MagicMock(stdout="stale.py\0"),
+                ],
+            ),
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {"ready": False, "reason": "base_drift"}
 
     def test_verify_pr_review_checkout_returns_diff_bound_to_verified_head(
         self,
@@ -2382,6 +2426,7 @@ class TestGitOps:
                 "worktree_path": str(tmp_path),
                 "branch": "70-existing",
                 "expected_head_sha": "a" * 40,
+                "expected_base_sha": "b" * 40,
                 "base_branch": "main",
                 "pr_number": 70,
             },
@@ -2412,6 +2457,7 @@ class TestGitOps:
             "changed_paths": ["old.py", "new.py"],
         }
         mock_sync.assert_called_once_with(tmp_path, "70-existing", pr_number=70, timeout=60)
+        assert mock_run.call_args_list[2].args[0] == ["git", "rev-parse", "FETCH_HEAD"]
         assert mock_run.call_args_list[3].args[0] == [
             "git",
             "diff",
@@ -2443,6 +2489,8 @@ class TestGitOps:
                 "worktree_path": str(tmp_path),
                 "branch": "70-existing",
                 "expected_head_sha": "a" * 40,
+                "expected_base_sha": "b" * 40,
+                "base_branch": "main",
                 "pr_number": 70,
             },
         )

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -4568,6 +4568,7 @@ class TestReadSurface:
                             "title": "docs(policy): current metadata",
                             "body": "Closes #1899\n",
                             "headRefOid": "a" * 40,
+                            "baseRefOid": "b" * 40,
                             "baseRefName": "main",
                         }
                     )
@@ -4584,6 +4585,7 @@ class TestReadSurface:
             "pr_title": "docs(policy): current metadata",
             "pr_description": "Closes #1899\n",
             "pr_head_sha": "a" * 40,
+            "pr_base_sha": "b" * 40,
             "pr_base_branch": "main",
         }
         assert calls == [
@@ -4592,7 +4594,7 @@ class TestReadSurface:
                 "view",
                 "1984",
                 "--json",
-                "title,body,headRefOid,baseRefName",
+                "title,body,headRefOid,baseRefOid,baseRefName",
                 "--repo",
                 "org/repo-a",
             ],
@@ -4612,6 +4614,7 @@ class TestReadSurface:
                         "title": "current title",
                         "body": "Closes #1899",
                         "headRefOid": "a" * 40,
+                        "baseRefOid": "b" * 40,
                         "baseRefName": "main",
                     }
                 )


### PR DESCRIPTION
## Summary

- capture GitHub's immutable PR base SHA with the head SHA
- reject base drift before deriving review evidence
- keep detached review checkout synchronization inside the authoritative barrier

## Validation

- uv run pytest tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_worker_pool.py tests/unit/automation/test_pipeline_github.py --no-cov -q
- uv run ruff check changed files
- uv run mypy changed automation modules

Closes #2680
