### PR TITLE
fix(automation): compact issue plan review timelines

### DIFF
--- a/docs/adr/0022-canonical-issue-timeline.md
+++ b/docs/adr/0022-canonical-issue-timeline.md
@@ -1,0 +1,45 @@
+# ADR-0022: Canonical two-comment issue timeline
+
+- Status: Accepted
+- Date: 2026-08-08
+- Tracks: #2719
+
+## Context
+
+Appending every plan revision, review, skip explanation, recovery payload, and
+raw plan diff made long-running issues too large for useful agent context and
+human review. The history duplicated source-control evidence while stale
+reviews competed with the current decision. Labels already provide durable
+pipeline state and pull requests already own implementation discussions.
+
+## Decision
+
+Automation retains exactly two actor-owned comments on a linked issue: the
+latest canonical implementation plan and the latest canonical plan review.
+Each revision replaces those comments in place. The current plan may contain a
+bounded hidden set of prior plan fingerprints for oscillation detection and a
+concise cumulative `Changes from Review` section containing high-level bullets.
+Raw patches are rejected before publication.
+
+Skip reasons are label-plus-log facts. Transient implementation-reply recovery
+records are stored on the pull request, and implementation responses remain in
+native PR review threads. A dry-run-first migration command removes only
+strictly recognized comments GitHub proves were authored by the authenticated
+actor; issue bodies and human or foreign comments are never mutated.
+
+## Alternatives considered
+
+- Retain append-only history but truncate prompt context: rejected because the
+  GitHub issue itself remains noisy and unbounded.
+- Store complete old plans in hidden comments: rejected because hidden markup
+  still consumes API and model context and duplicates Git history.
+- Delete every marker-bearing comment: rejected because marker text alone is
+  not ownership proof and could destroy human or foreign content.
+
+## Consequences
+
+The linked issue remains compact and stable across arbitrarily many review
+rounds. Detailed implementation evidence lives in commits and PR-native review
+threads. Public comment history is no longer the crash-recovery mechanism;
+canonical pointer readback and bounded fingerprints provide restart safety.
+Legacy history remains readable until the compaction migration has converged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ numbered, and listed here.
 | [0019](0019-pi-provider-parity-contract.md) | Provider-neutral Pi parity contract | Accepted |
 | [0020](0020-pi-runtime-and-console-inventory.md) | Exhaustive Pi runtime and console inventory | Accepted |
 | [0021](0021-durable-issue-wave-checkpoints.md) | Durable merge-checkpointed issue waves | Accepted |
+| [0022](0022-canonical-issue-timeline.md) | Canonical two-comment issue timeline | Accepted |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -589,16 +589,12 @@ absolute operator state:
 | `state:implementation-go` | review-scope | [`pr_review._eval`](../hephaestus/automation/pipeline/stages/pr_review.py) — **sole authority** |
 | `state:skip` | absolute | operator / exhaustion in [`pr_review`](../hephaestus/automation/pipeline/stages/pr_review.py) / [`implementation`](../hephaestus/automation/pipeline/stages/implementation.py) |
 
