### PR TITLE
fix(automation): recover queue runtime races

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1057,6 +1057,13 @@ Architectural contract:
 - The implementation agent replies to every fixed open thread but never resolves it.
 - The implementation stage rebases and lease-publishes the writer branch before
   review; a rebase is never performed by a reviewer checkout.
+- When that host rebase conflicts, it remains paused under the captured base and
+  PR-head lease. A separately budgeted edit-only agent may modify only the
+  host-reported conflict paths and has no shell/Git tool. The host rejects a
+  no-op, unresolved markers, index mutation, remote-head drift, missing captured
+  base ancestry, or unsigned/non-DCO replayed commits. Only the host stages the
+  resolution, continues the policy-signing rebase, and exact-lease-publishes the
+  rewritten head; the result always returns to a fresh PR review.
 - A post-push implementation-reply handoff is an exact, bounded host-only
   retry of one immutable response batch. A failed or partial PR-state read,
   including a per-thread read that temporarily lags the just-pushed head,
@@ -1222,7 +1229,7 @@ budgets. Every `routes.py` row and every doc row MUST agree.
 | `repo` | `FINISHED` | `*` → `FINISHED` | `clone = 2` |
 | `planning` | `PLAN_REVIEW` | `*` → `FINISHED` | `plan = 2` |
 | `plan_review` | `IMPLEMENTATION` | `nogo` → `PLANNING`; `plan_cycles_exhausted` → `FINISHED`; `*` → `PLANNING` | `plan_review_iter = 3`, `plan_cycles = 2` |
-| `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `test_fix = 1` |
+| `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `rebase_conflict = 2`, `test_fix = 1` |
 | `pr_review` | `MERGE_WAIT` | `agent_error` or `implementation_remediation` → `IMPLEMENTATION`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
 | `merge_wait` | `FINISHED` | `not_implementation_go`, `reviewed_head_missing`, or `reviewed_head_drift` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | `merge = 5` |
 | `finished` | `FINISHED` | — (terminal) | — |
@@ -1233,8 +1240,8 @@ Budget provenance (cross-check):
   are defined in [`pipeline/routing.py`](../hephaestus/automation/pipeline/routing.py),
   with the latter as the progress-aware extension cap.
 - `clone = 2`, `plan = 2`, `plan_cycles = 2`, `implement = 2`,
- `test_fix = 1`, `merge =
- DEFAULT_DRIVE_GREEN_LOOPS = 5` ←
+  `rebase_conflict = 2`, and `test_fix = 1` are fixed stage budgets.
+- `merge = DEFAULT_DRIVE_GREEN_LOOPS = 5` ←
  [`loop_runner.py LoopConfig.drive_green_loops`](../hephaestus/automation/loop_runner.py).
 - `merge = 5` (CLI default for `--drive-green-loops`,
  [`DEFAULT_DRIVE_GREEN_LOOPS`](../hephaestus/automation/pipeline/routing.py))

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -998,6 +998,7 @@ def rebase_worktree_onto(
     base_branch: str = "main",
     *,
     remote: str = "origin",
+    preserve_conflicts: bool = False,
     timeout: int | None = None,
 ) -> bool:
     """Mechanically rebase the worktree at ``cwd`` onto ``<remote>/<base_branch>``.
@@ -1015,8 +1016,10 @@ def rebase_worktree_onto(
     2. ``git rebase --force-rebase <remote>/<base_branch> --exec ...`` —
        replay the PR's commits on top of the latest base and run
        ``git commit --amend --no-edit -S -s`` after each replayed commit. On
-       conflict, ``git rebase --abort`` restores the pre-rebase HEAD so the
-       worktree is left clean for the agent path.
+       conflict, the default ``git rebase --abort`` restores the pre-rebase
+       HEAD. ``preserve_conflicts=True`` instead leaves the host-owned rebase
+       paused so an edit-only agent can change file contents before the host
+       validates and continues it.
 
     The caller is expected to push the rebased HEAD with
     :func:`push_current_branch_with_lease_on_divergence` (the rebase rewrites
@@ -1026,6 +1029,8 @@ def rebase_worktree_onto(
         cwd: Worktree path (already synced to the PR head).
         base_branch: Branch to rebase onto (default ``main``).
         remote: Remote name (default ``origin``).
+        preserve_conflicts: Leave a conflicted rebase paused for a later
+            host-owned continuation instead of aborting it.
         timeout: Optional timeout in seconds for each git command.
 
     Returns:
@@ -1047,15 +1052,16 @@ def rebase_worktree_onto(
         logger.info("Rebased worktree at %s onto %s/%s cleanly", cwd, remote, base_branch)
         return True
     except subprocess.CalledProcessError:
-        # Conflicts — abort so the worktree is restored to the PR head, then let
-        # the caller hand the real conflict to the agent. ``check=False`` because
-        # an abort that itself errors must not mask the conflict signal.
-        run(["git", "rebase", "--abort"], cwd=cwd, check=False, **_timeout_kw(timeout))
+        if not preserve_conflicts:
+            # ``check=False`` because an abort error must not mask the original
+            # conflict signal.
+            run(["git", "rebase", "--abort"], cwd=cwd, check=False, **_timeout_kw(timeout))
         logger.info(
-            "Rebase of worktree at %s onto %s/%s hit conflicts; aborted",
+            "Rebase of worktree at %s onto %s/%s hit conflicts; %s",
             cwd,
             remote,
             base_branch,
+            "preserved for host-owned resolution" if preserve_conflicts else "aborted",
         )
         return False
 

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from . import coordinator_observability as _observability
 from .coordinator_contract import _CoordinatorHost
+from .coordinator_shutdown import shutdown_signal_message
 from .coordinator_types import *
 
 # This collaborator consumes the façade's shared type namespace by design.
@@ -1325,14 +1326,12 @@ class CoordinatorRuntime(_CoordinatorHost):
 
         def _handler(signum: int, frame: object) -> None:
             if self.shutdown.is_set():
-                logger.warning("second signal %d: immediate shutdown", signum)
+                logger.warning(shutdown_signal_message(signum, self.config.grace_s, immediate=True))
                 self._immediate = True
                 self._wake_completion_wait()
             else:
                 logger.warning(
-                    "signal %d: graceful shutdown (grace %.0fs; press again to force)",
-                    signum,
-                    self.config.grace_s,
+                    shutdown_signal_message(signum, self.config.grace_s, immediate=False)
                 )
                 self.shutdown.set()
                 self._grace_deadline = time.monotonic() + self.config.grace_s

--- a/hephaestus/automation/pipeline/coordinator_shutdown.py
+++ b/hephaestus/automation/pipeline/coordinator_shutdown.py
@@ -1,0 +1,17 @@
+"""Operator-facing shutdown guidance for the queue coordinator."""
+
+from __future__ import annotations
+
+import signal
+
+
+def shutdown_signal_message(signum: int, grace_s: float, *, immediate: bool) -> str:
+    """Return guidance for the coordinator's cooperative shutdown."""
+    signal_name = "Ctrl+C" if signum == signal.SIGINT else f"signal {signum}"
+    if immediate:
+        return f"second {signal_name} received: forcing immediate teardown"
+    instruction = "press Ctrl+C again" if signum == signal.SIGINT else "send signal again"
+    return (
+        f"{signal_name} received: timed graceful shutdown started ({grace_s:.0f}s); "
+        f"{instruction} to force teardown"
+    )

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -164,6 +164,7 @@ from hephaestus.prompts import PromptCatalog
 
 logger = logging.getLogger(__name__)
 
