### PR TITLE
fix(automation): bind issue guards to implementation branches

### DIFF
--- a/docs/adr/0024-issue-work-ownership-guard.md
+++ b/docs/adr/0024-issue-work-ownership-guard.md
@@ -17,16 +17,20 @@ without an ownership check could clear a live run or alter the independent
 Use `state:in-progress` as an orthogonal, visible contention label. It is not
 part of the plan-state or implementation-state tuples and never authorizes a
 stage transition. The authoritative ownership record is canonical version-one
-JSON in the per-issue ref
-`refs/heads/hephaestus/issue-guards/issue-<N>`.
+JSON in a no-tree-change commit on the exact implementation branch for the
+issue. The branch is carried in the guard credential, so the guard and
+production writer share one ref: `refs/heads/<implementation-branch>`. A
+branch tip may contain ordinary implementation commits; readers walk
+first-parent history to find the newest guard record, while every guard child
+still advances that same branch with a non-forced compare-and-swap update.
 
 An automation run reads labels, refuses a live guard, creates an acquiring
 record, installs it with a non-forced ref operation, and reads it back before
 adding the label. It then records an active child and confirms both the
 record identity and label before dispatching work. Every issue mutation uses
 the target-bound guarded GitHub proxy, which re-confirms the claim immediately
-before the mutation. Claims carry repository, issue, claim UUID, and run UUID
-across worker boundaries.
+before the mutation. Claims carry repository, issue, branch, claim UUID, and
+run UUID across worker boundaries.
 
 Active claims use a four-hour lease. Renewal is owner-only and extends the
 lease through a ref child. Normal completion writes releasing/released
@@ -54,7 +58,8 @@ recovery credential if it is present.
 
 ## Consequences
 
-- GitHub receives one orthogonal label and one auditable ref history per issue.
+- GitHub receives one orthogonal label and one auditable history on the
+  implementation branch; no guard-only ref or branch is created.
 - All issue-bearing worker jobs must be bound to a matching guard credential;
   repository-wide label provisioning remains outside an issue guard.
 - A crashed process can leave visible, recoverable state. Operators must use

--- a/docs/runbooks/issue-work-guard-recovery.md
+++ b/docs/runbooks/issue-work-guard-recovery.md
@@ -5,13 +5,21 @@ orthogonal to the plan labels and is not proof that a plan transition is
 authorized. Do not remove it manually or use the normal automation token to
 clear it.
 
+Guard histories are stored as no-tree-change commits on the implementation
+branch itself. Always provide the exact branch name, including the direct-scope
+nonce when present; there is no separate guard ref.
+
 ## Inspect
 
 Use the read-only inspection mode to capture the current ref OID, claim UUID,
 lease expiry, phase, actor, and preserved plan labels:
 
 ```bash
-hephaestus-recover-issue-guard --repo OWNER/REPO --issue ISSUE --inspect
+hephaestus-recover-issue-guard \
+  --repo OWNER/REPO \
+  --issue ISSUE \
+  --branch IMPLEMENTATION_BRANCH \
+  --inspect
 ```
 
 The output is diagnostic only. If the claim is active and its lease plus the
@@ -30,6 +38,7 @@ hephaestus-recover-issue-guard \
   --recover \
   --repo OWNER/REPO \
   --issue ISSUE \
+  --branch IMPLEMENTATION_BRANCH \
   --expected-claim CLAIM_UUID \
   --expected-oid REF_OID \
   --reason 'confirmed abandoned runner after incident INC-123'

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -962,6 +962,47 @@ def get_pr_head_branch(pr_number: int) -> str | None:
         return None
 
 
+def pr_head_is_writable(pr_number: int, repository: tuple[str, str] | None) -> bool:
+    """Return whether a PR head belongs to the repository being automated.
+
+    A fork head is a valid read-only review target, but binding a guard to its
+    branch name would make the base repository create a duplicate production
+    branch. Missing or malformed repository identity therefore fails closed.
+    """
+    if repository is None:
+        return False
+    owner, repo_name = repository
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "headRepository,headRepositoryOwner",
+                "--repo",
+                f"{owner}/{repo_name}",
+            ],
+            check=False,
+        )
+        data = json.loads(result.stdout or "{}")
+    except Exception as exc:
+        logger.debug("Could not verify writable head for PR #%d: %s", pr_number, exc)
+        return False
+    if not isinstance(data, dict):
+        return False
+    head_repository = data.get("headRepository")
+    head_owner = data.get("headRepositoryOwner")
+    head_name = head_repository.get("name") if isinstance(head_repository, dict) else None
+    owner_login = head_owner.get("login") if isinstance(head_owner, dict) else None
+    return (
+        isinstance(head_name, str)
+        and isinstance(owner_login, str)
+        and head_name.casefold() == repo_name.casefold()
+        and owner_login.casefold() == owner.casefold()
+    )
+
+
 def write_work_report(work_units: int) -> None:
     """Write the phase's work-unit count to the path in $HEPH_WORK_REPORT.
 

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -2,8 +2,9 @@
 
 The visible ``state:in-progress`` label is intentionally only a contention
 signal.  The authoritative claim is a compare-and-confirm state machine stored
-in a per-issue Git ref.  Ref updates are non-forced, so two children of the
-same observed record cannot both become the current owner.
+in no-tree-change commits on the issue's implementation branch. Branch updates
+are non-forced, so two children of the same observed record cannot both become
+the current owner.
 """
 # The store implements a deliberately broad public protocol surface; its
 # individual methods mirror transport operations and are documented by the
@@ -41,7 +42,6 @@ _SHUTDOWN_MARGIN = timedelta(minutes=5)
 _FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 _REPOSITORY_RE = re.compile(r"[^/\s]+/[^/\s]+\Z")
 _GUARD_REASON_MAX = 512
-_GUARD_REF_PREFIX = "refs/heads/hephaestus/issue-guards/issue-"
 _REF_READBACK_ATTEMPTS = 4
 _REF_READBACK_DELAY_S = 0.25
 
@@ -63,7 +63,7 @@ class GuardConflictError(GuardError):
 
 
 class GuardPhase(StrEnum):
-    """Phases recorded in the issue guard ref."""
+    """Phases recorded in the implementation branch history."""
 
     ACQUIRING = "acquiring"
     ACTIVE = "active"
@@ -81,6 +81,19 @@ def _require_uuid(value: uuid.UUID, field: str) -> None:
 def _require_sha(value: str, field: str) -> None:
     if not isinstance(value, str) or _FULL_SHA_RE.fullmatch(value) is None:
         raise ValueError(f"{field} must be a full lowercase commit SHA")
+
+
+def _require_branch(value: str, field: str = "branch") -> None:
+    """Reject branch names that cannot safely identify a production ref."""
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value.startswith("refs/")
+        or ".." in value
+        or "@{" in value
+        or any(char.isspace() or char in "~^:?*[\\" for char in value)
+    ):
+        raise ValueError(f"{field} must be a valid branch name")
 
 
 def normalize_repository(repository: str) -> str:
@@ -113,7 +126,7 @@ def _decode_time(value: object) -> datetime:
 
 @dataclass(frozen=True)
 class GuardRecord:
-    """Strict version-one record stored in a guard ref commit."""
+    """Strict version-one record stored in an implementation-branch commit."""
 
     version: Literal[1]
     repository: str
@@ -225,6 +238,7 @@ class GuardCredential:
     issue: int
     claim_id: uuid.UUID
     run_id: uuid.UUID
+    branch: str
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "repository", normalize_repository(self.repository))
@@ -232,6 +246,7 @@ class GuardCredential:
             raise ValueError("issue must be a positive integer")
         _require_uuid(self.claim_id, "claim_id")
         _require_uuid(self.run_id, "run_id")
+        _require_branch(self.branch)
 
 
 @dataclass(frozen=True)
@@ -278,6 +293,9 @@ class GuardStore(Protocol):
     def remove_label(self, repository: str, issue: int, label: str) -> None:
         raise NotImplementedError
 
+    def bind_branch(self, branch: str) -> None:
+        raise NotImplementedError
+
     def read_ref(self, repository: str, issue: int) -> GuardSnapshot | None:
         raise NotImplementedError
 
@@ -289,7 +307,14 @@ class GuardStore(Protocol):
     ) -> tuple[str, datetime]:
         raise NotImplementedError
 
-    def create_ref(self, repository: str, issue: int, oid: str) -> None:
+    def create_ref(
+        self,
+        repository: str,
+        issue: int,
+        oid: str,
+        *,
+        expected_oid: str | None = None,
+    ) -> None:
         raise NotImplementedError
 
     def update_ref(self, repository: str, issue: int, oid: str, expected_oid: str) -> None:
@@ -317,10 +342,28 @@ class IssueGuard:
         *,
         run_id: uuid.UUID | None = None,
         actor: str | None = None,
+        branch: str | None = None,
     ) -> None:
         self.store = store
         self.run_id = run_id or uuid.uuid4()
         self.actor = actor
