### PR TITLE
fix(automation): reject empty PR diffs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ flowchart LR
 
     plan_review -. "nogo (iter 3 / plan_cycles 2)" .-> planning
     implementation -. "agent_error" .-> implementation
-    pr_review -. "agent_error / implementation_remediation" .-> implementation
+    pr_review -. "agent_error / empty_pr_diff / implementation_remediation" .-> implementation
     implementation -. "already_implementation_go_pr" .-> merge_wait
 ```
 
@@ -489,8 +489,8 @@ the scope's first stage so the scoped work is redone
 
 ### Cross-stage ping-pong bound
 
-Some regression edges (`pr_review → implementation` for `agent_error` or
-`implementation_remediation`)
+Some regression edges (`pr_review → implementation` for `agent_error`,
+`empty_pr_diff`, or `implementation_remediation`)
 can ping-pong. The
 [`_FAIL_BACK_CAP`](../hephaestus/automation/pipeline/coordinator.py)
 constant is the sum of every budget in
@@ -1224,7 +1224,7 @@ budgets. Every `routes.py` row and every doc row MUST agree.
 | `planning` | `PLAN_REVIEW` | `*` → `FINISHED` | `plan = 2` |
 | `plan_review` | `IMPLEMENTATION` | `nogo` → `PLANNING`; `plan_cycles_exhausted` → `FINISHED`; `*` → `PLANNING` | `plan_review_iter = 3`, `plan_cycles = 2` |
 | `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `rebase_conflict = 2`, `test_fix = 1` |
