### PR TITLE
fix(automation): allow host-staged rebase paths

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2487,11 +2487,16 @@ class WorkerPool:
     def _rebase_conflict_edit_scope_error(
         cwd: Path, *, conflict_paths: tuple[str, ...], timeout: int
     ) -> JobResult | None:
-        """Reject tracked, staged, or untracked changes outside conflicts."""
+        """Reject unstaged tracked or untracked changes outside conflicts.
+
+        The caller already proves that the complete index is byte-for-byte
+        unchanged from the host-owned paused-rebase snapshot.  Inspecting the
+        cached diff here would misclassify clean paths staged by Git before the
+        agent turn as agent edits.
+        """
         allowed = set(conflict_paths)
         probes = (
             ["git", "diff", "--name-only", "-z"],
-            ["git", "diff", "--cached", "--name-only", "-z"],
             ["git", "ls-files", "--others", "--exclude-standard", "-z"],
         )
         try:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2264,7 +2264,7 @@ class WorkerPool:
             if not paths or any(not is_safe_scope_retraction_path(path) for path in paths):
                 return JobResult(ok=False, error="paused rebase conflict paths invalid")
             index_result = git_utils.run(
-                ["git", "ls-files", "--unmerged", "-z", "--", *paths],
+                ["git", "ls-files", "--stage", "-z"],
                 cwd=cwd,
                 timeout=timeout,
             )

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2986,6 +2986,32 @@ class TestGitOps:
         assert result.ok is False
         assert result.error == "rebase conflict resolution changed paths outside host scope"
 
+    def test_rebase_conflict_scope_allows_host_staged_nonconflict_paths(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """Clean paths staged by the paused rebase are host state, not agent edits."""
+
+        def fake_run(argv: list[str], **_kwargs: object) -> MagicMock:
+            if argv == ["git", "diff", "--name-only", "-z"]:
+                return MagicMock(returncode=0, stdout="conflict.py\0")
+            if argv == ["git", "diff", "--cached", "--name-only", "-z"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout="conflict.py\0host-staged.py\0",
+                )
+            if argv == ["git", "ls-files", "--others", "--exclude-standard", "-z"]:
+                return MagicMock(returncode=0, stdout="")
+            raise AssertionError(f"unexpected git probe: {argv!r}")
+
+        with patch(f"{_WP}.git_utils.run", side_effect=fake_run):
+            result = pool._rebase_conflict_edit_scope_error(
+                tmp_path,
+                conflict_paths=("conflict.py",),
+                timeout=1,
+            )
+
+        assert result is None
+
     def test_continue_rebase_rejects_mutated_conflict_index(
         self, pool: WorkerPool, tmp_path: Path
     ) -> None:
@@ -3096,7 +3122,6 @@ class TestGitOps:
         ):
             run.side_effect = [
                 MagicMock(returncode=0, stdout="x.py\0"),
-                MagicMock(returncode=0, stdout="x.py\0"),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
@@ -3133,7 +3158,6 @@ class TestGitOps:
             patch(f"{_WP}.git_utils.run") as run,
         ):
             run.side_effect = [
-                MagicMock(returncode=0, stdout="x.py\0"),
                 MagicMock(returncode=0, stdout="x.py\0"),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),
@@ -3173,7 +3197,6 @@ class TestGitOps:
             patch(f"{_WP}.git_utils.run") as run,
         ):
             run.side_effect = [
-                MagicMock(returncode=0, stdout="x.py\0"),
                 MagicMock(returncode=0, stdout="x.py\0"),
                 MagicMock(returncode=0, stdout=""),
                 MagicMock(returncode=0, stdout=""),

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2856,9 +2856,13 @@ class TestGitOps:
     def test_conflict_receipt_binds_index_head_base_and_remote_head(
         self, pool: WorkerPool, tmp_path: Path
     ) -> None:
-        """The host captures all immutable inputs before agent file editing."""
+        """The host captures the complete index before agent file editing."""
         (tmp_path / "x.py").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> topic\n")
-        index_state = "100644 blob 1\tx.py\0100644 blob 2\tx.py\0"
+        index_state = (
+            "100644 host-blob 0\thost-staged.py\0"
+            "100644 ours-blob 1\tx.py\0"
+            "100644 theirs-blob 2\tx.py\0"
+        )
         with patch(f"{_WP}.git_utils.run") as run:
             run.side_effect = [
                 MagicMock(returncode=0, stdout="x.py\0"),
@@ -2883,6 +2887,12 @@ class TestGitOps:
         assert receipt["paused_head_sha"] == "c" * 40
         assert receipt["base_sha"] == "b" * 40
         assert receipt["expected_remote_sha"] == "a" * 40
+        assert run.call_args_list[1].args[0] == [
+            "git",
+            "ls-files",
+            "--stage",
+            "-z",
+        ]
 
     @staticmethod
     def _continue_rebase_job(tmp_path: Path) -> GitJob:
@@ -3051,6 +3061,30 @@ class TestGitOps:
 
         assert result.ok is False
         assert result.error == "conflict index was mutated outside host ownership"
+
+    def test_continue_rebase_rejects_agent_staged_nonconflict_path(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """A stage-0 mutation outside the conflict paths cannot enter continuation."""
+        (tmp_path / "x.py").write_text("resolved\n")
+        job = self._continue_rebase_job(tmp_path)
+        receipt = {
+            "conflict_paths": ("x.py",),
+            "conflict_snapshot": {"x.py": "after"},
+            # The complete index changed after the agent staged outside.py.
+            "conflict_index_snapshot": "2" * 64,
+            "paused_head_sha": "c" * 40,
+        }
+        with (
+            patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
+            patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}.git_utils.run") as run,
+        ):
+            result = pool._git_continue_rebase(job)
+
+        assert result.ok is False
+        assert result.error == "conflict index was mutated outside host ownership"
+        run.assert_not_called()
 
     def test_continue_rebase_rejects_changed_paused_head(
         self, pool: WorkerPool, tmp_path: Path


### PR DESCRIPTION
## Summary

- keep the exact paused-index ownership check as the staged-state authority
- scope post-agent path probes to unstaged tracked and untracked files
- cover mixed rebases with clean host-staged paths and conflict-only agent edits

## Testing

- `uv run pytest tests/unit/automation/pipeline/test_worker_pool.py -q --no-cov` (192 passed)
- full pre-push suite (7,559 passed, 13 skipped; 83.98% coverage)

Closes #2721