+        configured_branch = branch or getattr(store, "branch_name", None)
+        self.branch = configured_branch if isinstance(configured_branch, str) else ""
+        if self.branch:
+            _require_branch(self.branch)
+            self.store.bind_branch(self.branch)
+
+    def bind_branch(self, branch: str) -> None:
+        """Bind this service to the exact implementation branch."""
+        _require_branch(branch)
+        self.branch = branch
+        self.store.bind_branch(branch)
+
+    def _branch(self) -> str:
+        if not self.branch:
+            raise GuardUnavailableError("issue guard requires the implementation branch")
+        _require_branch(self.branch)
+        return self.branch
 
     def _actor(self) -> str:
         actor = self.actor or self.store.actor()
@@ -328,9 +371,14 @@ class IssueGuard:
             raise GuardUnavailableError("authenticated GitHub actor is unavailable")
         return actor
 
-    @staticmethod
-    def _credential(record: GuardRecord) -> GuardCredential:
-        return GuardCredential(record.repository, record.issue, record.claim_id, record.run_id)
+    def _credential(self, record: GuardRecord) -> GuardCredential:
+        return GuardCredential(
+            record.repository,
+            record.issue,
+            record.claim_id,
+            record.run_id,
+            self._branch(),
+        )
 
     @staticmethod
     def _lease_for(minimum_valid_for: timedelta) -> timedelta:
@@ -353,19 +401,22 @@ class IssueGuard:
         except GuardConflictError:
             raise
         except Exception as exc:
-            raise GuardConflictError("guard ref update lost its compare-and-swap") from exc
+            raise GuardConflictError(
+                "implementation branch update lost its compare-and-swap"
+            ) from exc
         for attempt in range(_REF_READBACK_ATTEMPTS):
             current = self.store.read_ref(repository, issue)
             if current is not None and current.oid == oid and current.record == record:
                 return current
             if attempt + 1 < _REF_READBACK_ATTEMPTS:
                 time.sleep(_REF_READBACK_DELAY_S)
-        raise GuardLostError("guard ref read-back did not confirm the child record")
+        raise GuardLostError("implementation branch read-back did not confirm the child record")
 
     def acquire(  # noqa: C901
         self, repository: str, issue: int, work_stage: str
     ) -> GuardHandle | None:
         """Claim an issue, returning ``None`` when another claim owns it."""
+        self._branch()
         repository = normalize_repository(repository)
         if isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0:
             raise ValueError("issue must be a positive integer")
@@ -412,7 +463,7 @@ class IssueGuard:
         oid, _ = self.store.create_commit(repository, tree, parents, record.to_json())
         try:
             if current is None:
-                self.store.create_ref(repository, issue, oid)
+                self.store.create_ref(repository, issue, oid, expected_oid=parents[0])
             else:
                 self.store.update_ref(repository, issue, oid, current.oid)
         except GuardConflictError:
@@ -463,6 +514,7 @@ class IssueGuard:
     def confirm(self, credential: GuardCredential, minimum_valid_for: timedelta) -> GuardHandle:
         """Re-read and prove ownership before a dispatch or mutation."""
         repository = normalize_repository(credential.repository)
+        self.bind_branch(credential.branch)
         current = self.store.read_ref(repository, credential.issue)
         labels = set(self.store.read_labels(repository, credential.issue))
         if current is None or current.record.phase is not GuardPhase.ACTIVE:
@@ -645,8 +697,16 @@ def replace_record(record: GuardRecord, **changes: Any) -> GuardRecord:
 class InMemoryGuardStore:
     """Deterministic store useful for unit tests and local protocol checks."""
 
-    def __init__(self, repository: str = "Owner/Repo", *, actor: str = "automation") -> None:
+    def __init__(
+        self,
+        repository: str = "Owner/Repo",
+        *,
+        actor: str = "automation",
+        branch: str = "test-auto-impl",
+    ) -> None:
         self.repository = normalize_repository(repository)
+        _require_branch(branch)
+        self.branch_name = branch
         self.labels: dict[tuple[str, int], set[str]] = {}
         self.refs: dict[tuple[str, int], GuardSnapshot] = {}
         self.now = datetime.now(UTC)
@@ -670,6 +730,10 @@ class InMemoryGuardStore:
     def remove_label(self, repository: str, issue: int, label: str) -> None:
         self.labels.setdefault((repository, issue), set()).discard(label)
 
+    def bind_branch(self, branch: str) -> None:
+        _require_branch(branch)
+        self.branch_name = branch
+
     def read_ref(self, repository: str, issue: int) -> GuardSnapshot | None:
         return self.refs.get((repository, issue))
 
@@ -686,9 +750,16 @@ class InMemoryGuardStore:
         self._commits[oid] = (record, tree, message)
         return oid, self.now
 
-    def create_ref(self, repository: str, issue: int, oid: str) -> None:
+    def create_ref(
+        self,
+        repository: str,
+        issue: int,
+        oid: str,
+        *,
+        expected_oid: str | None = None,
+    ) -> None:
         key = (repository, issue)
-        if key in self.refs:
+        if key in self.refs and expected_oid != self.refs[key].oid:
             raise GuardConflictError("ref already exists")
         record, tree, _message = self._commits[oid]
         if record is None:
@@ -759,10 +830,14 @@ class GitHubIssueGuardStore:
         self,
         repository: str,
         *,
+        branch: str | None = None,
         call: Callable[..., subprocess.CompletedProcess[str]] = gh_call,
         env: Mapping[str, str] | None = None,
     ) -> None:
         self.repository = normalize_repository(repository)
+        self.branch_name = branch
+        if branch is not None:
+            _require_branch(branch)
         self._call = call
         self._env = dict(env) if env is not None else None
         self._last_server_time: datetime | None = None
@@ -791,6 +866,34 @@ class GitHubIssueGuardStore:
         root = f"repos/{self.repository}"
         return f"{root}/{suffix}" if suffix else root
 
+    def bind_branch(self, branch: str) -> None:
+        """Bind all guard operations to the implementation branch."""
+        _require_branch(branch)
+        self.branch_name = branch
+
+    def _branch(self) -> str:
+        branch = self.branch_name
+        if not isinstance(branch, str) or not branch.strip():
+            raise GuardUnavailableError("guard store has no implementation branch")
+        _require_branch(branch)
+        return branch
+
+    def _ref_oid(self) -> str | None:
+        """Read the implementation branch tip, returning ``None`` if absent."""
+        status, body = self._request(
+            [self._path(f"git/ref/heads/{self._branch()}")],
+            check=False,
+        )
+        if status == 404:
+            return None
+        if status != 200 or not isinstance(body, dict):
+            raise GuardUnavailableError("implementation branch response was not successful")
+        obj = body.get("object")
+        oid = obj.get("sha") if isinstance(obj, dict) else None
+        if not isinstance(oid, str):
+            raise GuardUnavailableError("implementation branch response was malformed")
+        return oid
+
     def read_labels(self, repository: str, issue: int) -> Sequence[str]:
         status, body = self._request([self._path(f"issues/{issue}")])
         if status != 200 or not isinstance(body, dict):
@@ -818,40 +921,58 @@ class GitHubIssueGuardStore:
     def remove_label(self, repository: str, issue: int, label: str) -> None:
         self._request(["--method", "DELETE", self._path(f"issues/{issue}/labels/{label}")])
 
-    def _commit(self, repository: str, oid: str) -> tuple[str, datetime]:
+    def _commit_metadata(
+        self, repository: str, oid: str
+    ) -> tuple[str, str, tuple[str, ...], datetime]:
         status, body = self._request([self._path(f"git/commits/{oid}")])
         if status != 200 or not isinstance(body, dict):
-            raise GuardUnavailableError("guard commit response was not successful")
+            raise GuardUnavailableError("implementation branch commit response was not successful")
         tree = body.get("tree")
         tree_sha = tree.get("sha") if isinstance(tree, dict) else None
         message = body.get("message")
+        parents_data = body.get("parents")
+        parents: list[str] = []
+        if isinstance(parents_data, list):
+            for parent in parents_data:
+                parent_sha = parent.get("sha") if isinstance(parent, dict) else None
+                if isinstance(parent_sha, str):
+                    parents.append(parent_sha)
         if not isinstance(tree_sha, str) or not isinstance(message, str):
-            raise GuardUnavailableError("guard commit response was malformed")
-        return tree_sha, self.server_now()
+            raise GuardUnavailableError("implementation branch commit response was malformed")
+        return tree_sha, message, tuple(parents), self.server_now()
+
+    def _guard_record(self, repository: str, oid: str) -> GuardRecord | None:
+        """Find the newest guard record in the branch's first-parent history."""
+        current = oid
+        for _ in range(4096):
+            _tree, message, parents, _server_time = self._commit_metadata(repository, current)
+            try:
+                return GuardRecord.from_json(message)
+            except ValueError:
+                if message.lstrip().startswith("{"):
+                    raise GuardUnavailableError(
+                        "implementation branch contains a malformed guard record"
+                    ) from None
+            if not parents:
+                return None
+            current = parents[0]
+        raise GuardUnavailableError("implementation branch guard history is too deep")
 
     def read_ref(self, repository: str, issue: int) -> GuardSnapshot | None:
-        ref = f"heads/hephaestus/issue-guards/issue-{issue}"
-        status, body = self._request([self._path(f"git/ref/{ref}")], check=False)
-        if status == 404:
+        oid = self._ref_oid()
+        if oid is None:
             return None
-        if status != 200 or not isinstance(body, dict):
-            raise GuardUnavailableError("guard ref response was not successful")
-        obj = body.get("object")
-        oid = obj.get("sha") if isinstance(obj, dict) else None
-        if not isinstance(oid, str):
-            raise GuardUnavailableError("guard ref response was malformed")
-        tree, server_time = self._commit(repository, oid)
-        status, commit_body = self._request([self._path(f"git/commits/{oid}")])
-        message = commit_body.get("message") if isinstance(commit_body, dict) else None
-        if status != 200 or not isinstance(message, str):
-            raise GuardUnavailableError("guard record commit message was malformed")
-        try:
-            record = GuardRecord.from_json(message)
-        except ValueError as exc:
-            raise GuardUnavailableError("guard ref contains a malformed record") from exc
+        tree, _message, _parents, server_time = self._commit_metadata(repository, oid)
+        record = self._guard_record(repository, oid)
+        if record is None:
+            return None
         return GuardSnapshot(oid=oid, record=record, tree=tree, server_time=server_time)
 
     def default_tip(self, repository: str) -> tuple[str, str]:
+        branch_oid = self._ref_oid()
+        if branch_oid is not None:
+            tree, _message, _parents, _server_time = self._commit_metadata(repository, branch_oid)
+            return branch_oid, tree
         status, body = self._request([self._path("")])
         branch = body.get("default_branch") if isinstance(body, dict) else None
         if status != 200 or not isinstance(branch, str) or not branch:
@@ -861,7 +982,7 @@ class GitHubIssueGuardStore:
         oid = obj.get("sha") if isinstance(obj, dict) else None
         if status != 200 or not isinstance(oid, str):
             raise GuardUnavailableError("default branch ref was malformed")