-| `pr_review` | `MERGE_WAIT` | `agent_error` or `implementation_remediation` → `IMPLEMENTATION`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
+| `pr_review` | `MERGE_WAIT` | `agent_error`, `empty_pr_diff`, or `implementation_remediation` → `IMPLEMENTATION`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
 | `merge_wait` | `FINISHED` | `not_implementation_go`, `reviewed_head_missing`, or `reviewed_head_drift` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | `merge = 5` |
 | `finished` | `FINISHED` | — (terminal) | — |
 

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -122,6 +122,7 @@ ROUTES: dict[StageName, Route] = {
         next=StageName.MERGE_WAIT,
         fail_routes={
             "agent_error": StageName.IMPLEMENTATION,
+            "empty_pr_diff": StageName.IMPLEMENTATION,
             "implementation_remediation": StageName.IMPLEMENTATION,
             "exhaustion": StageName.FINISHED,
             "*": StageName.PR_REVIEW,

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -696,6 +696,14 @@ class ImplementationStage(Stage):
     def _adopted(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """ADOPTED advances to pr_review after the adopted worktree is ready."""
         issue = _issue_number(item)
+        if item.payload.pop("empty_diff_reimplementation", False):
+            logger.info(
+                "implementation:%d: adopted PR #%s has an empty diff; "
+                "running a substantive implementation pass",
+                issue,
+                item.pr,
+            )
+            return Continue(next_state=ADVISE_WAIT)
         # Existing-PR fast path complete: worktree ready on the PR's real
         # head branch — hand the PR to pr_review (doc step 1 "skip to
         # step 8": nothing to implement, commit, or create).

--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -460,6 +460,22 @@ class PrReviewJobs(_PrReviewHost):
                 # host checks are running. Keep the already-selected
                 # validation-only route instead of opening a second audit.
                 return Continue(next_state=VALIDATE_WAIT)
+            if not str(item.payload.get("pr_diff") or "").strip():
+                # A reviewer cannot attach a blocking finding to an empty
+                # diff. Sending this snapshot through the broad-review
+                # contract would therefore manufacture a clean audit and
+                # authorize an empty PR. Existing review threads are routed
+                # above and retain their normal remediation semantics.
+                item.payload.pop("reviewed_pr_head_sha", None)
+                item.payload["empty_diff_reimplementation"] = True
+                logger.warning(
+                    "pr_review:%d: empty cumulative diff; failing back to implementation",
+                    _issue_number(item),
+                )
+                return self._cleanup_review_worktree_then(
+                    item,
+                    StageOutcome(Disposition.FAIL_BACK, "empty_pr_diff"),
+                )
             return self._submit_review_job(item, ctx)
         snapshots = _validation_thread_snapshots(live_threads, receipts)
         remediation_threads = _normalize_remediation_threads(live_threads)

--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -18,7 +18,11 @@ from ..github_jobs import (
     ReplyHandoffAttempted,
 )
 from .pr_review_diagnostics import publish_host_verification_failure
-from .pr_review_recovery import consume_reply_handoff_receipt, restart_direct_pr_review
+from .pr_review_recovery import (
+    consume_reply_handoff_receipt,
+    empty_diff_outcome,
+    restart_direct_pr_review,
+)
 from .pr_review_threads import *
 from .pr_review_threads import (
     _REPLY_HANDOFF_RECEIPT,
@@ -418,14 +422,7 @@ class PrReviewJobs(_PrReviewHost):
         return JobRequest(job, on_done_state=VALIDATE_WAIT)
 
     def _route_threads_before_broad_review(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Recheck threads immediately before dispatching a broad audit.
-
-        ``on_enter`` owns the first routing decision, but a reviewer checkout
-        and its fixed host verification can take long enough for a new thread
-        to appear.  Never schedule a second broad audit for that new work:
-        give unreplied threads to implementation, or send a complete response
-        set to comment validation on the already-proven detached checkout.
-        """
+        """Route threads appearing during checkout before broad review."""
         if item.pr is None:
             return self._cleanup_review_worktree_then(
                 item,
@@ -460,22 +457,9 @@ class PrReviewJobs(_PrReviewHost):
                 # host checks are running. Keep the already-selected
                 # validation-only route instead of opening a second audit.
                 return Continue(next_state=VALIDATE_WAIT)
-            if not str(item.payload.get("pr_diff") or "").strip():
-                # A reviewer cannot attach a blocking finding to an empty
-                # diff. Sending this snapshot through the broad-review
-                # contract would therefore manufacture a clean audit and
-                # authorize an empty PR. Existing review threads are routed
-                # above and retain their normal remediation semantics.
-                item.payload.pop("reviewed_pr_head_sha", None)
-                item.payload["empty_diff_reimplementation"] = True
-                logger.warning(
-                    "pr_review:%d: empty cumulative diff; failing back to implementation",
-                    _issue_number(item),
-                )
-                return self._cleanup_review_worktree_then(
-                    item,
-                    StageOutcome(Disposition.FAIL_BACK, "empty_pr_diff"),
-                )
+            empty_diff = empty_diff_outcome(item)
+            if empty_diff:
+                return self._cleanup_review_worktree_then(item, empty_diff)
             return self._submit_review_job(item, ctx)
         snapshots = _validation_thread_snapshots(live_threads, receipts)
         remediation_threads = _normalize_remediation_threads(live_threads)

--- a/hephaestus/automation/pipeline/stages/pr_review_recovery.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_recovery.py
@@ -30,7 +30,7 @@ def empty_diff_outcome(item: WorkItem) -> StageOutcome | None:
     """Reject a thread-free review whose cumulative PR diff is empty."""
     if str(item.payload.get("pr_diff") or "").strip():
         return None
-    item.payload.pop("reviewed_pr_head_sha", None)
+    _clear_round_review_state(item)
     item.payload["empty_diff_reimplementation"] = True
     logger.warning(
         "pr_review:%d: empty cumulative diff; failing back to implementation",

--- a/hephaestus/automation/pipeline/stages/pr_review_recovery.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_recovery.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from hephaestus.automation.session_naming import (
     AGENT_ADDRESS_REVIEW,
     AGENT_PR_REVIEWER,
@@ -13,11 +15,28 @@ from ..reply_handoff import (
     PENDING_IMPLEMENTATION_REPLY_HANDOFF_VISIBILITY_RETRIES as _REPLY_VISIBILITY_RETRIES,
 )
 from ..work_item import WorkItem
+from .base import Disposition, StageOutcome
 from .pr_review_threads import (
     _REPLY_HANDOFF_RECEIPT,
     _REPLY_HANDOFF_RECEIPT_ERROR,
     _clear_round_review_state,
+    _issue_number,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def empty_diff_outcome(item: WorkItem) -> StageOutcome | None:
+    """Reject a thread-free review whose cumulative PR diff is empty."""
+    if str(item.payload.get("pr_diff") or "").strip():
+        return None
+    item.payload.pop("reviewed_pr_head_sha", None)
+    item.payload["empty_diff_reimplementation"] = True
+    logger.warning(
+        "pr_review:%d: empty cumulative diff; failing back to implementation",
+        _issue_number(item),
+    )
+    return StageOutcome(Disposition.FAIL_BACK, "empty_pr_diff")
 
 
 def restart_direct_pr_review(item: WorkItem) -> str | None:
@@ -76,4 +95,8 @@ def consume_reply_handoff_receipt(item: WorkItem, pending_request_key: str) -> s
     return receipt.status
 
 
-__all__ = ["consume_reply_handoff_receipt", "restart_direct_pr_review"]
+__all__ = [
+    "consume_reply_handoff_receipt",
+    "empty_diff_outcome",
+    "restart_direct_pr_review",
+]

--- a/tests/unit/automation/pipeline/stages/test_reason_routes.py
+++ b/tests/unit/automation/pipeline/stages/test_reason_routes.py
@@ -103,6 +103,7 @@ def test_scan_is_not_vacuous() -> None:
 def test_named_reasons_route_where_the_doc_says() -> None:
     """The doc's key cross-stage arrows hold for the emitted vocabulary."""
     assert ROUTES[StageName.PR_REVIEW].fail_routes["agent_error"] == StageName.IMPLEMENTATION
+    assert ROUTES[StageName.PR_REVIEW].fail_routes["empty_pr_diff"] == StageName.IMPLEMENTATION
     assert ROUTES[StageName.IMPLEMENTATION].fail_routes["plan_not_go"] == StageName.PLAN_REVIEW
     assert (
         ROUTES[StageName.IMPLEMENTATION].fail_routes["already_implementation_go_pr"]

--- a/tests/unit/automation/pipeline/stages/test_stage_cross.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_cross.py
@@ -198,10 +198,7 @@ class TestEmptyDiffReroutesToSubstantiveImplementation:
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """An empty review diff must be handed to implementation, not re-reviewed."""
-        assert (
-            ROUTES[StageName.PR_REVIEW].fail_routes["empty_pr_diff"]
-            == StageName.IMPLEMENTATION
-        )
+        assert ROUTES[StageName.PR_REVIEW].fail_routes["empty_pr_diff"] == StageName.IMPLEMENTATION
 
         impl_stage = ImplementationStage()
         item = make_work_item(issue=3, pr=1001, state="ADOPTED")

--- a/tests/unit/automation/pipeline/stages/test_stage_cross.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_cross.py
@@ -191,6 +191,29 @@ class TestAgentErrorPingPongTerminates:
         assert label_writes == []
 
 
+class TestEmptyDiffReroutesToSubstantiveImplementation:
+    """pr_review empty-diff fail-back reaches the implementation adopter."""
+
+    def test_empty_diff_fail_back_consumes_the_marker_before_re_adopting(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An empty review diff must be handed to implementation, not re-reviewed."""
+        assert (
+            ROUTES[StageName.PR_REVIEW].fail_routes["empty_pr_diff"]
+            == StageName.IMPLEMENTATION
+        )
+
+        impl_stage = ImplementationStage()
+        item = make_work_item(issue=3, pr=1001, state="ADOPTED")
+        item.branch = "3-real-branch"
+        item.payload["empty_diff_reimplementation"] = True
+
+        outcome = impl_stage.step(item, make_ctx())
+
+        assert outcome == Continue(next_state="ADVISE_WAIT")
+        assert "empty_diff_reimplementation" not in item.payload
+
+
 class TestPostReviewRebaseReusesRestoredWriter:
     """pr_review cleanup -> merge_wait rebase fail-back -> implementation reuses writer."""
 

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -620,6 +620,19 @@ class TestGate:
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition == Disposition.ADVANCE
 
+    def test_adopted_empty_diff_failback_runs_substantive_implementation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An empty reviewed diff reuses the PR writer but does not re-review it."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=1, pr=1001, state="ADOPTED")
+        item.payload["empty_diff_reimplementation"] = True
+
+        outcome = stage.step(item, make_ctx())
+
+        assert outcome == Continue(next_state="ADVISE_WAIT")
+        assert "empty_diff_reimplementation" not in item.payload
+
     def test_adopted_dirty_worktree_salvages_then_advances(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -530,6 +530,41 @@ class TestPrReviewStageOnEnter:
         assert result == Continue(next_state="ADDRESS_WAIT")
         assert item.payload["remediation_threads"][0]["thread_id"] == "live-thread-1001-0"
 
+    def test_checkout_rejects_empty_diff_before_review_or_go(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An empty cumulative PR diff must return to substantive implementation."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state=REVIEW_CHECKOUT_WAIT)
+        item.worktree = "/tmp/detached-review"
+        item.payload.update(
+            {
+                "review_worktree": item.worktree,
+                "review_checkout_expected_head": "a" * 40,
+                "review_checkout_ready": True,
+                "pr_diff": "\n\t",
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state=CLEANUP_REVIEW_WORKTREE_WAIT)
+        assert item.payload["empty_diff_reimplementation"] is True
+        assert "reviewed_pr_head_sha" not in item.payload
+        assert github.mutation_log == []
+
+        item.state = CLEANUP_REVIEW_WORKTREE_WAIT
+        removal = stage.step(item, ctx)
+        assert isinstance(removal, JobRequest)
+        assert isinstance(removal.job, GitJob)
+        assert removal.job.op == "remove_worktree"
+        stage.on_job_done(item, JobResult(ok=True), ctx)
+
+        assert stage.step(item, ctx) == StageOutcome(Disposition.FAIL_BACK, "empty_pr_diff")
+        assert item.payload["empty_diff_reimplementation"] is True
+
     def test_host_verification_rechecks_new_unreplied_thread_before_review(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -533,7 +533,7 @@ class TestPrReviewStageOnEnter:
     def test_checkout_rejects_empty_diff_before_review_or_go(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """An empty cumulative PR diff must return to substantive implementation."""
+        """An empty diff must revoke all round-scoped review evidence."""
         stage = PrReviewStage()
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
@@ -544,7 +544,13 @@ class TestPrReviewStageOnEnter:
                 "review_worktree": item.worktree,
                 "review_checkout_expected_head": "a" * 40,
                 "review_checkout_ready": True,
+                "reviewed_pr_head_sha": "a" * 40,
+                "reviewed_pr_proof_generation": 7,
+                "host_verification_receipts": [{"head_sha": "a" * 40, "ok": False}],
                 "pr_diff": "\n\t",
+                "review_audit": _valid_audit(),
+                "review_feedback": [{"body": "stale finding"}],
+                "review_changed_paths": ["example.py"],
             }
         )
 
@@ -553,6 +559,12 @@ class TestPrReviewStageOnEnter:
         assert result == Continue(next_state=CLEANUP_REVIEW_WORKTREE_WAIT)
         assert item.payload["empty_diff_reimplementation"] is True
         assert "reviewed_pr_head_sha" not in item.payload
+        assert "host_verification_receipts" not in item.payload
+        assert "pr_diff" not in item.payload
+        assert "review_audit" not in item.payload
+        assert "review_feedback" not in item.payload
+        assert "review_changed_paths" not in item.payload
+        assert "reviewed_pr_proof_generation" in item.payload
         assert github.mutation_log == []
 
         item.state = CLEANUP_REVIEW_WORKTREE_WAIT

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1218,6 +1218,21 @@ class TestFailBackRouting:
         assert item.stage is StageName.IMPLEMENTATION
         assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
 
+    def test_empty_pr_diff_routes_to_substantive_implementation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The empty-diff review guard must reach the marker's consumer."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        item = _issue_item(4, StageName.PR_REVIEW)
+        item.payload["empty_diff_reimplementation"] = True
+        coordinator._push_item(item, StageName.PR_REVIEW, enter=False)
+
+        coordinator._route(item, StageOutcome(Disposition.FAIL_BACK, "empty_pr_diff"))
+
+        assert item.stage is StageName.IMPLEMENTATION
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
+        assert item.payload["empty_diff_reimplementation"] is True
+
     def test_unknown_reason_uses_default_route(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -210,6 +210,7 @@ class TestROUTES:
                 next=StageName.MERGE_WAIT,
                 fail_routes={
                     "agent_error": StageName.IMPLEMENTATION,
+                    "empty_pr_diff": StageName.IMPLEMENTATION,
                     "implementation_remediation": StageName.IMPLEMENTATION,
                     "exhaustion": StageName.FINISHED,
                     "*": StageName.PR_REVIEW,

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -51,6 +51,7 @@ _REASON_BUDGET: dict[str, str | None] = {
     "already_implementation_go_pr": None,
     "head_changed": None,
     "agent_error": None,
+    "empty_pr_diff": None,
     "implementation_remediation": None,
     "exhaustion": None,
     "fix_exhausted": None,


### PR DESCRIPTION
## Summary

- reject empty cumulative PR diffs before a broad implementation review can manufacture a clean audit
- revoke the reviewed-head proof and fail back without mutating GitHub state
- reuse the adopted writable PR branch for a substantive advise and implementation pass
- preserve existing-thread remediation and validation-only behavior

## Testing

- `pytest --no-cov -q tests/unit/automation/pipeline` (1,443 passed, 4 deselected)
- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- `mypy --cache-dir=/dev/null` on changed production files
- `git diff --check`

Closes #2731