### PR TITLE
fix(automation): cryptographically sign issue guard commits

### DIFF
--- a/docs/adr/0024-issue-work-ownership-guard.md
+++ b/docs/adr/0024-issue-work-ownership-guard.md
@@ -20,20 +20,25 @@ stage transition. The authoritative ownership record is canonical version-one
 JSON in the body of a no-tree-change commit on the exact implementation branch
 for the issue. The commit uses a stable Conventional Commit subject and machine
 DCO trailer so the guard's own audit history satisfies the repository's PR
-policy. Readers also accept the legacy raw-JSON commit form so existing guards
-remain recoverable. The branch is carried in the guard credential, so the guard
-and production writer share one ref: `refs/heads/<implementation-branch>`. A
-branch tip may contain ordinary implementation commits; readers walk
-first-parent history to find the newest guard record, while every guard child
-still advances that same branch with a non-forced compare-and-swap update.
+policy. The commit is created and verified with the operator's configured Git
+signing identity, then published through an exact-head `--force-with-lease`
+compare-and-swap. GitHub's verification result is read back before the
+transition is accepted. Readers also accept the legacy raw-JSON commit form so
+existing guards remain recoverable. The branch is carried in the guard
+credential, so the guard and production writer share one ref:
+`refs/heads/<implementation-branch>`. A branch tip may contain ordinary
+implementation commits; readers walk first-parent history to find the newest
+guard record, while every guard child still advances that same branch with a
+server-enforced exact-head compare-and-swap update.
 
 An automation run reads labels, refuses a live guard, creates an acquiring
-record, installs it with a non-forced ref operation, and reads it back before
-adding the label. It then records an active child and confirms both the
-record identity and label before dispatching work. Every issue mutation uses
-the target-bound guarded GitHub proxy, which re-confirms the claim immediately
-before the mutation. Claims carry repository, issue, branch, claim UUID, and
-run UUID across worker boundaries.
+record, installs it with an exact-head leased ref operation, and reads it back
+before adding the label. A signing failure, a rejected lease, or an unverified
+GitHub signature fails closed. It then records an active child and confirms
+both the record identity and label before dispatching work. Every issue
+mutation uses the target-bound guarded GitHub proxy, which re-confirms the
+claim immediately before the mutation. Claims carry repository, issue, branch,
+claim UUID, and run UUID across worker boundaries.
 
 Active claims use a four-hour lease. Renewal is owner-only and extends the
 lease through a ref child. Normal completion writes releasing/released
@@ -44,7 +49,7 @@ owner-only release; an ambiguous or expired claim remains for recovery.
 Recovery is a separate operator-only command. It requires a distinct recovery
 credential, an allowlisted actor, the expected claim UUID and ref OID, an
 explicit reason, and the lease plus grace window to have elapsed. Recovery
-uses non-forced compare-and-swap children and preserves all plan labels,
+uses signed exact-head compare-and-swap children and preserves all plan labels,
 including `state:plan-blocked`. The normal automation path rejects the
 recovery credential if it is present.
 

--- a/docs/adr/0024-issue-work-ownership-guard.md
+++ b/docs/adr/0024-issue-work-ownership-guard.md
@@ -27,9 +27,13 @@ transition is accepted. Readers also accept the legacy raw-JSON commit form so
 existing guards remain recoverable. The branch is carried in the guard
 credential, so the guard and production writer share one ref:
 `refs/heads/<implementation-branch>`. A branch tip may contain ordinary
-implementation commits; readers walk first-parent history to find the newest
+implementation commits; readers inspect branch-only history to find the newest
 guard record, while every guard child still advances that same branch with a
 server-enforced exact-head compare-and-swap update.
+
+Before the first guard exists, the reader bounds discovery to commits unique
+to the implementation branch through the GitHub comparison API. It never
+walks the repository's shared default-branch history one commit at a time.
 
 An automation run reads labels, refuses a live guard, creates an acquiring
 record, installs it with an exact-head leased ref operation, and reads it back

--- a/docs/adr/0024-issue-work-ownership-guard.md
+++ b/docs/adr/0024-issue-work-ownership-guard.md
@@ -17,9 +17,12 @@ without an ownership check could clear a live run or alter the independent
 Use `state:in-progress` as an orthogonal, visible contention label. It is not
 part of the plan-state or implementation-state tuples and never authorizes a
 stage transition. The authoritative ownership record is canonical version-one
-JSON in a no-tree-change commit on the exact implementation branch for the
-issue. The branch is carried in the guard credential, so the guard and
-production writer share one ref: `refs/heads/<implementation-branch>`. A
+JSON in the body of a no-tree-change commit on the exact implementation branch
+for the issue. The commit uses a stable Conventional Commit subject and machine
+DCO trailer so the guard's own audit history satisfies the repository's PR
+policy. Readers also accept the legacy raw-JSON commit form so existing guards
+remain recoverable. The branch is carried in the guard credential, so the guard
+and production writer share one ref: `refs/heads/<implementation-branch>`. A
 branch tip may contain ordinary implementation commits; readers walk
 first-parent history to find the newest guard record, while every guard child
 still advances that same branch with a non-forced compare-and-swap update.

--- a/docs/adr/0024-issue-work-ownership-guard.md
+++ b/docs/adr/0024-issue-work-ownership-guard.md
@@ -23,9 +23,11 @@ DCO trailer so the guard's own audit history satisfies the repository's PR
 policy. The commit is created and verified with the operator's configured Git
 signing identity, then published through an exact-head `--force-with-lease`
 compare-and-swap. GitHub's verification result is read back before the
-transition is accepted. Readers also accept the legacy raw-JSON commit form so
-existing guards remain recoverable. The branch is carried in the guard
-credential, so the guard and production writer share one ref:
+transition is accepted. A rejected or unavailable verification triggers an
+exact-lease rollback pinned to the rejected commit, so it cannot remain at the
+branch tip. Readers also accept the legacy raw-JSON commit form so existing
+guards remain recoverable. The branch is carried in the guard credential, so
+the guard and production writer share one ref:
 `refs/heads/<implementation-branch>`. A branch tip may contain ordinary
 implementation commits; readers inspect branch-only history to find the newest
 guard record, while every guard child still advances that same branch with a

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -18,6 +18,7 @@ import logging
 import os
 import re
 import subprocess
+import tempfile
 import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -25,6 +26,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from enum import StrEnum
