### PR TITLE
fix(version): make bump-version fail closed for hatch-vcs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,9 +240,11 @@ git tags, not stored in a file:
 
 ### Releasing a new version
 
-You do not edit a version field. A release is cut by creating a signed git tag —
-see [`docs/RELEASING.md`](docs/RELEASING.md) for the full workflow. `hephaestus-bump-version`
-computes the next semver string and prints the `git tag` commands to run.
+You do not edit a version field. A release is cut by the signed Auto Tag Release
+workflow — see [`docs/RELEASING.md`](docs/RELEASING.md) for the full workflow.
+`hephaestus-bump-version` is compute-only for static projects and fails closed
+for hatch-vcs/tag-derived projects; it never writes `VERSION`, `pyproject.toml`,
+or `hephaestus/__init__.py`.
 
 ## Dependency Updates
 

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ zero totals, and zero requested/processed counts.
 
 | Command | Description |
 |---|---|
-| `hephaestus-bump-version` | Compute the next tag-derived semantic version without changing files or tags |
+| `hephaestus-bump-version` | Preview static-project bumps; refuses hatch-vcs state and directs releases to signed tags |
 | `hephaestus-check-package-versions` | Check optional package and documentation version references against the canonical tag |
 | `hephaestus-check-version-consistency` | Verify an expected version matches the canonical tag and installed distribution |
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,17 +43,20 @@ The package version itself does **not** need to be edited in any file: this proj
 hatch-vcs dynamic versioning, so the package version is derived from the git tag the
 `auto-tag` workflow pushes. There is no `[project].version` field to bump.
 
-To preview the next version locally without changing files or tags:
+The legacy `hephaestus-bump-version` command is compute-only for static-version
+projects. On this hatch-vcs repository it fails closed before reading the current
+tag or writing `VERSION`, `pyproject.toml`, or `hephaestus/__init__.py`.
+
+Create the authoritative signed tag through **Actions → Auto Tag Release → Run
+workflow**; do not use the command to modify version files. The release workflow
+then verifies the requested tag against hatch-vcs and a freshly installed wheel
+before publication.
+
+For a static-version project, the command can preview the next version locally:
 
 ```bash
 hephaestus-bump-version patch
 ```
-
-This command is compute-only. Create the authoritative signed tag through
-**Actions → Auto Tag Release → Run workflow**; do not copy the proposal into
-`VERSION`, `pyproject.toml`, or `hephaestus/__init__.py`. The release workflow
-then verifies the requested tag against hatch-vcs and a freshly installed wheel
-before publication.
 
 ## Manual Tag + Release (escape hatch)
 

--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -37,8 +37,13 @@ import sys
 from importlib.metadata import PackageNotFoundError, version as _dist_version
 from pathlib import Path
 
-from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
-from hephaestus.version.manager import parse_version
+from hephaestus.cli.utils import (
+    create_validation_parser,
+    emit_json_status,
+    format_output,
+    resolve_repo_root,
+)
+from hephaestus.version.manager import VersionManager, parse_version
 from hephaestus.version.parsing import parse_version_tuple
 
 # PyPI distribution name used for installed-artifact verification.
@@ -402,6 +407,43 @@ def _calculate_next_version(repo_root: Path, part: str) -> tuple[str, str]:
     return current_str, ".".join(str(component) for component in new)
 
 
+def _ensure_bump_supported(repo_root: Path) -> None:
+    """Reject static version-file updates for a dynamic-version repository.
+
+    The current CLI is compute-only, but this preflight protects the command's
+    contract if a write-capable implementation is reintroduced. It also runs
+    before resolving the current tag so a dynamic project cannot report a
+    successful file-backed bump.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Raises:
+        OSError: If the version configuration cannot be inspected.
+        ValueError: If the project declares a dynamic version.
+
+    """
+    VersionManager(
+        repo_root=repo_root,
+        version_files=[],
+        init_files=[],
+    ).ensure_update_supported()
+
+
+def _report_bump_refusal(exc: ValueError) -> None:
+    """Report a dynamic-version refusal and the supported release workflow."""
+    print(f"ERROR: version bump refused: {exc}", file=sys.stderr)
+    print(
+        "Hephaestus releases use the signed Auto Tag Release workflow; see docs/RELEASING.md.",
+        file=sys.stderr,
+    )
+
+
+def _report_bump_inspection_error(exc: OSError) -> None:
+    """Report a version-configuration inspection failure."""
+    print(f"ERROR: could not inspect version configuration: {exc}", file=sys.stderr)
+
+
 def preview_version(repo_root: Path, part: str, verbose: bool = False) -> str:
     """Compute the next semantic version without changing repository state.
 
@@ -429,6 +471,8 @@ def bump_version(
     part: str,
     dry_run: bool = False,
     verbose: bool = False,
+    *,
+    emit_human_output: bool = True,
 ) -> int:
     """Preview a version bump while preserving the legacy status-code API.
 