-Every **stage-issued** `state:skip` durable write (the `pr_review` and
-`implementation` write paths, plus repo-stage epic tagging) has a
-best-effort `gh_issue_upsert_comment` companion produced via
-[`format_skip_reason_comment`](../hephaestus/automation/state_labels.py), using
-the [`SKIP_REASON_MARKER`](../hephaestus/automation/state_labels.py) prefix
-`<!-- hephaestus-state-skip-reason -->` so the reason survives outside the
-run log (#2264). Epic tagging in
-[`repo._seed_pass`](../hephaestus/automation/pipeline/stages/repo.py) is the
-sole sanctioned seeding write: it adds both the skip label and this comment
-before excluding the epic from the rest of the pipeline.
+Every **stage-issued** `state:skip` write uses the label as its durable
+authority and emits the reason to structured run logs. It does not add an
+issue comment. Epic tagging in
+[`repo._seed_pass`](../hephaestus/automation/pipeline/stages/repo.py) remains
+the sole sanctioned seeding write and adds only the skip label before
+excluding the epic from the rest of the pipeline.
 
 Label colors per [`STATE_LABEL_SPECS`](../hephaestus/automation/state_labels.py).
 Provisioning script
@@ -740,11 +736,10 @@ Architectural contract:
 
 ### 5.2 Planning
 
-Planning produces one canonical implementation plan from the issue and its
-durable chronological journal. The GitHub journal remains complete for audit
-and recovery. A resumed rejected plan receives only bounded context for its
-current canonical plan and paired current review; superseded revisions do not
-compete with the active critique. A blocked plan is an automation stop: only
+Planning produces one canonical implementation plan from the issue, latest
+canonical plan, and latest canonical review. Superseded revisions are replaced,
+not appended. Bounded hidden fingerprints preserve oscillation detection
+without exposing old plans or raw patches. A blocked plan is an automation stop: only
 an external actor may resolve the dependency and replace `state:plan-blocked`
 with exactly one next plan-state label.
 
@@ -785,13 +780,13 @@ Architectural contract:
 - The first automation journal role is the canonical implementation plan,
   identified by an opaque marker and updated only by its owning GitHub actor.
 - A restarted rejected plan receives only its bounded current canonical plan
-  and paired current review. Superseded revision comments remain audit and
-  recovery artifacts and are not active planner context.
+  and paired current review. Superseded revisions are not public comments; the
+  latest plan carries bounded prior fingerprints for no-progress detection.
 - Journal ingestion is bounded by both comment count and body bytes. If either
   limit is exceeded, automation stops with an explicit manual-recovery error
   instead of silently dropping old plan/review revisions.
-- Historical revision comments are actor-owned, append-once, and never edited
-  or deleted.
+- Raw patches (`diff --git`, unified hunks, or fenced `diff` blocks) are
+  rejected before publication.
 - Each durable state transition is published with its corresponding canonical
   artifact, and restart routing reads the label rather than comment prose.
 - `state:plan-blocked` is never removed or replaced by automation. Comments do
@@ -820,8 +815,7 @@ flowchart LR
     Review -->|"plan-blocked"| BlockLatch["Confirmed blocked label"]
     BlockLatch --> BlockAudit["Canonical blocked explanation"]
     Label -->|"plan-go"| Implementation
-    Label -->|"plan-no-go"| Archive["Archive prior plan and review"]
-    Archive --> Planning
+    Label -->|"plan-no-go"| Planning
     BlockAudit --> External["Human or dependency"]
 ```
 
@@ -830,8 +824,8 @@ flowchart LR
 ```mermaid
 stateDiagram-v2
     [*] --> ReconcileJournal
-    ReconcileJournal --> LoadHistory: journal complete
-    ReconcileJournal --> ReconcileJournal: interrupted archive recovered
+    ReconcileJournal --> LoadHistory: canonical comments complete
+    ReconcileJournal --> ReconcileJournal: legacy archive recovered
     ReconcileJournal --> Failed: conflicting actor-owned immutable artifact
     LoadHistory --> Review: context available
     LoadHistory --> Failed: context unavailable
@@ -847,11 +841,10 @@ stateDiagram-v2
     ApplyLabel --> RetryReview: label write or confirmation failed
     ApplyLabel --> Approved: state:plan-go confirmed
     ApplyLabel --> AssessRevision: state:plan-no-go confirmed
-    AssessRevision --> ArchiveRevision: improvement remains possible
+    AssessRevision --> Amend: improvement remains possible
     AssessRevision --> Blocked: no improvement and planning is stuck
     AssessRevision --> Blocked: external decision or dependency required
     AssessRevision --> Failed: revision limit reached
-    ArchiveRevision --> Amend: prior plan archived with recovery payload
     Amend --> PublishRevision: revised plan produced
     PublishRevision --> Review: canonical comments updated
     Approved --> [*]
@@ -865,15 +858,13 @@ Architectural contract:
   by an opaque marker and updated only by its owning GitHub actor.
 - Marker collisions authored by other actors are inert. They cannot become
   canonical artifacts, establish replay identity, or stop an owned write.
-- Before canonical comments change, the previous plan and its review are
-  appended as immutable chronological comments.
-- The plan archive contains the next-plan recovery payload. On restart, a
-  missing review archive or canonical update is completed idempotently before
-  another agent runs.
+- Canonical comments are replaced in place. On restart, a stale or missing
+  canonical review is repaired to the current revision before another agent
+  runs. Retired archive comments are read only for migration recovery.
 - Review receives the current plan and direct prior critique. An amendment
-  receives the bounded current canonical plan and direct critique; superseded
-  journal revisions remain durable audit and recovery artifacts, not prompt
-  context.
+  receives the bounded current canonical plan and direct critique. Superseded
+  revisions are summarized only as cumulative high-level bullets in the
+  current plan's `Changes from Review` section.
 - A blocked verdict states exactly what decision or dependency is required.
   Because BLOCKED is the safety latch, its label is confirmed before the
   fallible explanatory write; an audit-write failure can never leave the item
@@ -1090,6 +1081,9 @@ Architectural contract:
   that ceiling, malformed pagination, or a cursor cycle fails the read without
   exposing partial review facts. Root-comment-only ownership and dedupe queries
   use `comments(first:1)` because later comments are outside those contracts.
+- Transient implementation-reply recovery records use the PR's issue-comment
+  channel, never the linked issue. Human-facing implementation responses remain
+  attached to their native PR review threads.
 - The review decision proof is a fresh GitHub snapshot plus a clean checkout
   at that snapshot's head. A GitHub marker can recover only a candidate reply
   after restart; it is never a substitute for that fresh proof.
@@ -1735,7 +1729,7 @@ Exit-code priority is:
  on that SHA; it rechecks the proof before writing the GO label. `merge_wait`
  compares that proof with the confirmed-unarmed live PR and issues a normal
  SHA-conditional merge rather than arming or polling auto-merge.
-- **Skip-reason marker** — the `<!-- hephaestus-state-skip-reason -->` HTML-comment marker ([`SKIP_REASON_MARKER`](../hephaestus/automation/state_labels.py)) that prefixes every `state:skip` reason-comment body produced by [`format_skip_reason_comment`](../hephaestus/automation/state_labels.py), so a repo reader can deterministically trace the automated skip reason.
+- **Skip-reason marker (legacy)** — the retired `<!-- hephaestus-state-skip-reason -->` marker retained only so the compaction tool can safely identify actor-owned comments from older releases. New skip reasons are recorded in run logs.
 - **File-system loader** — the Jinja `FileSystemLoader` resolved from `__file__`-relative paths in [`prompts/catalog.py`](../hephaestus/prompts/catalog.py); deliberately NOT `PackageLoader` to avoid importlib editable-install staleness (#2308).
 - **Advise-skipped breadcrumb** — the [`advise_skipped(reason)`](../hephaestus/automation/advise_runner.py) marker string returned by [`run_advise`](../hephaestus/automation/advise_runner.py) when Mnemosyne is unavailable, so a stage aborts as `SKIP` rather than failing; the reason is forwarded verbatim from [`resolve_marketplace`](../hephaestus/automation/advise_runner.py) (e.g. `clone_failed`, `manifest_missing`).
 - **Tool scope** — the explicit `(allowed_tools, permission_mode)` pair in [`AGENT_TOOL_SCOPES`](../hephaestus/automation/pipeline/tool_scopes.py) for one of the 9 pipeline agent roles (advise, planner, plan-reviewer, implementer, pr-reviewer, comment-classifier, address-review, ci-driver, learnings); unmapped roles fall through to the read-only [`DEFAULT_TOOL_SCOPE`](../hephaestus/automation/pipeline/tool_scopes.py) per the fail-closed security contract (#2319).

--- a/docs/runbooks/compact-issue-timelines.md
+++ b/docs/runbooks/compact-issue-timelines.md
@@ -1,0 +1,35 @@
+# Compacting automation-owned issue timelines
+
+Use this migration after upgrading from a release that appended plan/review
+history, skip-reason comments, or implementation-reply handoff records to the
+linked issue.
+
+The command is read-only by default and scans open and closed issues. It skips
+pull requests, preserves issue bodies, and ignores every comment that GitHub
+does not prove belongs to the authenticated actor.
+
+```bash
+uv run python scripts/compact_issue_timelines.py \
+  --repo HomericIntelligence/Hephaestus
+```
+
+Review every proposed comment ID, then apply the same inventory:
+
+```bash
+uv run python scripts/compact_issue_timelines.py \
+  --repo HomericIntelligence/Hephaestus \
+  --apply
+```
+
+Use `--state open` or `--state closed` to narrow the inventory, and `--issues
+123 456` for a recovery scope. Apply mode re-reads each changed issue and fails
+that issue if the canonical two-comment state did not converge. A malformed or
+conflicting legacy journal is reported and skipped without deleting anything.
+
+The expected final automation surface on a linked issue is:
+
+1. the latest canonical implementation plan;
+2. the latest canonical plan review.
+
+Human comments and the original issue body remain untouched. PR review threads
+and commit history retain detailed implementation evidence.

--- a/hephaestus/automation/github_api/labels.py
+++ b/hephaestus/automation/github_api/labels.py
@@ -6,12 +6,7 @@ import json
 
 import hephaestus.automation.github_api as _api
 
-from ..state_labels import (
-    SKIP_REASON_MARKER,
-    STATE_SKIP,
-    format_skip_reason_comment,
-    is_skipped,
-)
+from ..state_labels import STATE_SKIP, is_skipped
 
 
 def _label_cache_key(repo: tuple[str, str] | None = None) -> str:
@@ -211,18 +206,6 @@ def skip_epics(epics_labels: dict[int, list[str]], repo: tuple[str, str] | None 
             continue
         _api.gh_issue_add_labels(number, [STATE_SKIP], repo=repo)
         _api.logger.info("Issue #%s is an epic/roadmap tracking issue; tagged state:skip", number)
-        try:
-            _api.gh_issue_upsert_comment(
-                number,
-                SKIP_REASON_MARKER,
-                format_skip_reason_comment(
-                    "excluded from the planning loop as an epic/roadmap tracking "
-                    "issue (checklist of child work, not a code task)"
-                ),
-                repo=repo,
-            )
-        except Exception as exc:  # pragma: no cover - defensive best-effort
-            _api.logger.warning("could not post skip-reason comment on #%s: %s", number, exc)
 
 
 def gh_issue_remove_labels(issue_number: int, labels: list[str]) -> None:

--- a/hephaestus/automation/issue_timeline.py
+++ b/hephaestus/automation/issue_timeline.py
@@ -1,0 +1,186 @@
+"""Pure planning helpers for compacting automation-owned issue comments."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from hephaestus.automation.protocol import PLAN_CANONICAL_MARKER, PLAN_REVIEW_CANONICAL_MARKER
+from hephaestus.automation.review_journal import (
+    HISTORY_MARKER_PREFIX,
+    HISTORY_RE,
+    IssueComment,
+    archived_new_plan,
+    archived_old_plan,
+    is_plan_comment,
+    is_plan_review_comment,
+    journal_snapshot,
+    plan_fingerprint,
+    render_current_plan,
+    render_current_review,
+)
+from hephaestus.automation.state_labels import SKIP_REASON_MARKER
+
+IMPLEMENTATION_REPLY_HANDOFF_MARKER_PREFIX = "<!-- hephaestus-implementation-reply-handoff:"
+_IMPLEMENTATION_REPLY_HANDOFF_MARKER_RE = re.compile(
+    r"<!-- hephaestus-implementation-reply-handoff:pr=\d+:"
+    r"head=[0-9a-f]{40}(?:[0-9a-f]{24})?:batch=[0-9a-f]{32} -->"
+)
+
+
+@dataclass(frozen=True)
+class IssueTimelineCompaction:
+    """One issue's safe canonical updates and actor-owned deletions."""
+
+    plan_body: str | None = None
+    review_body: str | None = None
+    plan_needs_update: bool = False
+    review_needs_update: bool = False
+    delete_comment_ids: tuple[int, ...] = ()
+
+    @property
+    def has_changes(self) -> bool:
+        """Return whether applying this plan would mutate GitHub."""
+        return bool(self.plan_needs_update or self.review_needs_update or self.delete_comment_ids)
+
+
+def issue_comments_from_metadata(
+    metadata: Sequence[dict[str, Any]],
+    *,
+    viewer_login: str,
+) -> list[IssueComment]:
+    """Convert GitHub REST metadata into ownership-aware comments."""
+    normalized_login = viewer_login.strip().lower()
+    comments: list[IssueComment] = []
+    for raw in metadata:
+        author = raw.get("user") or raw.get("author")
+        author_login = str(author.get("login", "")) if isinstance(author, dict) else ""
+        if "viewerDidAuthor" in raw:
+            owned = raw.get("viewerDidAuthor") is True
+        else:
+            owned = bool(normalized_login and author_login.lower() == normalized_login)
+        raw_id = raw.get("databaseId", raw.get("id"))
+        comments.append(
+            IssueComment(
+                body=str(raw.get("body", "")),
+                author_login=author_login,
+                author_association=str(
+                    raw.get("author_association") or raw.get("authorAssociation") or ""
+                ),
+                created_at=str(raw.get("created_at") or raw.get("createdAt") or ""),
+                updated_at=str(raw.get("updated_at") or raw.get("updatedAt") or ""),
+                viewer_did_author=owned,
+                database_id=int(raw_id) if raw_id is not None else None,
+                url=str(raw.get("html_url") or raw.get("url") or ""),
+            )
+        )
+    return comments
+
+
+def _validate_legacy_markers(comments: Sequence[IssueComment]) -> None:
+    """Reject prefix collisions before planning any destructive mutation."""
+    for comment in comments:
+        first_line = comment.body.lstrip().partition("\n")[0].strip()
+        if (
+            first_line.startswith(HISTORY_MARKER_PREFIX)
+            and HISTORY_RE.fullmatch(first_line) is None
+        ):
+            raise RuntimeError("malformed legacy automation marker; manual review is required")
+        if (
+            first_line.startswith(IMPLEMENTATION_REPLY_HANDOFF_MARKER_PREFIX)
+            and _IMPLEMENTATION_REPLY_HANDOFF_MARKER_RE.fullmatch(first_line) is None
+        ):
+            raise RuntimeError("malformed legacy automation marker; manual review is required")
+
+
+def _is_obsolete_automation_comment(body: str) -> bool:
+    """Return whether an owned comment belongs to a removable automation role."""
+    stripped = body.lstrip()
+    return bool(
+        is_plan_comment(stripped)
+        or is_plan_review_comment(stripped)
+        or stripped.startswith(HISTORY_MARKER_PREFIX)
+        or stripped.startswith(SKIP_REASON_MARKER)
+        or stripped.startswith(IMPLEMENTATION_REPLY_HANDOFF_MARKER_PREFIX)
+    )
+
+
+def plan_issue_timeline_compaction(
+    comments: Sequence[IssueComment],
+) -> IssueTimelineCompaction:
+    """Return the safe mutations that enforce two canonical automation comments.
+
+    Only comments GitHub identifies as authored by the authenticated viewer are
+    considered. Human and foreign marker-bearing comments are intentionally
+    invisible to this planner.
+    """
+    owned = [comment for comment in comments if comment.viewer_did_author]
+    if not owned:
+        return IssueTimelineCompaction()
+
+    _validate_legacy_markers(owned)
+
+    # Parsing first makes conflicting or malformed legacy journal identities a
+    # per-issue hard failure before a destructive action is planned.
+    snapshot = journal_snapshot(owned)
+    plan_comments = [comment for comment in owned if is_plan_comment(comment.body)]
+    review_comments = [comment for comment in owned if is_plan_review_comment(comment.body)]
+    target_plan = plan_comments[-1] if plan_comments else None
+    target_review = review_comments[-1] if review_comments else None
+
+    prior_fingerprints = list(snapshot.prior_plan_fingerprints)
+    for comment in plan_comments[:-1]:
+        prior_fingerprints.append(plan_fingerprint(comment.body))
+    for artifact in snapshot.history:
+        if artifact.kind == "plan":
+            for plan in (archived_old_plan(artifact.body), archived_new_plan(artifact.body)):
+                if plan:
+                    prior_fingerprints.append(plan_fingerprint(plan))
+
+    plan_body = (
+        render_current_plan(
+            snapshot.current_plan,
+            revision=snapshot.revision,
+            prior_fingerprints=tuple(dict.fromkeys(prior_fingerprints)),
+        )
+        if target_plan is not None
+        else None
+    )
+    review_body = (
+        render_current_review(
+            snapshot.current_review,
+            revision=snapshot.current_review_revision or snapshot.revision,
+        )
+        if target_review is not None
+        else None
+    )
+
+    keep_ids = {
+        comment.database_id
+        for comment in (target_plan, target_review)
+        if comment is not None and comment.database_id is not None
+    }
+    delete_ids: list[int] = []
+    for comment in owned:
+        if not _is_obsolete_automation_comment(comment.body) or comment.database_id in keep_ids:
+            continue
+        if comment.database_id is None:
+            raise RuntimeError("owned obsolete automation comment has no database id")
+        delete_ids.append(comment.database_id)
+
+    # Canonical target bodies are PATCHed in place by the caller. Prefixing is
+    # asserted here so a parser regression cannot turn an upsert into a new
+    # third comment.
+    if plan_body is not None and not plan_body.startswith(PLAN_CANONICAL_MARKER):
+        raise AssertionError("canonical plan renderer lost its ownership marker")
+    if review_body is not None and not review_body.startswith(PLAN_REVIEW_CANONICAL_MARKER):
+        raise AssertionError("canonical review renderer lost its ownership marker")
+    return IssueTimelineCompaction(
+        plan_body=plan_body,
+        review_body=review_body,
+        plan_needs_update=bool(target_plan is not None and target_plan.body != plan_body),
+        review_needs_update=bool(target_review is not None and target_review.body != review_body),
+        delete_comment_ids=tuple(delete_ids),
+    )

--- a/hephaestus/automation/issue_timeline.py
+++ b/hephaestus/automation/issue_timeline.py
@@ -107,6 +107,11 @@ def _is_obsolete_automation_comment(body: str) -> bool:
     )
 
 
+def _has_exact_leading_marker(body: str, marker: str) -> bool:
+    """Return whether the first non-whitespace line is exactly *marker*."""
+    return body.lstrip().partition("\n")[0].strip() == marker
+
+
 def plan_issue_timeline_compaction(
     comments: Sequence[IssueComment],
 ) -> IssueTimelineCompaction:
@@ -127,8 +132,24 @@ def plan_issue_timeline_compaction(
     snapshot = journal_snapshot(owned)
     plan_comments = [comment for comment in owned if is_plan_comment(comment.body)]
     review_comments = [comment for comment in owned if is_plan_review_comment(comment.body)]
-    target_plan = plan_comments[-1] if plan_comments else None
-    target_review = review_comments[-1] if review_comments else None
+    canonical_plans = [
+        comment
+        for comment in plan_comments
+        if _has_exact_leading_marker(comment.body, PLAN_CANONICAL_MARKER)
+    ]
+    canonical_reviews = [
+        comment
+        for comment in review_comments
+        if _has_exact_leading_marker(comment.body, PLAN_REVIEW_CANONICAL_MARKER)
+    ]
+    target_plan = (
+        canonical_plans[-1] if canonical_plans else (plan_comments[-1] if plan_comments else None)
+    )
+    target_review = (
+        canonical_reviews[-1]
+        if canonical_reviews
+        else (review_comments[-1] if review_comments else None)
+    )
 
     prior_fingerprints = list(snapshot.prior_plan_fingerprints)
     for comment in plan_comments[:-1]:

--- a/hephaestus/automation/pipeline/plan_journal.py
+++ b/hephaestus/automation/pipeline/plan_journal.py
@@ -1,10 +1,8 @@
-"""Transactional GitHub journal updates for implementation-plan revisions.
+"""Transactional canonical comments for implementation-plan revisions.
 
-The canonical plan and review comments are mutable pointers to the current
-revision.  Superseded plan/review pairs are immutable issue comments.  A plan
-archive is written first because it contains the proposed next plan; that
-recovery payload lets a restart finish the remaining review-archive and
-canonical-plan writes without asking another agent to regenerate anything.
+An issue has one mutable plan pointer and one mutable review pointer. Older
+revisions are represented only by bounded plan fingerprints in hidden metadata;
+legacy append-only artifacts are read solely to migrate interrupted runs.
 """
 
 from __future__ import annotations
@@ -15,12 +13,10 @@ from typing import Protocol
 
 from hephaestus.automation.protocol import PLAN_REVIEW_CANONICAL_MARKER, PLAN_REVIEW_PREFIX
 from hephaestus.automation.review_journal import (
-    HISTORY_MARKER,
     IssueComment,
-    archive_plan_body,
-    archive_review_body,
     archived_new_plan,
     archived_old_plan,
+    contains_raw_patch,
     is_pending_review,
     journal_snapshot,
     normalized_plan,
@@ -40,10 +36,6 @@ class PlanJournalGitHub(Protocol):
 
     def gh_issue_json(self, issue_number: int) -> dict[str, object]:
         """Return live issue metadata including the authoritative labels."""
-        pass
-
-    def append_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
-        """Append one immutable, replay-safe issue comment."""
         pass
 
     def upsert_plan_comment(self, issue_number: int, plan: str) -> None:
@@ -120,7 +112,7 @@ def reconcile_plan_journal(issue_number: int, github: PlanJournalGitHub) -> list
     snapshot = journal_snapshot(comments)
     plan_artifacts = [artifact for artifact in snapshot.history if artifact.kind == "plan"]
     if not plan_artifacts:
-        if snapshot.current_plan and not snapshot.current_review:
+        if snapshot.current_plan and snapshot.current_review_revision != snapshot.revision:
             _upsert_pending_review(issue_number, snapshot.revision, github)
             return github.issue_comments(issue_number)
         return comments
@@ -134,36 +126,22 @@ def reconcile_plan_journal(issue_number: int, github: PlanJournalGitHub) -> list
     current_is_missing = not snapshot.current_plan and snapshot.revision == pending.revision + 1
     current_is_next = bool(snapshot.current_plan and snapshot.revision == pending.revision + 1)
     if current_is_next:
-        has_archived_review = any(
-            artifact.kind == "review" and artifact.revision == pending.revision
-            for artifact in snapshot.history
-        )
         review_is_stale = snapshot.current_review_revision != snapshot.revision
-        if has_archived_review and review_is_stale:
+        if review_is_stale:
             _upsert_pending_review(issue_number, snapshot.revision, github)
             return github.issue_comments(issue_number)
         return comments
     if not (current_is_superseded or current_is_missing):
         return comments
 
-    if snapshot.current_review_revision == pending.revision and snapshot.current_review:
-        review_marker = HISTORY_MARKER.format(revision=pending.revision, kind="review")
-        github.append_issue_comment(
-            issue_number,
-            review_marker,
-            archive_review_body(pending.revision, snapshot.current_review),
-        )
-    elif not any(
-        artifact.kind == "review" and artifact.revision == pending.revision
-        for artifact in snapshot.history
-    ):
-        # Advancing without the paired review would erase the decision that
-        # caused this revision, so leave the transaction visibly incomplete.
-        return comments
-
+    prior_fingerprints = tuple(sorted(known_plan_fingerprints(comments)))
     github.upsert_plan_comment(
         issue_number,
-        render_current_plan(next_plan, revision=pending.revision + 1),
+        render_current_plan(
+            next_plan,
+            revision=pending.revision + 1,
+            prior_fingerprints=prior_fingerprints,
+        ),
     )
     _upsert_pending_review(issue_number, pending.revision + 1, github)
     return github.issue_comments(issue_number)
@@ -176,7 +154,10 @@ def known_plan_fingerprints(comments: Sequence[IssueComment | str]) -> set[str]:
     for artifact in snapshot.history:
         if artifact.kind == "plan":
             plans.extend((archived_old_plan(artifact.body), archived_new_plan(artifact.body)))
-    return {plan_fingerprint(plan) for plan in plans if plan.strip()}
+    return {
+        *snapshot.prior_plan_fingerprints,
+        *(plan_fingerprint(plan) for plan in plans if plan.strip()),
+    }
 
 
 def publish_plan_revision(
@@ -209,6 +190,18 @@ def publish_plan_revision(
     candidate_plan = normalized_plan(candidate)
     candidate_fingerprint = plan_fingerprint(candidate)
     current_fingerprint = plan_fingerprint(snapshot.current_plan)
+
+    if contains_raw_patch(candidate):
+        return PlanPublication(
+            revision=snapshot.revision,
+            plan=snapshot.current_plan,
+            changed=False,
+            no_progress_reason=(
+                "The proposed plan contains a raw patch or diff hunk. Public plans must "
+                "describe intended changes without embedding source diffs; regenerate the "
+                "complete plan before publication."
+            ),
+        )
 
     if not candidate_plan:
         return PlanPublication(
@@ -287,22 +280,18 @@ def publish_plan_revision(
             f"exclusive {STATE_PLAN_NO_GO} label"
         )
 
-    plan_marker = HISTORY_MARKER.format(revision=snapshot.revision, kind="plan")
-    review_marker = HISTORY_MARKER.format(revision=snapshot.revision, kind="review")
-    github.append_issue_comment(
-        issue_number,
-        plan_marker,
-        archive_plan_body(snapshot.revision, snapshot.current_plan, candidate_plan),
-    )
-    github.append_issue_comment(
-        issue_number,
-        review_marker,
-        archive_review_body(snapshot.revision, snapshot.current_review),
-    )
     next_revision = snapshot.revision + 1
+    prior_fingerprints = (
+        *snapshot.prior_plan_fingerprints,
+        current_fingerprint,
+    )
     github.upsert_plan_comment(
         issue_number,
-        render_current_plan(candidate_plan, revision=next_revision),
+        render_current_plan(
+            candidate_plan,
+            revision=next_revision,
+            prior_fingerprints=prior_fingerprints,
+        ),
     )
     _upsert_pending_review(issue_number, next_revision, github)
     _confirm_publication(issue_number, candidate_plan, next_revision, github)

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -58,11 +58,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 
 from hephaestus.agents.runtime import DEFAULT_AGENT, agent_supports_model_reasoning_effort
 from hephaestus.automation.review_journal import IssueComment
-from hephaestus.automation.state_labels import (
-    SKIP_REASON_MARKER,
-    STATE_SKIP,
-    format_skip_reason_comment,
-)
+from hephaestus.automation.state_labels import STATE_SKIP
 
 from ..events import StageEvent
 from ..github_jobs import GitHubJob
@@ -720,17 +716,17 @@ def _is_confirmed_open_unarmed(pr_state: dict[str, Any] | None) -> bool:
 
 
 def write_skip_label(issue_number: int, ctx: StageContext, reason: str) -> None:
-    """Durably apply ``state:skip`` with a reason comment, non-fatally.
+    """Durably apply ``state:skip`` and log its reason, non-fatally.
 
     Single home for the exhaustion/no-commits skip write (previously
-    duplicated across the implementation and pr_review stages). The reason
-    is documented on the issue via the marker-keyed skip-reason comment so
-    it survives outside ephemeral run logs (#2256).
+    duplicated across the implementation and pr_review stages). The label is
+    the durable state authority; the reason belongs in structured run logs so
+    automation does not add a third canonical comment to the linked issue.
 
     Args:
         issue_number: GitHub issue number.
         ctx: Stage context carrying the GitHub accessor.
-        reason: Human-readable explanation for the skip, posted as a comment.
+        reason: Human-readable explanation included in the run log.
 
     """
     try:
@@ -742,16 +738,7 @@ def write_skip_label(issue_number: int, ctx: StageContext, reason: str) -> None:
             STATE_SKIP,
             e,
         )
-    try:
-        ctx.github.upsert_issue_comment(
-            issue_number, SKIP_REASON_MARKER, format_skip_reason_comment(reason)
-        )
-    except Exception as e:
-        logger.warning(
-            "pipeline:%d: failed to post skip-reason comment (non-fatal): %s",
-            issue_number,
-            e,
-        )
+    logger.warning("pipeline:%d: applied %s: %s", issue_number, STATE_SKIP, reason)
 
 
 @runtime_checkable

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -1020,7 +1020,10 @@ class ImplementationStage(Stage):
         pending = item.payload.get(_PENDING_GITHUB_REQUEST)
         if pending is None:
             pending = RecoverReplyJournalRequest(
-                issue_number=item.issue,
+                # Pull requests share the issue-comments REST channel. Keep
+                # this transient recovery record on the PR, never its linked
+                # issue, so the issue has only the canonical plan and review.
+                issue_number=item.pr,
                 pr_number=item.pr,
                 threads=FrozenJson.snapshot(snapshots),
             )
@@ -1062,13 +1065,13 @@ class ImplementationStage(Stage):
         pending = item.payload.get(_PENDING_GITHUB_REQUEST)
         if pending is None:
             pending = AppendReplyJournalRequest(
-                issue_number=item.issue,
+                issue_number=item.pr,
                 marker=marker,
                 body=body,
             )
             item.payload[_PENDING_GITHUB_REQUEST] = pending
         if not isinstance(pending, AppendReplyJournalRequest) or pending != (
-            AppendReplyJournalRequest(item.issue, marker, body)
+            AppendReplyJournalRequest(item.pr, marker, body)
         ):
             return StageOutcome(
                 Disposition.FINISH_FAIL,

--- a/hephaestus/automation/pipeline_github_mutations.py
+++ b/hephaestus/automation/pipeline_github_mutations.py
@@ -234,9 +234,8 @@ class PipelineGitHubMutations(_PipelineGitHubHost):
         if matching:
             if any(str(comment.get("body", "")) != body for comment in matching):
                 raise RuntimeError(f"immutable journal conflict for marker {marker!r}")
-            # Immutable history is append-only. Identical actor-owned copies
-            # can arise from a create race; tolerate them without rewriting or
-            # deleting the durable audit trail.
+            # This primitive still supports immutable non-issue artifacts.
+            # Identical actor-owned copies can arise from a create race.
             return
         self._post_issue_comment(issue_number, body)
         comments = self._repo_issue_comments(issue_number)
@@ -401,17 +400,6 @@ class PipelineGitHubMutations(_PipelineGitHubHost):
             for number, labels in epics_labels.items():
                 if STATE_SKIP not in labels:
                     self._add_labels(number, [STATE_SKIP])
-                    try:
-                        self.upsert_issue_comment(
-                            number,
-                            SKIP_REASON_MARKER,
-                            format_skip_reason_comment(
-                                "excluded from the planning loop as an epic/roadmap "
-                                "tracking issue (checklist of child work, not a code task)"
-                            ),
-                        )
-                    except Exception as exc:  # pragma: no cover - best-effort
-                        logger.warning("could not post skip-reason comment on #%s: %s", number, exc)
             return
         github_api.skip_epics(epics_labels)
 

--- a/hephaestus/automation/review_journal.py
+++ b/hephaestus/automation/review_journal.py
@@ -1,9 +1,8 @@
-"""Pure model and rendering helpers for the GitHub plan-review journal.
+"""Pure model and rendering helpers for canonical plan-review comments.
 
-GitHub comments are the durable audit log, while mutually-exclusive
-``state:*`` labels remain the authoritative pipeline state.  This module
-keeps those roles separate and centralizes the comment format so restart,
-prompt projection, and GitHub mutation code do not each invent parsers.
+The latest plan and latest review are the only automation comments retained on
+the linked issue, while mutually-exclusive ``state:*`` labels remain the
+authoritative pipeline state. Legacy history parsers remain for safe migration.
 """
 
 from __future__ import annotations
@@ -29,13 +28,20 @@ HISTORY_RE: Final[re.Pattern[str]] = re.compile(
     r"kind=(?P<kind>plan|review) -->"
 )
 REVISION_RE: Final[re.Pattern[str]] = re.compile(r"<!-- revision: (?P<revision>\d+) -->")
+PLAN_FINGERPRINTS_RE: Final[re.Pattern[str]] = re.compile(
+    r"<!-- prior-plan-fingerprints: (?P<fingerprints>[0-9a-f,]*) -->"
+)
+RAW_PATCH_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?m)^\s*```diff\s*$|^\s*diff --git\s+|^\s*@@\s+-\d+(?:,\d+)?\s+\+\d+"
+)
+MAX_PRIOR_PLAN_FINGERPRINTS: Final[int] = 16
 PLAN_REVIEW_STATES: Final[frozenset[str]] = frozenset(
     {"state:plan-go", "state:plan-no-go", "state:plan-blocked"}
 )
 
 #: Planning/review prompts receive the current plan and/or latest review in
 #: dedicated fields. Keep the restart-only current-revision context bounded
-#: so append-only superseded artifacts cannot compete with active feedback.
+#: so legacy superseded artifacts cannot compete with active feedback.
 MAX_CURRENT_REVISION_CONTEXT_CHARS: Final[int] = 12_000
 
 _OLD_PLAN_PAYLOAD = "<!-- hephaestus-plan-history:old-plan -->"
@@ -69,7 +75,7 @@ class IssueComment:
 
 @dataclass(frozen=True)
 class HistoryArtifact:
-    """One immutable superseded plan or review comment."""
+    """One legacy superseded plan or review comment awaiting compaction."""
 
     revision: int
     kind: str
@@ -78,13 +84,14 @@ class HistoryArtifact:
 
 @dataclass(frozen=True)
 class JournalSnapshot:
-    """Current canonical artifacts plus immutable history reconstructed from GitHub."""
+    """Current canonical artifacts plus any legacy history found on GitHub."""
 
     revision: int
     current_plan: str
     current_review: str
     current_review_revision: int | None
     history: tuple[HistoryArtifact, ...]
+    prior_plan_fingerprints: tuple[str, ...] = ()
 
 
 def as_issue_comment(comment: IssueComment | str) -> IssueComment:
@@ -141,11 +148,20 @@ def _without_revision_line(text: str) -> str:
     return stripped
 
 
+def _without_fingerprint_line(text: str) -> str:
+    stripped = text.lstrip()
+    first, separator, rest = stripped.partition("\n")
+    if PLAN_FINGERPRINTS_RE.fullmatch(first.strip()):
+        return rest if separator else ""
+    return stripped
+
+
 def extract_current_plan(body: str) -> str:
     """Return only the plan payload from a current or legacy plan comment."""
     text = _without_leading_line(body, PLAN_CANONICAL_MARKER)
     text = _without_leading_line(text, PLAN_COMMENT_MARKER)
-    return _without_revision_line(text).strip()
+    text = _without_revision_line(text)
+    return _without_fingerprint_line(text).strip()
 
 
 def extract_current_review(body: str) -> str:
@@ -155,12 +171,21 @@ def extract_current_review(body: str) -> str:
     return _without_revision_line(text).strip()
 
 
-def render_current_plan(plan: str, *, revision: int = 1) -> str:
+def render_current_plan(
+    plan: str,
+    *,
+    revision: int = 1,
+    prior_fingerprints: Sequence[str] = (),
+) -> str:
     """Render the editable current plan with an opaque canonical marker."""
     payload = extract_current_plan(plan)
+    fingerprints = tuple(dict.fromkeys(prior_fingerprints))[-MAX_PRIOR_PLAN_FINGERPRINTS:]
+    metadata = ""
+    if fingerprints:
+        metadata = f"\n<!-- prior-plan-fingerprints: {','.join(fingerprints)} -->"
     return (
         f"{PLAN_CANONICAL_MARKER}\n{PLAN_COMMENT_MARKER}\n"
-        f"<!-- revision: {revision} -->\n\n{payload}"
+        f"<!-- revision: {revision} -->{metadata}\n\n{payload}"
     )
 
 
@@ -248,13 +273,18 @@ def normalized_plan(plan: str) -> str:
     return "\n".join(line.rstrip() for line in extract_current_plan(plan).strip().splitlines())
 
 
+def contains_raw_patch(plan: str) -> bool:
+    """Return whether a proposed public plan embeds unified-diff material."""
+    return RAW_PATCH_RE.search(extract_current_plan(plan)) is not None
+
+
 def plan_fingerprint(plan: str) -> str:
     """Return a stable short fingerprint for a normalized plan."""
-    return hashlib.sha256(normalized_plan(plan).encode("utf-8")).hexdigest()[:16]
+    return hashlib.sha256(normalized_plan(plan).encode("utf-8")).hexdigest()
 
 
 def archive_plan_body(revision: int, old_plan: str, new_plan: str) -> str:
-    """Render append-only plan history, including the next plan for crash recovery."""
+    """Render the retired history format for migration compatibility tests."""
     old_payload = extract_current_plan(old_plan)
     new_payload = extract_current_plan(new_plan)
     diff = (
@@ -281,7 +311,7 @@ def archive_plan_body(revision: int, old_plan: str, new_plan: str) -> str:
 
 
 def archive_review_body(revision: int, review: str) -> str:
-    """Render the append-only review paired with a superseded plan."""
+    """Render the retired review-history format for migration compatibility."""
     marker = HISTORY_MARKER.format(revision=revision, kind="review")
     return (
         f"{marker}\n## Review of Previous Plan — Revision {revision}\n\n"
@@ -314,7 +344,7 @@ def _owned_comments(comments: Sequence[IssueComment | str]) -> list[IssueComment
 
 
 def journal_snapshot(comments: Sequence[IssueComment | str]) -> JournalSnapshot:
-    """Reconstruct the current plan/review and ordered immutable history."""
+    """Reconstruct current plan/review and ordered legacy history."""
     owned = _owned_comments(comments)
     history: list[HistoryArtifact] = []
     history_bodies: dict[tuple[int, str], str] = {}
@@ -348,6 +378,12 @@ def journal_snapshot(comments: Sequence[IssueComment | str]) -> JournalSnapshot:
     explicit_revision = comment_revision(current_plan_body) if current_plan_body else None
     revision = explicit_revision or max(1, archived_max + 1)
     review_revision = comment_revision(current_review_body) if current_review_body else None
+    fingerprint_match = PLAN_FINGERPRINTS_RE.search(current_plan_body)
+    prior_fingerprints = (
+        tuple(value for value in fingerprint_match.group("fingerprints").split(",") if value)
+        if fingerprint_match
+        else ()
+    )
     if current_review_body and review_revision is None and archived_max == 0:
         review_revision = revision
     return JournalSnapshot(
@@ -356,6 +392,7 @@ def journal_snapshot(comments: Sequence[IssueComment | str]) -> JournalSnapshot:
         current_review=(extract_current_review(current_review_body) if current_review_body else ""),
         current_review_revision=review_revision,
         history=tuple(sorted(history, key=lambda item: (item.revision, item.kind != "plan"))),
+        prior_plan_fingerprints=prior_fingerprints,
     )
 
 
@@ -381,9 +418,9 @@ def current_plan_context(
 ) -> str:
     """Return a bounded canonical-plan excerpt without superseded revisions.
 
-    The append-only journal remains the durable recovery and audit record.
-    This projection is only supplemental agent context for a resumed planner,
-    which already receives the immediate NOGO critique separately.
+    Bounded fingerprint metadata retains oscillation detection without exposing
+    superseded plans. This projection is supplemental context for a resumed
+    planner, which receives the latest canonical critique separately.
     """
     if max_chars <= 0:
         return ""
@@ -401,8 +438,8 @@ def current_revision_context(
 ) -> str:
     """Return bounded current plan context while preserving its paired review.
 
-    Superseded plan/review artifacts are deliberately excluded: they remain
-    durable on GitHub but can contain stale, mutually incompatible critique.
+    Superseded plan/review artifacts are deliberately excluded because they
+    contain stale, mutually incompatible critique and are removed by migration.
     When space is constrained, preserve the current review in full whenever
     possible and spend the remaining budget on a deterministic plan excerpt.
     """

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -68,14 +68,17 @@ ALL_IMPLEMENTATION_STATE_LABELS = (STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTAT
 #: selected issues that also carry ``state:plan-go`` and have no open PR.
 STATE_SKIP = "state:skip"
 
-#: Marker keying the single skip-reason comment per issue (#2256). Every
-#: ``state:skip`` application upserts one comment starting with this marker so
-#: the reason survives outside ephemeral run logs.
+#: Legacy marker retained only so the timeline compactor can identify old
+#: actor-owned skip comments. New skip writes use the label plus run logs and
+#: never create an issue comment.
 SKIP_REASON_MARKER = "<!-- hephaestus-state-skip-reason -->"
 
 
 def format_skip_reason_comment(reason: str) -> str:
-    """Render the marker-keyed comment body documenting a ``state:skip`` write.
+    """Render the legacy skip body for migration and compatibility tests.
+
+    Runtime paths must not publish this body. ``state:skip`` is the durable
+    authority and its human-readable reason is emitted to the run log.
 
     Args:
         reason: Human-readable explanation of why automation applied the label.

--- a/hephaestus/prompts/templates/default/planning/plan.j2
+++ b/hephaestus/prompts/templates/default/planning/plan.j2
@@ -38,8 +38,8 @@ options.</approach>
 <files_to_create>Each new file with its path and what it contains. Write
 "_None._" when none.</files_to_create>
 <files_to_modify>Each existing file as `path/to/file.py`, the exact change,
-and a fenced code snippet of the new/changed code. Cite `file.py:line` when
-you know the line.</files_to_modify>
+and the intended behavior. Cite `file.py:line` when you know the line. Do not
+include patches, diff hunks, or source-code blocks.</files_to_modify>
 <implementation_order>A numbered sequence of concrete steps.</implementation_order>
 <verification>One runnable command per acceptance criterion in the issue, each
 labelled with the criterion it proves. Use the repo's real runner
@@ -54,21 +54,21 @@ file as evidence.</verification>
 <skills_used>Skills you invoked during planning AND any team knowledge-base
 skills from the Prior Learnings section above.</skills_used>
 <changes_from_review>ONLY when a prior `## 🔍 Plan Review` is in your context
-(you are revising). Enumerate each change and name the specific review finding
-it addresses. On the FIRST plan, omit this section or write
-`_N/A — initial plan_`.</changes_from_review>
+(you are revising). Keep one cumulative, high-level bullet list of the
+improvements made across the review cycle. Preserve useful bullets from the
+prior plan and fold new findings into thematic summaries. Do not quote the
+reviewer, enumerate raw findings, list changed lines, or include code/diffs.
+On the FIRST plan, omit this section or write `_N/A — initial plan_`.</changes_from_review>
 
 ---
 
-**GOOD example 1** (concrete file:line + fenced change + per-criterion check):
+**GOOD example 1** (concrete file:line + behavioral change + per-criterion check):
 
 ## Files to Modify
 ### `hephaestus/io/utils.py`
-Replace the bare `open()` at `hephaestus/io/utils.py:142` with an atomic write:
-```python
-with _body_file(body) as tmp:
-    os.replace(tmp, target)
-```
+Replace the direct write at `hephaestus/io/utils.py:142` with the repository's
+atomic temporary-file replacement helper so interrupted writes preserve the
+previous complete target.
 ## Verification
 ```bash
 uv run pytest tests/unit/io/test_utils.py -k atomic   # acceptance criterion 1: no partial writes
@@ -100,9 +100,10 @@ See the comment above for the complete plan and verification steps.
 - Include test file creation in the plan.
 - Consider dependencies and integration points.
 - Keep the plan focused on the issue requirements.
-- When re-planning, make the `## Changes from review` section concrete: every
-  prior review finding must map to either a change you made or an explicit
-  note on why it does not apply — do NOT merely acknowledge findings.
+- When re-planning, make `## Changes from Review` a concise cumulative summary
+  of the resulting improvements. Detailed findings belong only in the latest
+  canonical review comment.
+- Never include a unified diff, `diff --git` output, or a fenced `diff` block.
 
 **Format:**
 Output markdown only. Start with the `# Implementation Plan` heading, then the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,6 +34,9 @@ through installed `hephaestus-*` console scripts.
 
 - **`show_prompt.py`** — Display the automation-pipeline agent prompt for a
   given GitHub issue and stage (planning, implementation, pr-review, …).
+- **`compact_issue_timelines.py`** — Dry-run-first migration that reduces open
+  and closed issue timelines to the latest actor-owned plan and plan review.
+  See `../docs/runbooks/compact-issue-timelines.md`.
 
 ### Installation / environment
 

--- a/scripts/compact_issue_timelines.py
+++ b/scripts/compact_issue_timelines.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Compact automation-owned GitHub issue timelines to two canonical comments.
+
+Dry-run is the default. Use ``--apply`` only after reviewing the per-issue
+plan. Issue bodies, human comments, foreign comments, and pull-request
+timelines are never edited by this command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+from hephaestus.automation import github_api
+from hephaestus.automation.issue_timeline import (
+    IssueTimelineCompaction,
+    issue_comments_from_metadata,
+    plan_issue_timeline_compaction,
+)
+from hephaestus.automation.protocol import (
+    PLAN_CANONICAL_MARKER,
+    PLAN_COMMENT_MARKER,
+    PLAN_REVIEW_CANONICAL_MARKER,
+    PLAN_REVIEW_PREFIX,
+)
+
+
+def _repo(value: str) -> tuple[str, str]:
+    owner, separator, name = value.partition("/")
+    if not separator or not owner or not name or "/" in name:
+        raise argparse.ArgumentTypeError("repository must be OWNER/NAME")
+    return owner, name
+
+
+def _issue_numbers(
+    repo: tuple[str, str],
+    *,
+    state: str,
+    selected: frozenset[int],
+) -> list[int]:
+    owner, name = repo
+    result = github_api._gh_call(
+        [
+            "api",
+            "--paginate",
+            "--slurp",
+            f"/repos/{owner}/{name}/issues?state={state}&per_page=100",
+        ]
+    )
+    pages = json.loads(result.stdout or "[]")
+    if not isinstance(pages, list):
+        raise RuntimeError("GitHub issue listing returned a non-list response")
+    records: list[dict[str, Any]] = []
+    for page in pages:
+        if isinstance(page, list):
+            records.extend(record for record in page if isinstance(record, dict))
+        elif isinstance(page, dict):
+            records.append(page)
+    return sorted(
+        int(record["number"])
+        for record in records
+        if record.get("number") is not None
+        and "pull_request" not in record
+        and (not selected or int(record["number"]) in selected)
+    )
+
+
+def _plan_issue(
+    issue_number: int,
+    *,
+    repo: tuple[str, str],
+    viewer_login: str,
+) -> IssueTimelineCompaction:
+    metadata = github_api.fetch_issue_comments_metadata(issue_number, repo)
+    return plan_issue_timeline_compaction(
+        issue_comments_from_metadata(metadata, viewer_login=viewer_login)
+    )
+
+
+def _apply_issue(
+    issue_number: int,
+    plan: IssueTimelineCompaction,
+    *,
+    repo: tuple[str, str],
+) -> None:
+    if plan.plan_needs_update and plan.plan_body is not None:
+        github_api.gh_issue_upsert_owned_comment(
+            issue_number,
+            PLAN_CANONICAL_MARKER,
+            plan.plan_body,
+            repo=repo,
+            legacy_marker=PLAN_COMMENT_MARKER,
+        )
+    if plan.review_needs_update and plan.review_body is not None:
+        github_api.gh_issue_upsert_owned_comment(
+            issue_number,
+            PLAN_REVIEW_CANONICAL_MARKER,
+            plan.review_body,
+            repo=repo,
+            legacy_marker=PLAN_REVIEW_PREFIX,
+        )
+    for comment_id in plan.delete_comment_ids:
+        github_api.gh_issue_delete_comment(comment_id, repo=repo, missing_ok=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=_repo, help="OWNER/NAME (defaults to current repo)")
+    parser.add_argument("--state", choices=("all", "open", "closed"), default="all")
+    parser.add_argument("--issues", nargs="*", type=int, default=())
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="apply the displayed plan; without this flag the command is read-only",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the fail-per-issue, ownership-checked compaction workflow."""
+    args = build_parser().parse_args(argv)
+    repo = args.repo or github_api.get_repo_info()
+    viewer_login = github_api.gh_current_login() or ""
+    if not viewer_login:
+        print("error: authenticated GitHub login could not be verified", file=sys.stderr)
+        return 2
+    failures = 0
+    changed = 0
+    for issue_number in _issue_numbers(
+        repo,
+        state=args.state,
+        selected=frozenset(args.issues),
+    ):
+        try:
+            plan = _plan_issue(issue_number, repo=repo, viewer_login=viewer_login)
+            if not plan.has_changes:
+                continue
+            changed += 1
+            action = "APPLY" if args.apply else "DRY-RUN"
+            print(
+                f"{action} #{issue_number}: "
+                f"plan_update={plan.plan_needs_update} "
+                f"review_update={plan.review_needs_update} "
+                f"delete={list(plan.delete_comment_ids)}"
+            )
+            if args.apply:
+                _apply_issue(issue_number, plan, repo=repo)
+                remaining = _plan_issue(issue_number, repo=repo, viewer_login=viewer_login)
+                if remaining.has_changes:
+                    raise RuntimeError("post-apply verification did not converge")
+        except Exception as error:  # fail one issue without abandoning the inventory
+            failures += 1
+            print(f"ERROR #{issue_number}: {type(error).__name__}: {error}", file=sys.stderr)
+    mode = "applied" if args.apply else "would change"
+    print(f"summary: {changed} issue(s) {mode}; {failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -2873,7 +2873,6 @@ class TestCommitPushAndPrCreate:
         assert result.disposition == Disposition.SKIP
         assert github.mutation_log == [
             ("gh_issue_add_labels", (9, (STATE_SKIP,))),
-            ("gh_issue_upsert_comment", (9, "<!-- hephaestus-state-skip-reason -->")),
         ]
 
     def test_no_commits_with_externally_armed_pr_blocks_without_skip_label(
@@ -2922,7 +2921,6 @@ class TestCommitPushAndPrCreate:
         assert stage.step(item, ctx) == StageOutcome(Disposition.SKIP, "no commits vs base")
         assert github.mutation_log == [
             ("gh_issue_add_labels", (9, (STATE_SKIP,))),
-            ("gh_issue_upsert_comment", (9, "<!-- hephaestus-state-skip-reason -->")),
         ]
 
     def test_skip_label_write_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
@@ -3168,7 +3166,7 @@ class TestFullWalks:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitHubJob)
         assert result.job.request == AppendReplyJournalRequest(
-            issue_number=3,
+            issue_number=7,
             marker=marker,
             body=body,
         )

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -189,7 +189,7 @@ class TestPlanReviewStageOnEnter:
         assert item.payload["plan_text"] == "Durable plan"
         assert item.payload["plan_revision"] == 4
 
-    def test_restart_reconciles_partial_archive_before_reviewing(
+    def test_restart_reconciles_legacy_archive_without_appending_review(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         stage = PlanReviewStage()
@@ -206,22 +206,35 @@ class TestPlanReviewStageOnEnter:
 
         assert item.payload["plan_text"] == "Plan 2 with tests"
         assert item.payload["plan_revision"] == 2
-        assert any(
+        assert not any(
             body.startswith(HISTORY_MARKER.format(revision=1, kind="review"))
             for body in github.comments[2]
         )
+        assert "Review pending for implementation plan revision 2" in github.comments[2][1]
 
-    def test_reconciliation_failure_leaves_old_canonical_plan_retryable(
+    def test_reconciliation_failure_leaves_new_canonical_plan_retryable(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         class FailOnceGitHub(FakeStageGitHub):
             fail_once = True
 
-            def append_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
-                if self.fail_once and marker.endswith("kind=review -->"):
+            def upsert_issue_comment(
+                self,
+                issue_number: int,
+                marker: str,
+                body: str,
+                *,
+                legacy_marker: str | None = None,
+            ) -> None:
+                if self.fail_once and "Review pending for implementation plan revision 2" in body:
                     self.fail_once = False
-                    raise RuntimeError("injected append failure")
-                super().append_issue_comment(issue_number, marker, body)
+                    raise RuntimeError("injected canonical review failure")
+                super().upsert_issue_comment(
+                    issue_number,
+                    marker,
+                    body,
+                    legacy_marker=legacy_marker,
+                )
 
         stage = PlanReviewStage()
         github = FailOnceGitHub()
@@ -233,9 +246,9 @@ class TestPlanReviewStageOnEnter:
         ctx = make_ctx(github=github)
         item = make_work_item(issue=3, state="ENTER")
 
-        with pytest.raises(RuntimeError, match="injected append failure"):
+        with pytest.raises(RuntimeError, match="injected canonical review failure"):
             stage.on_enter(item, ctx)
-        assert "Plan 1" in github.comments[3][0]
+        assert "Plan 2 with tests" in github.comments[3][0]
 
         assert stage.on_enter(item, ctx) is None
         assert item.payload["plan_text"] == "Plan 2 with tests"
@@ -885,7 +898,7 @@ class TestPlanReviewStageOnJobDone:
             ),
         ]
 
-    def test_amend_archives_previous_plan_and_review_before_replacing_canonical(
+    def test_amend_replaces_canonical_pair_without_history_comments(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         stage = PlanReviewStage()
@@ -904,14 +917,10 @@ class TestPlanReviewStageOnJobDone:
         stage.on_job_done(item, JobResult(ok=True, value="Plan v2 with tests"), ctx)
 
         comments = github.comments[2]
+        assert len(comments) == 2
         assert comments[0].startswith(PLAN_CANONICAL_MARKER)
         assert "<!-- revision: 2 -->" in comments[0]
         assert comments[1].startswith(PLAN_REVIEW_CANONICAL_MARKER)
-        assert comments[2].startswith("<!-- hephaestus-plan-history:revision=1:kind=plan -->")
-        assert "Plan v1" in comments[2]
-        assert "Changes from Revision 1 to Revision 2" in comments[2]
-        assert comments[3].startswith("<!-- hephaestus-plan-history:revision=1:kind=review -->")
-        assert "review text (NOGO)" in comments[3]
 
     def test_revised_plan_waits_for_exclusive_needs_plan_confirmation(
         self, make_ctx: Any, make_work_item: Any
@@ -1635,14 +1644,6 @@ class TestReviewFlowWithFakePool:
             (
                 "edit_labels",
                 (21, (STATE_PLAN_NO_GO,), (STATE_PLAN_GO, STATE_NEEDS_PLAN)),
-            ),
-            (
-                "append_issue_comment",
-                (21, "<!-- hephaestus-plan-history:revision=1:kind=plan -->"),
-            ),
-            (
-                "append_issue_comment",
-                (21, "<!-- hephaestus-plan-history:revision=1:kind=review -->"),
             ),
             ("gh_issue_upsert_comment", (21, PLAN_CANONICAL_MARKER)),
             ("gh_issue_upsert_comment", (21, PLAN_REVIEW_CANONICAL_MARKER)),

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -746,7 +746,7 @@ class TestPlanningStageStep:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
 
-    def test_replan_archives_pair_before_updating_both_canonical_comments(
+    def test_replan_replaces_both_canonical_comments_without_history(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """Feedback-triggered planning uses the same durable revision transaction."""
@@ -767,13 +767,10 @@ class TestPlanningStageStep:
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition == Disposition.ADVANCE
         comments = github.comments[27]
+        assert len(comments) == 2
         assert "<!-- revision: 2 -->" in comments[0]
         assert "Review pending for implementation plan revision 2" in comments[1]
-        assert comments[2].startswith("<!-- hephaestus-plan-history:revision=1:kind=plan -->")
-        assert comments[3].startswith("<!-- hephaestus-plan-history:revision=1:kind=review -->")
         assert [entry[0] for entry in github.mutation_log] == [
-            "append_issue_comment",
-            "append_issue_comment",
             "gh_issue_upsert_comment",
             "gh_issue_upsert_comment",
             "edit_labels",

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -4887,7 +4887,6 @@ class TestProgressAwareBudget:
             ("mark_pr_implementation_no_go", (1001,)),
             ("mark_pr_implementation_no_go", (1001,)),
             ("gh_issue_add_labels", (12, (STATE_SKIP,))),
-            ("gh_issue_upsert_comment", (12, "<!-- hephaestus-state-skip-reason -->")),
         ]
         assert item.payload["pr_review_round"] == 3
 
@@ -4921,9 +4920,8 @@ class TestProgressAwareBudget:
         assert item.payload["pr_review_round"] == 5
         assert item.attempts["pr_review_iter"] == 5  # lifetime audit trail
         assert item.attempts["pr_review_hard"] == 2  # extension rounds 4 and 5
-        assert github.mutation_log[-2:] == [
+        assert github.mutation_log[-1:] == [
             ("gh_issue_add_labels", (13, (STATE_SKIP,))),
-            ("gh_issue_upsert_comment", (13, "<!-- hephaestus-state-skip-reason -->")),
         ]
 
     def test_hard_cap_stops_even_with_progress(self, make_ctx: Any, make_work_item: Any) -> None:

--- a/tests/unit/automation/pipeline/test_github_jobs.py
+++ b/tests/unit/automation/pipeline/test_github_jobs.py
@@ -119,7 +119,7 @@ def test_runner_recovers_version_one_journal_and_delivers_exact_batch(
             pass
 
         def issue_comments(self, issue: int) -> list[IssueComment]:
-            assert issue == 3
+            assert issue == 7
             return [IssueComment(body=journal_body, viewer_did_author=True)]
 
         def gh_pr_state(self, pr: int) -> dict[str, object]:
@@ -147,7 +147,7 @@ def test_runner_recovers_version_one_journal_and_delivers_exact_batch(
     monkeypatch.setattr(module, "PipelineGitHub", FakePipelineGitHub)
     runner = module.PipelineGitHubJobRunner(org="example-org", dry_run=False)
     recovery_request = RecoverReplyJournalRequest(
-        issue_number=3,
+        issue_number=7,
         pr_number=7,
         threads=FrozenJson.snapshot(threads),
     )

--- a/tests/unit/automation/pipeline/test_plan_journal.py
+++ b/tests/unit/automation/pipeline/test_plan_journal.py
@@ -62,16 +62,15 @@ class _CrashOnceJournalGitHub(FakeStageGitHub):
         )
 
 
-@pytest.mark.parametrize("crash_on", ["review_archive", "canonical_plan", "pending_review"])
-def test_restart_completes_each_interrupted_revision_write(crash_on: str) -> None:
-    """Every write-success/next-write-failure window converges on restart."""
-    github = _CrashOnceJournalGitHub(crash_on)
+def test_restart_repairs_a_plan_written_before_pending_review() -> None:
+    """A restart replaces a stale review after the revised plan became durable."""
+    github = _CrashOnceJournalGitHub("pending_review")
     github.comments[7] = [
         render_current_plan("Plan v1", revision=1),
         render_current_review("Needs rollback.", revision=1),
     ]
 
-    with pytest.raises(RuntimeError, match=crash_on):
+    with pytest.raises(RuntimeError, match="pending_review"):
         publish_plan_revision(7, "Plan v2 with rollback", github, require_change=True)
 
     reconcile_plan_journal(7, github)
@@ -80,12 +79,34 @@ def test_restart_completes_each_interrupted_revision_write(crash_on: str) -> Non
     assert snapshot.revision == 2
     assert snapshot.current_plan == "Plan v2 with rollback"
     assert snapshot.current_review_revision == 2
-    assert [artifact.kind for artifact in snapshot.history] == ["plan", "review"]
+    assert snapshot.history == ()
     mutations_after_recovery = list(github.mutation_log)
 
     reconcile_plan_journal(7, github)
 
     assert github.mutation_log == mutations_after_recovery
+
+
+def test_failed_canonical_plan_write_preserves_the_previous_revision_for_retry() -> None:
+    """A failed first write loses no public artifact and a clean retry can publish."""
+    github = _CrashOnceJournalGitHub("canonical_plan")
+    github.comments[7] = [
+        render_current_plan("Plan v1", revision=1),
+        render_current_review("Needs rollback.", revision=1),
+    ]
+
+    with pytest.raises(RuntimeError, match="canonical_plan"):
+        publish_plan_revision(7, "Plan v2 with rollback", github, require_change=True)
+
+    preserved = journal_snapshot(github.issue_comments(7))
+    assert preserved.revision == 1
+    assert preserved.current_plan == "Plan v1"
+    assert preserved.current_review == "Needs rollback."
+
+    published = publish_plan_revision(7, "Plan v2 with rollback", github, require_change=True)
+
+    assert published.revision == 2
+    assert len(github.comments[7]) == 2
 
 
 def test_plan_oscillation_is_blocked_before_v1_is_republished() -> None:
@@ -103,6 +124,67 @@ def test_plan_oscillation_is_blocked_before_v1_is_republished() -> None:
     assert result.is_stuck
     assert "repeats a previous plan" in result.no_progress_reason
     assert github.comments[8] == before
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "# Implementation Plan\n\n```diff\n-old\n+new\n```",
+        "# Implementation Plan\n\ndiff --git a/a.py b/a.py\n@@ -1 +1 @@",
+    ],
+)
+def test_publication_rejects_raw_patch_content(candidate: str) -> None:
+    """A generated patch can never become a public canonical plan comment."""
+    github = FakeStageGitHub()
+
+    result = publish_plan_revision(8, candidate, github, require_change=False)
+
+    assert result.is_stuck
+    assert "raw patch" in result.no_progress_reason
+    assert github.comments.get(8, []) == []
+
+
+def test_amendment_replaces_canonical_comments_without_public_history() -> None:
+    """A revised plan leaves only the latest plan and latest review on the issue."""
+    github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO])
+    github.comments[8] = [
+        render_current_plan("Plan v1", revision=1),
+        render_current_review("Needs rollback.\n\nstate:plan-no-go", revision=1),
+    ]
+
+    result = publish_plan_revision(8, "Plan v2 with rollback", github, require_change=True)
+
+    assert result.changed
+    assert len(github.comments[8]) == 2
+    snapshot = journal_snapshot(github.issue_comments(8))
+    assert snapshot.revision == 2
+    assert snapshot.current_plan == "Plan v2 with rollback"
+    assert snapshot.current_review_revision == 2
+    assert snapshot.history == ()
+    public_text = "\n".join(str(comment) for comment in github.comments[8])
+    assert "Previous Implementation Plan" not in public_text
+    assert "Review of Previous Plan" not in public_text
+    assert "```diff" not in public_text
+
+
+def test_legacy_interrupted_archive_recovers_without_appending_more_history() -> None:
+    """Legacy crash recovery converges canonical pointers without new archives."""
+    github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO])
+    legacy_archive = archive_plan_body(1, "Plan v1", "Plan v2")
+    github.comments[8] = [
+        render_current_plan("Plan v1", revision=1),
+        render_current_review("Needs rollback.\n\nstate:plan-no-go", revision=1),
+        legacy_archive,
+    ]
+
+    reconcile_plan_journal(8, github)
+
+    snapshot = journal_snapshot(github.issue_comments(8))
+    assert snapshot.revision == 2
+    assert snapshot.current_plan == "Plan v2"
+    assert snapshot.current_review_revision == 2
+    assert not any(name == "gh_issue_comment" for name, _args in github.mutation_log)
+    assert not any(name == "append_issue_comment" for name, _args in github.mutation_log)
 
 
 def test_restart_rejects_conflicting_bodies_for_one_history_identity() -> None:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1365,13 +1365,15 @@ class TestSkipEpics:
     def teardown_method(self) -> None:
         _github_api_module._label_cache.clear()
 
+    @patch("hephaestus.automation.github_api.gh_issue_upsert_comment")
     @patch("hephaestus.automation.github_api.gh_issue_add_labels")
-    def test_tags_unskipped_epics(self, mock_add: Any) -> None:
-        """Each epic without state:skip gets exactly one add-label call."""
+    def test_tags_unskipped_epics(self, mock_add: Any, mock_comment: Any) -> None:
+        """Epic classification is represented by a label, never an issue comment."""
         skip_epics({10: ["epic"], 11: ["roadmap", "bug"]})
         assert mock_add.call_count == 2
         mock_add.assert_any_call(10, ["state:skip"], repo=None)
         mock_add.assert_any_call(11, ["state:skip"], repo=None)
+        mock_comment.assert_not_called()
 
     @patch("hephaestus.automation.github_api.gh_issue_add_labels")
     def test_skips_already_skipped_epic(self, mock_add: Any) -> None:

--- a/tests/unit/automation/test_issue_timeline.py
+++ b/tests/unit/automation/test_issue_timeline.py
@@ -8,7 +8,11 @@ from hephaestus.automation.issue_timeline import (
     issue_comments_from_metadata,
     plan_issue_timeline_compaction,
 )
-from hephaestus.automation.protocol import PLAN_CANONICAL_MARKER, PLAN_REVIEW_CANONICAL_MARKER
+from hephaestus.automation.protocol import (
+    PLAN_CANONICAL_MARKER,
+    PLAN_COMMENT_MARKER,
+    PLAN_REVIEW_CANONICAL_MARKER,
+)
 from hephaestus.automation.review_journal import (
     HISTORY_MARKER,
     IssueComment,
@@ -94,3 +98,17 @@ def test_malformed_legacy_marker_fails_before_planning_deletion() -> None:
 
     with pytest.raises(RuntimeError, match="malformed legacy automation marker"):
         plan_issue_timeline_compaction(comments)
+
+
+def test_existing_canonical_pointer_is_kept_when_newer_legacy_comment_exists() -> None:
+    """Migration updates the canonical ID then deletes a later legacy source."""
+    comments = [
+        _comment(1, render_current_plan("Older canonical", revision=1)),
+        _comment(2, f"{PLAN_COMMENT_MARKER}\n\nLatest legacy plan"),
+    ]
+
+    result = plan_issue_timeline_compaction(comments)
+
+    assert "Latest legacy plan" in (result.plan_body or "")
+    assert result.plan_needs_update
+    assert result.delete_comment_ids == (2,)

--- a/tests/unit/automation/test_issue_timeline.py
+++ b/tests/unit/automation/test_issue_timeline.py
@@ -1,0 +1,96 @@
+"""Behavior tests for strict automation-owned issue timeline compaction."""
+
+from __future__ import annotations
+
+import pytest
+
+from hephaestus.automation.issue_timeline import (
+    issue_comments_from_metadata,
+    plan_issue_timeline_compaction,
+)
+from hephaestus.automation.protocol import PLAN_CANONICAL_MARKER, PLAN_REVIEW_CANONICAL_MARKER
+from hephaestus.automation.review_journal import (
+    HISTORY_MARKER,
+    IssueComment,
+    archive_plan_body,
+    archive_review_body,
+    render_current_plan,
+    render_current_review,
+)
+from hephaestus.automation.state_labels import SKIP_REASON_MARKER
+
+
+def _comment(
+    database_id: int,
+    body: str,
+    *,
+    owned: bool = True,
+) -> IssueComment:
+    return IssueComment(
+        body=body,
+        viewer_did_author=owned,
+        database_id=database_id,
+    )
+
+
+def test_compaction_keeps_only_latest_owned_plan_and_review() -> None:
+    """Human text is inert while all obsolete automation artifacts are removed."""
+    handoff = "<!-- hephaestus-implementation-reply-handoff:pr=22:head=" + "a" * 40
+    handoff += ":batch=" + "b" * 32 + " -->\n<!-- {} -->"
+    comments = [
+        _comment(1, "Human clarification", owned=False),
+        _comment(2, render_current_plan("Plan v1", revision=1)),
+        _comment(3, render_current_review("NOGO", revision=1)),
+        _comment(4, archive_plan_body(1, "Plan v1", "Plan v2")),
+        _comment(5, archive_review_body(1, "NOGO")),
+        _comment(6, render_current_plan("Plan v2", revision=2)),
+        _comment(7, render_current_review("GO", revision=2)),
+        _comment(8, f"{SKIP_REASON_MARKER}\nold reason"),
+        _comment(9, handoff),
+        _comment(10, f"{HISTORY_MARKER.format(revision=9, kind='review')}\nforeign", owned=False),
+    ]
+
+    result = plan_issue_timeline_compaction(comments)
+
+    assert result.plan_body is not None
+    assert result.plan_body.startswith(PLAN_CANONICAL_MARKER)
+    assert "Plan v2" in result.plan_body
+    assert result.review_body is not None
+    assert result.review_body.startswith(PLAN_REVIEW_CANONICAL_MARKER)
+    assert "GO" in result.review_body
+    assert result.delete_comment_ids == (2, 3, 4, 5, 8, 9)
+
+
+def test_compaction_never_claims_or_deletes_foreign_marker_comments() -> None:
+    """Marker text alone cannot authorize mutation of another actor's comment."""
+    comments = [
+        _comment(1, render_current_plan("Foreign plan", revision=1), owned=False),
+        _comment(2, render_current_review("Foreign review", revision=1), owned=False),
+    ]
+
+    assert plan_issue_timeline_compaction(comments).delete_comment_ids == ()
+
+
+def test_metadata_ownership_requires_viewer_proof_or_exact_login() -> None:
+    """REST metadata cannot turn a foreign marker into an owned deletion."""
+    metadata = [
+        {"id": 1, "body": "mine", "viewerDidAuthor": True, "user": {"login": "else"}},
+        {"id": 2, "body": "also mine", "user": {"login": "HephaestusBot"}},
+        {"id": 3, "body": "foreign", "viewerDidAuthor": False, "user": {"login": "me"}},
+    ]
+
+    comments = issue_comments_from_metadata(metadata, viewer_login="hephaestusbot")
+
+    assert [comment.viewer_did_author for comment in comments] == [True, True, False]
+    assert [comment.database_id for comment in comments] == [1, 2, 3]
+
+
+def test_malformed_legacy_marker_fails_before_planning_deletion() -> None:
+    """A prefix collision is not enough evidence to delete an owned comment."""
+    comments = [
+        _comment(1, render_current_plan("Plan", revision=1)),
+        _comment(2, "<!-- hephaestus-plan-history:not-valid -->\nkeep me"),
+    ]
+
+    with pytest.raises(RuntimeError, match="malformed legacy automation marker"):
+        plan_issue_timeline_compaction(comments)

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -247,7 +247,8 @@ def test_plan_reviews_avoid_duplicate_diffs_and_source_snippets() -> None:
 
     rendered_contracts = [" ".join(rendered.split()) for rendered in (plan, review, loop_review)]
 
-    assert "a fenced code snippet of the new/changed code" in rendered_contracts[0]
+    assert "Do not include patches, diff hunks, or source-code blocks" in rendered_contracts[0]
+    assert "one cumulative, high-level bullet list" in rendered_contracts[0]
     assert all(
         "Do not include diff hunks or patch blocks" in rendered
         for rendered in rendered_contracts[1:]

--- a/tests/unit/scripts/test_compact_issue_timelines.py
+++ b/tests/unit/scripts/test_compact_issue_timelines.py
@@ -1,0 +1,64 @@
+"""CLI behavior for safe GitHub issue-timeline compaction."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.review_journal import render_current_plan, render_current_review
+
+
+@pytest.fixture
+def script_module() -> ModuleType:
+    """Load the standalone script as a testable module."""
+    path = Path(__file__).parents[3] / "scripts" / "compact_issue_timelines.py"
+    spec = importlib.util.spec_from_file_location("compact_issue_timelines", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dry_run_is_read_only_and_excludes_pull_requests(
+    script_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default mode inventories all issues but performs no mutations."""
+    comments = {
+        1: [
+            {"id": 11, "body": render_current_plan("Plan", revision=1), "user": {"login": "bot"}},
+            {"id": 12, "body": render_current_review("GO", revision=1), "user": {"login": "bot"}},
+            {
+                "id": 13,
+                "body": "<!-- hephaestus-state-skip-reason -->\nold",
+                "user": {"login": "bot"},
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        script_module.github_api,
+        "_gh_call",
+        lambda _args: SimpleNamespace(stdout='[[{"number":1},{"number":2,"pull_request":{}}]]'),
+    )
+    monkeypatch.setattr(script_module.github_api, "gh_current_login", lambda: "bot")
+    monkeypatch.setattr(
+        script_module.github_api,
+        "fetch_issue_comments_metadata",
+        lambda issue, _repo: comments[issue],
+    )
+    mutations: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        script_module.github_api,
+        "gh_issue_delete_comment",
+        lambda *args, **kwargs: mutations.append((*args, kwargs)),
+    )
+
+    assert script_module.main(["--repo", "owner/repo"]) == 0
+
+    assert mutations == []
+    assert "DRY-RUN #1" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- keep only the latest actor-owned plan and plan review on linked issues
- reject raw patches and retain bounded prior-plan fingerprints
- move reply recovery to PR timelines and log skip reasons without issue comments
- add a dry-run-first, ownership-safe migration for open and closed issues
- document the two-comment contract in ADR-0022 and its runbook

## Verification

- `uv run pytest tests/unit -q --no-cov` (7,017 passed)
- pre-push full suite (7,430 passed, 12 skipped)
- `uv run pre-commit run --all-files`
- live dry-run against issue #2363 (one canonical update, three obsolete actor-owned comments, zero failures)

Closes #2719