+from pathlib import Path
 from typing import Any, Literal, Protocol, Self
 
 from hephaestus.automation.state_labels import (
@@ -44,6 +46,7 @@ _REPOSITORY_RE = re.compile(r"[^/\s]+/[^/\s]+\Z")
 _GUARD_REASON_MAX = 512
 _REF_READBACK_ATTEMPTS = 4
 _REF_READBACK_DELAY_S = 0.25
+_SIGNATURE_READBACK_ATTEMPTS = 4
 _GUARD_COMMIT_SUBJECT = "chore(automation): record issue guard state"
 _GUARD_COMMIT_SIGNOFF = (
     "Signed-off-by: Hephaestus Automation <hephaestus-automation@users.noreply.github.com>"
@@ -853,15 +856,22 @@ class GitHubIssueGuardStore:
         *,
         branch: str | None = None,
         call: Callable[..., subprocess.CompletedProcess[str]] = gh_call,
+        git_call: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
         env: Mapping[str, str] | None = None,
+        staging_root: Path | None = None,
     ) -> None:
         self.repository = normalize_repository(repository)
         self.branch_name = branch
         if branch is not None:
             _require_branch(branch)
         self._call = call
+        self._git_call = git_call
         self._env = dict(env) if env is not None else None
+        self._staging_root = staging_root or Path.cwd() / "build"
         self._last_server_time: datetime | None = None
+        self._staged_commit: (
+            tuple[str, tuple[str, ...], tempfile.TemporaryDirectory[str]] | None
+        ) = None
 
     def _request(self, args: list[str], *, check: bool = True) -> tuple[int, dict[str, Any] | None]:
         result = self._call(
@@ -1009,21 +1019,65 @@ class GitHubIssueGuardStore:
     def create_commit(
         self, repository: str, tree: str, parents: Sequence[str], message: str
     ) -> tuple[str, datetime]:
-        args = [
-            "--method",
-            "POST",
-            self._path("git/commits"),
-            "-f",
-            f"message={message}",
-            "-f",
-            f"tree={tree}",
-        ]
-        for parent in parents:
-            args.extend(["-f", f"parents[]={parent}"])
-        status, body = self._request(args)
-        oid = body.get("sha") if isinstance(body, dict) else None
-        if status not in {200, 201} or not isinstance(oid, str):
-            raise GuardUnavailableError("guard commit creation failed")
+        """Stage a locally signed guard commit for an exact-lease push."""
+        normalize_repository(repository)
+        _require_sha(tree, "tree")
+        parent_oids = tuple(parents)
+        if not parent_oids:
+            raise ValueError("guard commits require at least one parent")
+        for parent in parent_oids:
+            _require_sha(parent, "parent")
+        GuardRecord.from_commit_message(message)
+        if self._staged_commit is not None:
+            raise GuardUnavailableError("a signed guard commit is already staged")
+
+        self._staging_root.mkdir(parents=True, exist_ok=True)
+        temporary = tempfile.TemporaryDirectory(
+            prefix="hephaestus-issue-guard-", dir=self._staging_root
+        )
+        repository_path = Path(temporary.name)
+        remote = f"https://github.com/{self.repository}.git"
+        environment = os.environ.copy()
+        if self._env is not None:
+            environment.update(self._env)
+
+        def run_git(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            return self._git_call(
+                args,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+                **kwargs,
+            )
+
+        try:
+            run_git(["git", "init", "--bare", str(repository_path)])
+            run_git(["git", "-C", str(repository_path), "remote", "add", "origin", remote])
+            run_git(
+                [
+                    "git",
+                    "-C",
+                    str(repository_path),
+                    "fetch",
+                    "--no-tags",
+                    "--depth=1",
+                    "origin",
+                    *parent_oids,
+                ]
+            )
+            commit_args = ["git", "-C", str(repository_path), "commit-tree", "-S", tree]
+            for parent in parent_oids:
+                commit_args.extend(["-p", parent])
+            created = run_git(commit_args, input=message)
+            oid = created.stdout.strip()
+            _require_sha(oid, "signed guard commit")
+            run_git(["git", "-C", str(repository_path), "verify-commit", oid])
+        except (OSError, subprocess.SubprocessError, ValueError) as exc:
+            temporary.cleanup()
+            raise GuardUnavailableError("signed guard commit creation failed") from exc
+
+        self._staged_commit = (oid, parent_oids, temporary)
         return oid, self.server_now()
 
     def create_ref(
@@ -1034,52 +1088,80 @@ class GitHubIssueGuardStore:
         *,
         expected_oid: str | None = None,
     ) -> None:
-        status, _ = self._request(
-            [
-                "--method",
-                "POST",
-                self._path("git/refs"),
-                "-f",
-                f"ref=refs/heads/{self._branch()}",
-                "-f",
-                f"sha={oid}",
-            ],
-            check=False,
-        )
-        if status in {409, 422}:
-            current_oid = self._ref_oid()
-            if expected_oid is None or current_oid != expected_oid:
-                raise GuardConflictError("implementation branch already exists or changed")
-            self._patch_ref(oid)
-            return
-        if status not in {200, 201}:
-            raise GuardUnavailableError("implementation branch creation failed")
+        current_oid = self._ref_oid()
+        if current_oid is not None and current_oid != expected_oid:
+            self._discard_staged_commit()
+            raise GuardConflictError("implementation branch already exists or changed")
+        lease = current_oid or ""
+        self._publish_staged_commit(oid, lease)
 
     def update_ref(self, repository: str, issue: int, oid: str, expected_oid: str) -> None:
-        current_oid = self._ref_oid()
-        if current_oid != expected_oid:
-            raise GuardConflictError(
-                "implementation branch changed before its compare-and-swap update"
-            )
-        self._patch_ref(oid)
+        _require_sha(expected_oid, "expected_oid")
+        self._publish_staged_commit(oid, expected_oid)
 
-    def _patch_ref(self, oid: str) -> None:
-        status, _ = self._request(
-            [
-                "--method",
-                "PATCH",
-                self._path(f"git/refs/heads/{self._branch()}"),
-                "-f",
-                f"sha={oid}",
-                "-F",
-                "force=false",
-            ],
-            check=False,
-        )
-        if status in {409, 422}:
-            raise GuardConflictError("implementation branch update lost its non-force CAS")
-        if status not in {200, 201}:
-            raise GuardUnavailableError("implementation branch update failed")
+    def _discard_staged_commit(self) -> None:
+        staged = self._staged_commit
+        self._staged_commit = None
+        if staged is not None:
+            staged[2].cleanup()
+
+    def _publish_staged_commit(self, oid: str, expected_oid: str) -> None:
+        """Push one staged commit with a server-enforced exact-head lease."""
+        staged = self._staged_commit
+        if staged is None or staged[0] != oid or expected_oid not in {"", *staged[1]}:
+            self._discard_staged_commit()
+            raise GuardUnavailableError("signed guard commit staging did not match the CAS")
+        repository_path = Path(staged[2].name)
+        branch_ref = f"refs/heads/{self._branch()}"
+        environment = os.environ.copy()
+        if self._env is not None:
+            environment.update(self._env)
+        try:
+            self._git_call(
+                [
+                    "git",
+                    "-C",
+                    str(repository_path),
+                    "push",
+                    f"--force-with-lease={branch_ref}:{expected_oid}",
+                    "origin",
+                    f"{oid}:{branch_ref}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            observed = self._ref_oid()
+            self._discard_staged_commit()
+            if observed != expected_oid:
+                raise GuardConflictError(
+                    "implementation branch changed before its signed CAS update"
+                ) from exc
+            raise GuardUnavailableError("signed guard commit push failed") from exc
+
+        try:
+            self._confirm_remote_signature(oid)
+        finally:
+            self._discard_staged_commit()
+
+    def _confirm_remote_signature(self, oid: str) -> None:
+        """Require GitHub to verify the newly published guard signature."""
+        for attempt in range(_SIGNATURE_READBACK_ATTEMPTS):
+            status, body = self._request([self._path(f"git/commits/{oid}")])
+            verification = body.get("verification") if isinstance(body, dict) else None
+            if status == 200 and isinstance(verification, dict):
+                if verification.get("verified") is True:
+                    return
+                reason = verification.get("reason")
+                if reason not in {"gpgverify_unavailable"}:
+                    raise GuardUnavailableError(
+                        f"GitHub rejected the guard commit signature: {reason or 'unknown'}"
+                    )
+            if attempt + 1 < _SIGNATURE_READBACK_ATTEMPTS:
+                time.sleep(_REF_READBACK_DELAY_S)
+        raise GuardUnavailableError("GitHub did not verify the guard commit signature")
 
     def actor(self) -> str:
         status, body = self._request(["user"])

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -1229,6 +1229,7 @@ class GitHubIssueGuardStore:
         environment: Mapping[str, str],
     ) -> None:
         """Remove an unverified commit through a lease pinned to its exact OID."""
+        restored_oid = expected_oid or None
         try:
             self._push_staged_ref(
                 repository_path,
@@ -1239,7 +1240,7 @@ class GitHubIssueGuardStore:
             )
         except (OSError, subprocess.SubprocessError) as exc:
             observed = self._ref_oid()
-            if observed == (expected_oid or None):
+            if observed == restored_oid:
                 return
             if observed != rejected_oid:
                 raise GuardConflictError(
@@ -1248,6 +1249,14 @@ class GitHubIssueGuardStore:
             raise GuardUnavailableError(
                 "unverified guard commit remained after rollback failed"
             ) from exc
+        observed = self._ref_oid()
+        if observed == restored_oid:
+            return
+        if observed != rejected_oid:
+            raise GuardConflictError(
+                "implementation branch changed during unverified guard rollback"
+            )
+        raise GuardUnavailableError("unverified guard commit remained after rollback")
 
     def _confirm_remote_signature(self, oid: str) -> None:
         """Require GitHub to verify the newly published guard signature."""

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -47,6 +47,8 @@ _GUARD_REASON_MAX = 512
 _REF_READBACK_ATTEMPTS = 4
 _REF_READBACK_DELAY_S = 0.25
 _SIGNATURE_READBACK_ATTEMPTS = 4
+_GUARD_HISTORY_LIMIT = 4096
+_COMPARE_PAGE_SIZE = 100
 _GUARD_COMMIT_SUBJECT = "chore(automation): record issue guard state"
 _GUARD_COMMIT_SIGNOFF = (
     "Signed-off-by: Hephaestus Automation <hephaestus-automation@users.noreply.github.com>"
@@ -972,38 +974,33 @@ class GitHubIssueGuardStore:
             raise GuardUnavailableError("implementation branch commit response was malformed")
         return tree_sha, message, tuple(parents), self.server_now()
 
-    def _guard_record(self, repository: str, oid: str) -> GuardRecord | None:
-        """Find the newest guard record in the branch's first-parent history."""
-        current = oid
-        for _ in range(4096):
-            _tree, message, parents, _server_time = self._commit_metadata(repository, current)
-            try:
-                return GuardRecord.from_commit_message(message)
-            except ValueError:
-                if message.lstrip().startswith("{") or message.startswith(_GUARD_COMMIT_SUBJECT):
-                    raise GuardUnavailableError(
-                        "implementation branch contains a malformed guard record"
-                    ) from None
-            if not parents:
-                return None
-            current = parents[0]
-        raise GuardUnavailableError("implementation branch guard history is too deep")
+    def _guard_record(self, oid: str, head_message: str) -> GuardRecord | None:
+        """Find the newest guard record without walking shared main history."""
+        record = self._record_from_message(head_message)
+        if record is not None:
+            return record
+        for candidate in reversed(self._commits_since_default(oid)):
+            commit = candidate.get("commit") if isinstance(candidate, dict) else None
+            candidate_message = commit.get("message") if isinstance(commit, dict) else None
+            if not isinstance(candidate_message, str):
+                raise GuardUnavailableError("branch comparison commit metadata was malformed")
+            record = self._record_from_message(candidate_message)
+            if record is not None:
+                return record
+        return None
 
-    def read_ref(self, repository: str, issue: int) -> GuardSnapshot | None:
-        oid = self._ref_oid()
-        if oid is None:
+    @staticmethod
+    def _record_from_message(message: str) -> GuardRecord | None:
+        try:
+            return GuardRecord.from_commit_message(message)
+        except ValueError:
+            if message.lstrip().startswith("{") or message.startswith(_GUARD_COMMIT_SUBJECT):
+                raise GuardUnavailableError(
+                    "implementation branch contains a malformed guard record"
+                ) from None
             return None
-        tree, _message, _parents, server_time = self._commit_metadata(repository, oid)
-        record = self._guard_record(repository, oid)
-        if record is None:
-            return None
-        return GuardSnapshot(oid=oid, record=record, tree=tree, server_time=server_time)
 
-    def default_tip(self, repository: str) -> tuple[str, str]:
-        branch_oid = self._ref_oid()
-        if branch_oid is not None:
-            tree, _message, _parents, _server_time = self._commit_metadata(repository, branch_oid)
-            return branch_oid, tree
+    def _default_branch_oid(self) -> str:
         status, body = self._request([self._path("")])
         branch = body.get("default_branch") if isinstance(body, dict) else None
         if status != 200 or not isinstance(branch, str) or not branch:
@@ -1013,6 +1010,55 @@ class GitHubIssueGuardStore:
         oid = obj.get("sha") if isinstance(obj, dict) else None
         if status != 200 or not isinstance(oid, str):
             raise GuardUnavailableError("default branch ref was malformed")
+        _require_sha(oid, "default branch tip")
+        return oid
+
+    def _commits_since_default(self, oid: str) -> list[dict[str, Any]]:
+        """Return branch-only commits through bounded compare pagination."""
+        base_oid = self._default_branch_oid()
+        if base_oid == oid:
+            return []
+        commits: list[dict[str, Any]] = []
+        total: int | None = None
+        page = 1
+        while total is None or len(commits) < total:
+            endpoint = f"compare/{base_oid}...{oid}?per_page={_COMPARE_PAGE_SIZE}&page={page}"
+            status, body = self._request([self._path(endpoint)])
+            page_commits = body.get("commits") if isinstance(body, dict) else None
+            observed_total = body.get("total_commits") if isinstance(body, dict) else None
+            if (
+                status != 200
+                or not isinstance(page_commits, list)
+                or isinstance(observed_total, bool)
+                or not isinstance(observed_total, int)
+                or observed_total < 0
+                or observed_total > _GUARD_HISTORY_LIMIT
+                or (total is not None and observed_total != total)
+            ):
+                raise GuardUnavailableError("branch comparison response was malformed or too deep")
+            total = observed_total
+            commits.extend(item for item in page_commits if isinstance(item, dict))
+            if len(commits) > total or (len(commits) < total and not page_commits):
+                raise GuardUnavailableError("branch comparison pagination was incomplete")
+            page += 1
+        return commits
+
+    def read_ref(self, repository: str, issue: int) -> GuardSnapshot | None:
+        oid = self._ref_oid()
+        if oid is None:
+            return None
+        tree, message, _parents, server_time = self._commit_metadata(repository, oid)
+        record = self._guard_record(oid, message)
+        if record is None:
+            return None
+        return GuardSnapshot(oid=oid, record=record, tree=tree, server_time=server_time)
+
+    def default_tip(self, repository: str) -> tuple[str, str]:
+        branch_oid = self._ref_oid()
+        if branch_oid is not None:
+            tree, _message, _parents, _server_time = self._commit_metadata(repository, branch_oid)
+            return branch_oid, tree
+        oid = self._default_branch_oid()
         tree, _message, _parents, _server_time = self._commit_metadata(repository, oid)
         return oid, tree
 

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -44,6 +44,10 @@ _REPOSITORY_RE = re.compile(r"[^/\s]+/[^/\s]+\Z")
 _GUARD_REASON_MAX = 512
 _REF_READBACK_ATTEMPTS = 4
 _REF_READBACK_DELAY_S = 0.25
+_GUARD_COMMIT_SUBJECT = "chore(automation): record issue guard state"
+_GUARD_COMMIT_SIGNOFF = (
+    "Signed-off-by: Hephaestus Automation <hephaestus-automation@users.noreply.github.com>"
+)
 
 
 class GuardError(RuntimeError):
@@ -162,7 +166,7 @@ class GuardRecord:
             raise ValueError("reason must be a bounded string")
 
     def to_json(self) -> str:
-        """Return the canonical JSON representation used as commit text."""
+        """Return the canonical JSON representation of this record."""
         return json.dumps(
             {
                 "actor": self.actor,
@@ -181,6 +185,10 @@ class GuardRecord:
             separators=(",", ":"),
             sort_keys=True,
         )
+
+    def to_commit_message(self) -> str:
+        """Return canonical guard text wrapped in a PR-policy-compliant message."""
+        return f"{_GUARD_COMMIT_SUBJECT}\n\n{self.to_json()}\n\n{_GUARD_COMMIT_SIGNOFF}"
 
     @classmethod
     def from_json(cls, value: str) -> Self:
@@ -228,6 +236,19 @@ class GuardRecord:
             return record
         except (KeyError, TypeError, ValueError) as exc:
             raise ValueError("guard record fields are invalid") from exc
+
+    @classmethod
+    def from_commit_message(cls, value: str) -> Self:
+        """Parse the current commit envelope or a legacy raw-JSON record."""
+        if not isinstance(value, str):
+            raise ValueError("guard commit message must be a string")
+        if value.startswith("{"):
+            return cls.from_json(value)
+        prefix = f"{_GUARD_COMMIT_SUBJECT}\n\n"
+        suffix = f"\n\n{_GUARD_COMMIT_SIGNOFF}"
+        if not value.startswith(prefix) or not value.endswith(suffix):
+            raise ValueError("guard commit message has an invalid envelope")
+        return cls.from_json(value[len(prefix) : -len(suffix)])
 
 
 @dataclass(frozen=True)
@@ -394,7 +415,7 @@ class IssueGuard:
         record: GuardRecord,
     ) -> GuardSnapshot:
         oid, _server_time = self.store.create_commit(
-            repository, previous.tree, [previous.oid], record.to_json()
+            repository, previous.tree, [previous.oid], record.to_commit_message()
         )
         try:
             self.store.update_ref(repository, issue, oid, previous.oid)
@@ -460,7 +481,7 @@ class IssueGuard:
             predecessor_oid=predecessor,
             reason="automation acquisition",
         )
-        oid, _ = self.store.create_commit(repository, tree, parents, record.to_json())
+        oid, _ = self.store.create_commit(repository, tree, parents, record.to_commit_message())
         try:
             if current is None:
                 self.store.create_ref(repository, issue, oid, expected_oid=parents[0])
@@ -746,7 +767,7 @@ class InMemoryGuardStore:
         self, repository: str, tree: str, parents: Sequence[str], message: str
     ) -> tuple[str, datetime]:
         oid = self._sha()
-        record = GuardRecord.from_json(message)
+        record = GuardRecord.from_commit_message(message)
         self._commits[oid] = (record, tree, message)
         return oid, self.now
 
@@ -947,9 +968,9 @@ class GitHubIssueGuardStore:
         for _ in range(4096):
             _tree, message, parents, _server_time = self._commit_metadata(repository, current)
             try:
-                return GuardRecord.from_json(message)
+                return GuardRecord.from_commit_message(message)
             except ValueError:
-                if message.lstrip().startswith("{"):
+                if message.lstrip().startswith("{") or message.startswith(_GUARD_COMMIT_SUBJECT):
                     raise GuardUnavailableError(
                         "implementation branch contains a malformed guard record"
                     ) from None

--- a/hephaestus/automation/issue_guard.py
+++ b/hephaestus/automation/issue_guard.py
@@ -1163,20 +1163,12 @@ class GitHubIssueGuardStore:
         if self._env is not None:
             environment.update(self._env)
         try:
-            self._git_call(
-                [
-                    "git",
-                    "-C",
-                    str(repository_path),
-                    "push",
-                    f"--force-with-lease={branch_ref}:{expected_oid}",
-                    "origin",
-                    f"{oid}:{branch_ref}",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-                env=environment,
+            self._push_staged_ref(
+                repository_path,
+                branch_ref,
+                expected_oid=expected_oid,
+                target_oid=oid,
+                environment=environment,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             observed = self._ref_oid()
@@ -1189,8 +1181,73 @@ class GitHubIssueGuardStore:
 
         try:
             self._confirm_remote_signature(oid)
+        except GuardUnavailableError:
+            self._rollback_unverified_commit(
+                repository_path,
+                branch_ref,
+                rejected_oid=oid,
+                expected_oid=expected_oid,
+                environment=environment,
+            )
+            raise
         finally:
             self._discard_staged_commit()
+
+    def _push_staged_ref(
+        self,
+        repository_path: Path,
+        branch_ref: str,
+        *,
+        expected_oid: str,
+        target_oid: str,
+        environment: Mapping[str, str],
+    ) -> None:
+        refspec = f"{target_oid}:{branch_ref}" if target_oid else f":{branch_ref}"
+        self._git_call(
+            [
+                "git",
+                "-C",
+                str(repository_path),
+                "push",
+                f"--force-with-lease={branch_ref}:{expected_oid}",
+                "origin",
+                refspec,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+
+    def _rollback_unverified_commit(
+        self,
+        repository_path: Path,
+        branch_ref: str,
+        *,
+        rejected_oid: str,
+        expected_oid: str,
+        environment: Mapping[str, str],
+    ) -> None:
+        """Remove an unverified commit through a lease pinned to its exact OID."""
+        try:
+            self._push_staged_ref(
+                repository_path,
+                branch_ref,
+                expected_oid=rejected_oid,
+                target_oid=expected_oid,
+                environment=environment,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            observed = self._ref_oid()
+            if observed == (expected_oid or None):
+                return
+            if observed != rejected_oid:
+                raise GuardConflictError(
+                    "implementation branch changed before unverified guard rollback"
+                ) from exc
+            raise GuardUnavailableError(
+                "unverified guard commit remained after rollback failed"
+            ) from exc
 
     def _confirm_remote_signature(self, oid: str) -> None:
         """Require GitHub to verify the newly published guard signature."""

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -397,6 +397,61 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa
     assert all("hephaestus/issue-guards" not in arg for args, _kwargs in calls for arg in args)
 
 
+def test_http_guard_store_bounds_initial_history_scan_to_branch_comparison() -> None:
+    """A new implementation branch does not trigger one REST call per main commit."""
+    branch_oid = "2" * 40
+    base_oid = "4" * 40
+    tree_oid = "3" * 40
+    calls: list[list[str]] = []
+
+    def response(body: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout=(
+                f"HTTP/1.1 200 OK\r\nDate: Tue, 01 Jan 2030 00:00:00 GMT\r\n\r\n{json.dumps(body)}"
+            ),
+            stderr="",
+        )
+
+    def call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        path = next(arg for arg in args if arg.startswith("repos/Owner/Repo"))
+        if path.endswith("git/ref/heads/2404-auto-impl"):
+            return response({"object": {"sha": branch_oid}})
+        if path == "repos/Owner/Repo":
+            return response({"default_branch": "main"})
+        if path.endswith("git/ref/heads/main"):
+            return response({"object": {"sha": base_oid}})
+        if path.endswith(f"git/commits/{branch_oid}"):
+            return response(
+                {
+                    "tree": {"sha": tree_oid},
+                    "message": "fix(example): implementation",
+                    "parents": [{"sha": base_oid}],
+                }
+            )
+        if "/compare/" in path:
+            return response(
+                {
+                    "total_commits": 1,
+                    "commits": [
+                        {
+                            "sha": branch_oid,
+                            "commit": {"message": "fix(example): implementation"},
+                        }
+                    ],
+                }
+            )
+        pytest.fail(f"unexpected per-commit history request: {path}")
+
+    store = GitHubIssueGuardStore("Owner/Repo", branch="2404-auto-impl", call=call)
+
+    assert store.read_ref("Owner/Repo", 2404) is None
+    assert sum("git/commits/" in arg for call_args in calls for arg in call_args) == 1
+    assert sum("/compare/" in arg for call_args in calls for arg in call_args) == 1
+
+
 def test_http_guard_store_stages_a_signed_commit_and_pushes_with_exact_lease(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -443,7 +443,7 @@ def test_http_guard_store_bounds_initial_history_scan_to_branch_comparison() -> 
                     ],
                 }
             )
-        pytest.fail(f"unexpected per-commit history request: {path}")
+        raise AssertionError(f"unexpected per-commit history request: {path}")
 
     store = GitHubIssueGuardStore("Owner/Repo", branch="2404-auto-impl", call=call)
 
@@ -601,7 +601,7 @@ def test_http_guard_store_classifies_rejected_lease_as_guard_conflict(tmp_path: 
 
 
 def test_http_guard_store_rejects_a_signature_github_does_not_verify(tmp_path: Path) -> None:
-    """Local verification alone cannot authorize a remotely unverified guard commit."""
+    """A remotely unverified guard commit is removed with an exact leased rollback."""
     record = GuardRecord(
         version=1,
         repository="Owner/Repo",
@@ -616,8 +616,18 @@ def test_http_guard_store_rejects_a_signature_github_does_not_verify(tmp_path: P
         reason="test",
     )
     commit_oid = "2" * 40
+    parent_oid = "4" * 40
+    remote_head = parent_oid
+    pushes: list[list[str]] = []
 
     def git_call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal remote_head
+        if "push" in args:
+            pushes.append(args)
+            lease = next(arg for arg in args if arg.startswith("--force-with-lease="))
+            expected = lease.rsplit(":", 1)[1]
+            assert remote_head == expected
+            remote_head = args[-1].split(":", 1)[0]
         stdout = f"{commit_oid}\n" if "commit-tree" in args else ""
         return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
 
@@ -640,10 +650,15 @@ def test_http_guard_store_rejects_a_signature_github_does_not_verify(tmp_path: P
         staging_root=tmp_path,
     )
     store._last_server_time = datetime(2030, 1, 1, tzinfo=UTC)
-    oid, _ = store.create_commit("Owner/Repo", "3" * 40, ["4" * 40], record.to_commit_message())
+    oid, _ = store.create_commit("Owner/Repo", "3" * 40, [parent_oid], record.to_commit_message())
 
     with pytest.raises(GuardUnavailableError, match="unknown_key"):
-        store.update_ref("Owner/Repo", 2404, oid, "4" * 40)
+        store.update_ref("Owner/Repo", 2404, oid, parent_oid)
+
+    assert remote_head == parent_oid
+    assert len(pushes) == 2
+    assert f"--force-with-lease=refs/heads/2404-auto-impl:{commit_oid}" in pushes[1]
+    assert f"{parent_oid}:refs/heads/2404-auto-impl" in pushes[1]
 
 
 class _FakeGitHub:

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -280,6 +280,22 @@ def test_guard_record_round_trips_and_recovery_secret_is_rejected() -> None:
     handle = IssueGuard(store).acquire("Owner/Repo", 2404, "planning")
     assert handle is not None
     assert GuardRecord.from_json(handle.record.to_json()) == handle.record
+    commit_message = handle.record.to_commit_message()
+    assert commit_message.startswith("chore(automation): record issue guard state\n\n")
+    assert commit_message.endswith(
+        "\n\nSigned-off-by: Hephaestus Automation <hephaestus-automation@users.noreply.github.com>"
+    )
+    assert GuardRecord.from_commit_message(commit_message) == handle.record
+    assert GuardRecord.from_commit_message(handle.record.to_json()) == handle.record
+    guard_messages = [
+        message for record, _tree, message in store._commits.values() if record is not None
+    ]
+    assert guard_messages
+    assert all(
+        message.startswith("chore(automation): record issue guard state\n\n")
+        and "\nSigned-off-by: Hephaestus Automation <" in message
+        for message in guard_messages
+    )
 
     assert_recovery_secret_absent({})
     with pytest.raises(GuardUnavailableError):

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -303,7 +304,7 @@ def test_guard_record_round_trips_and_recovery_secret_is_rejected() -> None:
 
 
 def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa: C901
-    """REST storage advances the implementation branch with non-force writes."""
+    """HTTP metadata and signed Git CAS preserve server-time guard semantics."""
     record = GuardRecord(
         version=1,
         repository="Owner/Repo",
@@ -322,7 +323,8 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa
     calls: list[tuple[list[str], dict[str, Any]]] = []
     date = "Tue, 01 Jan 2030 00:00:00 GMT"
     branch = "2404-auto-impl"
-    branch_reads = 0
+    pushed = False
+    git_calls: list[list[str]] = []
 
     def response(status: int, body: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
@@ -333,7 +335,6 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa
         )
 
     def call(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        nonlocal branch_reads
         calls.append((args, kwargs))
         paths = {arg for arg in args if arg.startswith("repos/Owner/Repo")}
         if args[-1] == "user":
@@ -341,8 +342,7 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa
         if any(path.endswith("issues/2404") for path in paths):
             return response(200, {"labels": [{"name": STATE_PLAN_GO}, {"name": 3}]})
         if any(path.endswith(f"git/ref/heads/{branch}") for path in paths):
-            branch_reads += 1
-            if branch_reads == 1:
+            if not pushed:
                 return response(404, {})
             return response(200, {"object": {"sha": commit_oid}})
         if any(path.endswith("git/ref/heads/main") for path in paths):
@@ -352,19 +352,32 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa
         if any("/git/commits/" in path for path in paths):
             return response(
                 200,
-                {"tree": {"sha": tree_oid}, "message": record.to_json(), "parents": []},
+                {
+                    "tree": {"sha": tree_oid},
+                    "message": record.to_commit_message(),
+                    "parents": [],
+                    "verification": {"verified": True, "reason": "valid"},
+                },
             )
-        if any(path.endswith("git/commits") for path in paths):
-            return response(201, {"sha": commit_oid})
-        if any(path.endswith("git/refs") for path in paths):
-            return response(201, {})
-        if any(path.endswith(f"git/refs/heads/{branch}") for path in paths):
-            return response(200, {})
         if "repos/Owner/Repo" in paths:
             return response(200, {"default_branch": "main"})
         return response(200, {})
 
-    github = GitHubIssueGuardStore("Owner/Repo", branch=branch, call=call, env={"GH_TOKEN": "test"})
+    def git_call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal pushed
+        git_calls.append(args)
+        if "push" in args:
+            pushed = True
+        stdout = f"{commit_oid}\n" if "commit-tree" in args else ""
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    github = GitHubIssueGuardStore(
+        "Owner/Repo",
+        branch=branch,
+        call=call,
+        git_call=git_call,
+        env={"GH_TOKEN": "test"},
+    )
     assert github.read_labels("Owner/Repo", 2404) == (STATE_PLAN_GO,)
     github.add_label("Owner/Repo", 2404, "state:extra")
     github.remove_label("Owner/Repo", 2404, "state:extra")
@@ -372,17 +385,210 @@ def test_http_guard_store_uses_server_time_and_non_force_refs() -> None:  # noqa
     assert github.default_tip("Owner/Repo") == ("4" * 40, tree_oid)
     assert any("repos/Owner/Repo" in args for args, _kwargs in calls)
     assert all("repos/Owner/Repo/" not in args for args, _kwargs in calls)
-    assert github.create_commit("Owner/Repo", tree_oid, ["4" * 40], record.to_json())[0]
+    assert github.create_commit("Owner/Repo", tree_oid, ["4" * 40], record.to_commit_message())[0]
     github.create_ref("Owner/Repo", 2404, commit_oid, expected_oid="4" * 40)
-    github.update_ref("Owner/Repo", 2404, commit_oid, commit_oid)
     snapshot = github.read_ref("Owner/Repo", 2404)
     assert snapshot is not None and snapshot.record == record
     assert all(kwargs["env"] == {"GH_TOKEN": "test"} for _args, kwargs in calls)
-    update = next(args for args, _kwargs in calls if "force=false" in args)
-    assert "force=false" in update
-    assert any(f"git/refs/heads/{branch}" in arg for arg in update)
+    update = next(args for args in git_calls if "push" in args)
+    assert f"--force-with-lease=refs/heads/{branch}:" in update
+    assert f"{commit_oid}:refs/heads/{branch}" in update
     assert all("refs/tags/" not in arg for args, _kwargs in calls for arg in args)
     assert all("hephaestus/issue-guards" not in arg for args, _kwargs in calls for arg in args)
+
+
+def test_http_guard_store_stages_a_signed_commit_and_pushes_with_exact_lease(
+    tmp_path: Path,
+) -> None:
+    """Production guard writes are signed locally and published by an exact CAS."""
+    record = GuardRecord(
+        version=1,
+        repository="Owner/Repo",
+        issue=2404,
+        claim_id=uuid4(),
+        run_id=uuid4(),
+        actor="automation",
+        phase=GuardPhase.ACTIVE,
+        work_stage="planning",
+        lease_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        predecessor_oid="1" * 40,
+        reason="test",
+    )
+    parent_oid = "4" * 40
+    tree_oid = "3" * 40
+    commit_oid = "2" * 40
+    git_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def git_call(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        git_calls.append((args, kwargs))
+        stdout = f"{commit_oid}\n" if "commit-tree" in args else ""
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert any(f"git/commits/{commit_oid}" in arg for arg in args)
+        body = {"verification": {"verified": True, "reason": "valid"}}
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=(
+                f"HTTP/1.1 200 OK\r\nDate: Tue, 01 Jan 2030 00:00:00 GMT\r\n\r\n{json.dumps(body)}"
+            ),
+            stderr="",
+        )
+
+    store = GitHubIssueGuardStore(
+        "Owner/Repo",
+        branch="2404-auto-impl",
+        call=call,
+        git_call=git_call,
+        staging_root=tmp_path,
+    )
+    store._last_server_time = datetime(2030, 1, 1, tzinfo=UTC)
+
+    oid, _server_time = store.create_commit(
+        "Owner/Repo", tree_oid, [parent_oid], record.to_commit_message()
+    )
+    assert oid == commit_oid
+    store.update_ref("Owner/Repo", 2404, oid, parent_oid)
+
+    commands = [args for args, _kwargs in git_calls]
+    assert any("commit-tree" in args and "-S" in args for args in commands)
+    assert any("verify-commit" in args and commit_oid in args for args in commands)
+    push = next(args for args in commands if "push" in args)
+    assert f"--force-with-lease=refs/heads/2404-auto-impl:{parent_oid}" in push
+    assert f"{commit_oid}:refs/heads/2404-auto-impl" in push
+
+
+def test_http_guard_store_fails_closed_when_local_signing_fails(tmp_path: Path) -> None:
+    """A signing failure cannot publish or retain a staged guard commit."""
+    record = GuardRecord(
+        version=1,
+        repository="Owner/Repo",
+        issue=2404,
+        claim_id=uuid4(),
+        run_id=uuid4(),
+        actor="automation",
+        phase=GuardPhase.ACTIVE,
+        work_stage="planning",
+        lease_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        predecessor_oid="1" * 40,
+        reason="test",
+    )
+    git_calls: list[list[str]] = []
+
+    def git_call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        git_calls.append(args)
+        if "commit-tree" in args:
+            raise subprocess.CalledProcessError(128, args, stderr="signing failed")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    store = GitHubIssueGuardStore(
+        "Owner/Repo",
+        branch="2404-auto-impl",
+        git_call=git_call,
+        staging_root=tmp_path,
+    )
+    store._last_server_time = datetime(2030, 1, 1, tzinfo=UTC)
+
+    with pytest.raises(GuardUnavailableError, match="signed guard commit creation failed"):
+        store.create_commit("Owner/Repo", "3" * 40, ["4" * 40], record.to_commit_message())
+
+    assert not any("push" in args for args in git_calls)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_http_guard_store_classifies_rejected_lease_as_guard_conflict(tmp_path: Path) -> None:
+    """A failed push plus a changed live head is a contention loss, not retryable I/O."""
+    record = GuardRecord(
+        version=1,
+        repository="Owner/Repo",
+        issue=2404,
+        claim_id=uuid4(),
+        run_id=uuid4(),
+        actor="automation",
+        phase=GuardPhase.ACTIVE,
+        work_stage="planning",
+        lease_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        predecessor_oid="1" * 40,
+        reason="test",
+    )
+    commit_oid = "2" * 40
+
+    def git_call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if "push" in args:
+            raise subprocess.CalledProcessError(1, args, stderr="stale info")
+        stdout = f"{commit_oid}\n" if "commit-tree" in args else ""
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        body = {"object": {"sha": "9" * 40}}
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=(
+                f"HTTP/1.1 200 OK\r\nDate: Tue, 01 Jan 2030 00:00:00 GMT\r\n\r\n{json.dumps(body)}"
+            ),
+            stderr="",
+        )
+
+    store = GitHubIssueGuardStore(
+        "Owner/Repo",
+        branch="2404-auto-impl",
+        call=call,
+        git_call=git_call,
+        staging_root=tmp_path,
+    )
+    store._last_server_time = datetime(2030, 1, 1, tzinfo=UTC)
+    oid, _ = store.create_commit("Owner/Repo", "3" * 40, ["4" * 40], record.to_commit_message())
+
+    with pytest.raises(GuardConflictError, match="changed before its signed CAS"):
+        store.update_ref("Owner/Repo", 2404, oid, "4" * 40)
+
+
+def test_http_guard_store_rejects_a_signature_github_does_not_verify(tmp_path: Path) -> None:
+    """Local verification alone cannot authorize a remotely unverified guard commit."""
+    record = GuardRecord(
+        version=1,
+        repository="Owner/Repo",
+        issue=2404,
+        claim_id=uuid4(),
+        run_id=uuid4(),
+        actor="automation",
+        phase=GuardPhase.ACTIVE,
+        work_stage="planning",
+        lease_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        predecessor_oid="1" * 40,
+        reason="test",
+    )
+    commit_oid = "2" * 40
+
+    def git_call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        stdout = f"{commit_oid}\n" if "commit-tree" in args else ""
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        body = {"verification": {"verified": False, "reason": "unknown_key"}}
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=(
+                f"HTTP/1.1 200 OK\r\nDate: Tue, 01 Jan 2030 00:00:00 GMT\r\n\r\n{json.dumps(body)}"
+            ),
+            stderr="",
+        )
+
+    store = GitHubIssueGuardStore(
+        "Owner/Repo",
+        branch="2404-auto-impl",
+        call=call,
+        git_call=git_call,
+        staging_root=tmp_path,
+    )
+    store._last_server_time = datetime(2030, 1, 1, tzinfo=UTC)
+    oid, _ = store.create_commit("Owner/Repo", "3" * 40, ["4" * 40], record.to_commit_message())
+
+    with pytest.raises(GuardUnavailableError, match="unknown_key"):
+        store.update_ref("Owner/Repo", 2404, oid, "4" * 40)
 
 
 class _FakeGitHub:

--- a/tests/unit/automation/test_issue_guard.py
+++ b/tests/unit/automation/test_issue_guard.py
@@ -418,21 +418,21 @@ def test_http_guard_store_bounds_initial_history_scan_to_branch_comparison() -> 
         calls.append(args)
         path = next(arg for arg in args if arg.startswith("repos/Owner/Repo"))
         if path.endswith("git/ref/heads/2404-auto-impl"):
-            return response({"object": {"sha": branch_oid}})
-        if path == "repos/Owner/Repo":
-            return response({"default_branch": "main"})
-        if path.endswith("git/ref/heads/main"):
-            return response({"object": {"sha": base_oid}})
-        if path.endswith(f"git/commits/{branch_oid}"):
-            return response(
+            result = response({"object": {"sha": branch_oid}})
+        elif path == "repos/Owner/Repo":
+            result = response({"default_branch": "main"})
+        elif path.endswith("git/ref/heads/main"):
+            result = response({"object": {"sha": base_oid}})
+        elif path.endswith(f"git/commits/{branch_oid}"):
+            result = response(
                 {
                     "tree": {"sha": tree_oid},
                     "message": "fix(example): implementation",
                     "parents": [{"sha": base_oid}],
                 }
             )
-        if "/compare/" in path:
-            return response(
+        elif "/compare/" in path:
+            result = response(
                 {
                     "total_commits": 1,
                     "commits": [
@@ -443,7 +443,9 @@ def test_http_guard_store_bounds_initial_history_scan_to_branch_comparison() -> 
                     ],
                 }
             )
-        raise AssertionError(f"unexpected per-commit history request: {path}")
+        else:
+            raise AssertionError(f"unexpected per-commit history request: {path}")
+        return result
 
     store = GitHubIssueGuardStore("Owner/Repo", branch="2404-auto-impl", call=call)
 
@@ -632,7 +634,11 @@ def test_http_guard_store_rejects_a_signature_github_does_not_verify(tmp_path: P
         return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
 
     def call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        body = {"verification": {"verified": False, "reason": "unknown_key"}}
+        path = next(arg for arg in args if arg.startswith("repos/Owner/Repo"))
+        if path.endswith("git/ref/heads/2404-auto-impl"):
+            body = {"object": {"sha": remote_head}}
+        else:
+            body = {"verification": {"verified": False, "reason": "unknown_key"}}
         return subprocess.CompletedProcess(
             args,
             0,
@@ -656,6 +662,75 @@ def test_http_guard_store_rejects_a_signature_github_does_not_verify(tmp_path: P
         store.update_ref("Owner/Repo", 2404, oid, parent_oid)
 
     assert remote_head == parent_oid
+    assert len(pushes) == 2
+    assert f"--force-with-lease=refs/heads/2404-auto-impl:{commit_oid}" in pushes[1]
+    assert f"{parent_oid}:refs/heads/2404-auto-impl" in pushes[1]
+
+
+def test_http_guard_store_fails_when_unverified_rollback_leaves_rejected_tip(
+    tmp_path: Path,
+) -> None:
+    """A false-success rollback is rejected if readback still sees the bad commit."""
+    record = GuardRecord(
+        version=1,
+        repository="Owner/Repo",
+        issue=2404,
+        claim_id=uuid4(),
+        run_id=uuid4(),
+        actor="automation",
+        phase=GuardPhase.ACTIVE,
+        work_stage="planning",
+        lease_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        predecessor_oid="1" * 40,
+        reason="test",
+    )
+    commit_oid = "2" * 40
+    parent_oid = "4" * 40
+    remote_head = parent_oid
+    pushes: list[list[str]] = []
+
+    def git_call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal remote_head
+        if "push" in args:
+            pushes.append(args)
+            lease = next(arg for arg in args if arg.startswith("--force-with-lease="))
+            expected = lease.rsplit(":", 1)[1]
+            assert remote_head == expected
+            target = args[-1].split(":", 1)[0]
+            if len(pushes) == 1:
+                remote_head = target
+        stdout = f"{commit_oid}\n" if "commit-tree" in args else ""
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def call(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        path = next(arg for arg in args if arg.startswith("repos/Owner/Repo"))
+        if path.endswith("git/ref/heads/2404-auto-impl"):
+            body = {"object": {"sha": remote_head}}
+        else:
+            body = {"verification": {"verified": False, "reason": "unknown_key"}}
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=(
+                f"HTTP/1.1 200 OK\r\nDate: Tue, 01 Jan 2030 00:00:00 GMT\r\n\r\n{json.dumps(body)}"
+            ),
+            stderr="",
+        )
+
+    store = GitHubIssueGuardStore(
+        "Owner/Repo",
+        branch="2404-auto-impl",
+        call=call,
+        git_call=git_call,
+        staging_root=tmp_path,
+    )
+    store._last_server_time = datetime(2030, 1, 1, tzinfo=UTC)
+    oid, _ = store.create_commit("Owner/Repo", "3" * 40, [parent_oid], record.to_commit_message())
+
+    with pytest.raises(GuardUnavailableError, match="unverified guard commit remained"):
+        store.update_ref("Owner/Repo", 2404, oid, parent_oid)
+
+    assert remote_head == commit_oid
     assert len(pushes) == 2
     assert f"--force-with-lease=refs/heads/2404-auto-impl:{commit_oid}" in pushes[1]
     assert f"{parent_oid}:refs/heads/2404-auto-impl" in pushes[1]


### PR DESCRIPTION
## Summary

- wrap guard JSON in a Conventional Commit and DCO-compliant envelope while preserving legacy parsing
- create no-tree-change guard commits with the configured Git signing identity
- publish guard transitions through exact-head force-with-lease CAS updates
- require both local and GitHub signature verification before accepting a transition
- cover signing success/failure, lease races, and remote verification failures

## Verification

- 24 focused issue-guard tests passed
- 3,679 automation tests passed (4 deselected)
- Ruff and mypy passed for changed Python surfaces

Closes #2734