### PR TITLE
test: fix mypy errors in plan-reviewer tests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1276,7 +1276,7 @@ budgets. Every `routes.py` row and every doc row MUST agree.
 |-------------------|------------------|-------------------------------------------------------------|----------------------------|
 | `repo` | `FINISHED` | `*` → `FINISHED` | `clone = 2` |
 | `planning` | `PLAN_REVIEW` | `*` → `FINISHED` | `plan = 2` |
-| `plan_review` | `IMPLEMENTATION` | `nogo` → `PLANNING`; `plan_cycles_exhausted` → `FINISHED`; `*` → `PLANNING` | `plan_review_iter = 3`, `plan_cycles = 2` |
+| `plan_review` | `IMPLEMENTATION` | `nogo` / `plan_missing` → `PLANNING`; `plan_cycles_exhausted` → `FINISHED`; `*` → `PLANNING` | `plan_review_iter = 3`, `plan_cycles = 2` |
 | `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `rebase_conflict = 2`, `test_fix = 1` |
 | `pr_review` | `MERGE_WAIT` | `agent_error`, `empty_pr_diff`, or `implementation_remediation` → `IMPLEMENTATION`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
 | `merge_wait` | `FINISHED` | `not_implementation_go`, `reviewed_head_missing`, or `reviewed_head_drift` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | `merge = 5` |

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -118,6 +118,7 @@ ROUTES: dict[StageName, Route] = {
         next=StageName.IMPLEMENTATION,
         fail_routes={
             "nogo": StageName.PLANNING,
+            "plan_missing": StageName.PLANNING,
             "plan_cycles_exhausted": StageName.FINISHED,
             "*": StageName.PLANNING,
         },

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -81,6 +81,7 @@ from hephaestus.automation.protocol import (
     PLAN_REVIEW_CANONICAL_MARKER,
 )
 from hephaestus.automation.review_journal import (
+    CommentJournalReadError,
     IssueComment,
     current_plan_context,
     is_pending_review,
@@ -522,13 +523,35 @@ class PlanReviewStage(Stage):
             labels = _require_issue_labels(item, ctx)
             if STATE_PLAN_BLOCKED in labels:
                 logger.info("plan_review:%d: already plan-blocked; stopping", item.issue)
-                ctx.github.ensure_blocked_audit(item.issue)
+                try:
+                    ctx.github.ensure_blocked_audit(item.issue)
+                except CommentJournalReadError as exc:
+                    logger.warning(
+                        "plan_review:%d: plan journal blocked-audit read failed: %s",
+                        item.issue,
+                        exc,
+                    )
+                    return StageOutcome(
+                        Disposition.RETRY,
+                        f"plan journal read failed: {exc}",
+                    )
                 return StageOutcome(Disposition.BLOCKED, "plan requires external intervention")
             if is_exclusive_plan_state(labels, STATE_PLAN_GO):
                 logger.info("plan_review:%d: already plan-go; advancing", item.issue)
                 return StageOutcome(Disposition.ADVANCE, "plan already approved")
 
-            comments = reconcile_plan_journal(item.issue, ctx.github)
+            try:
+                comments = reconcile_plan_journal(item.issue, ctx.github)
+            except CommentJournalReadError as exc:
+                logger.warning(
+                    "plan_review:%d: plan journal reconciliation read failed: %s",
+                    item.issue,
+                    exc,
+                )
+                return StageOutcome(
+                    Disposition.RETRY,
+                    f"plan journal read failed: {exc}",
+                )
             snapshot = journal_snapshot(comments)
             if snapshot.current_plan:
                 item.payload["plan_text"] = snapshot.current_plan

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -536,10 +536,6 @@ class PlanReviewStage(Stage):
                         f"plan journal read failed: {exc}",
                     )
                 return StageOutcome(Disposition.BLOCKED, "plan requires external intervention")
-            if is_exclusive_plan_state(labels, STATE_PLAN_GO):
-                logger.info("plan_review:%d: already plan-go; advancing", item.issue)
-                return StageOutcome(Disposition.ADVANCE, "plan already approved")
-
             try:
                 comments = reconcile_plan_journal(item.issue, ctx.github)
             except CommentJournalReadError as exc:
@@ -553,9 +549,21 @@ class PlanReviewStage(Stage):
                     f"plan journal read failed: {exc}",
                 )
             snapshot = journal_snapshot(comments)
-            if snapshot.current_plan:
-                item.payload["plan_text"] = snapshot.current_plan
-                item.payload["plan_revision"] = snapshot.revision
+            if not snapshot.current_plan:
+                item.payload.pop("plan_text", None)
+                item.payload.pop("plan_revision", None)
+                item.payload.pop("prior_review", None)
+                logger.warning(
+                    "plan_review:%d: canonical plan missing at admission; replanning",
+                    item.issue,
+                )
+                return StageOutcome(Disposition.FAIL_BACK, "plan_missing")
+
+            item.payload["plan_text"] = snapshot.current_plan
+            item.payload["plan_revision"] = snapshot.revision
+            if is_exclusive_plan_state(labels, STATE_PLAN_GO):
+                logger.info("plan_review:%d: already plan-go; advancing", item.issue)
+                return StageOutcome(Disposition.ADVANCE, "plan already approved")
             if snapshot.current_review and snapshot.current_review_revision == snapshot.revision:
                 item.payload["prior_review"] = snapshot.current_review
 

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -386,6 +386,7 @@ def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
             f"plan discovery failed: {lookup.error}",
         )
 
+    initial_plan_found = lookup.status is PlanDiscoveryStatus.FOUND
     plan_text = item.payload.get("plan_text")
     posted_plan = False
     if plan_text is not None:
@@ -407,7 +408,17 @@ def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
                 return publication_outcome
             posted_plan = True
 
-    if posted_plan or lookup.status is PlanDiscoveryStatus.FOUND:
+    # The initial lookup only decides whether publication is necessary.  Do
+    # not authorize the handoff from that stale snapshot: another actor can
+    # create or delete the canonical comment while VERIFY is running.
+    verified_lookup = ctx.github.discover_plan(item.issue)
+    if verified_lookup.status is PlanDiscoveryStatus.READ_ERROR:
+        return StageOutcome(
+            Disposition.RETRY,
+            f"plan discovery failed: {verified_lookup.error}",
+        )
+
+    if verified_lookup.status is PlanDiscoveryStatus.FOUND:
         labels = _require_issue_labels_for_transition(item.issue, ctx)
         if STATE_PLAN_BLOCKED in labels:
             return StageOutcome(
@@ -421,6 +432,9 @@ def _verify_plan(item: WorkItem, ctx: StageContext) -> StageOutcome:
             )
         logger.info("planning:%d: plan verified; advancing", item.issue)
         return StageOutcome(Disposition.ADVANCE, "plan generated and verified")
+
+    if posted_plan or initial_plan_found:
+        return StageOutcome(Disposition.RETRY, "plan disappeared before verification")
 
     attempt = item.attempts.get("plan", 0) + 1
     item.attempts["plan"] = attempt

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -184,7 +184,7 @@ class PlanReviewer:
         self._print_summary(results)
         return results
 
-    def _review_issue(self, issue_number: int, slot_id: int) -> WorkerResult:  # noqa: C901
+    def _review_issue(self, issue_number: int, slot_id: int) -> WorkerResult:
         """Review the plan for a single issue.
 
         Args:

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -213,30 +213,9 @@ class PlanReviewer:
                 # One strict admission read controls the standalone path.
                 # BLOCKED is an operator latch, contradictory labels fail
                 # closed, and only exclusive GO short-circuits as approved.
-                labels = self._read_plan_state_labels(issue_number)
-                active_states = set(labels).intersection(ALL_STATE_LABELS)
-                if STATE_PLAN_BLOCKED in active_states:
-                    if not self.options.dry_run:
-                        self._ensure_blocked_audit(issue_number)
-                    logger.info(
-                        "Issue %s: plan is BLOCKED; awaiting external intervention",
-                        issue_ref(issue_number),
-                    )
-                    return WorkerResult(
-                        issue_number=issue_number,
-                        success=True,
-                        already_reviewed=True,
-                    )
-                if len(active_states) > 1:
-                    raise RuntimeError(f"contradictory plan-state labels: {sorted(active_states)}")
-                if is_exclusive_plan_state(labels, STATE_PLAN_GO):
-                    logger.info(
-                        "Issue %s: latest plan review is APPROVED, skipping",
-                        issue_ref(issue_number),
-                    )
-                    return WorkerResult(
-                        issue_number=issue_number, success=True, already_reviewed=True
-                    )
+                admission = self._plan_admission_outcome(issue_number)
+                if admission is not None:
+                    return admission
 
                 plan_lookup = self._get_latest_plan(issue_number)
                 if plan_lookup.status is PlanDiscoveryStatus.READ_ERROR:
@@ -316,6 +295,37 @@ class PlanReviewer:
                     success=False,
                     error=str(e)[:80],
                 )
+
+    def _plan_admission_outcome(self, issue_number: int) -> WorkerResult | None:
+        """Return a terminal outcome from the read-only plan-state admission.
+
+        ``None`` means the issue is reviewable; otherwise the returned result
+        short-circuits :meth:`_review_issue` (BLOCKED / contradictory labels /
+        already-GO). Keeps the worker's complexity below the C901 gate.
+        """
+        labels = self._read_plan_state_labels(issue_number)
+        active_states = set(labels).intersection(ALL_STATE_LABELS)
+        if STATE_PLAN_BLOCKED in active_states:
+            if not self.options.dry_run:
+                self._ensure_blocked_audit(issue_number)
+            logger.info(
+                "Issue %s: plan is BLOCKED; awaiting external intervention",
+                issue_ref(issue_number),
+            )
+            return WorkerResult(
+                issue_number=issue_number,
+                success=True,
+                already_reviewed=True,
+            )
+        if len(active_states) > 1:
+            raise RuntimeError(f"contradictory plan-state labels: {sorted(active_states)}")
+        if is_exclusive_plan_state(labels, STATE_PLAN_GO):
+            logger.info(
+                "Issue %s: latest plan review is APPROVED, skipping",
+                issue_ref(issue_number),
+            )
+            return WorkerResult(issue_number=issue_number, success=True, already_reviewed=True)
+        return None
 
     def _fetch_issue_comments(self, issue_number: int) -> list[IssueComment]:
         """Fetch the complete bounded issue journal, caching it per instance.

--- a/tests/unit/automation/pipeline/stages/test_reason_routes.py
+++ b/tests/unit/automation/pipeline/stages/test_reason_routes.py
@@ -37,7 +37,7 @@ _STAGE_MODULES: dict[StageName, ModuleType] = {
 #: Reasons each stage is EXPECTED to emit (lock: additions must edit this).
 _EXPECTED_REASONS: dict[StageName, set[str]] = {
     StageName.PLANNING: set(),
-    StageName.PLAN_REVIEW: {"nogo", "plan_cycles_exhausted"},
+    StageName.PLAN_REVIEW: {"nogo", "plan_missing", "plan_cycles_exhausted"},
     StageName.IMPLEMENTATION: {"plan_not_go", "already_implementation_go_pr"},
     StageName.PR_REVIEW: {"agent_error", "implementation_remediation"},
     StageName.MERGE_WAIT: {

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -35,6 +35,7 @@ from hephaestus.automation.review_journal import (
     plan_fingerprint,
     render_current_plan,
     render_current_review,
+    render_pending_review,
 )
 from hephaestus.automation.review_types import ReviewVerdict
 from hephaestus.automation.state_labels import (
@@ -67,6 +68,14 @@ def _valid_delivery_receipt() -> dict[str, object]:
         "pr_number": 1,
         "local_only": False,
     }
+
+
+def _seed_canonical_plan(github: FakeStageGitHub, issue: int, plan: str = "Durable plan") -> None:
+    """Seed a complete canonical plan-review journal without reconciliation writes."""
+    github.comments[issue] = [
+        render_current_plan(plan),
+        render_pending_review(revision=1),
+    ]
 
 
 def _fence_present(prompt: str, label: str) -> bool:
@@ -156,6 +165,7 @@ class TestPlanReviewStageOnEnter:
         """A restart-reseeded item already state:plan-go advances with no job/writes."""
         stage = PlanReviewStage()
         github = FakeStageGitHub(labels=[STATE_PLAN_GO])
+        _seed_canonical_plan(github, 1, "Approved plan")
         ctx = make_ctx(github=github)
         item = make_work_item(issue=1, state="ENTER")
 
@@ -171,6 +181,7 @@ class TestPlanReviewStageOnEnter:
         """An item without state:plan-go is unaffected by the new guard."""
         stage = PlanReviewStage()
         github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN])
+        _seed_canonical_plan(github, 1)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=1, state="ENTER")
 
@@ -185,10 +196,30 @@ class TestPlanReviewStageOnEnter:
         """on_enter performs no durable writes and always proceeds."""
         stage = PlanReviewStage()
         github = FakeStageGitHub()
+        _seed_canonical_plan(github, 1)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=1, state="ENTER")
 
         assert stage.on_enter(item, ctx) is None
+        assert github.mutation_log == []
+
+    def test_on_enter_rejects_stale_payload_when_handoff_plan_was_deleted(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Admission requires the canonical plan, not planning's stale payload."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN])
+        item = make_work_item(issue=19, state="ENTER")
+        item.payload["plan_text"] = "Deleted plan from planning handoff"
+        item.payload["plan_revision"] = 3
+        item.payload["prior_review"] = "Stale review"
+
+        outcome = stage.on_enter(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(Disposition.FAIL_BACK, "plan_missing")
+        assert "plan_text" not in item.payload
+        assert "plan_revision" not in item.payload
+        assert "prior_review" not in item.payload
         assert github.mutation_log == []
 
     def test_on_enter_retries_journal_read_error(self, make_ctx: Any, make_work_item: Any) -> None:
@@ -307,7 +338,9 @@ class TestPlanReviewStageOnEnter:
     def test_on_enter_resets_round_for_new_cycle(self, make_ctx: Any, make_work_item: Any) -> None:
         """Entering with a fresh plan_cycles value resets the cycle counter."""
         stage = PlanReviewStage()
-        ctx = make_ctx()
+        github = FakeStageGitHub()
+        _seed_canonical_plan(github, 1)
+        ctx = make_ctx(github=github)
         item = make_work_item(issue=1, state="ENTER")
         item.attempts["plan_cycles"] = 1  # fail-back happened; new cycle
         item.payload["review_cycle"] = 0
@@ -334,6 +367,7 @@ class TestPlanReviewStageOnEnter:
         """A literal double on_enter changes nothing the second time."""
         stage = PlanReviewStage()
         github = FakeStageGitHub()
+        _seed_canonical_plan(github, 3)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=3, state="ENTER")
 
@@ -355,7 +389,9 @@ class TestPlanReviewStageOnEnter:
         cycle immediately exceed REVIEW_ERROR_RETRY_CAP.
         """
         stage = PlanReviewStage()
-        ctx = make_ctx()
+        github = FakeStageGitHub()
+        _seed_canonical_plan(github, 4)
+        ctx = make_ctx(github=github)
         item = make_work_item(issue=4, state="ENTER")
         item.attempts["plan_cycles"] = 1  # fail-back happened; new cycle
         item.payload["review_cycle"] = 0
@@ -1598,6 +1634,7 @@ class TestStaleVerdictAndErrorAccounting:
         """
         stage = PlanReviewStage()
         github = FakeStageGitHub()
+        _seed_canonical_plan(github, 31)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=31, state="EVAL")
         assert stage.on_enter(item, ctx) is None
@@ -1675,6 +1712,7 @@ class TestCycleRelativeBudget:
         """
         stage = PlanReviewStage()
         github = FakeStageGitHub()
+        _seed_canonical_plan(github, 33)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=33, state="ENTER")
 
@@ -1732,6 +1770,7 @@ class TestCycleRelativeBudget:
         """
         stage = PlanReviewStage()
         github = FakeStageGitHub()
+        _seed_canonical_plan(github, 36)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=36, state="ENTER")
         item.attempts["plan_cycles"] = 0

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -191,6 +191,41 @@ class TestPlanReviewStageOnEnter:
         assert stage.on_enter(item, ctx) is None
         assert github.mutation_log == []
 
+    def test_on_enter_retries_journal_read_error(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A transient journal read failure must retry rather than terminally fail."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub(journal_read_error="rate limited")
+        item = make_work_item(issue=17, state="ENTER")
+
+        outcome = stage.on_enter(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(
+            Disposition.RETRY,
+            "plan journal read failed: rate limited",
+        )
+        assert item.state == "ENTER"
+        assert github.mutation_log == []
+
+    def test_on_enter_retries_blocked_audit_read_error(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Blocked-audit recovery shares the retry boundary for transient reads."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub(
+            labels=[STATE_PLAN_BLOCKED],
+            journal_read_error="rate limited",
+        )
+        item = make_work_item(issue=18, state="ENTER")
+
+        outcome = stage.on_enter(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(
+            Disposition.RETRY,
+            "plan journal read failed: rate limited",
+        )
+        assert item.state == "ENTER"
+        assert github.mutation_log == []
+
     def test_restart_hydrates_current_plan_from_github(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -27,6 +27,7 @@ from hephaestus.automation.protocol import (
 )
 from hephaestus.automation.review_journal import (
     IssueComment,
+    PlanDiscoveryResult,
     render_current_plan,
     render_current_review,
 )
@@ -666,6 +667,48 @@ class TestPlanningStageStep:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
         assert github.mutation_log == []  # existing plan: no duplicate upsert
+
+    def test_verify_rechecks_found_plan_before_advancing(
+        self, make_ctx: Any, make_work_item: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A plan appearing after the initial absence read must not spend retry budget."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN])
+        lookups = iter(
+            [
+                PlanDiscoveryResult.absent(),
+                PlanDiscoveryResult.found(render_current_plan("Concurrent plan")),
+            ]
+        )
+        monkeypatch.setattr(github, "discover_plan", lambda _issue: next(lookups))
+        item = make_work_item(issue=15, state="VERIFY")
+
+        outcome = stage.step(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(Disposition.ADVANCE, "plan generated and verified")
+        assert item.attempts.get("plan", 0) == 0
+        assert github.mutation_log == []
+
+    def test_verify_retries_when_plan_disappears_before_advancing(
+        self, make_ctx: Any, make_work_item: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A plan deleted after discovery cannot authorize plan-review advancement."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN])
+        lookups = iter(
+            [
+                PlanDiscoveryResult.found(render_current_plan("Initially durable")),
+                PlanDiscoveryResult.absent(),
+            ]
+        )
+        monkeypatch.setattr(github, "discover_plan", lambda _issue: next(lookups))
+        item = make_work_item(issue=16, state="VERIFY")
+
+        outcome = stage.step(item, make_ctx(github=github))
+
+        assert outcome == StageOutcome(Disposition.RETRY, "plan disappeared before verification")
+        assert item.attempts.get("plan", 0) == 0
+        assert github.mutation_log == []
 
     def test_on_enter_journal_read_error_retries_without_mutation(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -39,6 +39,7 @@ from hephaestus.automation.pipeline.work_item import (
     LearningIntent,
     WorkItem,
 )
+from hephaestus.automation.review_journal import render_current_plan, render_pending_review
 from hephaestus.automation.review_types import ReviewVerdict
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
@@ -609,6 +610,10 @@ class TestCrashMatrixJournal:
         item.payload["issue_title"] = "A task"
         item.payload["issue_body"] = "Body"
         item.payload["plan_text"] = "# Implementation Plan\n\nDo the work."
+        gh.comments[issue] = [
+            render_current_plan(item.payload["plan_text"]),
+            render_pending_review(revision=1),
+        ]
 
         assert stage.on_enter(item, ctx) is None
         enter = stage.step(item, ctx)

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -202,6 +202,7 @@ class TestROUTES:
                 next=StageName.IMPLEMENTATION,
                 fail_routes={
                     "nogo": StageName.PLANNING,
+                    "plan_missing": StageName.PLANNING,
                     "plan_cycles_exhausted": StageName.FINISHED,
                     "*": StageName.PLANNING,
                 },

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -46,6 +46,7 @@ _REASONS = [*_DECLARED_REASONS, "unknown_reason"]
 # map to None.
 _REASON_BUDGET: dict[str, str | None] = {
     "nogo": "plan_review_iter",
+    "plan_missing": None,
     "plan_cycles_exhausted": "plan_cycles",
     "plan_not_go": None,
     "already_implementation_go_pr": None,


### PR DESCRIPTION
Repair plan-journal retry semantics for the #2388 plan-discovery contract.

- Re-read canonical plan state immediately before VERIFY advances, so concurrent create/delete races cannot authorize a stale handoff or consume the absence budget.
- Map typed journal-read failures in plan-review reconciliation and blocked-audit recovery to retryable outcomes, while preserving fail-closed handling for semantic journal conflicts.
- Cover concurrent plan-state changes and both transient plan-review read boundaries.

Closes #2388