### PR TITLE
fix(mnemosyne): resolve live repository metadata

### DIFF
--- a/hephaestus/github/mnemosyne_repo.py
+++ b/hephaestus/github/mnemosyne_repo.py
@@ -143,12 +143,16 @@ def fetch_current_repository_metadata() -> CurrentRepositoryMetadata:
     permission = data.get("viewerPermission")
     if not isinstance(login, str) or not login:
         raise MnemosyneResolutionError("current repository metadata is incomplete")
+    login = validate_owner(login)
+    if not isinstance(owner_type, str) or not owner_type:
+        owner_metadata = _gh_json(["api", f"users/{login}"])
+        owner_type = owner_metadata.get("type")
     if not isinstance(owner_type, str) or not owner_type:
         raise MnemosyneResolutionError("current repository metadata is incomplete")
     if not isinstance(permission, str) or not permission:
         raise MnemosyneResolutionError("current repository metadata is incomplete")
     return CurrentRepositoryMetadata(
-        owner=validate_owner(login),
+        owner=login,
         owner_type=owner_type,
         viewer_permission=permission,
     )
@@ -168,7 +172,14 @@ def _default_branch_and_head(data: dict[str, Any], slug: str) -> tuple[str, str]
     raw_oid = default_branch_ref.get("oid")
     if not head and isinstance(raw_oid, str):
         head = raw_oid
-    if not isinstance(branch, str) or not branch or not re.fullmatch(r"[0-9a-f]{40}", head):
+    if not isinstance(branch, str) or not branch:
+        raise MnemosyneResolutionError(f"{slug} metadata lacks a default branch name")
+    if re.fullmatch(r"[0-9a-f]{40}", head) is None:
+        ref = _gh_json(["api", f"repos/{slug}/git/ref/heads/{branch}"])
+        obj = ref.get("object")
+        raw_head = obj.get("sha") if isinstance(obj, dict) else None
+        head = raw_head if isinstance(raw_head, str) else ""
+    if re.fullmatch(r"[0-9a-f]{40}", head) is None:
         raise MnemosyneResolutionError(f"{slug} metadata lacks a default branch head SHA")
     return branch, head
 

--- a/tests/unit/github/test_mnemosyne_repo.py
+++ b/tests/unit/github/test_mnemosyne_repo.py
@@ -17,6 +17,8 @@ from hephaestus.github.mnemosyne_repo import (
     MnemosyneTarget,
     MnemosyneTrustBasis,
     RepositoryMetadata,
+    fetch_current_repository_metadata,
+    fetch_repository_metadata,
     resolve_mnemosyne_target,
     validate_owner,
 )
@@ -53,6 +55,55 @@ def test_validate_owner_rejects_slugs_and_unsafe_names() -> None:
     for owner in ("bad/owner", "-bad", "bad-", "bad--owner", "", "with space"):
         with pytest.raises(MnemosyneResolutionError):
             validate_owner(owner)
+
+
+def test_current_repository_metadata_reads_owner_type_when_repo_view_omits_it() -> None:
+    with (
+        patch.object(
+            mnemosyne_repo,
+            "_repo_view_json",
+            return_value={
+                "owner": {"login": "HomericIntelligence"},
+                "viewerPermission": "ADMIN",
+            },
+        ),
+        patch.object(
+            mnemosyne_repo,
+            "_gh_json",
+            return_value={"type": "Organization"},
+        ) as gh_json,
+    ):
+        metadata = fetch_current_repository_metadata()
+
+    assert metadata == CurrentRepositoryMetadata(
+        owner="HomericIntelligence",
+        owner_type="Organization",
+        viewer_permission="ADMIN",
+    )
+    gh_json.assert_called_once_with(["api", "users/HomericIntelligence"])
+
+
+def test_repository_metadata_reads_default_head_ref_when_repo_view_omits_oid() -> None:
+    with (
+        patch.object(
+            mnemosyne_repo,
+            "_repo_view_json",
+            return_value={
+                "defaultBranchRef": {"name": "main"},
+                "isFork": False,
+                "parent": None,
+            },
+        ),
+        patch.object(
+            mnemosyne_repo,
+            "_gh_json",
+            return_value={"object": {"sha": SHA}},
+        ) as gh_json,
+    ):
+        metadata = fetch_repository_metadata(UPSTREAM_SLUG)
+
+    assert metadata == UPSTREAM_METADATA
+    gh_json.assert_called_once_with(["api", f"repos/{UPSTREAM_SLUG}/git/ref/heads/main"])
 
 
 def test_explicit_owner_uses_new_env_var_and_skips_current_repo_probe(


### PR DESCRIPTION
## Summary

- recover the current repository owner type from GitHub when `gh repo view` omits it
- recover the target default-branch head through the exact Git ref when the repo view omits its OID
- preserve fail-closed owner, branch, and full-SHA validation

## Verification

- `pytest tests/unit/github/test_mnemosyne_repo.py tests/unit/automation/test_mnemosyne_binding.py tests/unit/automation/test_mnemosyne_skill_host.py --no-cov -q` (29 passed)
- `ruff check`, `ruff format --check`, and `mypy` on changed files
- live host-owned Athena advice: canonical `HomericIntelligence/Mnemosyne`, revision `efb38ca946ad6ac303843ccf4eddd2eb9252adc3`, trust `canonical upstream`

Closes #2517
