### PR TITLE
fix(ci): retry pinned GitHub artifact downloads

### DIFF
--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
         arm64) uv_asset="uv-aarch64-unknown-linux-gnu"; uv_sha256="769d373e146692c639b5fbaae33b331c297a32e03d30448772051902df52bbf4" ;; \
         *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
     esac \
-    && curl -fsSL "https://github.com/astral-sh/uv/releases/download/0.12.1/${uv_asset}.tar.gz" -o /tmp/uv.tar.gz \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 180 --connect-timeout 30 --max-time 300 "https://github.com/astral-sh/uv/releases/download/0.12.1/${uv_asset}.tar.gz" -o /tmp/uv.tar.gz \
     && echo "${uv_sha256}  /tmp/uv.tar.gz" | sha256sum --check \
     && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
     && rm /tmp/uv.tar.gz
@@ -161,7 +161,7 @@ RUN case "$TARGETARCH" in \
         arm64) gh_arch="arm64"; gh_sha256="0ba7a76739c865d82ebde24667d875d9b8caa55db47c7597c24accdd4defd2bb" ;; \
         *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
     esac \
-    && curl -fsSL "https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_${gh_arch}.deb" -o /tmp/gh.deb \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 180 --connect-timeout 30 --max-time 300 "https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_${gh_arch}.deb" -o /tmp/gh.deb \
     && echo "${gh_sha256}  /tmp/gh.deb" | sha256sum --check \
     && apt-get install -y /tmp/gh.deb \
     && rm -f /tmp/gh.deb

--- a/tests/unit/ci/test_containerfile_contract.py
+++ b/tests/unit/ci/test_containerfile_contract.py
@@ -94,3 +94,19 @@ def test_runtime_tools_follow_the_requested_build_architecture() -> None:
     assert 'echo "${gh_sha256}  /tmp/gh.deb" | sha256sum --check' in source
 
     assert source.count('*) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1') == 2
+
+
+def test_github_artifact_downloads_retry_transient_network_failures() -> None:
+    """Pinned GitHub downloads must survive transient runner network resets."""
+    source = CONTAINERFILE.read_text(encoding="utf-8")
+    download_lines = [
+        line.strip()
+        for line in source.splitlines()
+        if "curl -fsSL" in line and '"https://github.com/' in line
+    ]
+
+    assert len(download_lines) == 2
+    for line in download_lines:
+        assert "--retry 5" in line
+        assert "--retry-all-errors" in line
+        assert "--connect-timeout 30" in line


### PR DESCRIPTION
## Summary

- retry transient network failures when the CI image downloads pinned uv and GitHub CLI artifacts
- add a Containerfile contract regression test for the retry policy

## Root cause

Required Checks run 31207121624 failed in license-scan while curl downloaded the pinned uv archive and received Connection reset by peer. The remaining required jobs passed.

## Verification

- uv run --all-extras --locked pytest -q — 7,348 passed, 12 skipped, 5 deselected
- total coverage: 83.95%
- local targeted CI contract tests, Ruff, formatting, and diff checks passed
- Podman image build was not available locally because the Podman VM was unavailable

Closes #2708