@@ -441,6 +485,7 @@ def bump_version(
         part: Which part to increment — ``major``, ``minor``, or ``patch``.
         dry_run: Retained for compatibility; no writes occur regardless of its value.
         verbose: If True, print the current and proposed versions.
+        emit_human_output: Whether to print the successful human-readable preview.
 
     Returns:
         0 on success, 1 when the requested part or current version is invalid.
@@ -448,12 +493,21 @@ def bump_version(
     """
     del dry_run  # Retained solely for source compatibility; previews never write.
     try:
+        _ensure_bump_supported(repo_root)
+    except ValueError as exc:
+        _report_bump_refusal(exc)
+        return 1
+    except OSError as exc:
+        _report_bump_inspection_error(exc)
+        return 1
+
+    try:
         current_str, requested = _calculate_next_version(repo_root, part)
     except ValueError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    if verbose:
+    if verbose and emit_human_output:
         print(f"Computed next version: {current_str} -> {requested}")
     return 0
 
@@ -572,8 +626,11 @@ def bump_version_main() -> int:
 
     """
     parser = create_validation_parser(
-        "Compute the next tag-derived semantic version without changing files or tags",
-        epilog="Example: %(prog)s patch --verbose",
+        "Preview a static-project version bump; dynamic projects fail closed",
+        epilog=(
+            "Hephaestus releases use the signed Auto Tag Release workflow. "
+            "Example: %(prog)s patch --verbose"
+        ),
     )
     parser.add_argument(
         "part",
@@ -583,7 +640,10 @@ def bump_version_main() -> int:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Deprecated compatibility flag; version previews are always compute-only",
+        help=(
+            "Deprecated compatibility flag; previews are compute-only and dynamic "
+            "version projects are refused"
+        ),
     )
     parser.add_argument(
         "--verbose",
@@ -593,6 +653,20 @@ def bump_version_main() -> int:
     )
     args = parser.parse_args()
     root = resolve_repo_root(args)
+
+    try:
+        _ensure_bump_supported(root)
+    except ValueError as exc:
+        _report_bump_refusal(exc)
+        if args.json:
+            emit_json_status(1, message="version bump refused")
+        return 1
+    except OSError as exc:
+        _report_bump_inspection_error(exc)
+        if args.json:
+            emit_json_status(1, message="could not inspect version configuration")
+        return 1
+
     requested = preview_version(root, part=args.part, verbose=args.verbose and not args.json)
     if args.json:
         print(

--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -42,13 +42,14 @@ _HATCH_VCS_DYNAMIC_RE = re.compile(r'^\s*dynamic\s*=\s*\[\s*[^]]*"version"[^]]*\
 
 
 def _is_hatch_vcs_project(pyproject_content: str) -> bool:
-    """Return True if pyproject.toml declares a dynamic version via hatch-vcs.
+    """Return True if pyproject.toml declares a dynamic project version.
 
-    Detection is intentionally lenient: any ``dynamic = [..., "version", ...]``
-    declaration is sufficient. The narrower form
-    ``[tool.hatch.version] source = "vcs"`` is a stronger signal but the dynamic
-    declaration alone is enough to mean ``[project].version`` should not exist
-    and therefore should not be written.
+    Detection is intentionally broad: any ``dynamic = [..., "version", ...]``
+    declaration is enough to mean that a static ``VERSION`` or ``__version__``
+    update cannot be authoritative. Hephaestus uses this contract with
+    ``[tool.hatch.version] source = "vcs"``; refusing other dynamic providers
+    too keeps the aggregate updater fail closed rather than guessing how their
+    authoritative version is produced.
     """
     return bool(_HATCH_VCS_DYNAMIC_RE.search(pyproject_content))
 
@@ -132,6 +133,29 @@ class VersionManager:
                         self.init_files.append(init_file)
         else:
             self.init_files = init_files
+
+    def ensure_update_supported(self) -> None:
+        """Reject aggregate updates for projects with a dynamic version.
+
+        The aggregate updater writes secondary static version state. That state
+        cannot be authoritative when ``[project].dynamic`` contains
+        ``"version"`` (including Hephaestus's hatch-vcs/tag-derived contract),
+        so the check runs before version parsing or any file mutation.
+
+        Raises:
+            OSError: If an existing ``pyproject.toml`` cannot be read.
+            ValueError: If the project declares a dynamic version.
+
+        """
+        if self.pyproject_file is None or not self.pyproject_file.exists():
+            return
+
+        content = self.pyproject_file.read_text()
+        if _is_hatch_vcs_project(content):
+            raise ValueError(
+                "static version-file updates are unsupported when "
+                '[project].dynamic contains "version"'
+            )
 
     def update_pyproject_file(
         self, pyproject_file: Path, version: str, verbose: bool = True
@@ -246,6 +270,11 @@ class VersionManager:
             verbose: Print status messages
 
         """
+        # Fail before parsing or writing any aggregate version state. For a
+        # dynamic project, VERSION and __version__ would be misleading copies
+        # rather than authoritative release state.
+        self.ensure_update_supported()
+
         # Parse and validate version
         major, minor, patch = parse_version(version)
         if verbose:

--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -21,6 +21,7 @@ The project version is derived exclusively from Git tags through hatch-vcs.
 """
 
 import re
+import tomllib
 from pathlib import Path
 from typing import cast
 
@@ -38,20 +39,22 @@ class _UnsetType:
 _UNSET = _UnsetType()  # sentinel: use default pyproject_file path
 
 
-_HATCH_VCS_DYNAMIC_RE = re.compile(r'^\s*dynamic\s*=\s*\[\s*[^]]*"version"[^]]*\]', re.MULTILINE)
-
-
 def _is_hatch_vcs_project(pyproject_content: str) -> bool:
     """Return True if pyproject.toml declares a dynamic project version.
 
-    Detection is intentionally broad: any ``dynamic = [..., "version", ...]``
-    declaration is enough to mean that a static ``VERSION`` or ``__version__``
-    update cannot be authoritative. Hephaestus uses this contract with
-    ``[tool.hatch.version] source = "vcs"``; refusing other dynamic providers
-    too keeps the aggregate updater fail closed rather than guessing how their
-    authoritative version is produced.
+    Detection is intentionally broad: any valid TOML
+    ``[project].dynamic`` array containing ``"version"`` is enough to mean
+    that a static ``VERSION`` or ``__version__`` update cannot be authoritative.
+    Hephaestus uses this contract with ``[tool.hatch.version] source = "vcs"``;
+    refusing other dynamic providers too keeps the aggregate updater fail
+    closed rather than guessing how their authoritative version is produced.
     """
-    return bool(_HATCH_VCS_DYNAMIC_RE.search(pyproject_content))
+    project = tomllib.loads(pyproject_content).get("project")
+    if not isinstance(project, dict):
+        return False
+
+    dynamic = project.get("dynamic")
+    return isinstance(dynamic, list) and "version" in dynamic
 
 
 def parse_version(version: str) -> tuple[int, int, int]:
@@ -97,7 +100,8 @@ class VersionManager:
             init_files: List of __init__.py files to update.
                 Defaults to [repo_root/<package>/__init__.py].
             pyproject_file: Path to pyproject.toml. Defaults to repo_root/pyproject.toml.
-                Pass ``None`` explicitly to skip pyproject.toml updates entirely.
+                Pass ``None`` explicitly to skip pyproject.toml updates entirely. The
+                repository's pyproject.toml is still inspected before aggregate writes.
 
         """
         self.repo_root = repo_root or get_repo_root()
@@ -147,15 +151,19 @@ class VersionManager:
             ValueError: If the project declares a dynamic version.
 
         """
-        if self.pyproject_file is None or not self.pyproject_file.exists():
-            return
+        repository_pyproject = self.repo_root / "pyproject.toml"
+        inspection_files = [repository_pyproject]
+        if self.pyproject_file is not None and self.pyproject_file != repository_pyproject:
+            inspection_files.append(self.pyproject_file)
 
-        content = self.pyproject_file.read_text()
-        if _is_hatch_vcs_project(content):
-            raise ValueError(
-                "static version-file updates are unsupported when "
-                '[project].dynamic contains "version"'
-            )
+        for pyproject_file in inspection_files:
+            if not pyproject_file.exists():
+                continue
+            if _is_hatch_vcs_project(pyproject_file.read_text()):
+                raise ValueError(
+                    "static version-file updates are unsupported when "
+                    '[project].dynamic contains "version"'
+                )
 
     def update_pyproject_file(
         self, pyproject_file: Path, version: str, verbose: bool = True

--- a/tests/unit/docs/test_version_currency.py
+++ b/tests/unit/docs/test_version_currency.py
@@ -70,3 +70,16 @@ def test_migration_md_version_guard_fails_when_git_tags_are_absent(
 
     with pytest.raises(pytest.fail.Exception, match=r"No vX\.Y\.Z git tag reachable"):
         test_migration_md_version_does_not_trail_latest_git_tag()
+
+
+def test_release_docs_require_signed_tag_path_for_dynamic_versions() -> None:
+    """Keep all release-facing docs aligned with the fail-closed CLI contract."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    releasing = (REPO_ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
+
+    assert "refuses hatch-vcs state" in readme
+    assert "fails closed" in contributing
+    assert "signed Auto Tag Release" in contributing
+    assert "fails closed before reading the current" in releasing
+    assert "Actions → Auto Tag Release → Run workflow" in releasing

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -8,6 +8,7 @@ git tags, not a file. Tests inject a canonical version by monkeypatching
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -251,6 +252,109 @@ def test_bump_version_verbose(tmp_path, set_canonical, capsys):
 
     assert bump_version(tmp_path, "patch", verbose=True) == 0
     assert "Computed next version: 0.1.0 -> 0.1.1" in capsys.readouterr().out
+
+
+def test_bump_version_refuses_dynamic_project_before_tag_lookup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The library wrapper refuses dynamic projects before resolving a tag."""
+    pyproject = tmp_path / "pyproject.toml"
+    version_file = tmp_path / "VERSION"
+    init_file = tmp_path / "__init__.py"
+    pyproject.write_text(
+        '[project]\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n'
+    )
+    version_file.write_text("1.2.3\n")
+    init_file.write_text('__version__ = "1.2.3"\n')
+    before = {path: path.read_bytes() for path in (pyproject, version_file, init_file)}
+    monkeypatch.setattr(
+        consistency,
+        "_get_canonical_version",
+        lambda _root: pytest.fail("dynamic-project preflight must precede tag lookup"),
+    )
+
+    assert consistency.bump_version(tmp_path, "patch", verbose=True) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "signed Auto Tag Release workflow" in captured.err
+    assert {path: path.read_bytes() for path in before} == before
+
+
+@pytest.mark.parametrize("extra_args", [[], ["--dry-run"]])
+def test_bump_version_main_refuses_dynamic_project_without_output(
+    tmp_path: Path,
+    extra_args: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Human CLI modes fail closed without reading tags or writing static state."""
+    from hephaestus.version.consistency import bump_version_main
+
+    pyproject = tmp_path / "pyproject.toml"
+    version_file = tmp_path / "VERSION"
+    init_file = tmp_path / "__init__.py"
+    pyproject.write_text(
+        '[project]\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n'
+    )
+    version_file.write_text("1.2.3\n")
+    init_file.write_text('__version__ = "1.2.3"\n')
+    before = {path: path.read_bytes() for path in (pyproject, version_file, init_file)}
+    monkeypatch.setattr(
+        consistency,
+        "_get_canonical_version",
+        lambda _root: pytest.fail("dynamic-project preflight must precede tag lookup"),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-bump-version", "patch", "--repo-root", str(tmp_path), *extra_args],
+    )
+
+    assert bump_version_main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "signed Auto Tag Release workflow" in captured.err
+    assert {path: path.read_bytes() for path in before} == before
+
+
+def test_bump_version_main_json_refusal_is_single_valid_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """JSON refusal output remains parseable and keeps guidance on stderr."""
+    from hephaestus.version.consistency import bump_version_main
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n'
+    )
+    monkeypatch.setattr(
+        consistency,
+        "_get_canonical_version",
+        lambda _root: pytest.fail("dynamic-project preflight must precede tag lookup"),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "hephaestus-bump-version",
+            "patch",
+            "--repo-root",
+            str(tmp_path),
+            "--dry-run",
+            "--json",
+        ],
+    )
+
+    assert bump_version_main() == 1
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "status": "error",
+        "exit_code": 1,
+        "message": "version bump refused",
+    }
+    assert "signed Auto Tag Release workflow" in captured.err
+    assert not (tmp_path / "VERSION").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -281,6 +281,28 @@ def test_bump_version_refuses_dynamic_project_before_tag_lookup(
     assert {path: path.read_bytes() for path in before} == before
 
 
+def test_bump_version_refuses_single_quoted_dynamic_project_before_tag_lookup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A valid TOML literal string cannot bypass the dynamic-version preflight."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\ndynamic = ['version']\n\n[tool.hatch.version]\nsource = 'vcs'\n"
+    )
+    monkeypatch.setattr(
+        consistency,
+        "_get_canonical_version",
+        lambda _root: pytest.fail("dynamic-project preflight must precede tag lookup"),
+    )
+
+    assert consistency.bump_version(tmp_path, "patch", verbose=True) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "signed Auto Tag Release workflow" in captured.err
+    assert not (tmp_path / "VERSION").exists()
+
+
 @pytest.mark.parametrize("extra_args", [[], ["--dry-run"]])
 def test_bump_version_main_refuses_dynamic_project_without_output(
     tmp_path: Path,

--- a/tests/unit/version/test_manager.py
+++ b/tests/unit/version/test_manager.py
@@ -365,6 +365,7 @@ def test_version_manager_update_pyproject_skips_hatch_vcs_dynamic(tmp_path):
     [
         '[project]\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n',
         '[project]\ndynamic = ["version"]\n',
+        "[project]\ndynamic = ['version']\n\n[tool.hatch.version]\nsource = 'vcs'\n",
     ],
 )
 def test_version_manager_update_rejects_dynamic_version_without_mutation(
@@ -385,6 +386,33 @@ def test_version_manager_update_rejects_dynamic_version_without_mutation(
         version_files=[existing_version, missing_version],
         init_files=[init_file],
         pyproject_file=pyproject,
+    )
+
+    with pytest.raises(ValueError, match=r"dynamic.*version"):
+        manager.update("2.0.0", verbose=False)
+
+    assert {path: path.read_bytes() for path in before} == before
+    assert not missing_version.exists()
+
+
+def test_version_manager_update_rejects_dynamic_repo_when_pyproject_updates_disabled(
+    tmp_path: Path,
+) -> None:
+    """pyproject_file=None suppresses rewrites, not dynamic-version inspection."""
+    pyproject = tmp_path / "pyproject.toml"
+    existing_version = tmp_path / "VERSION"
+    missing_version = tmp_path / "SECONDARY_VERSION"
+    init_file = tmp_path / "__init__.py"
+    pyproject.write_text('[project]\ndynamic = ["version"]\n')
+    existing_version.write_text("1.2.3\n")
+    init_file.write_text('__version__ = "1.2.3"\n')
+    before = {path: path.read_bytes() for path in (pyproject, existing_version, init_file)}
+
+    manager = VersionManager(
+        repo_root=tmp_path,
+        version_files=[existing_version, missing_version],
+        init_files=[init_file],
+        pyproject_file=None,
     )
 
     with pytest.raises(ValueError, match=r"dynamic.*version"):

--- a/tests/unit/version/test_manager.py
+++ b/tests/unit/version/test_manager.py
@@ -2,6 +2,8 @@
 
 """Tests for hephaestus.version.manager module."""
 
+from pathlib import Path
+
 import pytest
 
 from hephaestus.version.manager import VersionManager, parse_version
@@ -356,6 +358,40 @@ def test_version_manager_update_pyproject_skips_hatch_vcs_dynamic(tmp_path):
     messages = [rec.getMessage() for rec in records]
     assert any("hatch-vcs" in m for m in messages)
     assert any("git tag -s v1.2.3" in m for m in messages)
+
+
+@pytest.mark.parametrize(
+    "pyproject_content",
+    [
+        '[project]\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n',
+        '[project]\ndynamic = ["version"]\n',
+    ],
+)
+def test_version_manager_update_rejects_dynamic_version_without_mutation(
+    tmp_path: Path, pyproject_content: str
+) -> None:
+    """Aggregate updates fail closed for hatch-vcs and other dynamic projects."""
+    pyproject = tmp_path / "pyproject.toml"
+    existing_version = tmp_path / "VERSION"
+    missing_version = tmp_path / "SECONDARY_VERSION"
+    init_file = tmp_path / "__init__.py"
+    pyproject.write_text(pyproject_content)
+    existing_version.write_text("1.2.3\n")
+    init_file.write_text('__version__ = "1.2.3"\n')
+    before = {path: path.read_bytes() for path in (pyproject, existing_version, init_file)}
+
+    manager = VersionManager(
+        repo_root=tmp_path,
+        version_files=[existing_version, missing_version],
+        init_files=[init_file],
+        pyproject_file=pyproject,
+    )
+
+    with pytest.raises(ValueError, match=r"dynamic.*version"):
+        manager.update("2.0.0", verbose=False)
+
+    assert {path: path.read_bytes() for path in before} == before
+    assert not missing_version.exists()
 
 
 def test_version_manager_update_pyproject_still_writes_static_project(tmp_path):


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2561.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2561

Generated by Hephaestus automation
