### PR TITLE
chore(automation): remove deprecated timeout environment aliases

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1428,9 +1428,11 @@ are NOT retried.
  `ci_driver_claude_timeout()` /
  `learn_claude_timeout()` /
  [`...`](../hephaestus/automation/agent_config.py) are
- phase-specific CLI-time defaults; every per-phase timeout reads
- `HEPH_<PHASE>_AGENT_TIMEOUT` so operators can tune without code
- change.
+ phase-specific CLI-time defaults. Shared phase budgets accept only
+ `HEPH_AGENT_PLAN_TIMEOUT`, `HEPH_AGENT_REVIEW_TIMEOUT`,
+ `HEPH_AGENT_IMPL_TIMEOUT`, and `HEPH_AGENT_LEARN_TIMEOUT`; the outer planning
+ wrapper accepts `HEPH_PLAN_STAGE_TIMEOUT`. Deprecated phase-specific fallback
+ aliases are not consulted.
 
 ---
 

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -38,10 +38,12 @@ the Codex provider and never modify Claude or Pi model IDs.
 
 Timeouts
 --------
-Each phase that shells out to an agent CLI or ``gh`` has historically
-hard-coded its own timeout. Centralising them here gives operators a way to
-tune slow repos / network conditions without code changes via
-``HEPH_<PHASE>_AGENT_TIMEOUT`` environment variables (values in seconds).
+Agent timeout overrides are accepted only from their canonical environment
+variables. Shared phase budgets use ``HEPH_AGENT_PLAN_TIMEOUT``,
+``HEPH_AGENT_REVIEW_TIMEOUT``, ``HEPH_AGENT_IMPL_TIMEOUT``, and
+``HEPH_AGENT_LEARN_TIMEOUT``; the outer planning wrapper uses
+``HEPH_PLAN_STAGE_TIMEOUT``. The remaining timeout accessors retain their
+function-specific ``HEPH_*`` variables defined below.
 
 If an env var is set but not an integer, the default is used and a warning is
 logged on first read; we never crash on a malformed timeout because the cost
@@ -249,38 +251,22 @@ def agent_default_timeout() -> int:
 
 def planner_claude_timeout() -> int:
     """Timeout for planner agent calls (default 1200s)."""
-    return read_timeout_env(
-        "HEPH_AGENT_PLAN_TIMEOUT",
-        AGENT_PLAN_TIMEOUT,
-        legacy_names=("HEPH_PLANNER_AGENT_TIMEOUT",),
-    )
+    return read_timeout_env("HEPH_AGENT_PLAN_TIMEOUT", AGENT_PLAN_TIMEOUT)
 
 
 def plan_stage_timeout() -> int:
     """Timeout for the outer ``hephaestus-plan-issues`` stage (default 7200s)."""
-    return read_timeout_env(
-        "HEPH_PLAN_STAGE_TIMEOUT",
-        PLAN_STAGE_TIMEOUT,
-        legacy_names=("HEPH_PLANNER_AGENT_TIMEOUT",),
-    )
+    return read_timeout_env("HEPH_PLAN_STAGE_TIMEOUT", PLAN_STAGE_TIMEOUT)
 
 
 def plan_reviewer_claude_timeout() -> int:
     """Timeout for agent calls inside the plan reviewer (default 1200s)."""
-    return read_timeout_env(
-        "HEPH_AGENT_REVIEW_TIMEOUT",
-        AGENT_REVIEW_TIMEOUT,
-        legacy_names=("HEPH_PLAN_REVIEWER_AGENT_TIMEOUT",),
-    )
+    return read_timeout_env("HEPH_AGENT_REVIEW_TIMEOUT", AGENT_REVIEW_TIMEOUT)
 
 
 def implementer_claude_timeout() -> int:
     """Timeout for the implementer's agent invocation (default 1800s)."""
-    return read_timeout_env(
-        "HEPH_AGENT_IMPL_TIMEOUT",
-        AGENT_IMPL_TIMEOUT,
-        legacy_names=("HEPH_IMPLEMENTER_AGENT_TIMEOUT",),
-    )
+    return read_timeout_env("HEPH_AGENT_IMPL_TIMEOUT", AGENT_IMPL_TIMEOUT)
 
 
 def advise_claude_timeout() -> int:
@@ -290,11 +276,7 @@ def advise_claude_timeout() -> int:
 
 def pr_reviewer_claude_timeout() -> int:
     """Timeout for the PR reviewer's agent analysis (default 1200s)."""
-    return read_timeout_env(
-        "HEPH_AGENT_REVIEW_TIMEOUT",
-        AGENT_REVIEW_TIMEOUT,
-        legacy_names=("HEPH_PR_REVIEWER_AGENT_TIMEOUT",),
-    )
+    return read_timeout_env("HEPH_AGENT_REVIEW_TIMEOUT", AGENT_REVIEW_TIMEOUT)
 
 
 def address_review_claude_timeout() -> int:
