### PR TITLE
fix(scripts): preserve stale worktree paths with spaces

### DIFF
--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -112,23 +112,26 @@ def _repo_root() -> Path:
 
 
 def _worktree_porcelain() -> str:
-    """Return the current repository's worktree inventory."""
-    return run_git(["worktree", "list", "--porcelain"]).stdout
+    """Return the current repository's NUL-delimited worktree inventory."""
+    return run_git(["worktree", "list", "--porcelain", "-z"]).stdout
 
 
 def _parse_worktree_porcelain(output: str, root: Path) -> list[tuple[Path, str]]:
-    """Return attached, non-primary worktrees from ``git worktree`` output."""
+    """Return attached, non-primary worktrees from NUL-delimited output."""
     worktrees: list[tuple[Path, str]] = []
+    primary: Path | None = None
     path: Path | None = None
     branch: str | None = None
-    for line in [*output.splitlines(), ""]:
-        if line.startswith("worktree "):
-            path = Path(line.removeprefix("worktree "))
+    for field in [*output.split("\0"), ""]:
+        if field.startswith("worktree "):
+            path = Path(field.removeprefix("worktree "))
+            if primary is None:
+                primary = path
             branch = None
-        elif line.startswith("branch refs/heads/"):
-            branch = line.removeprefix("branch refs/heads/")
-        elif not line:
-            if path is not None and branch is not None and path != root:
+        elif field.startswith("branch refs/heads/"):
+            branch = field.removeprefix("branch refs/heads/")
+        elif not field:
+            if path is not None and branch is not None and path not in {primary, root}:
                 worktrees.append((path, branch))
             path = None
             branch = None
@@ -169,12 +172,12 @@ def _worktree_is_dirty(path: Path) -> bool:
 def _worktree_is_locked(path: Path, porcelain: str) -> bool:
     """Return whether *path* is locked in the supplied worktree inventory."""
     stanza = False
-    for line in [*porcelain.splitlines(), ""]:
-        if line.startswith("worktree "):
-            stanza = Path(line.removeprefix("worktree ")) == path
-        elif not line:
+    for field in [*porcelain.split("\0"), ""]:
+        if field.startswith("worktree "):
+            stanza = Path(field.removeprefix("worktree ")) == path
+        elif not field:
             stanza = False
-        elif stanza and line.startswith("locked"):
+        elif stanza and field.startswith("locked"):
             return True
     return False
 

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -20,25 +20,55 @@ from hephaestus.github.tidy import (
 
 tidy_module = importlib.import_module("hephaestus.github.tidy")
 
-WORKTREE_PORCELAIN = """\
-worktree /repo
-HEAD abcdef
-branch refs/heads/main
+WORKTREE_PORCELAIN = "\0".join(
+    (
+        "worktree /repo",
+        "HEAD abcdef",
+        "branch refs/heads/main",
+        "",
+        "worktree /repo/.worktrees/123-finished",
+        "HEAD 123456",
+        "branch refs/heads/123-finished",
+        "",
+        "worktree /repo/.worktrees/topic",
+        "HEAD 789abc",
+        "branch refs/heads/topic",
+        "",
+        "worktree /repo/.worktrees/detached",
+        "HEAD deadbeef",
+        "detached",
+        "",
+        "bare",
+        "",
+    )
+)
 
-worktree /repo/.worktrees/123-finished
-HEAD 123456
-branch refs/heads/123-finished
+SPACED_WORKTREE_PORCELAIN = "\0".join(
+    (
+        "worktree /repo",
+        "HEAD abcdef",
+        "branch refs/heads/main",
+        "",
+        "worktree /repo/.worktrees/123 finished",
+        "HEAD 123456",
+        "branch refs/heads/123-finished",
+        "",
+    )
+)
 
-worktree /repo/.worktrees/topic
-HEAD 789abc
-branch refs/heads/topic
-
-worktree /repo/.worktrees/detached
-HEAD deadbeef
-detached
-
-bare
-"""
+LOCKED_SPACED_WORKTREE_PORCELAIN = "\0".join(
+    (
+        "worktree /repo",
+        "HEAD abcdef",
+        "branch refs/heads/main",
+        "",
+        "worktree /repo/.worktrees/123 finished",
+        "HEAD 123456",
+        "branch refs/heads/123-finished",
+        "locked",
+        "",
+    )
+)
 
 
 def test_tidy_swarm_model_matches_canonical_sonnet() -> None:
@@ -190,6 +220,34 @@ def test_parse_worktree_porcelain_skips_main_and_detached_worktrees() -> None:
     ]
 
 
