### PR TITLE
feat(automation): expose review iteration budget

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -215,6 +215,9 @@ class LoopConfig:
     """
 
     loops: int = 5
+    # Optional exact per-cycle cap shared by plan review and implementation
+    # review. None preserves the routing table's established 3/3/6 defaults.
+    review_iterations: int | None = None
     max_workers: int = LOOP_DEFAULT_MAX_WORKERS
     parallel_repos: int = 1
     # Dataclass default covers ONLY the iteration phases (``ALL_PHASES`` =
@@ -300,7 +303,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "--loops",
         type=_parse_positive_int,
         default=5,
-        help="Number of loop iterations (default: 5)",
+        help="Repository discovery reseed passes; does not change review budgets (default: 5)",
+    )
+    p.add_argument(
+        "--review-iterations",
+        type=_parse_positive_int,
+        default=None,
+        metavar="N",
+        help=(
+            "Exact per-cycle cap for both plan-review and implementation-review rounds. "
+            "Omit to preserve the routing defaults (plan 3; implementation soft 3/hard 6)."
+        ),
     )
     p.add_argument(
         "--drive-green-loops",
@@ -742,6 +755,16 @@ def _build_pipeline_config(
 
         circuit_breaker_snapshot_provider = all_circuit_breaker_snapshots
 
+    budget_overrides = {"merge": cfg.drive_green_loops}
+    if cfg.review_iterations is not None:
+        budget_overrides.update(
+            {
+                "plan_review_iter": cfg.review_iterations,
+                "pr_review_iter": cfg.review_iterations,
+                "pr_review_hard": cfg.review_iterations,
+            }
+        )
+
     return PipelineConfig(
         org=org,
         repos=repos,
@@ -770,7 +793,7 @@ def _build_pipeline_config(
         include_bot_prs=True,
         include_all_authors=cfg.drive_green_all,
         run_pre_pr_tests=cfg.run_pre_pr_tests,
-        budget_overrides={"merge": cfg.drive_green_loops},
+        budget_overrides=budget_overrides,
         serialize_file_overlap=cfg.serialize_file_overlap,
         metrics_port=cfg.metrics_port,
         circuit_breaker_snapshot_provider=circuit_breaker_snapshot_provider,
@@ -914,6 +937,7 @@ def main(argv: list[str] | None = None) -> int:
             root_scope_repos = [cwd_repo]
     cfg = LoopConfig(
         loops=args.loops,
+        review_iterations=args.review_iterations,
         max_workers=args.max_workers,
         drive_green_loops=args.drive_green_loops,
         serialize_file_overlap=args.serialize_file_overlap,

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -193,6 +193,31 @@ def test_build_pipeline_config_maps_drive_green_loops_to_budget(
     assert config.budget_overrides["merge"] == 3
 
 
+def test_build_pipeline_config_maps_explicit_review_iterations_to_exact_caps(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """One operator review cap governs plan and implementation review rounds."""
+    loop_runner.main(["--review-iterations", "10"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.budget_overrides == {
+        "merge": 5,
+        "plan_review_iter": 10,
+        "pr_review_iter": 10,
+        "pr_review_hard": 10,
+    }
+
+
+def test_build_pipeline_config_omits_review_overrides_by_default(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """Omitting the flag preserves the routing table's existing 3/3/6 defaults."""
+    loop_runner.main([])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.budget_overrides == {"merge": 5}
+
+
 def test_build_pipeline_config_maps_agent_and_models(
     dispatch: dict[str, MagicMock], monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -537,7 +537,19 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "loops",
             "_StoreAction",
             5,
-            help_text="Number of loop iterations (default: 5)",
+            help_text=(
+                "Repository discovery reseed passes; does not change review budgets (default: 5)"
+            ),
+        ),
+        _action_spec(
+            ("--review-iterations",),
+            "review_iterations",
+            "_StoreAction",
+            None,
+            help_text=(
+                "Exact per-cycle cap for both plan-review and implementation-review rounds. "
+                "Omit to preserve the routing defaults (plan 3; implementation soft 3/hard 6)."
+            ),
         ),
         _max_workers_spec(
             "Parallel workers per repo per phase (1-32, default: 6). Passes to child phases.",

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -160,6 +160,20 @@ def test_parse_args_accepts_drive_green_loops() -> None:
     assert loop_runner._parse_args([]).drive_green_loops == 5
 
 
+def test_parse_args_accepts_review_iterations() -> None:
+    """The review budget is explicit and does not reuse the reseed counter."""
+    assert loop_runner._parse_args(["--review-iterations", "10"]).review_iterations == 10
+    assert loop_runner._parse_args([]).review_iterations is None
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_parse_args_rejects_non_positive_review_iterations(bad: str) -> None:
+    """An explicit review budget must allow at least one review round."""
+    with pytest.raises(SystemExit) as excinfo:
+        loop_runner._parse_args(["--review-iterations", bad])
+    assert excinfo.value.code == 2
+
+
 @pytest.mark.parametrize("bad", ["0", "-1"])
 def test_parse_args_rejects_non_positive_drive_green_loops(bad: str) -> None:
     """The merge-poll budget must leave at least one current-run poll available."""


### PR DESCRIPTION
## Summary
- add --review-iterations as an explicit positive operator control
- apply the requested cap to plan review, PR review, and the PR hard bound
- preserve the existing route defaults when the flag is omitted and keep --loops scoped to repository reseeding

## Testing
- 107 focused tests passed
- ruff check and format passed
- mypy passed

Closes #2714