@@ -309,11 +291,7 @@ def ci_driver_claude_timeout() -> int:
 
 def learn_claude_timeout() -> int:
     """Timeout for ``/learn`` agent calls (default 1200s)."""
-    return read_timeout_env(
-        "HEPH_AGENT_LEARN_TIMEOUT",
-        AGENT_LEARN_TIMEOUT,
-        legacy_names=("HEPH_LEARN_AGENT_TIMEOUT",),
-    )
+    return read_timeout_env("HEPH_AGENT_LEARN_TIMEOUT", AGENT_LEARN_TIMEOUT)
 
 
 def follow_up_claude_timeout() -> int:

--- a/hephaestus/constants.py
+++ b/hephaestus/constants.py
@@ -81,28 +81,21 @@ PRE_PR_TEST_TIMEOUT: int = 600
 _REPO_ROOT_MARKER = "pyproject.toml"
 
 
-def read_timeout_env(
-    env_name: str,
-    default: int,
-    *,
-    legacy_names: tuple[str, ...] = (),
-) -> int:
+def read_timeout_env(env_name: str, default: int) -> int:
     """Read a timeout env var at call time, falling back to ``default``."""
-    for name in (env_name, *legacy_names):
-        raw = os.environ.get(name)
-        if raw is None:
-            continue
-        try:
-            return int(raw)
-        except ValueError:
-            _logger.warning(
-                "Ignoring non-integer %s=%r; using default %ds",
-                name,
-                raw,
-                default,
-            )
-            return default
-    return default
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        _logger.warning(
+            "Ignoring non-integer %s=%r; using default %ds",
+            env_name,
+            raw,
+            default,
+        )
+        return default
 
 
 def agent_impl_timeout() -> int:

--- a/tests/unit/automation/test_claude_timeouts.py
+++ b/tests/unit/automation/test_claude_timeouts.py
@@ -15,14 +15,12 @@ DEFAULT_THROUGHPUT_TIMEOUT_S = 1200
 
 def _clear_planner_timeout_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HEPH_AGENT_PLAN_TIMEOUT", raising=False)
-    monkeypatch.delenv("HEPH_PLANNER_AGENT_TIMEOUT", raising=False)
     monkeypatch.delenv("HEPH_PLANNER_CLAUDE_TIMEOUT", raising=False)
 
 
 def _clear_plan_stage_timeout_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HEPH_AGENT_PLAN_TIMEOUT", raising=False)
     monkeypatch.delenv("HEPH_PLAN_STAGE_TIMEOUT", raising=False)