+def test_parse_worktree_porcelain_skips_primary_from_linked_worktree() -> None:
+    """The primary worktree is never a cleanup candidate from a linked worktree."""
+    assert tidy_module._parse_worktree_porcelain(
+        WORKTREE_PORCELAIN,
+        Path("/repo/.worktrees/topic"),
+    ) == [(Path("/repo/.worktrees/123-finished"), "123-finished")]
+
+
+def test_worktree_porcelain_requests_nul_terminated_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worktree discovery requests Git's delimiter-safe porcelain format."""
+    result = subprocess.CompletedProcess([], 0, stdout="inventory", stderr="")
+    run_git = MagicMock(return_value=result)
+    monkeypatch.setattr(tidy_module, "run_git", run_git)
+
+    assert tidy_module._worktree_porcelain() == "inventory"
+    run_git.assert_called_once_with(["worktree", "list", "--porcelain", "-z"])
+
+
+def test_parse_worktree_porcelain_preserves_space_in_path() -> None:
+    """A worktree path containing spaces remains paired with its branch."""
+    assert tidy_module._parse_worktree_porcelain(
+        SPACED_WORKTREE_PORCELAIN,
+        Path("/repo"),
+    ) == [(Path("/repo/.worktrees/123 finished"), "123-finished")]
+
+
 def test_cleanup_stale_worktrees_dry_run_reports_closed_issue_without_removing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -209,6 +267,55 @@ def test_cleanup_stale_worktrees_dry_run_reports_closed_issue_without_removing(
     assert hasattr(tidy_module, "_cleanup_stale_worktrees")
     assert tidy_module._cleanup_stale_worktrees(tmp_path, "main", dry_run=True) == 0
     assert "Would remove stale worktree" in caplog.text
+    remove.assert_not_called()
+
+
+def test_cleanup_stale_worktree_with_space_path(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dry-run evaluates and reports the complete space-containing path."""
+    spaced_path = Path("/repo/.worktrees/123 finished")
+    caplog.set_level("INFO", logger="hephaestus.github.tidy")
+    monkeypatch.setattr(
+        tidy_module,
+        "_worktree_porcelain",
+        lambda: SPACED_WORKTREE_PORCELAIN,
+    )
+    monkeypatch.setattr(tidy_module, "_issue_is_closed", lambda issue: issue == 123)
+    monkeypatch.setattr(tidy_module, "_branch_is_merged", lambda branch, trunk: False)
+    is_dirty = MagicMock(return_value=False)
+    monkeypatch.setattr(tidy_module, "_worktree_is_dirty", is_dirty)
+    remove = MagicMock()
+    monkeypatch.setattr(tidy_module, "_remove_worktree", remove)
+
+    assert tidy_module._cleanup_stale_worktrees(Path("/repo"), "main", dry_run=True) == 0
+    is_dirty.assert_called_once_with(spaced_path)
+    assert str(spaced_path) in caplog.text
+    assert "123-finished" in caplog.text
+    remove.assert_not_called()
+
+
+def test_cleanup_skips_locked_worktree_with_space_path(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A locked spaced-path worktree is skipped without removal."""
+    spaced_path = Path("/repo/.worktrees/123 finished")
+    caplog.set_level("INFO", logger="hephaestus.github.tidy")
+    monkeypatch.setattr(
+        tidy_module,
+        "_worktree_porcelain",
+        lambda: LOCKED_SPACED_WORKTREE_PORCELAIN,
+    )
+    monkeypatch.setattr(tidy_module, "_issue_is_closed", lambda issue: issue == 123)
+    monkeypatch.setattr(tidy_module, "_branch_is_merged", lambda branch, trunk: False)
+    monkeypatch.setattr(tidy_module, "_worktree_is_dirty", lambda path: False)
+    remove = MagicMock()
+    monkeypatch.setattr(tidy_module, "_remove_worktree", remove)
+
+    assert tidy_module._cleanup_stale_worktrees(Path("/repo"), "main", dry_run=False) == 0
+    assert f"Skipping locked worktree {spaced_path}" in caplog.text
     remove.assert_not_called()
 
 

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -421,6 +421,56 @@ class TestTidyHandlers:
 class TestMain:
     """Smoke tests for hephaestus.github.tidy.main() covering --json branches."""
 
+    def test_cleanup_from_linked_worktree_never_targets_primary(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cleanup invoked from a linked worktree excludes the primary checkout."""
+        repo = tmp_path / "repo"
+        linked_root = tmp_path / "topic-linked"
+        stale_root = tmp_path / "123-finished"
+
+        def git(*args: str) -> None:
+            subprocess.run(
+                ["git", "-c", "commit.gpgsign=false", *args],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        git("init", "--initial-branch=main", str(repo))
+        git("-C", str(repo), "config", "user.name", "Test User")
+        git("-C", str(repo), "config", "user.email", "test@example.com")
+        (repo / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+        git("-C", str(repo), "add", "tracked.txt")
+        git("-C", str(repo), "commit", "-m", "test fixture")
+        git("-C", str(repo), "worktree", "add", "-b", "topic", str(linked_root))
+        git("-C", str(repo), "worktree", "add", "-b", "123-finished", str(stale_root))
+
+        monkeypatch.chdir(linked_root)
+        monkeypatch.setattr(tidy_module, "detect_repo_from_remote", lambda: "owner/repo")
+        monkeypatch.setattr(tidy_module, "_working_tree_clean", lambda: True)
+        monkeypatch.setattr(tidy_module, "_in_git_repo", lambda: True)
+        monkeypatch.setattr(tidy_module, "_worktree_is_dirty", lambda _path: False)
+        monkeypatch.setattr(tidy_module, "_issue_is_closed", lambda _issue: False)
+        monkeypatch.setattr(tidy_module, "_detect_default_branch", lambda _x: "main")
+        branch_is_merged = MagicMock(return_value=True)
+        monkeypatch.setattr(tidy_module, "_branch_is_merged", branch_is_merged)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-tidy",
+                "--cleanup-stale-worktrees",
+                "--dry-run",
+                "--agent",
+                "claude",
+            ],
+        )
+
+        assert tidy_module.main() == 0
+        assert [call.args[0] for call in branch_is_merged.call_args_list] == ["123-finished"]
+
     def test_env_validation_failure_json(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary
Implements the requested changes for issue #2568.

## Changes
See the PR diff for the full change set.

## Testing
Not run by the automation pipeline.

## Closes
Closes #2568

Generated by Hephaestus automation