-        tree, _ = self._commit(repository, oid)
+        tree, _message, _parents, _server_time = self._commit_metadata(repository, oid)
         return oid, tree
 
     def create_commit(
@@ -884,30 +1005,49 @@ class GitHubIssueGuardStore:
             raise GuardUnavailableError("guard commit creation failed")
         return oid, self.server_now()
 
-    def create_ref(self, repository: str, issue: int, oid: str) -> None:
+    def create_ref(
+        self,
+        repository: str,
+        issue: int,
+        oid: str,
+        *,
+        expected_oid: str | None = None,
+    ) -> None:
         status, _ = self._request(
             [
                 "--method",
                 "POST",
                 self._path("git/refs"),
                 "-f",
-                f"ref={_GUARD_REF_PREFIX}{issue}",
+                f"ref=refs/heads/{self._branch()}",
                 "-f",
                 f"sha={oid}",
             ],
             check=False,
         )
         if status in {409, 422}:
-            raise GuardConflictError("guard ref already exists")
+            current_oid = self._ref_oid()
+            if expected_oid is None or current_oid != expected_oid:
+                raise GuardConflictError("implementation branch already exists or changed")
+            self._patch_ref(oid)
+            return
         if status not in {200, 201}:
-            raise GuardUnavailableError("guard ref creation failed")
+            raise GuardUnavailableError("implementation branch creation failed")
 
     def update_ref(self, repository: str, issue: int, oid: str, expected_oid: str) -> None:
+        current_oid = self._ref_oid()
+        if current_oid != expected_oid:
+            raise GuardConflictError(
+                "implementation branch changed before its compare-and-swap update"
+            )
+        self._patch_ref(oid)
+
+    def _patch_ref(self, oid: str) -> None:
         status, _ = self._request(
             [
                 "--method",
                 "PATCH",
-                self._path(f"git/refs/heads/hephaestus/issue-guards/issue-{issue}"),
+                self._path(f"git/refs/heads/{self._branch()}"),
                 "-f",
                 f"sha={oid}",
                 "-F",
@@ -916,9 +1056,9 @@ class GitHubIssueGuardStore:
             check=False,
         )
         if status in {409, 422}:
-            raise GuardConflictError("guard ref update lost its non-force CAS")
+            raise GuardConflictError("implementation branch update lost its non-force CAS")
         if status not in {200, 201}:
-            raise GuardUnavailableError("guard ref update failed")
+            raise GuardUnavailableError("implementation branch update failed")
 
     def actor(self) -> str:
         status, body = self._request(["user"])

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -577,10 +577,10 @@ class IssueGuard:
             current.record.phase is GuardPhase.RELEASING
             and current.record.predecessor_oid == handle.oid
         )
-        if not resuming_release and (
-            current.oid != handle.oid
-            or current.record.phase not in {GuardPhase.ACTIVE, GuardPhase.ACQUIRING}
-        ):
+        if not resuming_release and current.record.phase not in {
+            GuardPhase.ACTIVE,
+            GuardPhase.ACQUIRING,
+        }:
             raise GuardLostError("refusing to release a guard not owned by this run")
         if current.record.lease_expires_at <= _server_now(self.store):
             raise GuardLostError("expired guard requires operator recovery")

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -16,7 +16,7 @@ from hephaestus.automation.issue_guard import (
     IssueGuard,
     assert_recovery_secret_absent,
 )
-from hephaestus.automation.pipeline.guarded_github import GuardedStageGitHub
+from hephaestus.automation.pipeline.guarded_github import GuardedStageGitHub, GuardTargetError
 
 from ..git_utils import issue_auto_impl_branch_name
 from .coordinator_dispatch import ImplementationDispatcher
@@ -343,10 +343,56 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         github = self._ctx_for_repo(repo).github
         existing_pr = github.find_pr_for_issue(issue)
         if existing_pr is not None:
-            branch = github.get_pr_head_branch(existing_pr)
-            if branch:
-                return branch
+            return self._guard_branch_for_pr(repo, existing_pr)
         return issue_auto_impl_branch_name(issue)
+
+    def _guard_branch_for_pr(self, repo: str, pr: int) -> str:
+        """Resolve a PR head only when it is the writable production branch."""
+        github = self._ctx_for_repo(repo).github
+        if not github.pr_head_is_writable(pr):
+            raise GuardTargetError(
+                f"PR #{pr} does not have a writable production branch in the base repository"
+            )
+        branch = github.get_pr_head_branch(pr)
+        if not isinstance(branch, str) or not branch.strip():
+            raise GuardTargetError(f"PR #{pr} has no verified production branch")
+        return branch.strip()
+
+    def _verify_issue_source_guard(
+        self, repo: str, issue: int, expected_pr: int | None, expected_branch: str
+    ) -> None:
+        """Revalidate an issue's PR and production branch after source admission."""
+        github = self._ctx_for_repo(repo).github
+        current_pr = github.find_pr_for_issue(issue)
+        if current_pr != expected_pr:
+            raise GuardTargetError("issue-to-PR association changed during admission")
+        if (
+            expected_pr is not None
+            and self._guard_branch_for_pr(repo, expected_pr) != expected_branch
+        ):
+            raise GuardTargetError("PR head branch changed during issue admission")
+
+    def _direct_issue_guard_identity(
+        self, repo: str, issue: int, run_nonce: str
+    ) -> tuple[int | None, str, bool]:
+        """Resolve a direct issue's guarded PR identity before classification."""
+        github = self._ctx_for_repo(repo).github
+        existing_pr = github.find_pr_for_issue(issue)
+        active = self._guard_enabled and not self.config.dry_run
+        branch = (
+            self._guard_branch_for_pr(repo, existing_pr)
+            if existing_pr is not None and active
+            else f"{issue}-auto-impl-direct-{run_nonce}"
+        )
+        return existing_pr, branch, active
+
+    def _verify_pr_source_guard(self, repo: str, pr: int, issue: int, expected_branch: str) -> None:
+        """Revalidate a direct PR's issue association and production branch."""
+        github = self._ctx_for_repo(repo).github
+        if github.find_issue_for_pr(pr) != issue:
+            raise GuardTargetError("PR-to-issue association changed during admission")
+        if self._guard_branch_for_pr(repo, pr) != expected_branch:
+            raise GuardTargetError("PR head branch changed during admission")
 
     def _claim_source_issue(
         self,
@@ -358,12 +404,13 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
     ) -> SourceGuardClaim:
         """Acquire a temporary source claim before any issue mutation."""
         repository = _guard_repository(self.config.org, repo)
-        branch = branch or self._guard_branch_for_issue(repo, issue)
-        handle = (
-            None
-            if self.config.dry_run or not self._guard_enabled
-            else self._guard_service(repository, branch).acquire(repository, issue, stage)
-        )
+        if self.config.dry_run or not self._guard_enabled:
+            handle = None
+        else:
+            resolved_branch = branch or self._guard_branch_for_issue(repo, issue)
+            handle = self._guard_service(repository, resolved_branch).acquire(
+                repository, issue, stage
+            )
         if handle is not None:
             self._temporary_source_guard_count += 1
         return SourceGuardClaim(self, repository, issue, handle)
@@ -436,6 +483,7 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
             raise GuardLostError("issue is already owned by another automation run")
         self._issue_guards[key] = acquired
         item.payload["_issue_guard_handle"] = acquired
+        item.payload["_issue_guard_branch"] = acquired.credential.branch
         return acquired
 
     def _confirm_item_guard(self, item: WorkItem, minimum_valid_for: timedelta) -> None:
@@ -443,12 +491,22 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         if self.config.dry_run or not self._guard_enabled or item.issue is None:
             return
         handle = self._guard_for_item(item)
+        if item.branch != handle.credential.branch:
+            raise GuardLostError("work item branch differs from its issue guard branch")
+        guard_branch = item.payload.get("_issue_guard_branch")
+        if guard_branch is not None and guard_branch != handle.credential.branch:
+            raise GuardLostError("work item guard branch differs from its issue guard branch")
+        if item.pr is not None:
+            current_branch = self._ctx_for_repo(item.repo).github.get_pr_head_branch(item.pr)
+            if current_branch != item.branch:
+                raise GuardLostError("PR head branch changed after issue guard admission")
         confirmed = self._guard_service(
             handle.credential.repository, handle.credential.branch
         ).confirm(handle.credential, minimum_valid_for)
         key = (handle.credential.repository, handle.credential.issue)
         self._issue_guards[key] = confirmed
         item.payload["_issue_guard_handle"] = confirmed
+        item.payload["_issue_guard_branch"] = confirmed.credential.branch
 
     def _release_guard_handle(
         self, repository: str, issue: int, handle: GuardHandle, reason: str

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -18,6 +18,7 @@ from hephaestus.automation.issue_guard import (
 )
 from hephaestus.automation.pipeline.guarded_github import GuardedStageGitHub
 
+from ..git_utils import issue_auto_impl_branch_name
 from .coordinator_dispatch import ImplementationDispatcher
 from .coordinator_runtime import CoordinatorRuntime
 from .coordinator_sources import SourceCoordinator
@@ -82,8 +83,12 @@ class SourceGuardClaim:
             self.transferred = True
             return
         key = (self.repository, self.issue)
+        if item.branch and item.branch != self.handle.credential.branch:
+            raise GuardLostError("work item branch differs from its issue guard branch")
+        item.branch = self.handle.credential.branch
         self.coordinator._issue_guards[key] = self.handle
         item.payload["_issue_guard_handle"] = self.handle
+        item.payload["_issue_guard_branch"] = self.handle.credential.branch
         self.transferred = True
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
@@ -325,20 +330,39 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         self._ctx_cache: OrderedDict[str, StageContext] = OrderedDict()
         self._ctx_cache_capacity = work_window
 
-    def _guard_service(self, repository: str) -> IssueGuard:
+    def _guard_service(self, repository: str, branch: str) -> IssueGuard:
         """Build a guard service carrying this coordinator's run identity."""
         return IssueGuard(
             self.guard_store_factory(repository),
             run_id=self.run_id,
+            branch=branch,
         )
 
-    def _claim_source_issue(self, repo: str, issue: int, stage: str) -> SourceGuardClaim:
+    def _guard_branch_for_issue(self, repo: str, issue: int) -> str:
+        """Resolve the exact writable implementation branch for an issue."""
+        github = self._ctx_for_repo(repo).github
+        existing_pr = github.find_pr_for_issue(issue)
+        if existing_pr is not None:
+            branch = github.get_pr_head_branch(existing_pr)
+            if branch:
+                return branch
+        return issue_auto_impl_branch_name(issue)
+
+    def _claim_source_issue(
+        self,
+        repo: str,
+        issue: int,
+        stage: str,
+        *,
+        branch: str | None = None,
+    ) -> SourceGuardClaim:
         """Acquire a temporary source claim before any issue mutation."""
         repository = _guard_repository(self.config.org, repo)
+        branch = branch or self._guard_branch_for_issue(repo, issue)
         handle = (
             None
             if self.config.dry_run or not self._guard_enabled
-            else self._guard_service(repository).acquire(repository, issue, stage)
+            else self._guard_service(repository, branch).acquire(repository, issue, stage)
         )
         if handle is not None:
             self._temporary_source_guard_count += 1
@@ -404,7 +428,10 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
             return handle
         if self.config.dry_run:
             raise GuardLostError("dry-run has no durable issue guard")
-        acquired = self._guard_service(key[0]).acquire(key[0], item.issue, item.stage.value)
+        branch = item.branch or self._guard_branch_for_issue(item.repo, item.issue)
+        if not item.branch:
+            item.branch = branch
+        acquired = self._guard_service(key[0], branch).acquire(key[0], item.issue, item.stage.value)
         if acquired is None:
             raise GuardLostError("issue is already owned by another automation run")
         self._issue_guards[key] = acquired
@@ -416,9 +443,9 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         if self.config.dry_run or not self._guard_enabled or item.issue is None:
             return
         handle = self._guard_for_item(item)
-        confirmed = self._guard_service(handle.credential.repository).confirm(
-            handle.credential, minimum_valid_for
-        )
+        confirmed = self._guard_service(
+            handle.credential.repository, handle.credential.branch
+        ).confirm(handle.credential, minimum_valid_for)
         key = (handle.credential.repository, handle.credential.issue)
         self._issue_guards[key] = confirmed
         item.payload["_issue_guard_handle"] = confirmed
@@ -429,7 +456,7 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         """Release an owner handle and retain it on failure for recovery."""
         if self.config.dry_run or not self._guard_enabled:
             return
-        self._guard_service(repository).release(handle, reason)
+        self._guard_service(repository, handle.credential.branch).release(handle, reason)
         self._issue_guards.pop((repository, issue), None)
         if self._temporary_source_guard_count:
             self._temporary_source_guard_count -= 1

--- a/hephaestus/automation/pipeline/coordinator_contract.py
+++ b/hephaestus/automation/pipeline/coordinator_contract.py
@@ -138,7 +138,9 @@ if TYPE_CHECKING:
         def _release_all_guards(self, reason: str) -> None:
             pass
 
-        def _claim_source_issue(self, repo: str, issue: int, stage: str) -> Any:
+        def _claim_source_issue(
+            self, repo: str, issue: int, stage: str, *, branch: str | None = None
+        ) -> Any:
             pass
 
         def _externalize_repo_issue_source(self, item: WorkItem, source: RepoIssueSource) -> bool:
@@ -220,6 +222,4 @@ if TYPE_CHECKING:
             pass
 
 else:
-
-    class _CoordinatorHost:
-        """Runtime-empty base for the statically checked host contract."""
+    _CoordinatorHost = object

--- a/hephaestus/automation/pipeline/coordinator_contract.py
+++ b/hephaestus/automation/pipeline/coordinator_contract.py
@@ -143,14 +143,14 @@ if TYPE_CHECKING:
         ) -> Any:
             pass
 
+        def __getattr__(self, name: str) -> Any: return None  # fmt: skip
+
         def _externalize_repo_issue_source(self, item: WorkItem, source: RepoIssueSource) -> bool:
             pass
 
-        def _drain_repo_issue_sources(self) -> None:
-            pass
+        def _drain_repo_issue_sources(self) -> None: pass  # fmt: skip
 
-        def _seed_products(self, item: WorkItem) -> None:
-            pass
+        def _seed_products(self, item: WorkItem) -> None: pass  # fmt: skip
 
         def _push_item(
             self,
@@ -181,8 +181,7 @@ if TYPE_CHECKING:
         def _drain_direct_issue_source(self) -> int:
             pass
 
-        def _drain_direct_pr_source(self) -> int:
-            pass
+        def _drain_direct_pr_source(self) -> int: pass  # fmt: skip
 
         def _prepare_direct_item(
             self, entry: Any, repo: str, base_sha: str, run_nonce: str | None = None
@@ -220,6 +219,7 @@ if TYPE_CHECKING:
 
         def _admit(self, item: WorkItem) -> bool:
             pass
-
 else:
-    _CoordinatorHost = object
+
+    class _CoordinatorHost:
+        pass

--- a/hephaestus/automation/pipeline/coordinator_sources.py
+++ b/hephaestus/automation/pipeline/coordinator_sources.py
@@ -1,8 +1,6 @@
 import sys
 from contextlib import nullcontext
-from typing import Any
-
-from hephaestus.automation.pipeline.guarded_github import GuardTargetError
+from typing import Any, cast
 
 from .coordinator_contract import _CoordinatorHost
 from .coordinator_types import *
@@ -481,12 +479,8 @@ class SourceCoordinator(_CoordinatorHost):
         overlap_enabled: bool,
     ) -> tuple[WorkItem | None, bool]:
         """Classify one source issue and snapshot its overlap reservation."""
-        raw_github = self._ctx_for_repo(source.repo).github
-        existing_pr = raw_github.find_pr_for_issue(issue)
-        guard_branch = (
-            raw_github.get_pr_head_branch(existing_pr)
-            if existing_pr
-            else f"{issue}-auto-impl-direct-{source.run_nonce}"
+        existing_pr, guard_branch, guard_active = self._direct_issue_guard_identity(
+            source.repo, issue, source.run_nonce
         )
         with self._claim_source_issue(
             source.repo, issue, "direct-issue-source", branch=guard_branch
@@ -494,6 +488,8 @@ class SourceCoordinator(_CoordinatorHost):
             if claim is None:
                 source.issues.append(issue)
                 return None, False
+            if guard_active:
+                self._verify_issue_source_guard(source.repo, issue, existing_pr, guard_branch)
             if source.wave_lease is None:
                 entry = self._seed_direct_issue_entry(source.repo, issue, github=claim.github)
             else:
@@ -608,7 +604,7 @@ class SourceCoordinator(_CoordinatorHost):
                 if self._guard_enabled and not self.config.dry_run
                 else None
             )
-            guard_branch = raw_github.get_pr_head_branch(pr) if linked_issue is not None else None
+            guard_branch = self._guard_branch_for_pr(source.repo, pr) if linked_issue else None
             claim = (
                 self._claim_source_issue(
                     source.repo, linked_issue, "direct-pr-source", branch=guard_branch
@@ -621,8 +617,10 @@ class SourceCoordinator(_CoordinatorHost):
                     source.pending_pr = pr
                     break
                 github = owned.github if owned is not None else raw_github
-                if claim is not None and github.find_issue_for_pr(pr) != linked_issue:
-                    raise GuardTargetError("PR-to-issue association changed during admission")
+                if claim is not None and claim.handle is not None:
+                    self._verify_pr_source_guard(
+                        source.repo, pr, cast(int, linked_issue), cast(str, guard_branch)
+                    )
                 entry = self._seed_direct_pr_scope(source.repo, (pr,), github=github)[0]
                 if entry.stage is None:
                     logger.info("seed excluded: %s", entry.reason)

--- a/hephaestus/automation/pipeline/coordinator_sources.py
+++ b/hephaestus/automation/pipeline/coordinator_sources.py
@@ -481,7 +481,16 @@ class SourceCoordinator(_CoordinatorHost):
         overlap_enabled: bool,
     ) -> tuple[WorkItem | None, bool]:
         """Classify one source issue and snapshot its overlap reservation."""
-        with self._claim_source_issue(source.repo, issue, "direct-issue-source") as claim:
+        raw_github = self._ctx_for_repo(source.repo).github
+        existing_pr = raw_github.find_pr_for_issue(issue)
+        guard_branch = (
+            raw_github.get_pr_head_branch(existing_pr)
+            if existing_pr
+            else f"{issue}-auto-impl-direct-{source.run_nonce}"
+        )
+        with self._claim_source_issue(
+            source.repo, issue, "direct-issue-source", branch=guard_branch
+        ) as claim:
             if claim is None:
                 source.issues.append(issue)
                 return None, False
@@ -502,7 +511,6 @@ class SourceCoordinator(_CoordinatorHost):
                     claim.github.skip_epics({entry.skip_tag_obligation.issue: []})
                 logger.info("seed excluded: %s", entry.reason)
                 return None, False
-
             item = self._prepare_direct_item(entry, source.repo, source.base_sha, source.run_nonce)
             if source.wave_lease is not None:
                 item.payload[WAVE_LEASE_PAYLOAD] = source.wave_lease
@@ -513,7 +521,6 @@ class SourceCoordinator(_CoordinatorHost):
                 if item_claims and item_claims.intersection(active_claims):
                     return None, True
                 item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(item_claims)
-
             claim.transfer_to(item)
             return item, False
 
@@ -530,13 +537,11 @@ class SourceCoordinator(_CoordinatorHost):
         source = self._direct_issue_source
         if source is None:
             return 0
-
         active_claims = frozenset(self._active_implementation_file_claims())
         overlap_enabled = self._overlap_serialization_enabled()
         if overlap_enabled and source.overlap_blocked_claims == active_claims:
             return 0
         source.overlap_blocked_claims = None
-
         pushed = 0
         scanned = 0
         scan_limit = len(source.issues)
@@ -544,7 +549,6 @@ class SourceCoordinator(_CoordinatorHost):
         while self._direct_issue_queues_can_accept() and source.issues and scanned < scan_limit:
             issue = source.issues.popleft()
             scanned += 1
-
             item, overlaps = self._prepare_direct_issue_item(
                 source,
                 issue,
@@ -598,17 +602,17 @@ class SourceCoordinator(_CoordinatorHost):
                     self._direct_pr_source = None
                     break
 
-            # The compatibility helper returns exactly one entry here; unlike
-            # the legacy call over ``config.prs`` it cannot retain a source
-            # sized list while waiting for capacity.
             raw_github = self._ctx_for_repo(source.repo).github
             linked_issue = (
                 raw_github.find_issue_for_pr(pr)
                 if self._guard_enabled and not self.config.dry_run
                 else None
             )
+            guard_branch = raw_github.get_pr_head_branch(pr) if linked_issue is not None else None
             claim = (
-                self._claim_source_issue(source.repo, linked_issue, "direct-pr-source")
+                self._claim_source_issue(
+                    source.repo, linked_issue, "direct-pr-source", branch=guard_branch
+                )
                 if linked_issue is not None
                 else None
             )

--- a/hephaestus/automation/pipeline/guarded_github.py
+++ b/hephaestus/automation/pipeline/guarded_github.py
@@ -80,13 +80,16 @@ class GuardedStageGitHub:
             self.credential.issue,
             self.credential.claim_id,
             self.credential.run_id,
+            self.credential.branch,
         )
 
     def _issue(self, issue_number: int) -> None:
         if issue_number != self.credential.issue:
             raise GuardTargetError("GitHub issue target differs from guard credential")
         try:
-            IssueGuard(self.guard_store).confirm(self.credential, timedelta(0))
+            IssueGuard(self.guard_store, branch=self.credential.branch).confirm(
+                self.credential, timedelta(0)
+            )
         except GuardError:
             raise
         except Exception as exc:

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -438,6 +438,7 @@ class ImplementationStage(Stage):
         logger.info("implementation:%d: requesting worktree job", issue)
         adopted = bool(item.payload.get("existing_pr"))
         direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
+        guard_managed_branch = item.payload.get("_issue_guard_branch") == item.branch
         if not adopted and direct_base_sha is not None and not is_full_commit_sha(direct_base_sha):
             return StageOutcome(Disposition.FINISH_FAIL, "direct_scope_base_pin_invalid")
         kwargs: dict[str, object] = {
@@ -449,9 +450,11 @@ class ImplementationStage(Stage):
             # remote head instead (the anti-clobber reset of
             # _prepare_worktree_for_existing_pr :649/:693, so re-running
             # never discards pushed commits). Values coordinator-vetted.
-            "refresh_base": not adopted and direct_base_sha is None,
+            "refresh_base": not adopted and direct_base_sha is None and not guard_managed_branch,
             "repo_root": str(ctx.paths.repo_root),
         }
+        if guard_managed_branch:
+            kwargs["guard_managed_branch"] = True
         direct_worktree_nonce = item.payload.get(DIRECT_SCOPE_WORKTREE_NONCE_KEY)
         direct_branch_prefix = f"{issue}-auto-impl-direct-"
         direct_branch_nonce = (
@@ -967,7 +970,9 @@ class ImplementationStage(Stage):
         # require a new receipt nor lease-push against the unrelated trunk
         # SHA.
         requires_fresh_direct_reservation = (
-            not bool(item.payload.get("existing_pr")) and direct_base_sha is not None
+            not bool(item.payload.get("existing_pr"))
+            and direct_base_sha is not None
+            and item.payload.get("_issue_guard_branch") != item.branch
         )
         if requires_fresh_direct_reservation:
             if not is_full_commit_sha(direct_base_sha):
@@ -1535,7 +1540,9 @@ class ImplementationStage(Stage):
                 item.worktree = ""
             direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
             requires_fresh_direct_reservation = (
-                not bool(item.payload.get("existing_pr")) and direct_base_sha is not None
+                not bool(item.payload.get("existing_pr"))
+                and direct_base_sha is not None
+                and item.payload.get("_issue_guard_branch") != item.branch
             )
             reservation = (
                 result.value.get("direct_scope_reservation")
@@ -1573,7 +1580,9 @@ class ImplementationStage(Stage):
             item.payload["worktree_diff"] = str(value.get("diff", ""))
             direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
             requires_fresh_direct_reservation = (
-                not bool(item.payload.get("existing_pr")) and direct_base_sha is not None
+                not bool(item.payload.get("existing_pr"))
+                and direct_base_sha is not None
+                and item.payload.get("_issue_guard_branch") != item.branch
             )
             if requires_fresh_direct_reservation:
                 reservation = value.get("direct_scope_reservation")

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -416,7 +416,7 @@ class ImplementationStage(Stage):
         """ENTER advances to GATE."""
         return Continue(next_state=GATE)
 
-    def _worktree_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+    def _worktree_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
         """WORKTREE_WAIT submits the create-worktree git job."""
         issue = _issue_number(item)
         if (
@@ -438,7 +438,10 @@ class ImplementationStage(Stage):
         logger.info("implementation:%d: requesting worktree job", issue)
         adopted = bool(item.payload.get("existing_pr"))
         direct_base_sha = item.payload.get(DIRECT_SCOPE_BASE_SHA_KEY)
-        guard_managed_branch = item.payload.get("_issue_guard_branch") == item.branch
+        guard_branch = item.payload.get("_issue_guard_branch")
+        if guard_branch is not None and guard_branch != item.branch:
+            return StageOutcome(Disposition.FINISH_FAIL, "issue_guard_branch_changed")
+        guard_managed_branch = guard_branch == item.branch
         if not adopted and direct_base_sha is not None and not is_full_commit_sha(direct_base_sha):
             return StageOutcome(Disposition.FINISH_FAIL, "direct_scope_base_pin_invalid")
         kwargs: dict[str, object] = {
@@ -1762,8 +1765,13 @@ class ImplementationStage(Stage):
         if external_arm is not None:
             return external_arm
         head_branch = ctx.github.get_pr_head_branch(existing_pr)
-        if head_branch:
-            item.branch = head_branch
+        guard_branch = item.payload.get("_issue_guard_branch")
+        if not isinstance(head_branch, str) or not head_branch.strip():
+            return StageOutcome(Disposition.FINISH_FAIL, "pr_head_branch_unavailable")
+        head_branch = head_branch.strip()
+        if guard_branch is not None and guard_branch != head_branch:
+            return StageOutcome(Disposition.FINISH_FAIL, "issue_guard_branch_changed")
+        item.branch = head_branch
         impl_go_route = self._impl_go_route(item, existing_pr, pr_implementation_state)
         if impl_go_route is not None:
             return impl_go_route

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -3083,6 +3083,7 @@ class WorkerPool:
         """Validate and atomically reserve a direct-scope implementation branch."""
         base_sha = kwargs.pop("base_sha", None)
         branch_name = str(kwargs.get("branch_name") or "")
+        guard_managed_branch = bool(kwargs.pop("guard_managed_branch", False))
         if base_sha is None:
             return None, branch_name
         if sync_to_remote or bool(kwargs.get("refresh_base", False)):
@@ -3096,6 +3097,11 @@ class WorkerPool:
             return JobResult(ok=False, error="direct scope checkout pin mismatch")
         if not branch_name:
             return JobResult(ok=False, error="direct scope branch name is missing")
+        if guard_managed_branch:
+            # The issue guard atomically created/advanced this exact
+            # implementation branch. That branch is the direct-scope
+            # reservation, so an absent-only reservation would race with it.
+            return None, branch_name
         git_utils.reserve_remote_branch_if_absent(
             branch_name,
             base_sha,

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -32,6 +32,7 @@ from hephaestus.automation._review_utils import (
     drain_completed_futures,
     find_pr_for_issue,
     get_pr_head_branch,
+    pr_head_is_writable,
     print_worker_summary,
     work_report_context,
 )
@@ -729,7 +730,14 @@ class PlanReviewer:
             branch = issue_auto_impl_branch_name(issue)
             existing_pr = find_pr_for_issue(issue)
             if existing_pr is not None:
-                branch = get_pr_head_branch(existing_pr) or branch
+                if not pr_head_is_writable(existing_pr, self.repo_target):
+                    raise RuntimeError(
+                        f"PR #{existing_pr} does not have a writable production branch"
+                    )
+                branch = get_pr_head_branch(existing_pr)
+                if not isinstance(branch, str) or not branch.strip():
+                    raise RuntimeError(f"PR #{existing_pr} has no verified production branch")
+                branch = branch.strip()
         if branch is not None:
             service.bind_branch(branch)
         service.run_id = self.run_id

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -30,6 +30,8 @@ from hephaestus.agents.runtime import (
 from hephaestus.automation._review_utils import (
     build_automation_parser,
     drain_completed_futures,
+    find_pr_for_issue,
+    get_pr_head_branch,
     print_worker_summary,
     work_report_context,
 )
@@ -40,7 +42,13 @@ from hephaestus.utils.terminal import terminal_guard
 from .agent_config import DEFAULT_AGENT_TIMEOUT
 from .claude_invoke import invoke_claude_with_session, scan_quota_reset
 from .claude_models import reviewer_model
-from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref
+from .git_utils import (
+    get_repo_info,
+    get_repo_root,
+    get_repo_slug,
+    issue_auto_impl_branch_name,
+    issue_ref,
+)
 from .github_api import (
     fetch_issue_comments_metadata,
     gh_current_login,
@@ -214,7 +222,7 @@ class PlanReviewer:
                 if self._guard_factory is not None and not self.options.dry_run:
                     if self.repository is None:
                         raise RuntimeError("standalone plan reviewer repository is unavailable")
-                    guard_service = self._new_guard_service(self.repository)
+                    guard_service = self._new_guard_service(self.repository, issue=issue_number)
                     guard_handle = guard_service.acquire(
                         self.repository, issue_number, "plan-review"
                     )
@@ -706,11 +714,24 @@ class PlanReviewer:
         """Return explicit repository arguments for the guarded path."""
         return {"repo": self.repo_target} if self.repo_target is not None else {}
 
-    def _new_guard_service(self, repository: str) -> IssueGuard:
+    def _new_guard_service(
+        self,
+        repository: str,
+        *,
+        issue: int | None = None,
+        branch: str | None = None,
+    ) -> IssueGuard:
         """Create a guard service carrying this reviewer run identity."""
         if self._guard_factory is None:
             raise RuntimeError("standalone guard factory is unavailable")
         service = self._guard_factory(repository)
+        if branch is None and issue is not None:
+            branch = issue_auto_impl_branch_name(issue)
+            existing_pr = find_pr_for_issue(issue)
+            if existing_pr is not None:
+                branch = get_pr_head_branch(existing_pr) or branch
+        if branch is not None:
+            service.bind_branch(branch)
         service.run_id = self.run_id
         return service
 
@@ -718,7 +739,10 @@ class PlanReviewer:
         """Confirm a standalone claim immediately before a durable write."""
         if handle is None or self._guard_factory is None:
             return
-        service = self._new_guard_service(handle.credential.repository)
+        service = self._new_guard_service(
+            handle.credential.repository,
+            branch=handle.credential.branch,
+        )
         service.confirm(handle.credential, timedelta(0))
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:

--- a/hephaestus/automation/recover_issue_guard.py
+++ b/hephaestus/automation/recover_issue_guard.py
@@ -32,6 +32,11 @@ def _build_parser() -> ArgumentParser:
     )
     parser.add_argument("--repo", required=True, metavar="OWNER/REPO")
     parser.add_argument("--issue", required=True, type=int)
+    parser.add_argument(
+        "--branch",
+        required=True,
+        help="Exact implementation branch carrying this issue guard",
+    )
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--inspect", action="store_true")
     mode.add_argument("--recover", action="store_true")
@@ -83,17 +88,17 @@ def main(argv: list[str] | None = None) -> int:
         if args.issue <= 0:
             raise GuardError("issue must be positive")
         if args.inspect:
-            store = GitHubIssueGuardStore(repository)
+            store = GitHubIssueGuardStore(repository, branch=args.branch)
             print(json.dumps(_snapshot_json(repository, args.issue, store), sort_keys=True))
             return 0
         if args.expected_claim is None or not args.expected_oid or not args.reason:
             raise GuardError("--recover requires --expected-claim, --expected-oid, and --reason")
         environment, actors = _recovery_environment()
-        store = GitHubIssueGuardStore(repository, env=environment)
+        store = GitHubIssueGuardStore(repository, branch=args.branch, env=environment)
         actor = store.actor()
         if actor.casefold() not in actors:
             raise GuardError("authenticated actor is not in HEPHAESTUS_GUARD_RECOVERY_ACTORS")
-        snapshot = IssueGuard(store).recover(
+        snapshot = IssueGuard(store, branch=args.branch).recover(
             repository,
             args.issue,
             expected_claim=args.expected_claim,

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -517,6 +517,26 @@ class TestGate:
         assert item.payload["existing_pr"] is True
         assert github.mutation_log == []
 
+    def test_gate_existing_pr_rejects_guard_branch_drift(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """PR adoption cannot replace the production branch bound to a guard."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(
+            labels=[STATE_PLAN_GO],
+            open_pr=1001,
+            pr_head_branch="replacement-branch",
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+        item.payload["_issue_guard_branch"] = "production-branch"
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "issue_guard_branch_changed")
+        assert item.branch == ""
+        assert github.mutation_log == []
+
     def test_gate_existing_pr_stands_down_when_auto_merge_is_externally_armed(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -15,12 +15,14 @@ import uuid
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
 from hephaestus.automation.direct_review_recovery import record_direct_review_recovery
+from hephaestus.automation.issue_guard import GuardLostError, InMemoryGuardStore, IssueGuard
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import (
     _FAIL_BACK_CAP,
@@ -32,6 +34,7 @@ from hephaestus.automation.pipeline.github_jobs import (
     GitHubJob,
     ReplyJournalAppended,
 )
+from hephaestus.automation.pipeline.guarded_github import GuardTargetError
 from hephaestus.automation.pipeline.jobs import (
     WORKTREE_MATERIALIZED_KEY,
     AgentJob,
@@ -174,6 +177,75 @@ class TestCoordinatorHealth:
 
         coordinator.shutdown.set()
         assert coordinator._health_snapshot()["status"] == "stopping"
+
+
+class TestIssueGuardBranchIdentity:
+    """Guard admission and dispatch remain bound to the production branch."""
+
+    def test_fork_pr_is_rejected_before_guard_branch_resolution(self, tmp_path: Path) -> None:
+        """A fork head cannot cause a same-named base-repository branch."""
+        coordinator = Coordinator(
+            PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path),
+            github=FakeStageGitHub(
+                open_pr=812,
+                pr_head_branch="fork-feature",
+                pr_head_writable=False,
+            ),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+
+        with pytest.raises(GuardTargetError, match="writable production branch"):
+            coordinator._guard_branch_for_issue("repo-a", 617)
+
+    def test_dispatch_rejects_item_branch_drift(self, tmp_path: Path) -> None:
+        """A queued item cannot dispatch against a branch different from its claim."""
+        store = InMemoryGuardStore(branch="production")
+        config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            guard_store_factory=lambda _repository: store,
+            install_signals=False,
+        )
+        handle = IssueGuard(store, run_id=coordinator.run_id, branch="production").acquire(
+            "org/repo-a", 617, "implementation"
+        )
+        assert handle is not None
+        item = _issue_item(617, StageName.IMPLEMENTATION)
+        item.branch = "replacement-branch"
+        item.payload["_issue_guard_handle"] = handle
+        item.payload["_issue_guard_branch"] = "production"
+        coordinator._issue_guards[("org/repo-a", 617)] = handle
+
+        with pytest.raises(GuardLostError, match="branch differs"):
+            coordinator._confirm_item_guard(item, timedelta(0))
+
+    def test_dispatch_rejects_pr_head_drift(self, tmp_path: Path) -> None:
+        """A PR head replacement is rejected before a guarded job dispatch."""
+        store = InMemoryGuardStore(branch="production")
+        config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(pr_head_branch="replacement-branch"),
+            pool=FakeWorkerPool(),
+            guard_store_factory=lambda _repository: store,
+            install_signals=False,
+        )
+        handle = IssueGuard(store, run_id=coordinator.run_id, branch="production").acquire(
+            "org/repo-a", 617, "implementation"
+        )
+        assert handle is not None
+        item = _issue_item(617, StageName.IMPLEMENTATION)
+        item.pr = 812
+        item.branch = "production"
+        item.payload["_issue_guard_handle"] = handle
+        item.payload["_issue_guard_branch"] = "production"
+        coordinator._issue_guards[("org/repo-a", 617)] = handle
+
+        with pytest.raises(GuardLostError, match="PR head branch changed"):
+            coordinator._confirm_item_guard(item, timedelta(0))
 
     @pytest.mark.parametrize("condition", ["queue_depth", "open_breaker", "stalled_ticks"])
     def test_health_snapshot_reports_each_defined_degradation(

--- a/tests/unit/automation/pipeline/test_github_jobs.py
+++ b/tests/unit/automation/pipeline/test_github_jobs.py
@@ -46,7 +46,7 @@ def test_guarded_job_binding_accepts_freshly_verified_linked_pr_conversation(
         request=AppendReplyJournalRequest(7, marker, f'{marker}\n<!-- {{"format":1}} -->'),
         descr="append PR journal",
     )
-    guard = GuardCredential("org/repo", 3, uuid4(), uuid4())
+    guard = GuardCredential("org/repo", 3, uuid4(), uuid4(), "3-auto-impl")
 
     bound = GuardedGitHubJob.bind(operation, guard, org="org", linked_pr=7)
 
@@ -69,7 +69,7 @@ def test_guarded_job_binding_rejects_unrelated_conversation(tmp_path: Path) -> N
     with pytest.raises(ValueError, match="guard issue or linked PR"):
         GuardedGitHubJob.bind(
             operation,
-            GuardCredential("org/repo", 3, uuid4(), uuid4()),
+            GuardCredential("org/repo", 3, uuid4(), uuid4(), "3-auto-impl"),
             org="org",
             linked_pr=8,
         )

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -74,7 +74,10 @@ def test_non_owner_cannot_confirm_or_recover_a_live_claim() -> None:
     assert handle is not None
 
     with pytest.raises(GuardLostError):
-        owner.confirm(GuardCredential("Owner/Repo", 2404, uuid4(), uuid4()), timedelta(0))
+        owner.confirm(
+            GuardCredential("Owner/Repo", 2404, uuid4(), uuid4(), "test-auto-impl"),
+            timedelta(0),
+        )
     with pytest.raises(GuardConflictError):
         owner.recover(
             "Owner/Repo",
@@ -261,8 +264,8 @@ def test_guard_record_round_trips_and_recovery_secret_is_rejected() -> None:
         assert_recovery_secret_absent({"HEPHAESTUS_GUARD_RECOVERY_TOKEN": "operator"})
 
 
-def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:
-    """REST storage parses Date headers and sends explicit non-forced ref writes."""
+def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa: C901
+    """REST storage advances the implementation branch with non-force writes."""
     record = GuardRecord(
         version=1,
         repository="Owner/Repo",
@@ -280,6 +283,8 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:
     tree_oid = "3" * 40
     calls: list[tuple[list[str], dict[str, Any]]] = []
     date = "Tue, 01 Jan 2030 00:00:00 GMT"
+    branch = "2404-auto-impl"
+    branch_reads = 0
 
     def response(status: int, body: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
@@ -290,31 +295,38 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:
         )
 
     def call(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal branch_reads
         calls.append((args, kwargs))
         paths = {arg for arg in args if arg.startswith("repos/Owner/Repo")}
         if args[-1] == "user":
             return response(200, {"login": "operator"})
         if any(path.endswith("issues/2404") for path in paths):
             return response(200, {"labels": [{"name": STATE_PLAN_GO}, {"name": 3}]})
+        if any(path.endswith(f"git/ref/heads/{branch}") for path in paths):
+            branch_reads += 1
+            if branch_reads == 1:
+                return response(404, {})
+            return response(200, {"object": {"sha": commit_oid}})
         if any(path.endswith("git/ref/heads/main") for path in paths):
             return response(200, {"object": {"sha": "4" * 40}})
-        if any(path.endswith("git/ref/heads/hephaestus/issue-guards/issue-2404") for path in paths):
-            return response(200, {"object": {"sha": commit_oid}})
         if any(path.endswith(f"git/commits/{'4' * 40}") for path in paths):
-            return response(200, {"tree": {"sha": tree_oid}, "message": "tip"})
+            return response(200, {"tree": {"sha": tree_oid}, "message": "tip", "parents": []})
         if any("/git/commits/" in path for path in paths):
-            return response(200, {"tree": {"sha": tree_oid}, "message": record.to_json()})
+            return response(
+                200,
+                {"tree": {"sha": tree_oid}, "message": record.to_json(), "parents": []},
+            )
         if any(path.endswith("git/commits") for path in paths):
             return response(201, {"sha": commit_oid})
-        if any(path.endswith("git/refs") for path in paths) or any(
-            "issue-2404" in path for path in paths
-        ):
+        if any(path.endswith("git/refs") for path in paths):
             return response(201, {})
+        if any(path.endswith(f"git/refs/heads/{branch}") for path in paths):
+            return response(200, {})
         if "repos/Owner/Repo" in paths:
             return response(200, {"default_branch": "main"})
         return response(200, {})
 
-    github = GitHubIssueGuardStore("Owner/Repo", call=call, env={"GH_TOKEN": "test"})
+    github = GitHubIssueGuardStore("Owner/Repo", branch=branch, call=call, env={"GH_TOKEN": "test"})
     assert github.read_labels("Owner/Repo", 2404) == (STATE_PLAN_GO,)
     github.add_label("Owner/Repo", 2404, "state:extra")
     github.remove_label("Owner/Repo", 2404, "state:extra")
@@ -323,13 +335,16 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:
     assert any("repos/Owner/Repo" in args for args, _kwargs in calls)
     assert all("repos/Owner/Repo/" not in args for args, _kwargs in calls)
     assert github.create_commit("Owner/Repo", tree_oid, ["4" * 40], record.to_json())[0]
-    github.create_ref("Owner/Repo", 2404, commit_oid)
-    github.update_ref("Owner/Repo", 2404, commit_oid, "1" * 40)
+    github.create_ref("Owner/Repo", 2404, commit_oid, expected_oid="4" * 40)
+    github.update_ref("Owner/Repo", 2404, commit_oid, commit_oid)
     snapshot = github.read_ref("Owner/Repo", 2404)
     assert snapshot is not None and snapshot.record == record
     assert all(kwargs["env"] == {"GH_TOKEN": "test"} for _args, kwargs in calls)
     update = next(args for args, _kwargs in calls if "force=false" in args)
     assert "force=false" in update
+    assert any(f"git/refs/heads/{branch}" in arg for arg in update)
+    assert all("refs/tags/" not in arg for args, _kwargs in calls for arg in args)
+    assert all("hephaestus/issue-guards" not in arg for args, _kwargs in calls for arg in args)
 
 
 class _FakeGitHub:
@@ -425,7 +440,8 @@ def test_recovery_cli_inspects_without_recovery_credentials(
     """Inspection is read-only and does not require the operator token."""
 
     class EmptyStore:
-        def __init__(self, _repository: str) -> None:
+        def __init__(self, _repository: str, *, branch: str) -> None:
+            assert branch == "2404-auto-impl"
             pass
 
         def read_ref(self, _repository: str, _issue: int) -> None:
@@ -437,13 +453,39 @@ def test_recovery_cli_inspects_without_recovery_credentials(
     monkeypatch.delenv("HEPHAESTUS_GUARD_RECOVERY_TOKEN", raising=False)
     monkeypatch.setattr(recover_issue_guard, "GitHubIssueGuardStore", EmptyStore)
 
-    assert recover_issue_guard.main(["--repo", "Owner/Repo", "--issue", "2404", "--inspect"]) == 0
+    assert (
+        recover_issue_guard.main(
+            [
+                "--repo",
+                "Owner/Repo",
+                "--issue",
+                "2404",
+                "--branch",
+                "2404-auto-impl",
+                "--inspect",
+            ]
+        )
+        == 0
+    )
     assert '"guard": null' in capsys.readouterr().out
 
 
 def test_recovery_cli_rejects_incomplete_recovery_request() -> None:
     """Recovery mode requires all expected-identity evidence before I/O."""
-    assert recover_issue_guard.main(["--repo", "Owner/Repo", "--issue", "2404", "--recover"]) == 1
+    assert (
+        recover_issue_guard.main(
+            [
+                "--repo",
+                "Owner/Repo",
+                "--issue",
+                "2404",
+                "--branch",
+                "2404-auto-impl",
+                "--recover",
+            ]
+        )
+        == 1
+    )
 
 
 def test_recovery_cli_enforces_operator_actor_allowlist(
@@ -455,7 +497,8 @@ def test_recovery_cli_enforces_operator_actor_allowlist(
     monkeypatch.setenv("GH_TOKEN", "normal-token")
 
     class ActorStore:
-        def __init__(self, _repository: str, *, env: dict[str, str]) -> None:
+        def __init__(self, _repository: str, *, branch: str, env: dict[str, str]) -> None:
+            assert branch == "2404-auto-impl"
             assert env["GH_TOKEN"]
 
         def actor(self) -> str:
@@ -469,6 +512,8 @@ def test_recovery_cli_enforces_operator_actor_allowlist(
                 "Owner/Repo",
                 "--issue",
                 "2404",
+                "--branch",
+                "2404-auto-impl",
                 "--recover",
                 "--expected-claim",
                 str(uuid4()),

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -20,6 +20,7 @@ from hephaestus.automation.issue_guard import (
     GuardLostError,
     GuardPhase,
     GuardRecord,
+    GuardSnapshot,
     GuardUnavailableError,
     InMemoryGuardStore,
     IssueGuard,
@@ -136,6 +137,27 @@ def test_owner_can_renew_and_release_a_guard() -> None:
     renewed = service.renew(fresh, timedelta(hours=2))
     assert renewed.oid != fresh.oid
     service.release(renewed, "completed successfully")
+
+    assert store.refs[("Owner/Repo", 2404)].record.phase is GuardPhase.RELEASED
+    assert STATE_IN_PROGRESS not in store.labels[("Owner/Repo", 2404)]
+
+
+def test_owner_can_release_after_ordinary_implementation_commit() -> None:
+    """A shared production branch may advance between work and release."""
+    store = InMemoryGuardStore()
+    service = IssueGuard(store)
+    handle = service.acquire("Owner/Repo", 2404, "implementation")
+    assert handle is not None
+
+    current = store.refs[("Owner/Repo", 2404)]
+    store.refs[("Owner/Repo", 2404)] = GuardSnapshot(
+        oid="f" * 40,
+        record=current.record,
+        tree=current.tree,
+        server_time=store.now,
+    )
+
+    service.release(handle, "completed after implementation commit")
 
     assert store.refs[("Owner/Repo", 2404)].record.phase is GuardPhase.RELEASED
     assert STATE_IN_PROGRESS not in store.labels[("Owner/Repo", 2404)]

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -198,6 +198,30 @@ class TestGetLatestPlan:
         assert result is None
 
 
+class TestPlanReviewerGuardBranchIdentity:
+    """Standalone plan guards use the writable production PR head only."""
+
+    def test_fork_pr_cannot_bind_a_base_repository_guard_branch(self) -> None:
+        """Fork PRs fail closed before the standalone guard can acquire."""
+        from hephaestus.automation import plan_reviewer
+        from hephaestus.automation.issue_guard import InMemoryGuardStore, IssueGuard
+
+        store = InMemoryGuardStore()
+        options = PlanReviewerOptions(issues=[617], dry_run=False, max_workers=1, enable_ui=False)
+        with (
+            patch.object(plan_reviewer, "get_repo_info", return_value=("Owner", "Repo")),
+            patch.object(plan_reviewer, "find_pr_for_issue", return_value=812),
+            patch.object(plan_reviewer, "pr_head_is_writable", return_value=False),
+        ):
+            reviewer = PlanReviewer(
+                options,
+                guard_factory=lambda _repository: IssueGuard(store),
+            )
+
+            with pytest.raises(RuntimeError, match="writable production branch"):
+                reviewer._new_guard_service("Owner/Repo", issue=617)
+
+
 class TestPostReviewStateLabels:
     """Standalone review persistence uses only the state-token/label contract."""
 

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -24,6 +24,7 @@ from hephaestus.automation._review_utils import (
     load_state_file,
     log_file_path,
     parse_json_block,
+    pr_head_is_writable,
     print_worker_summary,
     save_state_file,
 )
@@ -621,6 +622,47 @@ class TestGetPrHeadBranch:
             side_effect=RuntimeError("gh boom"),
         ):
             assert get_pr_head_branch(996) is None
+
+
+class TestPrHeadIsWritable:
+    """PR head ownership is required before binding a production guard."""
+
+    def test_accepts_same_repository_head(self) -> None:
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result(
+                {
+                    "headRepository": {"name": "Repo"},
+                    "headRepositoryOwner": {"login": "Owner"},
+                }
+            ),
+        ) as gh_call:
+            assert pr_head_is_writable(812, ("Owner", "Repo")) is True
+
+        args = gh_call.call_args.args[0]
+        assert "--repo" in args
+        assert "Owner/Repo" in args
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {
+                "headRepository": {"name": "Repo"},
+                "headRepositoryOwner": {"login": "Contributor"},
+            },
+            {"headRepository": None, "headRepositoryOwner": None},
+            {},
+        ],
+    )
+    def test_rejects_foreign_or_missing_head_identity(self, payload: dict[str, Any]) -> None:
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result(payload),
+        ):
+            assert pr_head_is_writable(812, ("Owner", "Repo")) is False
+
+    def test_rejects_missing_target_repository(self) -> None:
+        assert pr_head_is_writable(812, None) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Bind every issue guard to the exact implementation branch carried by its credential.
- Store no-tree-change guard commits directly in `refs/heads/<implementation-branch>` and scan first-parent history around ordinary implementation commits.
- Reuse the guard-created implementation branch for direct-scope worktrees, with no separate guard branch, tag, or legacy guard-ref compatibility path.
- Require recovery operations to name the exact implementation branch.

## Root cause

Issue ownership and implementation history were assigned different Git refs. That allowed an issue to have both its production branch (for example, `2365-auto-impl-direct-d91c3bc4f005466786fa3ddf25a4590c`) and a separate guard branch. The guard state now advances the production branch itself through no-tree-change commits and non-forced compare-and-swap updates.

## Review follow-up

- Guard release now tolerates ordinary implementation commits while retaining claim, run, phase, lease, and label ownership checks.
- Fork or malformed PR heads fail closed before a base-repository guard can be acquired.
- Issue-to-PR association, PR head branch, guard payload, and work-item branch identity are revalidated before dispatch and existing-PR adoption.
- Plan review uses the same writable production-head rule.
- The coordinator contract fallback no longer uses an unused global assignment.

## Checks

- `uv run pytest tests/unit -q` — 7166 passed, 7 skipped, 4 deselected; 83.83% coverage.
- Focused guard/branch/architecture suite — 416 passed, 3 deselected.
- Changed-file pre-commit hooks passed, including Ruff, mypy, Bandit, and secret scans.
- Locked pre-push unit/integration gate passed.

Closes #2404