+
 #: Warn when any stage.step() call exceeds this duration (seconds) — the
 #: stage protocol promises short (<~60s) main-thread steps. 15s proved too
 #: tight in practice: routine repo-stage steps (clone + label reads over the

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -27,6 +27,7 @@ GIT_OPS: frozenset[str] = frozenset(
         "verify_pr_review_checkout",
         "remove_worktree",
         "rebase",
+        "continue_rebase",
         "push",
         "commit_push",
         "release_branch_reservation",

--- a/hephaestus/automation/pipeline/plan_journal.py
+++ b/hephaestus/automation/pipeline/plan_journal.py
@@ -62,6 +62,10 @@ class PlanJournalGitHub(Protocol):
         pass
 
 
+class PlanRevisionOwnershipError(RuntimeError):
+    """A different pipeline item owns the authoritative plan revision."""
+
+
 def _upsert_pending_review(
     issue_number: int,
     revision: int,
@@ -89,9 +93,9 @@ def _confirm_publication(
         or snapshot.current_review_revision != expected_revision
         or not is_pending_review(snapshot.current_review, revision=expected_revision)
     ):
-        raise RuntimeError(
+        raise PlanRevisionOwnershipError(
             f"concurrent plan journal write detected for revision {expected_revision}; "
-            "manual recovery is required"
+            "another pipeline item owns the published revision"
         )
 
 
@@ -278,7 +282,7 @@ def publish_plan_revision(
         if isinstance(label, (dict, str))
     }
     if not is_exclusive_plan_state(labels, STATE_PLAN_NO_GO):
-        raise RuntimeError(
+        raise PlanRevisionOwnershipError(
             f"cannot supersede plan revision {snapshot.revision} without an authoritative "
             f"exclusive {STATE_PLAN_NO_GO} label"
         )

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -83,7 +83,8 @@ class Route:
 #   plan_review_iter=3, pr_review_iter=3, pr_review_hard=6
 #                                             <- architecture doc stage sections
 #   clone=2, plan=2, plan_cycles=2,
-#   implement=2, test_fix=1                <- architecture doc stage sections
+#   implement=2, rebase_conflict=2, test_fix=1
+#                                             <- architecture doc stage sections
 #   merge=DEFAULT_DRIVE_GREEN_LOOPS        <- loop_runner.py LoopConfig.drive_green_loops
 #                                             and --drive-green-loops defaults
 ROUTES: dict[StageName, Route] = {
@@ -115,7 +116,7 @@ ROUTES: dict[StageName, Route] = {
             "already_implementation_go_pr": StageName.MERGE_WAIT,
             "*": StageName.FINISHED,
         },
-        budgets={"implement": 2, "test_fix": 1},
+        budgets={"implement": 2, "rebase_conflict": 2, "test_fix": 1},
     ),
     StageName.PR_REVIEW: Route(
         next=StageName.MERGE_WAIT,
@@ -138,6 +139,8 @@ ROUTES: dict[StageName, Route] = {
             "not_implementation_go": StageName.PR_REVIEW,
             "reviewed_head_missing": StageName.PR_REVIEW,
             "reviewed_head_drift": StageName.PR_REVIEW,
+            "merge_conflicting": StageName.IMPLEMENTATION,
+            "post_review_rebase_required": StageName.IMPLEMENTATION,
             "*": StageName.FINISHED,
         },
         budgets={"merge": DEFAULT_DRIVE_GREEN_LOOPS},

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -8,13 +8,15 @@ ownership check) and
 binding contract):
 
 - States: ENTER -> GATE -> WORKTREE_WAIT -> DIRTY_DECISION_WAIT ->
-  ADVISE_WAIT -> IMPLEMENT_WAIT -> TEST_WAIT -> TESTFIX_WAIT ->
+  ADVISE_WAIT -> IMPLEMENT_WAIT -> REBASE_CONTINUE_WAIT / TEST_WAIT -> TESTFIX_WAIT ->
   COMMIT_PUSH_WAIT -> PR_CREATE. The existing-PR fast path short-circuits
   WORKTREE_WAIT -> DIRTY_DECISION_WAIT -> ADOPTED (ADVANCE to pr_review).
-- Budgets: ``implement`` = 2 (bounds implement attempts INCLUDING
+- Budgets: ``implement`` = 2 (bounds ordinary implement attempts INCLUDING
   agent_error retries — the doc's "agent_error -> RETRY (consumes the
   implement budget)"), ``test_fix`` = 1 (one fix attempt on red pre-PR
-  tests). Both read from ROUTES via ``ctx.budget``, never hardcoded here.
+  tests), ``rebase_conflict`` = 2 (bounds edit-only conflict-resolution
+  turns independently), and ``test_fix`` = 1. All read from ROUTES via
+  ``ctx.budget``, never hardcoded here.
 - GATE [M]: ``state:skip`` check first (operator-only, absolute — #1835);
   skips the item regardless of plan-go/implementation-go, before either the
   existing-PR fast path or the fresh-implement plan-go gate below. Then the
@@ -169,6 +171,8 @@ GATE = "GATE"
 WORKTREE_WAIT = "WORKTREE_WAIT"
 DIRTY_DECISION_WAIT = "DIRTY_DECISION_WAIT"
 REBASE_WAIT = "REBASE_WAIT"
+REBASE_CONFLICT_WAIT = "REBASE_CONFLICT_WAIT"
+REBASE_CONTINUE_WAIT = "REBASE_CONTINUE_WAIT"
 ADOPTED = "ADOPTED"
 ADVISE_WAIT = "ADVISE_WAIT"
 IMPLEMENT_WAIT = "IMPLEMENT_WAIT"
@@ -186,6 +190,8 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     WORKTREE_WAIT: "_worktree_wait",
     DIRTY_DECISION_WAIT: "_dirty_decision_wait",
     REBASE_WAIT: "_rebase_wait",
+    REBASE_CONFLICT_WAIT: "_rebase_conflict_wait",
+    REBASE_CONTINUE_WAIT: "_rebase_continue_wait",
     ADOPTED: "_adopted",
     ADVISE_WAIT: "_advise_wait",
     IMPLEMENT_WAIT: "_implement_wait",
@@ -276,6 +282,8 @@ def build_implementation_prompt(
     branch_name: str = "",
     worktree_path: str = "",
     advise_findings: str = "",
+    rebase_conflict: bool = False,
+    rebase_conflict_paths: tuple[str, ...] = (),
 ) -> str:
     """Compose the implementation prompt with the advise-findings block.
 
@@ -292,6 +300,9 @@ def build_implementation_prompt(
         branch_name: Feature branch the worktree is on.
         worktree_path: Worktree the implementer works in.
         advise_findings: Advise-step findings; empty string means no block.
+        rebase_conflict: Whether the host's mechanical rebase found conflicts
+            whose file contents the implementation agent must resolve.
+        rebase_conflict_paths: Host-validated paths the agent may edit.
 
     Returns:
         The full implementer prompt, with the findings block appended when
@@ -305,13 +316,20 @@ def build_implementation_prompt(
         branch_name=branch_name,
         worktree_path=worktree_path,
     )
-    if not advise_findings:
+    if not advise_findings and not rebase_conflict:
         return prompt
     blocks: list[str] = [prompt]
     if advise_findings:
         blocks.append(
             PromptCatalog.current().render(
                 "implementation/advise_append.j2", advise_findings=advise_findings
+            )
+        )
+    if rebase_conflict:
+        blocks.append(
+            PromptCatalog.current().render(
+                "implementation/rebase_conflict_append.j2",
+                conflict_paths=rebase_conflict_paths,
             )
         )
     return "".join(blocks)
@@ -399,7 +417,10 @@ class ImplementationStage(Stage):
         """WORKTREE_WAIT submits the create-worktree git job."""
         issue = _issue_number(item)
         if (
-            item.payload.get("implementation_remediation")
+            (
+                item.payload.get("implementation_remediation")
+                or item.payload.get("post_review_rebase_required")
+            )
             and item.payload.pop("implementation_writer_restored", False)
             and item.worktree
         ):
@@ -525,10 +546,12 @@ class ImplementationStage(Stage):
             if outcome.disposition is Disposition.RETRY:
                 item.state = WORKTREE_WAIT
             return outcome
-        # An adopted PR is rebased by the implementation stage before every
-        # review.  This is deliberately not reviewer work: the reviewer owns
-        # only its detached snapshot and never changes a PR branch.
-        if item.payload.get("existing_pr_impl_go"):
+        # Reviewers never rebase. A reviewed head that merge-wait finds behind
+        # or conflicting returns here for implementation-owned rebasing, then
+        # passes through a fresh review of the rewritten head.
+        if item.payload.get("post_review_rebase_required"):
+            adopted_next = REBASE_WAIT
+        elif item.payload.get("existing_pr_impl_go"):
             adopted_next = ADOPTED
         else:
             adopted_next = REBASE_WAIT if item.payload.get("existing_pr") else ADVISE_WAIT
@@ -565,9 +588,13 @@ class ImplementationStage(Stage):
         """
         if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "rebase_pr_unavailable")
+        if item.payload.get("rebase_conflict"):
+            return Continue(next_state=REBASE_CONFLICT_WAIT)
         if item.payload.pop("rebase_error", None):
             return StageOutcome(Disposition.FINISH_FAIL, "implementation_rebase_failed")
         if item.payload.pop("rebase_complete", None):
+            item.payload.pop("post_review_rebase_required", None)
+            item.payload.pop("rebase_conflict", None)
             return Continue(
                 next_state=(
                     IMPLEMENT_WAIT if item.payload.get("implementation_remediation") else ADOPTED
@@ -594,6 +621,41 @@ class ImplementationStage(Stage):
             descr="rebase_writer_before_review",
         )
         return JobRequest(job, on_done_state=REBASE_WAIT)
+
+    def _rebase_continue_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Let the host validate, complete, sign, and lease-publish a paused rebase."""
+        if item.payload.pop("rebase_error", None):
+            return StageOutcome(Disposition.FINISH_FAIL, "implementation_rebase_failed")
+        if item.payload.pop("rebase_complete", None):
+            item.payload.pop("post_review_rebase_required", None)
+            item.payload.pop("rebase_conflict", None)
+            item.payload.pop("rebase_conflict_paths", None)
+            item.payload.pop("rebase_conflict_snapshot", None)
+            item.payload.pop("rebase_base_sha", None)
+            item.payload.pop("rebase_expected_remote_sha", None)
+            return Continue(next_state=ADOPTED)
+        if item.payload.pop("rebase_conflict_agent_error", None):
+            return Continue(next_state=REBASE_CONFLICT_WAIT)
+        if not item.payload.pop("rebase_conflict_agent_complete", False):
+            return Continue(next_state=REBASE_CONFLICT_WAIT)
+        if item.pr is None:
+            return StageOutcome(Disposition.FINISH_FAIL, "rebase_pr_unavailable")
+        job = GitJob(
+            repo=item.repo,
+            op="continue_rebase",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            kwargs={
+                "cwd": _worktree_path(item, ctx),
+                "base_sha": item.payload.get("rebase_base_sha"),
+                "remote": "origin",
+                "branch": item.branch,
+                "expected_remote_sha": item.payload.get("rebase_expected_remote_sha"),
+                "conflict_paths": item.payload.get("rebase_conflict_paths"),
+                "conflict_snapshot": item.payload.get("rebase_conflict_snapshot"),
+            },
+            descr="complete_host_owned_rebase",
+        )
+        return JobRequest(job, on_done_state=REBASE_CONTINUE_WAIT)
 
     def _adopted(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """ADOPTED advances to pr_review after the adopted worktree is ready."""
@@ -640,15 +702,9 @@ class ImplementationStage(Stage):
     def _implement_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """IMPLEMENT_WAIT submits the implementation job when budget remains."""
         issue = _issue_number(item)
-        budget = ctx.budget("implement")
-        if item.attempts.get("implement", 0) >= budget:
-            logger.error(
-                "implementation:%d: implement budget exhausted (%d/%d)",
-                issue,
-                item.attempts.get("implement", 0),
-                budget,
-            )
-            return StageOutcome(Disposition.FINISH_FAIL, "implement_exhausted")
+        exhausted = self._ordinary_implement_budget_outcome(item, ctx, issue)
+        if exhausted is not None:
+            return exhausted
         # Clear stale results at submission so a failed later attempt can
         # never replay an earlier attempt's output downstream.
         item.payload.pop("implement_error", None)
@@ -748,10 +804,62 @@ class ImplementationStage(Stage):
                 "branch_name": item.branch,
                 "worktree_path": item.worktree,
                 "advise_findings": item.payload.get("advise_findings", ""),
+                "rebase_conflict": bool(item.payload.get("rebase_conflict")),
+                "rebase_conflict_paths": tuple(item.payload.get("rebase_conflict_paths") or ()),
             },
             descr="implement",
         )
         return JobRequest(job, on_done_state=TEST_WAIT)
+
+    @staticmethod
+    def _ordinary_implement_budget_outcome(
+        item: WorkItem, ctx: StageContext, issue: int
+    ) -> StageOutcome | None:
+        """Return the ordinary implementation exhaustion outcome, if reached."""
+        budget = ctx.budget("implement")
+        attempts = item.attempts.get("implement", 0)
+        if attempts < budget:
+            return None
+        logger.error(
+            "implementation:%d: implement budget exhausted (%d/%d)",
+            issue,
+            attempts,
+            budget,
+        )
+        return StageOutcome(Disposition.FINISH_FAIL, "implement_exhausted")
+
+    def _rebase_conflict_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Build one separately-budgeted edit-only conflict-resolution turn."""
+        issue = _issue_number(item)
+        if not item.payload.get("rebase_conflict"):
+            return StageOutcome(Disposition.FINISH_FAIL, "rebase_conflict_receipt_missing")
+        if item.attempts.get("rebase_conflict", 0) >= ctx.budget("rebase_conflict"):
+            return StageOutcome(Disposition.FINISH_FAIL, "rebase_conflict_exhausted")
+        logger.info("implementation:%d: requesting edit-only rebase resolution", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
+            prompt_builder=build_implementation_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=implementer_claude_timeout(),
+            allowed_tools="Read,Write,Edit,Glob,Grep",
+            session_agent=AGENT_IMPLEMENTER,
+            resume_session_id=item.session_ids.get(AGENT_IMPLEMENTER),
+            prompt_kwargs={
+                "issue_number": item.issue,
+                "issue_title": item.payload.get("issue_title", ""),
+                "issue_body": item.payload.get("issue_body", ""),
+                "branch_name": item.branch,
+                "worktree_path": item.worktree,
+                "advise_findings": "",
+                "rebase_conflict": True,
+                "rebase_conflict_paths": tuple(item.payload.get("rebase_conflict_paths") or ()),
+            },
+            descr="resolve_rebase_conflict",
+        )
+        return JobRequest(job, on_done_state=REBASE_CONTINUE_WAIT)
 
     def _test_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """TEST_WAIT either retries the implementer or runs the pre-PR tests."""
@@ -1004,9 +1112,29 @@ class ImplementationStage(Stage):
         if item.state == REBASE_WAIT:
             if result.ok:
                 item.payload["rebase_complete"] = True
+            elif result.error == "mechanical rebase hit conflicts; resolution required":
+                logger.warning(
+                    "implementation:%s: writer rebase paused for host-owned conflict resolution",
+                    item.issue,
+                )
+                self._record_rebase_conflict(item, result)
             else:
                 logger.warning(
                     "implementation:%s: writer rebase failed: %s", item.issue, result.error
+                )
+                item.payload["rebase_error"] = True
+            return
+
+        if item.state == REBASE_CONTINUE_WAIT:
+            if result.ok:
+                item.payload["rebase_complete"] = True
+            elif (result.error or "").startswith("rebase conflict resolution required"):
+                self._record_rebase_conflict(item, result)
+            else:
+                logger.warning(
+                    "implementation:%s: host rebase completion failed: %s",
+                    item.issue,
+                    result.error,
                 )
                 item.payload["rebase_error"] = True
             return
@@ -1018,6 +1146,10 @@ class ImplementationStage(Stage):
 
         if item.state == IMPLEMENT_WAIT:
             self._on_implement_done(item, result)
+            return
+
+        if item.state == REBASE_CONFLICT_WAIT:
+            self._on_rebase_conflict_agent_done(item, result)
             return
 
         if item.state == TEST_WAIT:
@@ -1274,11 +1406,46 @@ class ImplementationStage(Stage):
             logger.warning("implementation:%s: implement job failed: %s", item.issue, result.error)
             item.payload["implement_error"] = True
             return
+        item.payload.pop("post_review_rebase_required", None)
+        item.payload.pop("rebase_conflict", None)
         if result.value:
             if item.payload.get("implementation_remediation"):
                 item.payload["remediation_output"] = result.value
             else:
                 item.payload["implement_summary"] = str(result.value)
+
+    @staticmethod
+    def _on_rebase_conflict_agent_done(item: WorkItem, result: JobResult) -> None:
+        """Count one conflict-only turn without consuming implementation budget."""
+        item.attempts["rebase_conflict"] = item.attempts.get("rebase_conflict", 0) + 1
+        if result.ok:
+            item.payload["rebase_conflict_agent_complete"] = True
+        else:
+            item.payload["rebase_conflict_agent_error"] = True
+
+    @staticmethod
+    def _record_rebase_conflict(item: WorkItem, result: JobResult) -> None:
+        """Retain only a complete host-produced conflict receipt on the item."""
+        value = result.value if isinstance(result.value, dict) else {}
+        paths = value.get("conflict_paths")
+        snapshot = value.get("conflict_snapshot")
+        base_sha = value.get("base_sha")
+        expected_remote_sha = value.get("expected_remote_sha")
+        if (
+            not isinstance(paths, (list, tuple))
+            or not paths
+            or not all(isinstance(path, str) and path for path in paths)
+            or not isinstance(snapshot, dict)
+            or not is_full_commit_sha(base_sha)
+            or not is_full_commit_sha(expected_remote_sha)
+        ):
+            item.payload["rebase_error"] = True
+            return
+        item.payload["rebase_conflict"] = True
+        item.payload["rebase_conflict_paths"] = tuple(paths)
+        item.payload["rebase_conflict_snapshot"] = snapshot
+        item.payload["rebase_base_sha"] = base_sha
+        item.payload["rebase_expected_remote_sha"] = expected_remote_sha
 
     @staticmethod
     def _on_worktree_done(item: WorkItem, result: JobResult) -> None:
@@ -1496,6 +1663,8 @@ class ImplementationStage(Stage):
         """
         has_go, _has_no_go = pr_implementation_state
         if not has_go:
+            return None
+        if item.payload.get("post_review_rebase_required"):
             return None
         logger.info(
             "implementation:%d: PR #%d already implementation-go; routing to merge-wait",

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import secrets
 import shlex
 from collections.abc import Callable
@@ -631,6 +632,8 @@ class ImplementationStage(Stage):
             item.payload.pop("rebase_conflict", None)
             item.payload.pop("rebase_conflict_paths", None)
             item.payload.pop("rebase_conflict_snapshot", None)
+            item.payload.pop("rebase_conflict_index_snapshot", None)
+            item.payload.pop("rebase_paused_head_sha", None)
             item.payload.pop("rebase_base_sha", None)
             item.payload.pop("rebase_expected_remote_sha", None)
             return Continue(next_state=ADOPTED)
@@ -652,6 +655,8 @@ class ImplementationStage(Stage):
                 "expected_remote_sha": item.payload.get("rebase_expected_remote_sha"),
                 "conflict_paths": item.payload.get("rebase_conflict_paths"),
                 "conflict_snapshot": item.payload.get("rebase_conflict_snapshot"),
+                "conflict_index_snapshot": item.payload.get("rebase_conflict_index_snapshot"),
+                "paused_head_sha": item.payload.get("rebase_paused_head_sha"),
             },
             descr="complete_host_owned_rebase",
         )
@@ -702,9 +707,9 @@ class ImplementationStage(Stage):
     def _implement_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """IMPLEMENT_WAIT submits the implementation job when budget remains."""
         issue = _issue_number(item)
-        exhausted = self._ordinary_implement_budget_outcome(item, ctx, issue)
-        if exhausted is not None:
-            return exhausted
+        entry_outcome = self._implementation_agent_turn_entry_outcome(item, ctx, issue)
+        if entry_outcome is not None:
+            return entry_outcome
         # Clear stale results at submission so a failed later attempt can
         # never replay an earlier attempt's output downstream.
         item.payload.pop("implement_error", None)
@@ -810,6 +815,15 @@ class ImplementationStage(Stage):
             descr="implement",
         )
         return JobRequest(job, on_done_state=TEST_WAIT)
+
+    @staticmethod
+    def _implementation_agent_turn_entry_outcome(
+        item: WorkItem, ctx: StageContext, issue: int
+    ) -> StepResult | None:
+        """Return any outcome that must happen before an ordinary implement turn."""
+        if item.payload.get("rebase_conflict"):
+            return Continue(next_state=REBASE_CONFLICT_WAIT)
+        return ImplementationStage._ordinary_implement_budget_outcome(item, ctx, issue)
 
     @staticmethod
     def _ordinary_implement_budget_outcome(
@@ -1429,6 +1443,8 @@ class ImplementationStage(Stage):
         value = result.value if isinstance(result.value, dict) else {}
         paths = value.get("conflict_paths")
         snapshot = value.get("conflict_snapshot")
+        index_snapshot = value.get("conflict_index_snapshot")
+        paused_head_sha = value.get("paused_head_sha")
         base_sha = value.get("base_sha")
         expected_remote_sha = value.get("expected_remote_sha")
         if (
@@ -1436,6 +1452,9 @@ class ImplementationStage(Stage):
             or not paths
             or not all(isinstance(path, str) and path for path in paths)
             or not isinstance(snapshot, dict)
+            or not isinstance(index_snapshot, str)
+            or re.fullmatch(r"[0-9a-f]{64}", index_snapshot) is None
+            or not is_full_commit_sha(paused_head_sha)
             or not is_full_commit_sha(base_sha)
             or not is_full_commit_sha(expected_remote_sha)
         ):
@@ -1444,6 +1463,8 @@ class ImplementationStage(Stage):
         item.payload["rebase_conflict"] = True
         item.payload["rebase_conflict_paths"] = tuple(paths)
         item.payload["rebase_conflict_snapshot"] = snapshot
+        item.payload["rebase_conflict_index_snapshot"] = index_snapshot
+        item.payload["rebase_paused_head_sha"] = paused_head_sha
         item.payload["rebase_base_sha"] = base_sha
         item.payload["rebase_expected_remote_sha"] = expected_remote_sha
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -209,6 +209,8 @@ _PENDING_GITHUB_REQUEST = "_pending_github_request"
 _REPLY_JOURNAL_RECOVERY_RESULT = "_reply_journal_recovery_result"
 _REPLY_JOURNAL_APPEND_RESULT = "_reply_journal_append_result"
 _REPLY_HANDOFF_RESULT = "_reply_handoff_result"
+_SYNC_RESTORED_WRITER_BEFORE_REBASE = "sync_restored_writer_before_rebase"
+_REBASE_HEAD_DRIFT = "rebase_head_drift"
 
 
 def _issue_number(item: WorkItem) -> int:
@@ -429,6 +431,8 @@ class ImplementationStage(Stage):
             # detached, read-only snapshot.  Reuse it for remediation: trying
             # to create a second worktree for the same PR branch would either
             # fail the branch-ownership guard or tempt review to write there.
+            if item.payload.get("post_review_rebase_required"):
+                item.payload[_SYNC_RESTORED_WRITER_BEFORE_REBASE] = True
             item.payload["worktree_dirty"] = False
             return Continue(next_state=DIRTY_DECISION_WAIT)
         logger.info("implementation:%d: requesting worktree job", issue)
@@ -591,11 +595,17 @@ class ImplementationStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "rebase_pr_unavailable")
         if item.payload.get("rebase_conflict"):
             return Continue(next_state=REBASE_CONFLICT_WAIT)
+        if item.payload.pop(_REBASE_HEAD_DRIFT, None):
+            item.payload.pop("post_review_rebase_required", None)
+            item.payload.pop("rebase_conflict", None)
+            item.payload.pop(_SYNC_RESTORED_WRITER_BEFORE_REBASE, None)
+            return Continue(next_state=ADOPTED)
         if item.payload.pop("rebase_error", None):
             return StageOutcome(Disposition.FINISH_FAIL, "implementation_rebase_failed")
         if item.payload.pop("rebase_complete", None):
             item.payload.pop("post_review_rebase_required", None)
             item.payload.pop("rebase_conflict", None)
+            item.payload.pop(_SYNC_RESTORED_WRITER_BEFORE_REBASE, None)
             return Continue(
                 next_state=(
                     IMPLEMENT_WAIT if item.payload.get("implementation_remediation") else ADOPTED
@@ -607,18 +617,22 @@ class ImplementationStage(Stage):
         expected_head = state.get("headRefOid") if isinstance(state, dict) else None
         if not is_full_commit_sha(expected_head):
             return StageOutcome(Disposition.FINISH_FAIL, "rebase_pr_head_unavailable")
+        kwargs: dict[str, object] = {
+            "cwd": _worktree_path(item, ctx),
+            "base_branch": "main",
+            "remote": "origin",
+            "publish_rebased_head": True,
+            "branch": item.branch,
+            "expected_remote_sha": expected_head,
+        }
+        if item.payload.get(_SYNC_RESTORED_WRITER_BEFORE_REBASE):
+            kwargs["sync_to_expected_remote_head"] = True
+            kwargs["pr_number"] = item.pr
         job = GitJob(
             repo=item.repo,
             op="rebase",
             timeout_s=GIT_JOB_TIMEOUT_S,
-            kwargs={
-                "cwd": _worktree_path(item, ctx),
-                "base_branch": "main",
-                "remote": "origin",
-                "publish_rebased_head": True,
-                "branch": item.branch,
-                "expected_remote_sha": expected_head,
-            },
+            kwargs=kwargs,
             descr="rebase_writer_before_review",
         )
         return JobRequest(job, on_done_state=REBASE_WAIT)
@@ -1125,7 +1139,11 @@ class ImplementationStage(Stage):
 
         if item.state == REBASE_WAIT:
             if result.ok:
-                item.payload["rebase_complete"] = True
+                value = result.value if isinstance(result.value, dict) else {}
+                if value.get("head_drift"):
+                    item.payload[_REBASE_HEAD_DRIFT] = True
+                else:
+                    item.payload["rebase_complete"] = True
             elif result.error == "mechanical rebase hit conflicts; resolution required":
                 logger.warning(
                     "implementation:%s: writer rebase paused for host-owned conflict resolution",

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -75,6 +75,17 @@ FINISH = MW_FINISH
 _REQUESTABLE_READINESS = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE"})
 _RETRYABLE_READINESS = frozenset({"BEHIND", "BLOCKED", "UNKNOWN"})
 _CONFLICTING_READINESS = frozenset({"CONFLICTING", "DIRTY"})
+
+
+def _post_review_rebase_reason(status: str, mergeable: str) -> str | None:
+    """Return the implementation-owned rebase reason for reviewed readiness."""
+    if status in _CONFLICTING_READINESS or mergeable == "CONFLICTING":
+        return "merge_conflicting"
+    if status == "BEHIND":
+        return "post_review_rebase_required"
+    return None
+
+
 _READINESS_WAIT_INITIAL_S = 5.0
 _READINESS_WAIT_TIMEOUT_S = 30 * 60.0
 _READINESS_WAIT_DELAY_CAP_S = 60.0
@@ -224,6 +235,8 @@ class MergeWaitStage(Stage):
             return StageOutcome(Disposition.BLOCKED, outcome)
         if outcome in {"not_implementation_go", "reviewed_head_drift"}:
             return StageOutcome(Disposition.FAIL_BACK, outcome)
+        if outcome in {"merge_conflicting", "post_review_rebase_required"}:
+            return self._post_review_rebase(item, outcome)
         if outcome == "readiness_wait":
             if receipt.attempted and item.attempts["merge"] >= ctx.budget("merge"):
                 return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
@@ -473,11 +486,18 @@ class MergeWaitStage(Stage):
                 declined_fingerprint=declined_fingerprint,
                 park_if_ready=park_if_ready,
             )
-        if status in _CONFLICTING_READINESS or mergeable == "CONFLICTING":
-            return StageOutcome(Disposition.FINISH_FAIL, "merge_conflicting")
+        rebase_reason = _post_review_rebase_reason(status, mergeable)
+        if rebase_reason is not None:
+            return self._post_review_rebase(item, rebase_reason)
         if status not in _RETRYABLE_READINESS and mergeable != "UNKNOWN":
             return StageOutcome(Disposition.FINISH_FAIL, "merge_readiness_unknown")
         return self._park_for_readiness(item, ctx)
+
+    @staticmethod
+    def _post_review_rebase(item: WorkItem, reason: str) -> StageOutcome:
+        """Send a reviewed stale/conflicting head to implementation ownership."""
+        item.payload["post_review_rebase_required"] = True
+        return StageOutcome(Disposition.FAIL_BACK, reason)
 
     @staticmethod
     def _readiness_fingerprint(item: WorkItem, readiness: dict[str, Any]) -> list[str] | None:

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -61,7 +61,11 @@ from hephaestus.automation.state_labels import (
 )
 from hephaestus.prompts import PromptCatalog
 
-from ..plan_journal import publish_plan_revision, reconcile_plan_journal
+from ..plan_journal import (
+    PlanRevisionOwnershipError,
+    publish_plan_revision,
+    reconcile_plan_journal,
+)
 from .base import (
     AgentJob,
     Continue,
@@ -329,12 +333,17 @@ def _publish_candidate_plan(
             Disposition.BLOCKED,
             "plan was blocked externally while planning was in flight",
         )
-    publication = publish_plan_revision(
-        item.issue,
-        str(item.payload["plan_text"]),
-        ctx.github,
-        require_change=requires_revision,
-    )
+    try:
+        publication = publish_plan_revision(
+            item.issue,
+            str(item.payload["plan_text"]),
+            ctx.github,
+            require_change=requires_revision,
+        )
+    except PlanRevisionOwnershipError:
+        note = "plan is being worked by another pipeline item; ejected from queue"
+        logger.info("planning:%d: %s", item.issue, note)
+        return StageOutcome(Disposition.FINISH_PASS, note)
     item.payload["plan_text"] = publication.plan
     item.payload["plan_revision"] = publication.revision
     if publication.is_stuck:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2053,8 +2053,10 @@ class WorkerPool:
                 error="detached reviewer rebase publication is unsupported",
             )
         publish_rebased_head = bool(kwargs.pop("publish_rebased_head", False))
+        sync_to_expected_remote_head = bool(kwargs.pop("sync_to_expected_remote_head", False))
         branch = str(kwargs.pop("branch", "") or "")
         expected_remote_sha = kwargs.pop("expected_remote_sha", None)
+        pr_number = kwargs.pop("pr_number", None)
         cwd = Path(str(kwargs.get("cwd") or ""))
         if publish_rebased_head:
             if not branch or not _is_full_commit_sha(expected_remote_sha) or not cwd.is_dir():
@@ -2062,6 +2064,17 @@ class WorkerPool:
             remote = str(kwargs.get("remote", "origin"))
             base_branch = str(kwargs.get("base_branch", "main"))
             base_ref = f"{remote}/{base_branch}"
+            synced = self._sync_writer_to_expected_remote_head(
+                cwd,
+                enabled=sync_to_expected_remote_head,
+                branch=branch,
+                remote=remote,
+                pr_number=pr_number,
+                expected_remote_sha=expected_remote_sha,
+                timeout=job.timeout_s,
+            )
+            if synced is not None:
+                return synced
             git_utils.run(
                 ["git", "fetch", remote, base_branch],
                 cwd=cwd,
@@ -2125,6 +2138,63 @@ class WorkerPool:
             ok=True,
             value={"rebased": True, "published": True, "head_sha": source_sha},
         )
+
+    def _sync_writer_to_expected_remote_head(
+        self,
+        cwd: Path,
+        *,
+        enabled: bool,
+        branch: str,
+        remote: str,
+        pr_number: object,
+        expected_remote_sha: str,
+        timeout: int,
+    ) -> JobResult | None:
+        """Sync a restored writer checkout and prove it matches the rebase lease."""
+        if not enabled:
+            return None
+        try:
+            if not git_utils.is_clean_working_tree(cwd, timeout=timeout):
+                return JobResult(
+                    ok=False,
+                    error="restored writer checkout dirty before remote sync",
+                )
+            try:
+                sync_pr_number = (
+                    int(pr_number)
+                    if isinstance(pr_number, (int, str)) and not isinstance(pr_number, bool)
+                    else None
+                )
+            except ValueError:
+                sync_pr_number = None
+            git_utils.sync_worktree_to_remote_branch(
+                cwd,
+                branch,
+                remote=remote,
+                pr_number=sync_pr_number,
+                timeout=timeout,
+            )
+            source_sha = self._read_publish_head(cwd, timeout=timeout)
+            if isinstance(source_sha, JobResult):
+                return source_sha
+            if source_sha != expected_remote_sha:
+                return JobResult(
+                    ok=True,
+                    value={
+                        "rebased": False,
+                        "published": False,
+                        "head_drift": True,
+                        "head_sha": source_sha,
+                    },
+                )
+            if not git_utils.is_clean_working_tree(cwd, timeout=timeout):
+                return JobResult(
+                    ok=False,
+                    error="restored writer checkout dirty after remote sync",
+                )
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            return JobResult(ok=False, error=f"restored writer remote sync failed: {exc}")
+        return None
 
     def _conflict_receipt(
         self,

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2145,6 +2145,21 @@ class WorkerPool:
             paths = tuple(path for path in paths_result.stdout.split("\0") if path)
             if not paths or any(not is_safe_scope_retraction_path(path) for path in paths):
                 return JobResult(ok=False, error="paused rebase conflict paths invalid")
+            index_result = git_utils.run(
+                ["git", "ls-files", "--unmerged", "-z", "--", *paths],
+                cwd=cwd,
+                timeout=timeout,
+            )
+            if not index_result.stdout:
+                return JobResult(ok=False, error="paused rebase conflict index invalid")
+            index_snapshot = hashlib.sha256(index_result.stdout.encode()).hexdigest()
+            paused_head_sha = git_utils.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=cwd,
+                timeout=timeout,
+            ).stdout.strip()
+            if not _is_full_commit_sha(paused_head_sha):
+                return JobResult(ok=False, error="paused rebase head invalid")
             base_sha = git_utils.run(
                 ["git", "rev-parse", f"{remote}/{base_branch}"],
                 cwd=cwd,
@@ -2159,6 +2174,8 @@ class WorkerPool:
             "rebased": False,
             "conflict_paths": paths,
             "conflict_snapshot": snapshot,
+            "conflict_index_snapshot": index_snapshot,
+            "paused_head_sha": paused_head_sha,
             "base_sha": base_sha,
             "expected_remote_sha": expected_remote_sha,
         }
@@ -2176,7 +2193,17 @@ class WorkerPool:
         parsed = self._parse_rebase_continuation(job)
         if isinstance(parsed, JobResult):
             return parsed
-        cwd, branch, remote, base_sha, expected_remote_sha, paths, snapshot = parsed
+        (
+            cwd,
+            branch,
+            remote,
+            base_sha,
+            expected_remote_sha,
+            paths,
+            snapshot,
+            index_snapshot,
+            paused_head_sha,
+        ) = parsed
         remote_head = self._read_remote_branch_head(
             cwd, remote=remote, branch=branch, timeout=job.timeout_s
         )
@@ -2191,6 +2218,8 @@ class WorkerPool:
             remote=remote,
             paths=paths,
             snapshot=snapshot,
+            index_snapshot=index_snapshot,
+            paused_head_sha=paused_head_sha,
             base_sha=base_sha,
             expected_remote_sha=expected_remote_sha,
             timeout=job.timeout_s,
@@ -2232,7 +2261,7 @@ class WorkerPool:
     @staticmethod
     def _parse_rebase_continuation(
         job: GitJob,
-    ) -> tuple[Path, str, str, str, str, tuple[str, ...], dict[str, object]] | JobResult:
+    ) -> tuple[Path, str, str, str, str, tuple[str, ...], dict[str, object], str, str] | JobResult:
         """Validate and normalize coordinator-owned continuation arguments."""
         kwargs = job.kwargs
         cwd = Path(str(kwargs.get("cwd") or ""))
@@ -2242,6 +2271,8 @@ class WorkerPool:
         expected_remote_sha = kwargs.get("expected_remote_sha")
         raw_paths = kwargs.get("conflict_paths")
         raw_snapshot = kwargs.get("conflict_snapshot")
+        index_snapshot = kwargs.get("conflict_index_snapshot")
+        paused_head_sha = kwargs.get("paused_head_sha")
         if (
             not cwd.is_dir()
             or not branch
@@ -2250,13 +2281,26 @@ class WorkerPool:
             or not isinstance(raw_paths, (list, tuple))
             or not raw_paths
             or not isinstance(raw_snapshot, dict)
+            or not isinstance(index_snapshot, str)
+            or re.fullmatch(r"[0-9a-f]{64}", index_snapshot) is None
+            or not _is_full_commit_sha(paused_head_sha)
         ):
             return JobResult(ok=False, error="rebase continuation arguments invalid")
         paths = tuple(str(path) for path in raw_paths)
         if any(not is_safe_scope_retraction_path(path) for path in paths):
             return JobResult(ok=False, error="rebase continuation paths invalid")
         snapshot = {str(path): value for path, value in raw_snapshot.items()}
-        return cwd, branch, remote, base_sha, expected_remote_sha, paths, snapshot
+        return (
+            cwd,
+            branch,
+            remote,
+            base_sha,
+            expected_remote_sha,
+            paths,
+            snapshot,
+            index_snapshot,
+            paused_head_sha,
+        )
 
     def _validate_rebase_conflict_edits(
         self,
@@ -2265,6 +2309,8 @@ class WorkerPool:
         remote: str,
         paths: tuple[str, ...],
         snapshot: dict[str, object],
+        index_snapshot: str,
+        paused_head_sha: str,
         base_sha: str,
         expected_remote_sha: str,
         timeout: int,
@@ -2288,6 +2334,10 @@ class WorkerPool:
         )
         if set(current_paths) != set(paths):
             return JobResult(ok=False, error="conflict index was mutated outside host ownership")
+        if current_receipt.get("conflict_index_snapshot") != index_snapshot:
+            return JobResult(ok=False, error="conflict index was mutated outside host ownership")
+        if current_receipt.get("paused_head_sha") != paused_head_sha:
+            return JobResult(ok=False, error="paused rebase head changed outside host ownership")
         current_snapshot = current_receipt.get("conflict_snapshot")
         if not isinstance(current_snapshot, dict) or all(
             current_snapshot.get(path) == snapshot.get(path) for path in paths
@@ -2306,6 +2356,37 @@ class WorkerPool:
                 value=current_receipt,
                 error="rebase conflict resolution required: conflict markers remain",
             )
+        scope_error = self._rebase_conflict_edit_scope_error(
+            cwd,
+            conflict_paths=paths,
+            timeout=timeout,
+        )
+        if scope_error is not None:
+            return scope_error
+        return None
+
+    @staticmethod
+    def _rebase_conflict_edit_scope_error(
+        cwd: Path, *, conflict_paths: tuple[str, ...], timeout: int
+    ) -> JobResult | None:
+        """Reject tracked, staged, or untracked changes outside conflicts."""
+        allowed = set(conflict_paths)
+        probes = (
+            ["git", "diff", "--name-only", "-z"],
+            ["git", "diff", "--cached", "--name-only", "-z"],
+            ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+        )
+        try:
+            for argv in probes:
+                result = git_utils.run(argv, cwd=cwd, timeout=timeout)
+                changed = {path for path in result.stdout.split("\0") if path}
+                if not changed.issubset(allowed):
+                    return JobResult(
+                        ok=False,
+                        error="rebase conflict resolution changed paths outside host scope",
+                    )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return JobResult(ok=False, error="cannot validate rebase conflict edit scope")
         return None
 
     def _continue_rebase_process(

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1949,6 +1949,9 @@ class WorkerPool:
         elif job.op == "rebase":
             return self._git_rebase(job)
 
+        elif job.op == "continue_rebase":
+            return self._git_continue_rebase(job)
+
         elif job.op == "push":
             git_utils.push_current_branch_with_lease_on_divergence(
                 **job.kwargs,
@@ -2080,7 +2083,11 @@ class WorkerPool:
                 )
             if ancestry.returncode != 1:
                 return JobResult(ok=False, error="cannot determine writer base ancestry")
-        result = git_utils.rebase_worktree_onto(**kwargs, timeout=job.timeout_s)
+        result = git_utils.rebase_worktree_onto(
+            **kwargs,
+            preserve_conflicts=publish_rebased_head,
+            timeout=job.timeout_s,
+        )
         if not result:
             if not publish_rebased_head:
                 return JobResult(
@@ -2088,10 +2095,19 @@ class WorkerPool:
                     value=False,
                     error="mechanical rebase hit conflicts; aborted",
                 )
+            receipt = self._conflict_receipt(
+                cwd,
+                remote=remote,
+                base_branch=base_branch,
+                expected_remote_sha=expected_remote_sha,
+                timeout=job.timeout_s,
+            )
+            if isinstance(receipt, JobResult):
+                return receipt
             return JobResult(
                 ok=False,
-                value={"rebased": False},
-                error="mechanical rebase hit conflicts; aborted",
+                value=receipt,
+                error="mechanical rebase hit conflicts; resolution required",
             )
         if not publish_rebased_head:
             return JobResult(ok=True, value=True)
@@ -2109,6 +2125,262 @@ class WorkerPool:
             ok=True,
             value={"rebased": True, "published": True, "head_sha": source_sha},
         )
+
+    def _conflict_receipt(
+        self,
+        cwd: Path,
+        *,
+        remote: str,
+        base_branch: str,
+        expected_remote_sha: str,
+        timeout: int,
+    ) -> dict[str, object] | JobResult:
+        """Capture the immutable inputs and file snapshot of a paused rebase."""
+        try:
+            paths_result = git_utils.run(
+                ["git", "diff", "--name-only", "--diff-filter=U", "-z"],
+                cwd=cwd,
+                timeout=timeout,
+            )
+            paths = tuple(path for path in paths_result.stdout.split("\0") if path)
+            if not paths or any(not is_safe_scope_retraction_path(path) for path in paths):
+                return JobResult(ok=False, error="paused rebase conflict paths invalid")
+            base_sha = git_utils.run(
+                ["git", "rev-parse", f"{remote}/{base_branch}"],
+                cwd=cwd,
+                timeout=timeout,
+            ).stdout.strip()
+            if not _is_full_commit_sha(base_sha):
+                return JobResult(ok=False, error="paused rebase base head invalid")
+            snapshot = {path: self._conflict_path_digest(cwd, path) for path in paths}
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            return JobResult(ok=False, error=f"cannot capture paused rebase: {exc}")
+        return {
+            "rebased": False,
+            "conflict_paths": paths,
+            "conflict_snapshot": snapshot,
+            "base_sha": base_sha,
+            "expected_remote_sha": expected_remote_sha,
+        }
+
+    @staticmethod
+    def _conflict_path_digest(cwd: Path, path: str) -> str:
+        """Return a stable digest for one host-validated conflict path."""
+        target = cwd / path
+        if not target.exists():
+            return "<absent>"
+        return hashlib.sha256(target.read_bytes()).hexdigest()
+
+    def _git_continue_rebase(self, job: GitJob) -> JobResult:
+        """Validate edit-only conflict output, finish policy rebase, and lease-publish."""
+        parsed = self._parse_rebase_continuation(job)
+        if isinstance(parsed, JobResult):
+            return parsed
+        cwd, branch, remote, base_sha, expected_remote_sha, paths, snapshot = parsed
+        remote_head = self._read_remote_branch_head(
+            cwd, remote=remote, branch=branch, timeout=job.timeout_s
+        )
+        if isinstance(remote_head, JobResult):
+            return remote_head
+        if remote_head != expected_remote_sha:
+            return JobResult(
+                ok=False, error="remote writer head changed during conflict resolution"
+            )
+        edits = self._validate_rebase_conflict_edits(
+            cwd,
+            remote=remote,
+            paths=paths,
+            snapshot=snapshot,
+            base_sha=base_sha,
+            expected_remote_sha=expected_remote_sha,
+            timeout=job.timeout_s,
+        )
+        if edits is not None:
+            return edits
+        continued = self._continue_rebase_process(
+            cwd,
+            remote=remote,
+            base_sha=base_sha,
+            expected_remote_sha=expected_remote_sha,
+            paths=paths,
+            timeout=job.timeout_s,
+        )
+        if continued is not None:
+            return continued
+        metadata = self._verify_rebased_commit_metadata(
+            cwd, base_sha=base_sha, timeout=job.timeout_s
+        )
+        if metadata is not None:
+            return metadata
+        source_sha = self._read_publish_head(cwd, timeout=job.timeout_s)
+        if isinstance(source_sha, JobResult):
+            return source_sha
+        if source_sha == expected_remote_sha:
+            return JobResult(ok=False, error="completed rebase did not rewrite the branch head")
+        git_utils.push_head_to_branch(
+            branch,
+            expected_remote_sha,
+            cwd,
+            source_sha=source_sha,
+            timeout=job.timeout_s,
+        )
+        return JobResult(
+            ok=True,
+            value={"rebased": True, "published": True, "head_sha": source_sha},
+        )
+
+    @staticmethod
+    def _parse_rebase_continuation(
+        job: GitJob,
+    ) -> tuple[Path, str, str, str, str, tuple[str, ...], dict[str, object]] | JobResult:
+        """Validate and normalize coordinator-owned continuation arguments."""
+        kwargs = job.kwargs
+        cwd = Path(str(kwargs.get("cwd") or ""))
+        branch = str(kwargs.get("branch") or "")
+        remote = str(kwargs.get("remote") or "origin")
+        base_sha = kwargs.get("base_sha")
+        expected_remote_sha = kwargs.get("expected_remote_sha")
+        raw_paths = kwargs.get("conflict_paths")
+        raw_snapshot = kwargs.get("conflict_snapshot")
+        if (
+            not cwd.is_dir()
+            or not branch
+            or not _is_full_commit_sha(base_sha)
+            or not _is_full_commit_sha(expected_remote_sha)
+            or not isinstance(raw_paths, (list, tuple))
+            or not raw_paths
+            or not isinstance(raw_snapshot, dict)
+        ):
+            return JobResult(ok=False, error="rebase continuation arguments invalid")
+        paths = tuple(str(path) for path in raw_paths)
+        if any(not is_safe_scope_retraction_path(path) for path in paths):
+            return JobResult(ok=False, error="rebase continuation paths invalid")
+        snapshot = {str(path): value for path, value in raw_snapshot.items()}
+        return cwd, branch, remote, base_sha, expected_remote_sha, paths, snapshot
+
+    def _validate_rebase_conflict_edits(
+        self,
+        cwd: Path,
+        *,
+        remote: str,
+        paths: tuple[str, ...],
+        snapshot: dict[str, object],
+        base_sha: str,
+        expected_remote_sha: str,
+        timeout: int,
+    ) -> JobResult | None:
+        """Reject out-of-band index edits, no-op agents, and residual markers."""
+        current_receipt = self._conflict_receipt(
+            cwd,
+            remote=remote,
+            base_branch="main",
+            expected_remote_sha=expected_remote_sha,
+            timeout=timeout,
+        )
+        if isinstance(current_receipt, JobResult):
+            return current_receipt
+        current_receipt["base_sha"] = base_sha
+        raw_current_paths = current_receipt.get("conflict_paths")
+        current_paths: tuple[str, ...] = (
+            tuple(str(path) for path in raw_current_paths)
+            if isinstance(raw_current_paths, (list, tuple))
+            else ()
+        )
+        if set(current_paths) != set(paths):
+            return JobResult(ok=False, error="conflict index was mutated outside host ownership")
+        current_snapshot = current_receipt.get("conflict_snapshot")
+        if not isinstance(current_snapshot, dict) or all(
+            current_snapshot.get(path) == snapshot.get(path) for path in paths
+        ):
+            return JobResult(
+                ok=False,
+                value=current_receipt,
+                error="rebase conflict resolution required: agent made no file changes",
+            )
+        marker = re.compile(rb"^(<<<<<<<|=======|>>>>>>>)", re.MULTILINE)
+        if any(
+            (cwd / path).is_file() and marker.search((cwd / path).read_bytes()) for path in paths
+        ):
+            return JobResult(
+                ok=False,
+                value=current_receipt,
+                error="rebase conflict resolution required: conflict markers remain",
+            )
+        return None
+
+    def _continue_rebase_process(
+        self,
+        cwd: Path,
+        *,
+        remote: str,
+        base_sha: str,
+        expected_remote_sha: str,
+        paths: tuple[str, ...],
+        timeout: int,
+    ) -> JobResult | None:
+        """Stage only validated conflicts and let Git continue the policy rebase."""
+        try:
+            git_utils.run(["git", "add", "--", *paths], cwd=cwd, timeout=timeout)
+            git_utils.run(
+                ["git", "diff", "--cached", "--check"],
+                cwd=cwd,
+                timeout=timeout,
+            )
+            env = _controlled_git_env()
+            env["GIT_EDITOR"] = "true"
+            git_utils.run(
+                ["git", "rebase", "--continue"],
+                cwd=cwd,
+                env=env,
+                timeout=timeout,
+            )
+        except subprocess.CalledProcessError:
+            next_receipt = self._conflict_receipt(
+                cwd,
+                remote=remote,
+                base_branch="main",
+                expected_remote_sha=expected_remote_sha,
+                timeout=timeout,
+            )
+            if isinstance(next_receipt, dict):
+                next_receipt["base_sha"] = base_sha
+                return JobResult(
+                    ok=False,
+                    value=next_receipt,
+                    error="rebase conflict resolution required: additional conflicts found",
+                )
+            return JobResult(ok=False, error="host could not continue rebase")
+        return None
+
+    @staticmethod
+    def _verify_rebased_commit_metadata(
+        cwd: Path, *, base_sha: str, timeout: int
+    ) -> JobResult | None:
+        """Prove captured-base ancestry plus signature and DCO metadata."""
+        ancestry = git_utils.run(
+            ["git", "merge-base", "--is-ancestor", str(base_sha), "HEAD"],
+            cwd=cwd,
+            check=False,
+            timeout=timeout,
+        )
+        if ancestry.returncode != 0:
+            return JobResult(ok=False, error="completed rebase lacks captured base ancestry")
+        commits = git_utils.run(
+            ["git", "rev-list", "--reverse", f"{base_sha}..HEAD"],
+            cwd=cwd,
+            timeout=timeout,
+        ).stdout.split()
+        if not commits:
+            return JobResult(ok=False, error="completed rebase produced no branch commits")
+        for commit in commits:
+            raw_commit = git_utils.run(
+                ["git", "cat-file", "-p", commit],
+                cwd=cwd,
+                timeout=timeout,
+            ).stdout
+            if "\ngpgsig " not in f"\n{raw_commit}" or "Signed-off-by:" not in raw_commit:
+                return JobResult(ok=False, error="completed rebase commit metadata invalid")
+        return None
 
     def _git_sync_checkout(self, job: GitJob) -> JobResult:
         """Validate and fast-forward a clean reusable checkout.
@@ -2682,15 +2954,17 @@ class WorkerPool:
             cwd=worktree,
             timeout=job.timeout_s,
         )
+        # The reviewer is bound to the branch point of the captured PR pair,
+        # not to the base branch's current HEAD. Fetching only makes the
+        # captured base object available; advancement of the branch is an
+        # implementation concern after review.
         base = git_utils.run(
-            ["git", "rev-parse", "FETCH_HEAD"],
+            ["git", "merge-base", expected_base, head],
             cwd=worktree,
             timeout=job.timeout_s,
         ).stdout.strip()
         if not _is_full_commit_sha(base):
-            return JobResult(ok=False, error="review checkout base ref unavailable")
-        if base != expected_base:
-            return JobResult(ok=True, value={"ready": False, "reason": "base_drift"})
+            return JobResult(ok=False, error="review checkout branch point unavailable")
         diff = git_utils.run(
             ["git", "diff", "--no-ext-diff", "--binary", f"{base}...{head}"],
             cwd=worktree,

--- a/hephaestus/automation/pipeline_github_jobs.py
+++ b/hephaestus/automation/pipeline_github_jobs.py
@@ -319,6 +319,8 @@ class PipelineGitHubJobRunner:
                 return None, fingerprint
             if status in conflicting or mergeable == "CONFLICTING":
                 return "merge_conflicting", fingerprint
+            if status == "BEHIND":
+                return "post_review_rebase_required", fingerprint
             if status not in retryable and mergeable != "UNKNOWN":
                 return "merge_readiness_unknown", fingerprint
             return "readiness_wait", fingerprint

--- a/hephaestus/prompts/templates/default/implementation/rebase_conflict_append.j2
+++ b/hephaestus/prompts/templates/default/implementation/rebase_conflict_append.j2
@@ -1,0 +1,16 @@
+
+## Rebase Conflict Resolution Required
+
+The host has paused a signed-policy rebase after finding conflicts. Your role is limited to
+editing the conflicted file contents listed below. Do not run Git commands, stage files, continue
+or abort the rebase, commit, push, or edit any path outside this list. The host will validate the
+index, continue and sign the rebase, verify ancestry and metadata, and publish with an exact-head
+lease before sending the rewritten head to a fresh review.
+
+Conflicted paths:
+{% for path in conflict_paths %}- `{{ path }}`
+{% endfor %}
+
+Resolve every listed file according to the linked issue and current codebase behavior. Remove all
+conflict markers, preserve the compatible intent of both sides, and return a concise explanation
+of the content edits. If the safe resolution is unclear, leave the file unresolved and say why.

--- a/tests/unit/automation/pipeline/stages/test_stage_cross.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_cross.py
@@ -18,6 +18,7 @@ from hephaestus.automation.pipeline.jobs import GitJob, JobResult
 from hephaestus.automation.pipeline.routing import ROUTES, Disposition, StageName
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.implementation import ImplementationStage
+from hephaestus.automation.pipeline.stages.merge_wait import MergeWaitStage
 from hephaestus.automation.pipeline.stages.pr_review import PrReviewStage
 from hephaestus.automation.state_labels import STATE_PLAN_GO
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
@@ -26,6 +27,10 @@ from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 # Sanity anchors: the reasons this composition exercises are ROUTES rows.
 assert ROUTES[StageName.PR_REVIEW].fail_routes["agent_error"] == StageName.IMPLEMENTATION
 assert ROUTES[StageName.IMPLEMENTATION].next == StageName.PR_REVIEW
+assert (
+    ROUTES[StageName.MERGE_WAIT].fail_routes["post_review_rebase_required"]
+    == StageName.IMPLEMENTATION
+)
 
 _LABEL_MUTATIONS = {
     "gh_issue_add_labels",
@@ -184,3 +189,83 @@ class TestAgentErrorPingPongTerminates:
         assert final.note == "agent_error_exhausted"
         label_writes = [name for name, _ in github.mutation_log if name in _LABEL_MUTATIONS]
         assert label_writes == []
+
+
+class TestPostReviewRebaseReusesRestoredWriter:
+    """pr_review cleanup -> merge_wait rebase fail-back -> implementation reuses writer."""
+
+    def test_transition_reuses_restored_writer_without_second_worktree(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A stale reviewed head resumes the stowed writer before rebasing."""
+        pr_stage = PrReviewStage()
+        impl_stage = ImplementationStage()
+        github = FakeStageGitHub(
+            labels=[STATE_PLAN_GO],
+            open_pr=1001,
+            pr_head_branch="1-real-branch",
+            pr_impl_state=(True, False),
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.branch = "1-real-branch"
+        item.worktree = "/tmp/detached-review"
+        item.payload.update(
+            {
+                "writer_worktree": "/tmp/implementation-writer",
+                "review_worktree": "/tmp/detached-review",
+            }
+        )
+
+        cleanup = pr_stage._cleanup_review_worktree_then(
+            item,
+            StageOutcome(Disposition.ADVANCE, "review_go"),
+        )
+        assert cleanup == Continue(next_state="CLEANUP_REVIEW_WORKTREE_WAIT")
+        item.state = cleanup.next_state
+
+        remove = pr_stage.step(item, ctx)
+        assert isinstance(remove, JobRequest)
+        assert isinstance(remove.job, GitJob)
+        assert remove.job.op == "remove_worktree"
+        pr_stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+        item.state = remove.on_done_state
+
+        reviewed = pr_stage.step(item, ctx)
+        assert reviewed == StageOutcome(Disposition.ADVANCE, "review_go")
+        assert ROUTES[StageName.PR_REVIEW].next is StageName.MERGE_WAIT
+        assert item.worktree == "/tmp/implementation-writer"
+        assert item.payload["implementation_writer_restored"] is True
+        assert "writer_worktree" not in item.payload
+        assert "review_worktree" not in item.payload
+
+        rebase_failback = MergeWaitStage._post_review_rebase(
+            item,
+            "post_review_rebase_required",
+        )
+        assert rebase_failback == StageOutcome(
+            Disposition.FAIL_BACK,
+            "post_review_rebase_required",
+        )
+
+        item.stage = ROUTES[StageName.MERGE_WAIT].fail_routes[rebase_failback.note]
+        item.state = "ENTER"
+        assert impl_stage.on_enter(item, ctx) is None
+
+        entered = impl_stage.step(item, ctx)
+        assert entered == Continue(next_state="GATE")
+        item.state = entered.next_state
+
+        gated = impl_stage.step(item, ctx)
+        assert gated == Continue(next_state="WORKTREE_WAIT")
+        item.state = gated.next_state
+
+        reused = impl_stage.step(item, ctx)
+        assert reused == Continue(next_state="DIRTY_DECISION_WAIT")
+        assert item.worktree == "/tmp/implementation-writer"
+        assert item.payload["worktree_dirty"] is False
+        assert "implementation_writer_restored" not in item.payload
+
+        item.state = reused.next_state
+        dirty = impl_stage.step(item, ctx)
+        assert dirty == Continue(next_state="REBASE_WAIT")

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -391,6 +391,26 @@ class TestGate:
         assert item.pr == 1001
         assert item.branch == "1-real-branch"
 
+    def test_post_review_rebase_requirement_adopts_implementation_go_pr(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Merge-wait can send a reviewed head to its implementer for rebasing."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(
+            open_pr=1001, pr_impl_state=(True, False), pr_head_branch="1-real-branch"
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+        item.payload["post_review_rebase_required"] = True
+
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="WORKTREE_WAIT")
+        assert item.payload["existing_pr"] is True
+        item.state = "DIRTY_DECISION_WAIT"
+        item.payload["worktree_dirty"] = False
+        assert stage.step(item, ctx) == Continue(next_state="REBASE_WAIT")
+
     def test_gate_existing_fork_with_impl_go_routes_to_merge_wait(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -643,29 +663,99 @@ class TestGate:
         stage.on_job_done(item, JobResult(ok=True, value={"rebased": True}), ctx)
         assert stage.step(item, ctx) == Continue(next_state="ADOPTED")
 
-    def test_rebase_conflict_warning_preserves_actionable_reason(
+    def test_rebase_conflict_uses_edit_only_agent_and_separate_budget(
         self,
         make_ctx: Any,
         make_work_item: Any,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """The implementation warning explains that the rebase was aborted."""
+        """A paused rebase gets a bounded edit-only agent turn."""
         stage = ImplementationStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="REBASE_WAIT")
         result = JobResult(
             ok=False,
-            value={"rebased": False},
-            error="mechanical rebase hit conflicts; aborted",
+            value={
+                "rebased": False,
+                "conflict_paths": ("hephaestus/example.py",),
+                "conflict_snapshot": {"hephaestus/example.py": "before"},
+                "base_sha": "b" * 40,
+                "expected_remote_sha": "a" * 40,
+            },
+            error="mechanical rebase hit conflicts; resolution required",
         )
 
         with caplog.at_level("WARNING", logger=implementation_module.__name__):
             stage.on_job_done(item, result, ctx)
 
-        assert item.payload["rebase_error"] is True
+        assert item.payload["rebase_conflict"] is True
+        assert item.payload["rebase_conflict_paths"] == ("hephaestus/example.py",)
         assert caplog.messages == [
-            "implementation:1: writer rebase failed: mechanical rebase hit conflicts; aborted"
+            "implementation:1: writer rebase paused for host-owned conflict resolution"
         ]
+
+        item.payload.update(
+            {
+                "issue_title": "Resolve schema validation",
+                "issue_body": "Keep the existing behavior.",
+            }
+        )
+        assert stage.step(item, ctx) == Continue(next_state="REBASE_CONFLICT_WAIT")
+        item.state = "REBASE_CONFLICT_WAIT"
+        item.attempts["implement"] = ctx.budget("implement")
+
+        request = stage.step(item, ctx)
+
+        assert isinstance(request, JobRequest)
+        assert isinstance(request.job, AgentJob)
+        assert request.job.prompt_kwargs["rebase_conflict"] is True
+        assert request.job.allowed_tools == "Read,Write,Edit,Glob,Grep"
+        assert request.on_done_state == "REBASE_CONTINUE_WAIT"
+        prompt = request.job.prompt_builder(**request.job.prompt_kwargs)
+        assert "Rebase Conflict Resolution Required" in prompt
+        assert "Do not run Git commands" in prompt
+        assert "hephaestus/example.py" in prompt
+
+    def test_rebase_conflict_attempts_are_bounded_independently(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Conflict retries terminate without consuming normal implementation turns."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_CONFLICT_WAIT")
+        item.payload.update(
+            {
+                "rebase_conflict": True,
+                "rebase_conflict_paths": ("hephaestus/example.py",),
+            }
+        )
+        item.attempts["implement"] = ctx.budget("implement")
+        item.attempts["rebase_conflict"] = ctx.budget("rebase_conflict")
+
+        assert stage.step(item, ctx) == StageOutcome(
+            Disposition.FINISH_FAIL, "rebase_conflict_exhausted"
+        )
+
+    def test_successful_conflict_agent_requires_host_completion_before_flags_clear(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An agent exit alone cannot authorize or publish a rebased head."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_CONFLICT_WAIT")
+        item.payload.update(
+            {
+                "post_review_rebase_required": True,
+                "rebase_conflict": True,
+                "rebase_conflict_paths": ("hephaestus/example.py",),
+            }
+        )
+
+        stage.on_job_done(item, JobResult(ok=True, value="resolved"), ctx)
+
+        assert item.payload["rebase_conflict"] is True
+        assert item.payload["post_review_rebase_required"] is True
+        assert item.attempts["rebase_conflict"] == 1
 
 
 class TestImplementationStateSkipGate:
@@ -1018,6 +1108,27 @@ class TestWorktreeAndAdvise:
         )
 
         result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="DIRTY_DECISION_WAIT")
+        assert item.payload["worktree_dirty"] is False
+        assert "implementation_writer_restored" not in item.payload
+
+    def test_post_review_rebase_reuses_the_writer_stowed_for_read_only_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Merge-wait re-entry must reuse the same-run writer checkout."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=1, pr=1001, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl"
+        item.worktree = "/tmp/implementation-writer"
+        item.payload.update(
+            {
+                "post_review_rebase_required": True,
+                "implementation_writer_restored": True,
+            }
+        )
+
+        result = stage.step(item, make_ctx())
 
         assert result == Continue(next_state="DIRTY_DECISION_WAIT")
         assert item.payload["worktree_dirty"] is False

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1241,7 +1241,53 @@ class TestWorktreeAndAdvise:
 
         assert result == Continue(next_state="DIRTY_DECISION_WAIT")
         assert item.payload["worktree_dirty"] is False
+        assert item.payload["sync_restored_writer_before_rebase"] is True
         assert "implementation_writer_restored" not in item.payload
+
+        item.state = result.next_state
+        dirty = stage.step(item, make_ctx())
+        assert dirty == Continue(next_state="REBASE_WAIT")
+
+        item.state = dirty.next_state
+        rebase = stage.step(item, make_ctx())
+        assert isinstance(rebase, JobRequest)
+        assert isinstance(rebase.job, GitJob)
+        assert rebase.job.kwargs["sync_to_expected_remote_head"] is True
+        assert rebase.job.kwargs["pr_number"] == 1001
+
+    def test_restored_writer_head_drift_returns_to_fresh_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A restored writer that syncs past its rebase proof is never published."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_WAIT")
+        item.payload.update(
+            {
+                "post_review_rebase_required": True,
+                "sync_restored_writer_before_rebase": True,
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=True,
+                value={
+                    "rebased": False,
+                    "published": False,
+                    "head_drift": True,
+                    "head_sha": "b" * 40,
+                },
+            ),
+            ctx,
+        )
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="ADOPTED")
+        assert "post_review_rebase_required" not in item.payload
+        assert "sync_restored_writer_before_rebase" not in item.payload
+        assert "rebase_complete" not in item.payload
 
     def test_direct_scope_worktree_uses_its_bootstrap_pin_without_refresh(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -679,6 +679,8 @@ class TestGate:
                 "rebased": False,
                 "conflict_paths": ("hephaestus/example.py",),
                 "conflict_snapshot": {"hephaestus/example.py": "before"},
+                "conflict_index_snapshot": "1" * 64,
+                "paused_head_sha": "c" * 40,
                 "base_sha": "b" * 40,
                 "expected_remote_sha": "a" * 40,
             },
@@ -690,6 +692,8 @@ class TestGate:
 
         assert item.payload["rebase_conflict"] is True
         assert item.payload["rebase_conflict_paths"] == ("hephaestus/example.py",)
+        assert item.payload["rebase_conflict_index_snapshot"] == "1" * 64
+        assert item.payload["rebase_paused_head_sha"] == "c" * 40
         assert caplog.messages == [
             "implementation:1: writer rebase paused for host-owned conflict resolution"
         ]
@@ -736,6 +740,69 @@ class TestGate:
             Disposition.FINISH_FAIL, "rebase_conflict_exhausted"
         )
 
+    def test_rebase_conflict_in_implement_wait_bypasses_ordinary_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A host conflict routed through IMPLEMENT_WAIT keeps its conflict turn."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="IMPLEMENT_WAIT")
+        item.payload.update(
+            {
+                "rebase_conflict": True,
+                "rebase_conflict_paths": ("hephaestus/example.py",),
+            }
+        )
+        item.attempts["implement"] = ctx.budget("implement")
+
+        assert stage.step(item, ctx) == Continue(next_state="REBASE_CONFLICT_WAIT")
+
+        item.state = "REBASE_CONFLICT_WAIT"
+        request = stage.step(item, ctx)
+
+        assert isinstance(request, JobRequest)
+        assert isinstance(request.job, AgentJob)
+        assert request.job.descr == "resolve_rebase_conflict"
+        assert item.attempts["implement"] == ctx.budget("implement")
+
+    def test_rebase_conflict_reentry_bypasses_exhausted_ordinary_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A second host conflict still gets its own bounded agent turn."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_CONTINUE_WAIT")
+        item.attempts["implement"] = ctx.budget("implement")
+        item.attempts["rebase_conflict"] = 1
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                value={
+                    "conflict_paths": ("hephaestus/example.py",),
+                    "conflict_snapshot": {"hephaestus/example.py": "after first pass"},
+                    "conflict_index_snapshot": "2" * 64,
+                    "paused_head_sha": "d" * 40,
+                    "base_sha": "b" * 40,
+                    "expected_remote_sha": "a" * 40,
+                },
+                error="rebase conflict resolution required: hephaestus/example.py",
+            ),
+            ctx,
+        )
+
+        assert stage.step(item, ctx) == Continue(next_state="REBASE_CONFLICT_WAIT")
+
+        item.state = "REBASE_CONFLICT_WAIT"
+        request = stage.step(item, ctx)
+
+        assert isinstance(request, JobRequest)
+        assert isinstance(request.job, AgentJob)
+        assert request.job.descr == "resolve_rebase_conflict"
+        assert item.attempts["implement"] == ctx.budget("implement")
+        assert item.attempts["rebase_conflict"] == 1
+
     def test_successful_conflict_agent_requires_host_completion_before_flags_clear(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -748,6 +815,11 @@ class TestGate:
                 "post_review_rebase_required": True,
                 "rebase_conflict": True,
                 "rebase_conflict_paths": ("hephaestus/example.py",),
+                "rebase_conflict_snapshot": {"hephaestus/example.py": "before"},
+                "rebase_conflict_index_snapshot": "1" * 64,
+                "rebase_paused_head_sha": "c" * 40,
+                "rebase_base_sha": "b" * 40,
+                "rebase_expected_remote_sha": "a" * 40,
             }
         )
 
@@ -756,6 +828,43 @@ class TestGate:
         assert item.payload["rebase_conflict"] is True
         assert item.payload["post_review_rebase_required"] is True
         assert item.attempts["rebase_conflict"] == 1
+
+        item.state = "REBASE_CONTINUE_WAIT"
+        request = stage.step(item, ctx)
+
+        assert isinstance(request, JobRequest)
+        assert isinstance(request.job, GitJob)
+        assert request.job.op == "continue_rebase"
+        assert request.job.kwargs["expected_remote_sha"] == "a" * 40
+        assert request.job.kwargs["conflict_index_snapshot"] == "1" * 64
+        assert request.job.kwargs["paused_head_sha"] == "c" * 40
+
+    def test_host_completed_conflict_rebase_clears_receipt_and_requires_fresh_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Only host publication clears conflict state and advances to PR review."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_CONTINUE_WAIT")
+        item.payload.update(
+            {
+                "post_review_rebase_required": True,
+                "rebase_complete": True,
+                "rebase_conflict": True,
+                "rebase_conflict_paths": ("hephaestus/example.py",),
+                "rebase_conflict_snapshot": {"hephaestus/example.py": "before"},
+                "rebase_conflict_index_snapshot": "1" * 64,
+                "rebase_paused_head_sha": "c" * 40,
+                "rebase_base_sha": "b" * 40,
+                "rebase_expected_remote_sha": "a" * 40,
+            }
+        )
+
+        assert stage.step(item, ctx) == Continue(next_state="ADOPTED")
+        assert "post_review_rebase_required" not in item.payload
+        assert "rebase_conflict" not in item.payload
+        assert "rebase_conflict_index_snapshot" not in item.payload
+        assert "rebase_paused_head_sha" not in item.payload
 
 
 class TestImplementationStateSkipGate:

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -957,10 +957,10 @@ def test_fresh_same_head_proof_retries_a_prior_unstable_decline(
 
 
 @pytest.mark.parametrize("merge_state_status", ["CONFLICTING", "DIRTY"])
-def test_405_conflicting_or_dirty_readiness_is_terminal(
+def test_405_conflicting_or_dirty_readiness_returns_to_implementer(
     make_ctx: Any, make_work_item: Any, merge_state_status: str
 ) -> None:
-    """Conflict-like GitHub readiness states are not retried as transient readiness."""
+    """A reviewed conflict is handed to the implementation agent to resolve."""
     github = _ConditionalGitHub(
         states=[_open_pr(), _open_pr(), _open_pr()],
         merge_results=[
@@ -982,13 +982,33 @@ def test_405_conflicting_or_dirty_readiness_is_terminal(
         ],
     )
 
-    result = _complete_merge_cycle(
-        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
-    )
+    item = _reviewed_item(make_work_item)
+    result = _complete_merge_cycle(MergeWaitStage(), item, make_ctx(github=github))
 
-    assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_conflicting")
+    assert result == StageOutcome(Disposition.FAIL_BACK, "merge_conflicting")
+    assert item.payload["post_review_rebase_required"] is True
     assert github.merge_attempts == [(12, "a" * 40)]
     assert github.mutation_log == []
+
+
+def test_reviewed_behind_head_returns_to_implementer_for_rebase(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A reviewer does not validate against current main; implementation rebases later."""
+    github = _ConditionalGitHub(
+        readiness={
+            **_open_pr(),
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BEHIND",
+        }
+    )
+    item = _reviewed_item(make_work_item)
+
+    result = _complete_merge_cycle(MergeWaitStage(), item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "post_review_rebase_required")
+    assert item.payload["post_review_rebase_required"] is True
+    assert github.merge_attempts == []
 
 
 def test_409_reconciliation_external_arm_blocks_without_label_mutation(
@@ -1085,7 +1105,7 @@ def test_200_without_merged_true_is_terminal(make_ctx: Any, make_work_item: Any)
     assert result == StageOutcome(Disposition.FINISH_FAIL, "merge_not_merged")
 
 
-def test_readiness_wait_allows_one_full_ci_restart_with_a_bounded_deadline(
+def test_blocked_readiness_wait_allows_one_full_ci_restart_with_a_bounded_deadline(
     make_ctx: Any, make_work_item: Any
 ) -> None:
     """A normal CI restart fits while readiness waiting remains bounded."""
@@ -1097,7 +1117,7 @@ def test_readiness_wait_allows_one_full_ci_restart_with_a_bounded_deadline(
             "autoMergeRequest": None,
             "baseRefName": "main",
             "mergeable": "MERGEABLE",
-            "mergeStateStatus": "BEHIND",
+            "mergeStateStatus": "BLOCKED",
         },
     )
     item = _reviewed_item(make_work_item)

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -847,10 +847,13 @@ class TestPlanningStageStep:
         assert outcome.disposition == Disposition.ADVANCE
         assert "<!-- revision: 2 -->" in github.comments[270][0]
 
-    def test_review_text_cannot_authorize_revision_without_no_go_or_blocked_label(
-        self, make_ctx: Any, make_work_item: Any
+    def test_concurrent_revision_owner_ejects_item_without_poisoning_pipeline(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A no-go-looking comment remains inert while the issue says needs-plan."""
+        """A lost plan-label race is reported as another item's work, not fatal."""
         stage = PlanningStage()
         github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN], has_plan=False)
         github.comments[271] = [
@@ -862,8 +865,16 @@ class TestPlanningStageStep:
         item.payload["plan_text"] = "Plan v2 with rollback"
         item.payload["requires_plan_revision"] = True
 
-        with pytest.raises(RuntimeError, match="label"):
-            stage.step(item, ctx)
+        with caplog.at_level("INFO"):
+            outcome = stage.step(item, ctx)
+
+        assert outcome == StageOutcome(
+            Disposition.FINISH_PASS,
+            "plan is being worked by another pipeline item; ejected from queue",
+        )
+        assert any(
+            "being worked by another pipeline item" in message for message in caplog.messages
+        )
 
     def test_replan_without_change_publishes_blocked_review_and_stops(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
+++ b/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
@@ -18,6 +18,7 @@ PIPELINE_DIR = Path(__file__).parents[4] / "hephaestus" / "automation" / "pipeli
 
 READ_ONLY = "Read,Glob,Grep"
 WRITE = "Read,Write,Edit,Glob,Grep,Bash"
+EDIT_ONLY = "Read,Write,Edit,Glob,Grep"
 ADDRESS = "Read,Write,Edit,Glob,Grep,Bash,Task,Skill"
 PR_REVIEW = "Read,Glob,Grep,Bash,Skill,Agent,WebFetch"
 READ_ONLY_SCOPES = frozenset({READ_ONLY, PR_REVIEW})
@@ -43,6 +44,11 @@ EXPECTED_SCOPES = {
     ): READ_ONLY,
     ("stages/implementation.py", "_implement_wait", "get_address_review_prompt"): ADDRESS,
     ("stages/implementation.py", "_implement_wait", "build_implementation_prompt"): WRITE,
+    (
+        "stages/implementation.py",
+        "_rebase_conflict_wait",
+        "build_implementation_prompt",
+    ): EDIT_ONLY,
     ("stages/implementation.py", "_testfix_wait", "build_test_fix_prompt"): WRITE,
     ("stages/pr_review_jobs.py", "_submit_review_job", "get_pr_review_analysis_prompt"): PR_REVIEW,
     ("stages/pr_review_jobs.py", "_validate_wait", "get_review_validation_prompt"): READ_ONLY,

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -684,6 +684,34 @@ class TestQuiescence:
         assert any(reason.startswith("poisoned: boom") for reason in reasons)
         assert any(reason == "fine" for reason in reasons)
 
+    def test_duplicate_plan_owner_ejection_keeps_run_successful(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A benign duplicate-owner terminal result must not make the run exit 1."""
+        seed = [
+            SeedEntry(kind="issue", identifier=271, stage=StageName.PLANNING, reason="duplicate")
+        ]
+        coordinator, _, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            seed_entries=[seed],
+        )
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            StageOutcome(
+                Disposition.FINISH_PASS,
+                "plan is being worked by another pipeline item; ejected from queue",
+            )
+        )
+
+        assert coordinator.run() == 0
+        assert coordinator.ledger == [
+            ItemResult(
+                passed=True,
+                reason="plan is being worked by another pipeline item; ejected from queue",
+                final_stage=StageName.PLANNING,
+            )
+        ]
+
     def test_pr_review_adoption_records_completion_before_wait_state(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -285,6 +285,28 @@ class TestInterruptSemantics:
         assert coordinator._completion_wakeup.is_set()
         assert coordinator.completion_q.empty()
 
+    def test_sigint_reports_timed_grace_and_second_ctrl_c_instruction(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An operator sees exactly how Ctrl+C shutdown escalation works."""
+        coordinator = _coordinator(tmp_path, monkeypatch, grace_s=17.0)
+        coordinator._install_signal_handlers()
+        import signal as signal_mod
+
+        handler = signal_mod.getsignal(signal_mod.SIGINT)
+        assert callable(handler)
+
+        with caplog.at_level("WARNING"):
+            handler(signal_mod.SIGINT, None)
+
+        assert caplog.messages[-1] == (
+            "Ctrl+C received: timed graceful shutdown started (17s); "
+            "press Ctrl+C again to force teardown"
+        )
+
 
 class TestNormalTeardownExitSemantics:
     """Ordinary pool cleanup must not manufacture an interrupt outcome (#2431)."""

--- a/tests/unit/automation/pipeline/test_plan_journal.py
+++ b/tests/unit/automation/pipeline/test_plan_journal.py
@@ -138,5 +138,5 @@ def test_publication_rejects_concurrent_canonical_pointer_overwrite() -> None:
 
     github = CompetingWriterGitHub()
 
-    with pytest.raises(RuntimeError, match=r"concurrent plan journal write.*manual recovery"):
+    with pytest.raises(RuntimeError, match=r"concurrent plan journal write.*another pipeline item"):
         publish_plan_revision(9, "Expected plan", github, require_change=False)

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -204,7 +204,7 @@ class TestROUTES:
                     "already_implementation_go_pr": StageName.MERGE_WAIT,
                     "*": StageName.FINISHED,
                 },
-                budgets={"implement": 2, "test_fix": 1},
+                budgets={"implement": 2, "rebase_conflict": 2, "test_fix": 1},
             ),
             StageName.PR_REVIEW: Route(
                 next=StageName.MERGE_WAIT,
@@ -223,6 +223,8 @@ class TestROUTES:
                     "not_implementation_go": StageName.PR_REVIEW,
                     "reviewed_head_missing": StageName.PR_REVIEW,
                     "reviewed_head_drift": StageName.PR_REVIEW,
+                    "merge_conflicting": StageName.IMPLEMENTATION,
+                    "post_review_rebase_required": StageName.IMPLEMENTATION,
                     "*": StageName.FINISHED,
                 },
                 budgets={"merge": routing.DEFAULT_DRIVE_GREEN_LOOPS},

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -39,7 +39,8 @@ _REASONS = [*_DECLARED_REASONS, "unknown_reason"]
 # their stage rather than retry it consume no retry budget: plan_not_go
 # (implementation -> plan_review), already_implementation_go_pr (-> merge_wait),
 # not_implementation_go / reviewed_head_missing / reviewed_head_drift
-# (merge_wait -> pr_review),
+# (merge_wait -> pr_review), merge_conflicting / post_review_rebase_required
+# (merge_wait -> implementation),
 # missing_worktree (-> implementation),
 # no_pr (-> finished), and merge-wait re-review routes all
 # map to None.
@@ -56,6 +57,8 @@ _REASON_BUDGET: dict[str, str | None] = {
     "not_implementation_go": None,
     "reviewed_head_missing": None,
     "reviewed_head_drift": None,
+    "merge_conflicting": None,
+    "post_review_rebase_required": None,
     "missing_worktree": None,
     "no_pr": None,
     # #2054 terminalizes every open merge-wait item after containment.

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -219,7 +219,7 @@ class TestRetryDelayConsumption:
                     "baseRefName": "main",
                     "autoMergeRequest": None,
                     "mergeable": "MERGEABLE",
-                    "mergeStateStatus": "BEHIND",
+                    "mergeStateStatus": "BLOCKED",
                 }
 
         coordinator, clock = clocked

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import queue
@@ -2756,6 +2757,8 @@ class TestGitOps:
                 "rebased": False,
                 "conflict_paths": ("x.py",),
                 "conflict_snapshot": {"x.py": "before"},
+                "conflict_index_snapshot": "1" * 64,
+                "paused_head_sha": "c" * 40,
                 "base_sha": "b" * 40,
                 "expected_remote_sha": "a" * 40,
             }
@@ -2765,6 +2768,37 @@ class TestGitOps:
         assert result.ok is False
         assert result.value == receipt.return_value
         assert result.error == "mechanical rebase hit conflicts; resolution required"
+
+    def test_conflict_receipt_binds_index_head_base_and_remote_head(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """The host captures all immutable inputs before agent file editing."""
+        (tmp_path / "x.py").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> topic\n")
+        index_state = "100644 blob 1\tx.py\0100644 blob 2\tx.py\0"
+        with patch(f"{_WP}.git_utils.run") as run:
+            run.side_effect = [
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout=index_state),
+                MagicMock(returncode=0, stdout="c" * 40),
+                MagicMock(returncode=0, stdout="b" * 40),
+            ]
+
+            receipt = pool._conflict_receipt(
+                tmp_path,
+                remote="origin",
+                base_branch="main",
+                expected_remote_sha="a" * 40,
+                timeout=60,
+            )
+
+        assert isinstance(receipt, dict)
+        assert receipt["conflict_paths"] == ("x.py",)
+        assert (
+            receipt["conflict_index_snapshot"] == hashlib.sha256(index_state.encode()).hexdigest()
+        )
+        assert receipt["paused_head_sha"] == "c" * 40
+        assert receipt["base_sha"] == "b" * 40
+        assert receipt["expected_remote_sha"] == "a" * 40
 
     @staticmethod
     def _continue_rebase_job(tmp_path: Path) -> GitJob:
@@ -2780,6 +2814,8 @@ class TestGitOps:
                 "expected_remote_sha": "a" * 40,
                 "conflict_paths": ("x.py",),
                 "conflict_snapshot": {"x.py": "before"},
+                "conflict_index_snapshot": "1" * 64,
+                "paused_head_sha": "c" * 40,
             },
         )
 
@@ -2789,6 +2825,8 @@ class TestGitOps:
         receipt = {
             "conflict_paths": ("x.py",),
             "conflict_snapshot": {"x.py": "before"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "c" * 40,
         }
         with (
             patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
@@ -2810,6 +2848,8 @@ class TestGitOps:
         receipt = {
             "conflict_paths": ("x.py",),
             "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "c" * 40,
         }
         with (
             patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
@@ -2819,6 +2859,128 @@ class TestGitOps:
 
         assert result.ok is False
         assert result.error == "rebase conflict resolution required: conflict markers remain"
+
+    def test_continue_rebase_rejects_edits_outside_conflict_paths(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """The host rejects an agent turn that dirtied any non-conflict path."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "c" * 40,
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if argv == ["git", "diff", "--name-only", "-z"]:
+                return MagicMock(returncode=0, stdout="x.py\0outside.py\0")
+            if argv[:3] == ["git", "merge-base", "--is-ancestor"]:
+                return MagicMock(returncode=0, stdout="")
+            if argv[:3] == ["git", "rev-list", "--reverse"]:
+                return MagicMock(returncode=0, stdout="c" * 40)
+            if argv[:3] == ["git", "cat-file", "-p"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "tree deadbeef\ngpgsig signature\n\nfix\n\n"
+                        "Signed-off-by: Test User <test@example.com>\n"
+                    ),
+                )
+            return MagicMock(returncode=0, stdout="")
+
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch.object(pool, "_read_publish_head", return_value="d" * 40),
+            patch(f"{_WP}.git_utils.push_head_to_branch"),
+            patch(f"{_WP}.git_utils.run", side_effect=fake_run),
+        ):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "rebase conflict resolution changed paths outside host scope"
+
+    def test_continue_rebase_rejects_mutated_conflict_index(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """Only the host may mutate the paused rebase index."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "2" * 64,
+            "paused_head_sha": "c" * 40,
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if argv[:3] == ["git", "merge-base", "--is-ancestor"]:
+                return MagicMock(returncode=0, stdout="")
+            if argv[:3] == ["git", "rev-list", "--reverse"]:
+                return MagicMock(returncode=0, stdout="c" * 40)
+            if argv[:3] == ["git", "cat-file", "-p"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "tree deadbeef\ngpgsig signature\n\nfix\n\n"
+                        "Signed-off-by: Test User <test@example.com>\n"
+                    ),
+                )
+            return MagicMock(returncode=0, stdout="x.py\0")
+
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch.object(pool, "_read_publish_head", return_value="d" * 40),
+            patch(f"{_WP}.git_utils.push_head_to_branch"),
+            patch(f"{_WP}.git_utils.run", side_effect=fake_run),
+        ):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "conflict index was mutated outside host ownership"
+
+    def test_continue_rebase_rejects_changed_paused_head(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """Agent file editing cannot move the host-owned paused rebase head."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "d" * 40,
+        }
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if argv[:3] == ["git", "merge-base", "--is-ancestor"]:
+                return MagicMock(returncode=0, stdout="")
+            if argv[:3] == ["git", "rev-list", "--reverse"]:
+                return MagicMock(returncode=0, stdout="e" * 40)
+            if argv[:3] == ["git", "cat-file", "-p"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "tree deadbeef\ngpgsig signature\n\nfix\n\n"
+                        "Signed-off-by: Test User <test@example.com>\n"
+                    ),
+                )
+            return MagicMock(returncode=0, stdout="x.py\0")
+
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch.object(pool, "_read_publish_head", return_value="f" * 40),
+            patch(f"{_WP}.git_utils.push_head_to_branch"),
+            patch(f"{_WP}.git_utils.run", side_effect=fake_run),
+        ):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "paused rebase head changed outside host ownership"
 
     def test_continue_rebase_rejects_remote_head_drift(
         self, pool: WorkerPool, tmp_path: Path
@@ -2831,15 +2993,17 @@ class TestGitOps:
         assert result.ok is False
         assert result.error == "remote writer head changed during conflict resolution"
 
-    def test_continue_rebase_rejects_unsigned_or_non_dco_commit(
+    def test_continue_rebase_rejects_missing_captured_base_ancestry(
         self, pool: WorkerPool, tmp_path: Path
     ) -> None:
-        """Host completion verifies every replayed commit's signature and DCO trailer."""
+        """A host-completed rebase must descend from its captured base head."""
         (tmp_path / "x.py").write_text("resolved\n")
         job = self._continue_rebase_job(tmp_path)
         receipt = {
             "conflict_paths": ("x.py",),
             "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "c" * 40,
         }
         with (
             patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
@@ -2847,12 +3011,53 @@ class TestGitOps:
             patch(f"{_WP}.git_utils.run") as run,
         ):
             run.side_effect = [
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=1, stdout=""),
+            ]
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "completed rebase lacks captured base ancestry"
+
+    @pytest.mark.parametrize(
+        "raw_commit",
+        [
+            "tree deadbeef\n\nmessage\n\nSigned-off-by: Test User <test@example.com>\n",
+            "tree deadbeef\ngpgsig signature\n\nmessage\n",
+        ],
+    )
+    def test_continue_rebase_rejects_unsigned_or_non_dco_commit(
+        self, pool: WorkerPool, tmp_path: Path, raw_commit: str
+    ) -> None:
+        """Host completion verifies every replayed commit's signature and DCO trailer."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "c" * 40,
+        }
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}.git_utils.run") as run,
+        ):
+            run.side_effect = [
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout="c" * 40),
-                MagicMock(returncode=0, stdout="tree deadbeef\n\nmessage\n"),
+                MagicMock(returncode=0, stdout=raw_commit),
             ]
             result = pool._git_continue_rebase(job)
 
@@ -2868,6 +3073,8 @@ class TestGitOps:
         receipt = {
             "conflict_paths": ("x.py",),
             "conflict_snapshot": {"x.py": "after"},
+            "conflict_index_snapshot": "1" * 64,
+            "paused_head_sha": "c" * 40,
         }
         signed = (
             "tree deadbeef\ngpgsig -----BEGIN SIGNATURE-----\n\nfix\n\n"
@@ -2882,6 +3089,9 @@ class TestGitOps:
             patch(f"{_WP}.git_utils.run") as run,
         ):
             run.side_effect = [
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout="x.py\0"),
+                MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2371,13 +2371,13 @@ class TestGitOps:
         assert result.value == {"ready": False, "reason": "head_drift"}
         mock_sync.assert_called_once_with(tmp_path, "70-existing", pr_number=70, timeout=60)
 
-    def test_verify_pr_review_checkout_retries_when_remote_base_drifted(
+    def test_verify_pr_review_checkout_uses_original_branch_point_when_base_advances(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
     ) -> None:
-        """A moved base ref cannot produce review evidence for the captured PR."""
+        """Review binds to the PR branch point instead of current base-branch HEAD."""
         job = GitJob(
             repo="test/repo",
             op="verify_pr_review_checkout",
@@ -2399,7 +2399,7 @@ class TestGitOps:
                 side_effect=[
                     MagicMock(stdout="a" * 40 + "\n"),
                     MagicMock(stdout=""),
-                    MagicMock(stdout="b" * 40 + "\n"),
+                    MagicMock(stdout="d" * 40 + "\n"),
                     MagicMock(stdout="checkout diff for stale base"),
                     MagicMock(stdout="stale.py\0"),
                 ],
@@ -2409,7 +2409,13 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is True
-        assert result.value == {"ready": False, "reason": "base_drift"}
+        assert result.value == {
+            "ready": True,
+            "head": "a" * 40,
+            "base": "d" * 40,
+            "diff": "checkout diff for stale base",
+            "changed_paths": ["stale.py"],
+        }
 
     def test_verify_pr_review_checkout_returns_diff_bound_to_verified_head(
         self,
@@ -2457,7 +2463,12 @@ class TestGitOps:
             "changed_paths": ["old.py", "new.py"],
         }
         mock_sync.assert_called_once_with(tmp_path, "70-existing", pr_number=70, timeout=60)
-        assert mock_run.call_args_list[2].args[0] == ["git", "rev-parse", "FETCH_HEAD"]
+        assert mock_run.call_args_list[2].args[0] == [
+            "git",
+            "merge-base",
+            "b" * 40,
+            "a" * 40,
+        ]
         assert mock_run.call_args_list[3].args[0] == [
             "git",
             "diff",
@@ -2703,6 +2714,7 @@ class TestGitOps:
         mock_rebase.assert_called_once_with(
             cwd=Path("/tmp/wt"),
             base_branch="main",
+            preserve_conflicts=False,
             timeout=60,
         )
         assert result.ok is rebase_clean
@@ -2734,17 +2746,162 @@ class TestGitOps:
                 return_value=False,
             ),
             patch(f"{_WP}.git_utils.run") as run,
+            patch.object(pool, "_conflict_receipt") as receipt,
         ):
             run.side_effect = [
                 MagicMock(returncode=0),
                 MagicMock(returncode=1),
             ]
+            receipt.return_value = {
+                "rebased": False,
+                "conflict_paths": ("x.py",),
+                "conflict_snapshot": {"x.py": "before"},
+                "base_sha": "b" * 40,
+                "expected_remote_sha": "a" * 40,
+            }
             pool.submit(job, StageName.IMPLEMENTATION)
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert result.value == {"rebased": False}
-        assert result.error == "mechanical rebase hit conflicts; aborted"
+        assert result.value == receipt.return_value
+        assert result.error == "mechanical rebase hit conflicts; resolution required"
+
+    @staticmethod
+    def _continue_rebase_job(tmp_path: Path) -> GitJob:
+        return GitJob(
+            repo="test/repo",
+            op="continue_rebase",
+            timeout_s=60,
+            kwargs={
+                "cwd": tmp_path,
+                "remote": "origin",
+                "branch": "7-auto-impl",
+                "base_sha": "b" * 40,
+                "expected_remote_sha": "a" * 40,
+                "conflict_paths": ("x.py",),
+                "conflict_snapshot": {"x.py": "before"},
+            },
+        )
+
+    def test_continue_rebase_rejects_noop_agent(self, pool: WorkerPool, tmp_path: Path) -> None:
+        """An unchanged conflict snapshot cannot advance to Git continuation."""
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "before"},
+        }
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}.git_utils.run") as run,
+        ):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "rebase conflict resolution required: agent made no file changes"
+        run.assert_not_called()
+
+    def test_continue_rebase_rejects_unresolved_markers(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """Edited content still carrying conflict markers remains paused."""
+        (tmp_path / "x.py").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> topic\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+        }
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+        ):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "rebase conflict resolution required: conflict markers remain"
+
+    def test_continue_rebase_rejects_remote_head_drift(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """The captured PR head is an exact publication lease, not a hint."""
+        job = self._continue_rebase_job(tmp_path)
+        with patch.object(pool, "_read_remote_branch_head", return_value="c" * 40):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "remote writer head changed during conflict resolution"
+
+    def test_continue_rebase_rejects_unsigned_or_non_dco_commit(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """Host completion verifies every replayed commit's signature and DCO trailer."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+        }
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}.git_utils.run") as run,
+        ):
+            run.side_effect = [
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout="c" * 40),
+                MagicMock(returncode=0, stdout="tree deadbeef\n\nmessage\n"),
+            ]
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "completed rebase commit metadata invalid"
+
+    def test_continue_rebase_signs_verifies_and_exact_lease_publishes(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """A valid resolution advances only through the host's exact-head publication."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+        }
+        signed = (
+            "tree deadbeef\ngpgsig -----BEGIN SIGNATURE-----\n\nfix\n\n"
+            "Signed-off-by: Micah Villmow "
+            "<4211002+mvillmow@users.noreply.github.com>\n"
+        )
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch.object(pool, "_read_publish_head", return_value="d" * 40),
+            patch(f"{_WP}.git_utils.push_head_to_branch") as push,
+            patch(f"{_WP}.git_utils.run") as run,
+        ):
+            run.side_effect = [
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout="c" * 40),
+                MagicMock(returncode=0, stdout=signed),
+            ]
+            result = pool._git_continue_rebase(job)
+
+        assert result == JobResult(
+            ok=True,
+            value={"rebased": True, "published": True, "head_sha": "d" * 40},
+        )
+        push.assert_called_once_with(
+            "7-auto-impl",
+            "a" * 40,
+            tmp_path,
+            source_sha="d" * 40,
+            timeout=60,
+        )
 
     def test_writer_rebase_keeps_exact_head_when_current_base_is_already_ancestor(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -3222,6 +3222,60 @@ class TestGitOps:
         rebase.assert_not_called()
         push.assert_not_called()
 
+    def test_restored_writer_publish_rebase_syncs_and_returns_to_review_on_head_drift(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A restored writer must not rebase stale local H against newer remote E."""
+        expected_head = "a" * 40
+        synced_head = "b" * 40
+        job = GitJob(
+            repo="test/repo",
+            op="rebase",
+            timeout_s=60,
+            kwargs={
+                "cwd": tmp_path,
+                "base_branch": "main",
+                "remote": "origin",
+                "publish_rebased_head": True,
+                "branch": "7-auto-impl",
+                "expected_remote_sha": expected_head,
+                "sync_to_expected_remote_head": True,
+                "pr_number": 70,
+            },
+        )
+        with (
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True) as clean,
+            patch(f"{_WP}.git_utils.sync_worktree_to_remote_branch") as sync,
+            patch.object(pool, "_read_publish_head", return_value=synced_head),
+            patch(f"{_WP}.git_utils.run") as run,
+            patch(f"{_WP}.git_utils.rebase_worktree_onto") as rebase,
+            patch(f"{_WP}.git_utils.push_head_to_branch") as push,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {
+            "rebased": False,
+            "published": False,
+            "head_drift": True,
+            "head_sha": synced_head,
+        }
+        clean.assert_called_once_with(tmp_path, timeout=60)
+        sync.assert_called_once_with(
+            tmp_path,
+            "7-auto-impl",
+            remote="origin",
+            pr_number=70,
+            timeout=60,
+        )
+        run.assert_not_called()
+        rebase.assert_not_called()
+        push.assert_not_called()
+
     def test_direct_rebase_dispatch_rejects_the_retired_publish_mode(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -1204,6 +1204,31 @@ class TestRebaseWorktreeOnto:
         # The abort must be best-effort so it cannot mask the conflict signal.
         assert abort_kwargs.get("check") is False
 
+    def test_conflict_can_remain_paused_for_host_owned_resolution(
+        self, git_utils_mocks: Any
+    ) -> None:
+        """Writer rebases preserve conflict state only when explicitly requested."""
+        rebase_err = subprocess.CalledProcessError(1, ["git", "rebase"])
+        git_utils_mocks.run.side_effect = [
+            Mock(returncode=0),
+            Mock(returncode=0, stdout=""),
+            rebase_err,
+        ]
+
+        assert (
+            rebase_worktree_onto(
+                Path("/tmp/worktree-xyz"),
+                "main",
+                preserve_conflicts=True,
+            )
+            is False
+        )
+
+        assert all(
+            call.args[0] != ["git", "rebase", "--abort"]
+            for call in git_utils_mocks.run.call_args_list
+        )
+
     def test_removes_untracked_files_that_are_tracked_by_base_ref(
         self, git_utils_mocks: Any, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- eject stale plan publishers as duplicate queue ownership instead of poisoning the pipeline
- validate PR snapshots from their original branch point and defer rebasing until after review
- route post-review behind/conflicting heads to the implementation agent for rebase and conflict resolution
- explain timed graceful shutdown and second-Ctrl+C forced teardown

## Verification

- `uv run --all-extras --locked pytest -q`
- 7,351 passed, 12 skipped, 5 deselected
- coverage: 83.94%

Closes #2711