-    monkeypatch.delenv("HEPH_PLANNER_AGENT_TIMEOUT", raising=False)
 
 
 def test_planner_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -76,16 +74,6 @@ def test_plan_stage_timeout_env(
     """HEPH_PLAN_STAGE_TIMEOUT tunes the outer plan-stage wrapper."""
     _clear_plan_stage_timeout_env(monkeypatch)
     monkeypatch.setenv("HEPH_PLAN_STAGE_TIMEOUT", "9000")
-
-    assert claude_timeouts.plan_stage_timeout() == 9000
-
-
-def test_plan_stage_timeout_legacy_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The old planner-specific env name still tunes the wrapper for compatibility."""
-    _clear_plan_stage_timeout_env(monkeypatch)
-    monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "9000")
 
     assert claude_timeouts.plan_stage_timeout() == 9000
 
@@ -193,57 +181,58 @@ def test_agent_timeout_envs_are_read_per_call(
 
 
 @pytest.mark.parametrize(
-    ("primary_env", "legacy_env", "timeout_fn"),
+    ("canonical_env", "deprecated_env", "timeout_fn", "default"),
     [
         (
             "HEPH_AGENT_PLAN_TIMEOUT",
             "HEPH_PLANNER_AGENT_TIMEOUT",
             claude_timeouts.planner_claude_timeout,
+            DEFAULT_THROUGHPUT_TIMEOUT_S,
+        ),
+        (
+            "HEPH_PLAN_STAGE_TIMEOUT",
+            "HEPH_PLANNER_AGENT_TIMEOUT",
+            claude_timeouts.plan_stage_timeout,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_AGENT_REVIEW_TIMEOUT",
             "HEPH_PLAN_REVIEWER_AGENT_TIMEOUT",
             claude_timeouts.plan_reviewer_claude_timeout,
+            DEFAULT_THROUGHPUT_TIMEOUT_S,
         ),
         (
             "HEPH_AGENT_IMPL_TIMEOUT",
             "HEPH_IMPLEMENTER_AGENT_TIMEOUT",
             claude_timeouts.implementer_claude_timeout,
+            1800,
         ),
         (
             "HEPH_AGENT_REVIEW_TIMEOUT",
             "HEPH_PR_REVIEWER_AGENT_TIMEOUT",
             claude_timeouts.pr_reviewer_claude_timeout,
+            DEFAULT_THROUGHPUT_TIMEOUT_S,
         ),
         (
             "HEPH_AGENT_LEARN_TIMEOUT",
             "HEPH_LEARN_AGENT_TIMEOUT",
             claude_timeouts.learn_claude_timeout,
+            DEFAULT_THROUGHPUT_TIMEOUT_S,
         ),
     ],
 )
-def test_phase_specific_agent_envs_are_legacy_fallbacks(
+def test_deprecated_agent_timeout_aliases_are_ignored(
     monkeypatch: pytest.MonkeyPatch,
-    primary_env: str,
-    legacy_env: str,
+    canonical_env: str,
+    deprecated_env: str,
     timeout_fn: Callable[[], int],
+    default: int,
 ) -> None:
-    """Old phase-specific HEPH_*_AGENT_TIMEOUT names remain supported."""
-    monkeypatch.delenv(primary_env, raising=False)
-    monkeypatch.setenv(legacy_env, "555")
+    """Deprecated phase-specific timeout aliases do not affect configuration."""
+    monkeypatch.delenv(canonical_env, raising=False)
+    monkeypatch.setenv(deprecated_env, "555")
 
-    assert timeout_fn() == 555
-
-
-def test_planner_timeout_primary_env_wins_over_legacy(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The new HEPH_AGENT_PLAN_TIMEOUT wins over the old planner-specific name."""
-    _clear_planner_timeout_env(monkeypatch)
-    monkeypatch.setenv("HEPH_AGENT_PLAN_TIMEOUT", "444")
-    monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "555")
-
-    assert claude_timeouts.planner_claude_timeout() == 444
+    assert timeout_fn() == default
 
 
 def test_planner_timeout_invalid_agent_env_logs_and_defaults(

--- a/tests/unit/constants/test_constants.py
+++ b/tests/unit/constants/test_constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 
 import pytest
@@ -133,37 +134,11 @@ def test_read_timeout_env_reads_primary_env_per_call(
     assert constants.agent_git_timeout() == 42
 
 
-def test_read_timeout_env_supports_legacy_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Callers can preserve old phase-specific env names while using new defaults."""
-    monkeypatch.delenv("HEPH_AGENT_PLAN_TIMEOUT", raising=False)
-    monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "901")
-
-    assert (
-        constants.read_timeout_env(
-            "HEPH_AGENT_PLAN_TIMEOUT",
-            constants.AGENT_PLAN_TIMEOUT,
-            legacy_names=("HEPH_PLANNER_AGENT_TIMEOUT",),
-        )
-        == 901
-    )
-
-
-def test_read_timeout_env_prefers_primary_over_legacy(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The new generic env name wins when both primary and legacy names are set."""
-    monkeypatch.setenv("HEPH_AGENT_PLAN_TIMEOUT", "301")
-    monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "901")
-
-    assert (
-        constants.read_timeout_env(
-            "HEPH_AGENT_PLAN_TIMEOUT",
-            constants.AGENT_PLAN_TIMEOUT,
-            legacy_names=("HEPH_PLANNER_AGENT_TIMEOUT",),
-        )
-        == 301
+def test_read_timeout_env_has_no_legacy_names_parameter() -> None:
+    """The timeout helper exposes only one canonical environment-variable name."""
+    assert tuple(inspect.signature(constants.read_timeout_env).parameters) == (
+        "env_name",
+        "default",
     )
 
 
@@ -176,20 +151,3 @@ def test_read_timeout_env_falls_back_on_malformed_value(
     monkeypatch.setenv("HEPH_AGENT_GIT_TIMEOUT", bad_value)
 
     assert constants.read_timeout_env("HEPH_AGENT_GIT_TIMEOUT", 77) == 77
-
-
-def test_read_timeout_env_falls_back_on_malformed_legacy_value(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A malformed legacy override falls back to the default rather than crashing."""
-    monkeypatch.delenv("HEPH_AGENT_PLAN_TIMEOUT", raising=False)
-    monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "not-a-number")
-
-    assert (
-        constants.read_timeout_env(
-            "HEPH_AGENT_PLAN_TIMEOUT",
-            constants.AGENT_PLAN_TIMEOUT,
-            legacy_names=("HEPH_PLANNER_AGENT_TIMEOUT",),
-        )
-        == constants.AGENT_PLAN_TIMEOUT
-    )


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2473.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2473

Generated by Hephaestus automation
