### PR TITLE
feat(automation): add auxiliary learning lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,14 +533,16 @@ Make sure all temporary files are in the build/ directory.
 
 The remainder of this document is a single-page map of the AI-agent topology and
 conventions used by Hephaestus and the wider HomericIntelligence ecosystem.
-The queue topology below is implemented as seven in-memory stage queues.
+The queue topology below is implemented as six main-lane queues and two
+auxiliary queues.
 
 ## Agents the codebase orchestrates
 
 The default `hephaestus-automation-loop` path is the queue-based in-process
 pipeline in `hephaestus.automation.pipeline.coordinator`. The coordinator owns
-seven in-memory stage queues and dispatches agent/build/git jobs to a worker
-pool. Each agent job runs either **Claude Code** or **Codex**, chosen via the
+eight bounded stage queues. A main worker pool runs ordinary work. A separate
+host-only pool runs learning and terminal cleanup. Each agent job runs either
+**Claude Code** or **Codex**, chosen via the
 optional `--agent` CLI flag or auto-detected with a Claude preference when
 omitted (see `hephaestus.agents.runtime.add_agent_argument`).
 
@@ -562,8 +564,12 @@ mutates native auto-merge.
 | plan_review | `hephaestus.automation.pipeline.stages.plan_review` | Strict plan review, amendment, and plan labels |
 | implementation | `hephaestus.automation.pipeline.stages.implementation` | PR-writer worktree, rebase, implementation, tests, commit/push, and PR creation |
 | pr_review | `hephaestus.automation.pipeline.stages.pr_review` | Detached read-only snapshot review, validation, one batched inline review, and implementation labels |
-| merge_wait | `hephaestus.automation.pipeline.stages.merge_wait` | Conditionally merges the exact reviewed head and preserves post-merge learning |
-| finished | `hephaestus.automation.pipeline.stages.finished` | Terminal ledger and worktree cleanup/preservation |
+| merge_wait | `hephaestus.automation.pipeline.stages.merge_wait` | Conditionally merges the exact reviewed head and emits post-merge learning intent |
+| learning | `hephaestus.automation.pipeline.stages.learning` | Claims durable intents and submits host-owned learning work |
+| finished | `hephaestus.automation.pipeline.stages.finished` | Terminal ledger and auxiliary worktree cleanup/preservation |
+
+`--learning-workers` and `--learning-queue-capacity` bound the auxiliary lane
+independently. Both default to `1`. `--no-learn` bypasses new learning work.
 
 Console scripts preserve their historical names. Stage-scoped wrappers are
 thin queue-pipeline scoped entry points over the coordinator; manual commands

--- a/docs/adr/0026-auxiliary-host-learning-lane.md
+++ b/docs/adr/0026-auxiliary-host-learning-lane.md
@@ -54,6 +54,6 @@ terminal.
 
 This decision provides scheduling, recovery, and cleanup infrastructure. It
 does not prepare Mnemosyne content or the host-owned delivery request. Issue
-#2754 owns that production capability. Until it is complete, a request without
+2754 owns that production capability. Until it is complete, a request without
 a prepared delivery fails as ancillary post-processing. The primary pipeline
 result does not change, and cleanup still waits for that terminal failure.

--- a/docs/adr/0026-auxiliary-host-learning-lane.md
+++ b/docs/adr/0026-auxiliary-host-learning-lane.md
@@ -51,3 +51,9 @@ capacity, completion, shutdown, and failure accounting. A crash-left claimed
 intent fails as `outcome_unknown` instead of risking a duplicate delivery.
 Operators must observe the rollback gate until all new journal records are
 terminal.
+
+This decision provides scheduling, recovery, and cleanup infrastructure. It
+does not prepare Mnemosyne content or the host-owned delivery request. Issue
+#2754 owns that production capability. Until it is complete, a request without
+a prepared delivery fails as ancillary post-processing. The primary pipeline
+result does not change, and cleanup still waits for that terminal failure.

--- a/docs/adr/0026-auxiliary-host-learning-lane.md
+++ b/docs/adr/0026-auxiliary-host-learning-lane.md
@@ -1,0 +1,53 @@
+# ADR-0026: Auxiliary host-learning lane
+
+- Status: Accepted
+- Date: 2026-08-11
+- Tracks: #2705
+
+## Context
+
+Approved-plan and post-merge learning ran on the main pipeline worker pool.
+One slow host operation could stop unrelated work when the main pool had one
+worker. Cleanup also had to remain after learning, so moving only the host call
+was not sufficient.
+
+## Decision
+
+Use an implicit `learning → finished` auxiliary lane. Plan review and merge
+wait emit immutable, deterministic learning intents. They do not submit a
+learning job. `LearningStage` owns a lock-guarded journal with `pending`,
+`claimed`, `succeeded`, and `failed` states. Only a committed claim can submit
+one host-owned `AthenaSkillJob`.
+
+Use an independent bounded pool and permit budget. The pool accepts host
+learning and the two terminal cleanup operations only. It has no generic agent
+dispatch. Destination capacity is reserved before source capacity is released.
+Learning failure is ancillary. Cleanup starts only after all intents are
+terminal.
+
+For terminal main work, create a compact post-processing record before the
+handoff. Keep only the confirmed result, intent keys, resume stage, and
+cleanup receipts. Do not keep PR diffs, review audits, prompts, or agent
+output in the auxiliary backlog.
+
+The rollback gate is strict. Do not run an older executable while a new
+learning-journal intent is nonterminal. Drain or park the new lane and handle
+all nonterminal intents with the new version first. An older executable cannot
+read the new journal and can repeat host delivery.
+
+## Alternatives considered
+
+- Keep learning on the main pool. Rejected because it blocks unrelated work.
+- Use an unbounded spill backlog. Rejected because it removes backpressure.
+- Dispatch generic agent jobs from the auxiliary pool. Rejected because
+  Athena learning is a host boundary, not a provider lane.
+- Dual-write the legacy record. Rejected because it adds a migration platform
+  without a product requirement.
+
+## Consequences
+
+Main work can continue while learning runs. Learning and cleanup have separate
+capacity, completion, shutdown, and failure accounting. A crash-left claimed
+intent fails as `outcome_unknown` instead of risking a duplicate delivery.
+Operators must observe the rollback gate until all new journal records are
+terminal.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ numbered, and listed here.
 | [0022](0022-canonical-issue-timeline.md) | Canonical two-comment issue timeline | Accepted |
 | [0023](0023-pi-package-bootstrap-and-preflight.md) | Pi package bootstrap and preflight | Accepted |
 | [0025](0025-athena-mnemosyne-pi-semantics.md) | Provider-neutral Athena and Mnemosyne semantics | Accepted |
+| [0026](0026-auxiliary-host-learning-lane.md) | Auxiliary host-learning lane | Accepted |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,9 +209,9 @@ thread lock, outer) **and**
 [`_interruptible_file_lock`](../hephaestus/automation/pipeline/worker_pool.py)
 (cross-process flock, inner). Worktrees share `.git`, so two concurrent
 operations on the same checkout would race.
-The only cross-thread **payload** channel is the bounded
-[`CompletionQueue`](../hephaestus/automation/pipeline/queues.py)
-(`queue.Queue[(JobHandle, JobResult)]`, capacity `C`). A separate
+The only cross-thread **payload** channels are the bounded main and auxiliary
+[`CompletionQueue`](../hephaestus/automation/pipeline/queues.py) instances
+(`queue.Queue[(JobHandle, JobResult)]`). A separate
 `threading.Event` latch is control-plane-only: workers set it after a
 non-blocking completion publish, and signal handlers set it to wake an idle
 coordinator. Neither writes a sentinel into the completion queue or blocks on
@@ -518,8 +518,8 @@ cross-stage cycles terminate even if a stage has a budget bookkeeping bug
 
 The single per-item record moving through the queue. Thread-safety is by
 construction: a `WorkItem` and its `StageQueue` are only ever touched by
-the coordinator thread; the only cross-thread payload channel is the bounded
-[`CompletionQueue`](../hephaestus/automation/pipeline/queues.py). Event latches
+the coordinator thread; the only cross-thread payload channels are the bounded
+main and auxiliary completion queues. Event latches
 carry wake/fault signals only, never `WorkItem` or `JobResult` payloads.
 Key fields:
 
@@ -682,9 +682,9 @@ flowchart LR
     M -. "approval invalidated" .-> Q
 ```
 
-GitHub is the durable journal. After a restart, labels, issue comments, pull
-request reviews, review threads, and merge state reconstruct where work should
-resume.
+GitHub facts reconstruct the main workflow after a restart. The learning
+journal, arming store, and issue-wave checkpoints reconstruct their owned
+auxiliary, merge, and issue-wave obligations.
 
 ### 5.1 Repo intake
 
@@ -1600,7 +1600,9 @@ When `event_log_path` is configured, the coordinator also appends diagnostic
 records to JSONL. That file is best-effort: an I/O failure logs a
 warning and disables further JSONL writes without changing pipeline routing.
 It is not a queue snapshot or recovery journal. GitHub labels, comments, and
-PR state remain the only restart authority.
+PR state are normal restart authorities. `LearningJournalStore`,
+`ArmingStateStore`, and issue-wave checkpoints supply the other durable state
+listed in the journal contract above.
 
 ### Gauges
 
@@ -1756,7 +1758,7 @@ Exit-code priority is:
 - **StageQueue** — FIFO queue for one
  [`StageName`](../hephaestus/automation/pipeline/routing.py), owned only
  by the coordinator. [`queues.py`](../hephaestus/automation/pipeline/queues.py).
-- **CompletionQueue** — the bounded cross-thread payload channel
+- **CompletionQueue** — the bounded main and auxiliary cross-thread payload channels
  (`queue.Queue[(JobHandle, JobResult)]`, capacity `C`). Event latches carry
  wake and saturation signals without queue payloads.
  [`queues.py`](../hephaestus/automation/pipeline/queues.py).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1611,7 +1611,7 @@ are reported through `hephaestus_metrics_series_overflow_total`.
 |-------------------------------------------|--------|-----------|-----:|---------|-----------|
 | `hephaestus_pipeline_queue_depth` | Gauge | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `learning`, `finished` | 8 | `0` | Item count per pipeline stage. Useful for detecting back-pressure. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | 1 | `0` | Total in-flight jobs across all worker pools. |
-| `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo`: open repository names | 100 | `0` | In-flight jobs by repo, capped by `max_workers`. |
+| `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo`: open repository names | 100 | `0` | Main-lane in-flight jobs by repo, capped by `max_workers`. Auxiliary work is reported by the lane gauges. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`: open breaker names; `state`: `closed`, `open`, `half_open` | 100 | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |
 | `hephaestus_pipeline_alert_active` | Gauge | `name`: `circuit_breaker_open`, `queue_depth_exceeds`, `pipeline_stalled` | 3 | `0` | `1` while a fired alert is unresolved, `0` when resolved. |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,7 +251,7 @@ tick does, in order:
 4. **Emit observability tick** — push queue-depth / in-flight / circuit
  breaker gauges and record alert transitions
  ([`_emit_observability_tick`](../hephaestus/automation/pipeline/coordinator.py)).
-5. **Drain queues down-stream first** — `finished → merge_wait →
+5. **Drain queues down-stream first** — `finished → learning → merge_wait →
  pr_review → implementation → plan_review → planning → repo`
  ([`_DRAIN_ORDER`](../hephaestus/automation/pipeline/coordinator.py)).
  Implementation drains separately to enforce dependency topo-order
@@ -554,14 +554,13 @@ Key fields:
 `str`-flavored `Enum`:
 
 ```
-REPO → PLANNING → PLAN_REVIEW → IMPLEMENTATION → PR_REVIEW →
- MERGE_WAIT → FINISHED
+REPO → PLANNING → PLAN_REVIEW → IMPLEMENTATION → PR_REVIEW → MERGE_WAIT
+LEARNING → FINISHED
 ```
 
-Declaration order matches
-[`PIPELINE_ORDER`](../hephaestus/automation/pipeline/routing.py) and the
-[`_DRAIN_ORDER`](../hephaestus/automation/pipeline/coordinator.py) reversed.
-DO NOT REORDER — the `PipelineScope` contiguity check indexes by position.
+`MAIN_PIPELINE_ORDER` controls scope contiguity. `LEARNING` and `FINISHED` are
+the auxiliary lane. Declaration order matches `PIPELINE_ORDER`; `_DRAIN_ORDER`
+uses its reverse order. Do not reorder these values.
 
 ### [§`Disposition`](../hephaestus/automation/pipeline/routing.py)
 
@@ -575,6 +574,8 @@ DO NOT REORDER — the `PipelineScope` contiguity check indexes by position.
  `ROUTES[stage].fail_routes.get(note, …)`; failing-back from the
  coordinator's safety cap finishes failed.
 - `SKIP` — finish failed with reason `skip:<note>`.
+- `EJECT` — remove work that a different live process owns. Record a passed
+ terminal summary without cleanup or another delivery attempt.
 - `BLOCKED` — finish failed with reason `blocked:<note>`.
 - `FINISH_PASS` / `FINISH_FAIL` — terminal; pass with reason `<note>` /
  fail with reason `<note>`.
@@ -1191,6 +1192,10 @@ An ambiguous crash-left claim becomes terminal `failed` with
 `outcome_unknown`; it is not submitted twice. Learning failure is ancillary
 and cannot change a confirmed main result.
 
+A live claim held by another process ejects the duplicate item. The owner keeps
+the claim, the main result, and the cleanup obligation. A terminal learning
+record stays recoverable until `finished` records a bounded cleanup result.
+
 Main and learning permits are separate. Handoffs reserve the bounded
 destination before they release the source. Approved-plan work returns to the
 scope-trimmed main destination. Post-merge work continues to `finished` only
@@ -1611,6 +1616,8 @@ are reported through `hephaestus_metrics_series_overflow_total`.
 |-------------------------------------------|--------|-----------|-----:|---------|-----------|
 | `hephaestus_pipeline_queue_depth` | Gauge | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `learning`, `finished` | 8 | `0` | Item count per pipeline stage. Useful for detecting back-pressure. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | 1 | `0` | Total in-flight jobs across all worker pools. |
+| `hephaestus_pipeline_lane_queue_depth` | Gauge | `lane`: `main`, `auxiliary` | 2 | `0` | Queued items partitioned by worker lane. |
+| `hephaestus_pipeline_lane_inflight_jobs` | Gauge | `lane`: `main`, `auxiliary` | 2 | `0` | In-flight jobs partitioned by worker lane. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo`: open repository names | 100 | `0` | Main-lane in-flight jobs by repo, capped by `max_workers`. Auxiliary work is reported by the lane gauges. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`: open breaker names; `state`: `closed`, `open`, `half_open` | 100 | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |
 | `hephaestus_pipeline_alert_active` | Gauge | `name`: `circuit_breaker_open`, `queue_depth_exceeds`, `pipeline_stalled` | 3 | `0` | `1` while a fired alert is unresolved, `0` when resolved. |
@@ -1753,9 +1760,9 @@ Exit-code priority is:
  (`queue.Queue[(JobHandle, JobResult)]`, capacity `C`). Event latches carry
  wake and saturation signals without queue payloads.
  [`queues.py`](../hephaestus/automation/pipeline/queues.py).
-- **Durable journal** — GitHub labels, comments, PR state, and
- `ArmingStateStore` records. Restart reconstruction reads this;
- nothing else.
+- **Durable journal** — GitHub labels, comments, PR state,
+ `LearningJournalStore` records, `ArmingStateStore` records, and issue-wave
+ checkpoints. Restart reconstruction reads these stores.
 - **Timer-park** — non-blocking retry/backoff by pushing an item onto
  the coordinator timer heap
  ([`_timer_park`](../hephaestus/automation/pipeline/coordinator.py)).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,10 +24,10 @@ Optimization"), file paths are repo-relative.
 ## Table of contents
 
 1. [Goals, non-goals and design principles](#1-goals-non-goals-and-design-principles)
-2. [System overview: single coordinator, seven queues, one worker pool](#2-system-overview)
+2. [System overview: one coordinator, eight queues, two worker pools](#2-system-overview)
 3. [Cross-cutting invariants](#3-cross-cutting-invariants)
 4. [WorkItem and the durable journal](#4-workitem-and-the-durable-journal)
-5. [The seven queue stages](#5-the-seven-queue-stages)
+5. [The eight queue stages](#5-the-eight-queue-stages)
 
 - [5.1 Repo intake](#51-repo-intake)
 - [5.2 Planning](#52-planning)
@@ -35,7 +35,8 @@ Optimization"), file paths are repo-relative.
 - [5.4 Implementation](#54-implementation)
 - [5.5 PR review](#55-pr-review)
 - [5.6 Merge wait](#56-merge-wait)
-- [5.7 Finished](#57-finished)
+- [5.7 Learning](#57-learning)
+- [5.8 Finished](#58-finished)
 
 1. [The ROUTES table — single source of truth](#6-the-routes-table)
 2. [Seeding and restart reconstruction](#7-seeding-and-restart-reconstruction)
@@ -52,9 +53,9 @@ Optimization"), file paths are repo-relative.
 
 ### Goals
 
-- **Single durable journal.** GitHub labels, comments, PR state and
- `ArmingStateStore` records are the normal crash-resistant truth. The one
- explicit exception is the repository-scoped issue-wave checkpoint, which
+- **Durable journals.** GitHub labels, comments, and PR state are the normal
+ crash-resistant truth. `LearningJournalStore` records auxiliary intent
+ claims and terminal results. The repository-scoped issue-wave checkpoint
  records only immutable selected issue identifiers, terminal outcomes, merge
  receipts, and verified main revisions. Stages may not persist any other
  state. Restart =
@@ -140,11 +141,12 @@ in §5.1, which tags `state:skip` on epics before any other durable mutation.
 The default path is **`hephaestus-automation-loop`**, the queue-based
 in-process pipeline whose coordinator lives at
 [`hephaestus.automation.pipeline.coordinator`](../hephaestus/automation/pipeline/coordinator.py).
-The coordinator owns **seven in-memory stage queues** and dispatches
-agent / build-test / git-network jobs to a single `WorkerPool`. Each agent
+The coordinator owns **eight bounded in-memory stage queues**. It dispatches
+ordinary agent, build-test, Git, and GitHub jobs to `WorkerPool`. It dispatches
+host learning and terminal cleanup to `AuxiliaryWorkerPool`. Each agent
 job runs Claude or Codex, chosen by `--agent` (default Claude).
 
-#### Seven-stage queue block diagram
+#### Main and auxiliary queue block diagram
 
 ```mermaid
 flowchart LR
@@ -153,7 +155,10 @@ flowchart LR
     plan_review --> implementation["4. Implementation"]
     implementation --> pr_review["5. PR review"]
     pr_review --> merge_wait["6. Merge wait"]
-    merge_wait --> finished["7. Finished"]
+    plan_review -. "approved-plan intent" .-> learning["7. Learning"]
+    merge_wait -. "post-merge intent" .-> learning
+    learning --> implementation
+    learning --> finished["8. Finished"]
 
     plan_review -. "nogo (iter 3 / plan_cycles 2)" .-> planning
     implementation -. "agent_error" .-> implementation
@@ -169,7 +174,7 @@ reason vocabulary" stages must reference verbatim in `StageOutcome.note`.
 
 The main thread (coordinator) OWNS:
 
-- all seven stage queues ([`self.queues`](../hephaestus/automation/pipeline/coordinator.py))
+- all eight stage queues ([`self.queues`](../hephaestus/automation/pipeline/coordinator.py))
 - the timer heap ([`self.timers`](../hephaestus/automation/pipeline/coordinator.py))
 - the in-flight registry ([`self.in_flight`](../hephaestus/automation/pipeline/coordinator.py))
 - all routing and disposition semantics ([`_route`](../hephaestus/automation/pipeline/coordinator.py))
@@ -179,7 +184,7 @@ The main thread (coordinator) OWNS:
  auto-merge)
 It NEVER launches agents, builds/tests or git/network operations. It never
 sleeps — wakeups are the timer's responsibility.
-The single worker pool ([`WorkerPool`](../hephaestus/automation/pipeline/worker_pool.py))
+The main worker pool ([`WorkerPool`](../hephaestus/automation/pipeline/worker_pool.py))
 executes everything else: agent invocations (Claude or Codex), build/test
 subprocesses, git operations, and the closed worker-owned GitHub operations.
 `StageContext.github` remains coordinator-thread-owned and never crosses this
@@ -216,9 +221,13 @@ queue capacity
 [`Coordinator._wake_completion_wait`](../hephaestus/automation/pipeline/coordinator.py)).
 The idle coordinator may wait on that event for its bounded poll interval
 ([`_IDLE_POLL_S = 1.0`](../hephaestus/automation/pipeline/coordinator.py)); it
-does not make a producer or signal handler wait. Pool size = `parallel_repos × max_workers`.
-Each stage-queue capacity and the
-completion-queue capacity are `C = max(1, parallel_repos × max_workers)`
+does not make a producer or signal handler wait. Main pool size is
+`parallel_repos × max_workers`. The auxiliary pool size is
+`learning_workers`. Main queue capacity is
+`C = max(1, parallel_repos × max_workers)`. Learning queue and permit capacity
+use `learning_queue_capacity`. Auxiliary completion capacity is the larger of
+`learning_queue_capacity` and `learning_workers`, so every running worker owns
+a completion slot. Lane permits are independent.
 ([`_work_window`](../hephaestus/automation/pipeline/coordinator.py),
 [`WorkerPool(size=…)`](../hephaestus/automation/pipeline/worker_pool.py)).
 
@@ -306,10 +315,12 @@ disposition to the queue.
 Let `C = max(1, parallel_repos × max_workers)`. `C` is a global live-work
 window, not a per-stage concurrency target. Every stage queue and the
 completion queue have capacity `C`, while the coordinator holds one global
-permit for every nonterminal `WorkItem`. Consequently, seven stage queues do
-not permit `7C` simultaneous work items: an item holds the same permit as it
-moves through the pipeline and releases it only after `finished` records its
-outcome.
+permit for every nonterminal main-lane `WorkItem`. The auxiliary lane has its
+own permit bound. Consequently, eight stage queues do not permit a multiple of
+`C` simultaneous work items. An item keeps its lane permit while it moves
+within that lane. A cross-lane handoff transfers permit ownership only after
+the destination accepts the item. The auxiliary permit is released after
+`finished` records the outcome.
 
 Queue draining claims an item through a
 [`StageQueueLease`](../hephaestus/automation/pipeline/queues.py). The lease keeps
@@ -641,9 +652,9 @@ seeding reads labels and PR state, never reviewer decision prose.
 
 ---
 
-## 5. The seven queue stages
+## 5. The eight queue stages
 
-The seven stages are architectural responsibilities, not implementation
+The eight stages are architectural responsibilities, not implementation
 modules. This section describes boundaries, durable state, and transitions.
 Worker types, helper functions, payload fields, and source-code structure are
 intentionally omitted.
@@ -658,7 +669,10 @@ flowchart LR
     V --> I["4. Implementation"]
     I --> Q["5. PR review"]
     Q --> M["6. Merge wait"]
-    M --> F["7. Finished"]
+    V -. "approved-plan intent" .-> L["7. Learning"]
+    M -. "post-merge intent" .-> L
+    L --> I
+    L --> F["8. Finished"]
 
     V -. "revision needed" .-> P
     V -. "external intervention needed" .-> H["Operator or dependency"]
@@ -1166,7 +1180,23 @@ Architectural contract:
   transport ambiguity, and every actual request remain subject to fresh
   lifecycle, head, label, thread, and protection checks.
 
-### 5.7 `finished`
+### 5.7 `learning`
+
+Learning is an implicit auxiliary stage for every main-stage scope. Plan review
+emits an approved-plan intent after the plan label is confirmed. Merge wait
+emits a post-merge intent only after merge confirmation. The stage writes the
+intent journal before dispatch, claims one deterministic key, and submits only
+a host-owned `AthenaSkillJob`. Known failures retry within the `learn` budget.
+An ambiguous crash-left claim becomes terminal `failed` with
+`outcome_unknown`; it is not submitted twice. Learning failure is ancillary
+and cannot change a confirmed main result.
+
+Main and learning permits are separate. Handoffs reserve the bounded
+destination before they release the source. Approved-plan work returns to the
+scope-trimmed main destination. Post-merge work continues to `finished` only
+after all intents are terminal.
+
+### 5.8 `finished`
 
 Finished records the final outcome exactly once and applies workspace retention
 policy. It does not change issue, review, or merge verdicts.
@@ -1226,6 +1256,7 @@ budgets. Every `routes.py` row and every doc row MUST agree.
 | `implementation` | `PR_REVIEW` | `plan_not_go` → `PLAN_REVIEW`; `already_implementation_go_pr` → `MERGE_WAIT`; `*` → `FINISHED` | `implement = 2`, `rebase_conflict = 2`, `test_fix = 1` |
 | `pr_review` | `MERGE_WAIT` | `agent_error`, `empty_pr_diff`, or `implementation_remediation` → `IMPLEMENTATION`; `exhaustion` → `FINISHED`; `*` → `PR_REVIEW` | `pr_review_iter = 3`, `pr_review_hard = 6` |
 | `merge_wait` | `FINISHED` | `not_implementation_go`, `reviewed_head_missing`, or `reviewed_head_drift` → `PR_REVIEW`; `closed` → `FINISHED`; `*` → `FINISHED` | `merge = 5` |
+| `learning` | `FINISHED` | `resume_implementation` → `IMPLEMENTATION`; `resume_plan_review` → `PLAN_REVIEW`; `*` → `FINISHED` | `learn = 2` |
 | `finished` | `FINISHED` | — (terminal) | — |
 
 Budget provenance (cross-check):
@@ -1233,7 +1264,7 @@ Budget provenance (cross-check):
 - `plan_review_iter = 3`, `pr_review_iter = 3`, and `pr_review_hard = 6`
   are defined in [`pipeline/routing.py`](../hephaestus/automation/pipeline/routing.py),
   with the latter as the progress-aware extension cap.
-- `clone = 2`, `plan = 2`, `plan_cycles = 2`, `implement = 2`,
+- `clone = 2`, `plan = 2`, `plan_cycles = 2`, `implement = 2`, `learn = 2`,
   `rebase_conflict = 2`, and `test_fix = 1` are fixed stage budgets.
 - `merge = DEFAULT_DRIVE_GREEN_LOOPS = 5` ←
  [`loop_runner.py LoopConfig.drive_green_loops`](../hephaestus/automation/loop_runner.py).
@@ -1341,8 +1372,8 @@ and require operator handling.
 
 ## 8. The worker pool and job contract
 
-[`WorkerPool`](../hephaestus/automation/pipeline/worker_pool.py) is the
-single executor. It receives frozen specs and returns bounded
+`WorkerPool` is the main executor. `AuxiliaryWorkerPool` is the closed
+host-learning and cleanup executor. Both receive frozen specs and return bounded
 [`JobResult`](../hephaestus/automation/pipeline/jobs.py) tuples. Workers never
 touch `WorkItem`s or stage queues. GitHub I/O is allowed only through the
 closed typed runner; generic worker code does not import the GitHub
@@ -1384,6 +1415,15 @@ implementation.
 - [`CompactJob`](../hephaestus/automation/pipeline/jobs.py) — a best-effort
  `/compact` turn for a persisted Claude, Codex, or Pi session; it never blocks
  the retry lifecycle.
+- [`AthenaSkillJob(kind="learn")`](../hephaestus/automation/pipeline/athena_skill_jobs.py)
+ is the only learning job accepted by the auxiliary pool. That pool also
+ accepts only `remove_worktree` and `release_branch_reservation` Git cleanup.
+ It has no generic agent-dispatch path.
+
+After a confirmed merge, the coordinator creates a compact
+`PostProcessingRecord`. It retains the primary result, intent keys, resume
+stage, and cleanup receipts. It removes PR diffs, review audits, prompt text,
+and other stage-local payloads before the auxiliary queue accepts the item.
 
 ### Result semantics
 
@@ -1514,6 +1554,10 @@ repository checkpoint verifies the previous wave. It also accepts
 `--max-workers` and per-agent `--agent` plus per-phase reasoning
 controls:
 
+- `--learning-workers N` controls host-learning concurrency (default `1`).
+- `--learning-queue-capacity N` bounds auxiliary backlog (default `1`).
+- `--no-learn` creates no new learning intent.
+
 - `--planner-reasoning-effort`
 - `--implementer-reasoning-effort`
 - `--reviewer-reasoning-effort`
@@ -1565,7 +1609,7 @@ are reported through `hephaestus_metrics_series_overflow_total`.
 
 | Gauge | Type | Labels and allowed values | Cap | Default | Semantics |
 |-------------------------------------------|--------|-----------|-----:|---------|-----------|
-| `hephaestus_pipeline_queue_depth` | Gauge | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `finished` | 7 | `0` | Item count per pipeline stage. Useful for detecting back-pressure. |
+| `hephaestus_pipeline_queue_depth` | Gauge | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `learning`, `finished` | 8 | `0` | Item count per pipeline stage. Useful for detecting back-pressure. |
 | `hephaestus_pipeline_inflight_jobs` | Gauge | (none) | 1 | `0` | Total in-flight jobs across all worker pools. |
 | `hephaestus_pipeline_inflight_per_repo` | Gauge | `repo`: open repository names | 100 | `0` | In-flight jobs by repo, capped by `max_workers`. |
 | `hephaestus_circuit_breaker_state` | Gauge | `name`: open breaker names; `state`: `closed`, `open`, `half_open` | 100 | `0` | `1` for the active state, `0` for prior states (only emitted from the optional `circuit_breaker_snapshot_provider`). |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1204,7 +1204,11 @@ after all intents are terminal.
 ### 5.8 `finished`
 
 Finished records the final outcome exactly once and applies workspace retention
-policy. It does not change issue, review, or merge verdicts.
+policy. A post-merge writer worktree remains available while learning runs.
+Finished removes it only after all durable learning intents are terminal. The
+cleanup job verifies the registered branch or detached head and refuses a
+dirty checkout. It never forces removal. Finished does not change issue,
+review, or merge verdicts.
 
 States: `ENTER → RECORD → CLEANUP → DONE`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -322,6 +322,11 @@ within that lane. A cross-lane handoff transfers permit ownership only after
 the destination accepts the item. The auxiliary permit is released after
 `finished` records the outcome.
 
+The auxiliary lane does not create Mnemosyne content or delivery authority.
+Issue #2754 owns that host preparation seam. Until it is complete, a missing
+prepared delivery becomes a terminal ancillary learning failure. It does not
+change the primary result, and cleanup still waits for that terminal state.
+
 Queue draining claims an item through a
 [`StageQueueLease`](../hephaestus/automation/pipeline/queues.py). The lease keeps
 the source queue slot occupied while a stage runs. A transition is

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,7 +80,7 @@ points at the emission chokepoint in `coordinator_runtime.py`.
 | `hephaestus_pipeline_inflight_jobs` | gauge | — | 1 | Jobs currently owned by both worker pools. |
 | `hephaestus_pipeline_lane_queue_depth` | gauge | `lane`: `main`, `auxiliary` | 2 | Queued work items partitioned by worker lane. |
 | `hephaestus_pipeline_lane_inflight_jobs` | gauge | `lane`: `main`, `auxiliary` | 2 | In-flight jobs partitioned by worker lane. |
-| `hephaestus_pipeline_inflight_per_repo` | gauge | `repo`: open repository names | 100 | In-flight jobs partitioned by repository. |
+| `hephaestus_pipeline_inflight_per_repo` | gauge | `repo`: open repository names | 100 | Main-lane in-flight jobs partitioned by repository. Use the lane gauges for auxiliary work. |
 | `hephaestus_pipeline_loops_total` | gauge | — | 1 | Reseed passes run by this coordinator process. |
 | `hephaestus_pipeline_stalled_ticks` | gauge | — | 1 | Consecutive drain ticks without pipeline progress. |
 | `hephaestus_circuit_breaker_state` | gauge | `name`: open breaker names; `state`: `closed`, `open`, `half_open` | 100 | Circuit-breaker lifecycle state (the active state has value `1`, others `0`). |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -76,15 +76,18 @@ points at the emission chokepoint in `coordinator_runtime.py`.
 
 | Metric | Type | Labels and allowed values | Series cap | Meaning |
 | --- | --- | --- | ---: | --- |
-| `hephaestus_pipeline_queue_depth` | gauge | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `finished` | 7 | Queued work items waiting in each stage queue. |
-| `hephaestus_pipeline_inflight_jobs` | gauge | — | 1 | Jobs currently owned by the worker pool. |
+| `hephaestus_pipeline_queue_depth` | gauge | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `learning`, `finished` | 8 | Queued work items waiting in each stage queue. |
+| `hephaestus_pipeline_inflight_jobs` | gauge | — | 1 | Jobs currently owned by both worker pools. |
+| `hephaestus_pipeline_lane_queue_depth` | gauge | `lane`: `main`, `auxiliary` | 2 | Queued work items partitioned by worker lane. |
+| `hephaestus_pipeline_lane_inflight_jobs` | gauge | `lane`: `main`, `auxiliary` | 2 | In-flight jobs partitioned by worker lane. |
 | `hephaestus_pipeline_inflight_per_repo` | gauge | `repo`: open repository names | 100 | In-flight jobs partitioned by repository. |
 | `hephaestus_pipeline_loops_total` | gauge | — | 1 | Reseed passes run by this coordinator process. |
 | `hephaestus_pipeline_stalled_ticks` | gauge | — | 1 | Consecutive drain ticks without pipeline progress. |
 | `hephaestus_circuit_breaker_state` | gauge | `name`: open breaker names; `state`: `closed`, `open`, `half_open` | 100 | Circuit-breaker lifecycle state (the active state has value `1`, others `0`). |
 | `hephaestus_pipeline_alert_active` | gauge | `name`: `circuit_breaker_open`, `queue_depth_exceeds`, `pipeline_stalled` | 3 | Whether a named alert condition is currently active (`1`) or resolved (`0`). |
-| `hephaestus_pipeline_jobs_total` | counter | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `finished`; `outcome`: `ok`, `failed`, `interrupted` | 21 | Completed jobs by stage and outcome. |
+| `hephaestus_pipeline_jobs_total` | counter | `stage`: `repo`, `planning`, `plan_review`, `implementation`, `pr_review`, `merge_wait`, `learning`, `finished`; `outcome`: `ok`, `failed`, `interrupted` | 24 | Completed jobs by stage and outcome. |
 | `hephaestus_pipeline_agent_job_seconds_total` | counter | — | 1 | Cumulative agent-job wall-clock seconds (negative durations clamped to `0`). |
+| `hephaestus_pipeline_auxiliary_job_seconds_total` | counter | — | 1 | Cumulative host-learning and cleanup wall-clock seconds. |
 | `hephaestus_metrics_series_overflow_total` | counter | `family`: overflowing registered metric-family name | one per overflowing family | New metric-series updates discarded after a family cap. |
 
 Every metric family has a cap. The registry default is 100 series, while

--- a/docs/runbooks/automation-loop-crash.md
+++ b/docs/runbooks/automation-loop-crash.md
@@ -58,11 +58,19 @@ failures:
   <stage>` in `=== Pipeline summary ===`; they are never FAILED by the
   interrupt path and do not run through normal stage success/failure routing.
 - Restart reconstructs the in-memory queues from the durable journal: GitHub
-  labels, PR state, and local worktrees. There is no persisted queue snapshot.
+  labels, PR state, local worktrees, and `build/.automation-state/learning-intent-*.json`.
+  There is no persisted queue snapshot.
   Re-run the same scoped command to let seeding classify the issue back into
   the correct entry queue.
 - To inspect journal reconstruction without launching work, run the scoped
   pipeline command with `--dry-run --loops 1 -v`.
+
+Inspect learning records before rollback. `pending` can run again. A crash-left
+`claimed` record becomes terminal `failed` with `outcome_unknown` and is not
+submitted twice. `succeeded` and `failed` are terminal. Do not start an older
+Hephaestus executable until every learning record is terminal or has been
+parked and handled by the new version. Use `--no-learn` only to bypass new
+learning; it does not make an older executable understand the new journal.
 
 ## Recover
 

--- a/hephaestus/automation/arming_state.py
+++ b/hephaestus/automation/arming_state.py
@@ -23,168 +23,17 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
-from datetime import UTC, datetime
-from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
 from hephaestus.io.utils import write_secure
-from hephaestus.utils.file_lock import file_lock
 
 from ._review_utils import load_state_file
+from .learning_journal import LearningJournalError, LearningJournalStore
+
+__all__ = ["ArmingStateStore", "LearningJournalError", "LearningJournalStore"]
 
 logger = logging.getLogger(__name__)
-
-_LEARNING_STATUSES = frozenset({"pending", "claimed", "succeeded", "failed"})
-
-
-class LearningJournalStore:
-    """Persist strict, bounded state for auxiliary learning intents."""
-
-    def __init__(self, state_dir_provider: Callable[[], Path]) -> None:
-        """Use the current automation state directory on every operation."""
-        self._state_dir_provider = state_dir_provider
-
-    @staticmethod
-    def _digest(key: str) -> str:
-        """Return a path-safe stable identifier for an intent key."""
-        return sha256(key.encode("utf-8")).hexdigest()
-
-    def path(self, key: str) -> Path:
-        """Return the journal record path for ``key``."""
-        return self._state_dir_provider() / f"learning-intent-{self._digest(key)}.json"
-
-    def lock_path(self, key: str) -> Path:
-        """Return the stable sibling lock path for ``key``."""
-        return self.path(key).with_suffix(".lock")
-
-    def load(self, key: str) -> dict[str, Any] | None:
-        """Read one valid journal record, or return ``None``."""
-        path = self.path(key)
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            return None
-        except (OSError, json.JSONDecodeError, TypeError) as exc:
-            logger.warning("Could not read learning intent %s: %s", key, exc)
-            return None
-        if not isinstance(raw, dict) or raw.get("key") != key:
-            return None
-        if raw.get("status") not in _LEARNING_STATUSES:
-            return None
-        return dict(raw)
-
-    def ensure_pending(
-        self, key: str, *, kind: str, identity: dict[str, object] | None = None
-    ) -> dict[str, Any]:
-        """Create a pending record once and return its current value."""
-        if not key or not kind:
-            raise ValueError("learning intent key and kind must be non-empty")
-        with file_lock(self.lock_path(key), require_exclusive=True):
-            current = self.load(key)
-            if current is not None:
-                if current.get("kind") != kind:
-                    raise ValueError("learning intent key was reused for another kind")
-                return current
-            now = datetime.now(UTC).isoformat()
-            record = {
-                "key": key,
-                "kind": kind,
-                "status": "pending",
-                "attempts": 0,
-                "created_at": now,
-                "updated_at": now,
-                **dict(identity or {}),
-            }
-            self._write(key, record)
-            return record
-
-    def incomplete_for_issue(self, *, repo: str, issue: int) -> list[dict[str, Any]]:
-        """Return bounded nonterminal intent records for one issue."""
-        state_dir = self._state_dir_provider()
-        records: list[dict[str, Any]] = []
-        for path in sorted(state_dir.glob("learning-intent-*.json")):
-            try:
-                raw = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError, TypeError):
-                continue
-            if (
-                isinstance(raw, dict)
-                and raw.get("repo") == repo
-                and raw.get("issue") == issue
-                and raw.get("status") in {"pending", "claimed"}
-            ):
-                records.append(dict(raw))
-        return records
-
-    def disable(self, key: str) -> dict[str, Any]:
-        """Mark reconstructed nonterminal work disabled without host dispatch."""
-        with file_lock(self.lock_path(key), require_exclusive=True):
-            record = self.load(key)
-            if record is None:
-                raise KeyError(key)
-            if record["status"] not in {"pending", "claimed"}:
-                return record
-            record["status"] = "failed"
-            record["error"] = "learning_disabled"
-            record["updated_at"] = datetime.now(UTC).isoformat()
-            self._write(key, record)
-            return record
-
-    def claim(self, key: str) -> bool:
-        """Commit ``pending → claimed`` and return whether this call won."""
-        with file_lock(self.lock_path(key), require_exclusive=True):
-            record = self.load(key)
-            if record is None:
-                raise KeyError(key)
-            if record["status"] != "pending":
-                return False
-            record["status"] = "claimed"
-            record["attempts"] = int(record.get("attempts", 0)) + 1
-            record["updated_at"] = datetime.now(UTC).isoformat()
-            self._write(key, record)
-            return True
-
-    def finish(
-        self,
-        key: str,
-        *,
-        succeeded: bool,
-        error: str = "",
-        receipt_summary: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Commit a claimed intent to a terminal result."""
-        with file_lock(self.lock_path(key), require_exclusive=True):
-            record = self.load(key)
-            if record is None:
-                raise KeyError(key)
-            if record["status"] != "claimed":
-                raise ValueError(f"cannot finish learning intent from {record['status']}")
-            record["status"] = "succeeded" if succeeded else "failed"
-            record["updated_at"] = datetime.now(UTC).isoformat()
-            if error:
-                record["error"] = error[:1000]
-            if receipt_summary:
-                record["receipt_summary"] = dict(receipt_summary)
-            self._write(key, record)
-            return record
-
-    def retry(self, key: str, *, error: str) -> dict[str, Any]:
-        """Return a known failed claim to pending for a bounded retry."""
-        with file_lock(self.lock_path(key), require_exclusive=True):
-            record = self.load(key)
-            if record is None:
-                raise KeyError(key)
-            if record["status"] != "claimed":
-                raise ValueError(f"cannot retry learning intent from {record['status']}")
-            record["status"] = "pending"
-            record["updated_at"] = datetime.now(UTC).isoformat()
-            record["error"] = error[:1000]
-            self._write(key, record)
-            return record
-
-    def _write(self, key: str, record: dict[str, Any]) -> None:
-        write_secure(self.path(key), json.dumps(record, indent=2, sort_keys=True) + "\n")
 
 
 class ArmingStateStore:

--- a/hephaestus/automation/arming_state.py
+++ b/hephaestus/automation/arming_state.py
@@ -23,14 +23,168 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
+from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
 from hephaestus.io.utils import write_secure
+from hephaestus.utils.file_lock import file_lock
 
 from ._review_utils import load_state_file
 
 logger = logging.getLogger(__name__)
+
+_LEARNING_STATUSES = frozenset({"pending", "claimed", "succeeded", "failed"})
+
+
+class LearningJournalStore:
+    """Persist strict, bounded state for auxiliary learning intents."""
+
+    def __init__(self, state_dir_provider: Callable[[], Path]) -> None:
+        """Use the current automation state directory on every operation."""
+        self._state_dir_provider = state_dir_provider
+
+    @staticmethod
+    def _digest(key: str) -> str:
+        """Return a path-safe stable identifier for an intent key."""
+        return sha256(key.encode("utf-8")).hexdigest()
+
+    def path(self, key: str) -> Path:
+        """Return the journal record path for ``key``."""
+        return self._state_dir_provider() / f"learning-intent-{self._digest(key)}.json"
+
+    def lock_path(self, key: str) -> Path:
+        """Return the stable sibling lock path for ``key``."""
+        return self.path(key).with_suffix(".lock")
+
+    def load(self, key: str) -> dict[str, Any] | None:
+        """Read one valid journal record, or return ``None``."""
+        path = self.path(key)
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError, TypeError) as exc:
+            logger.warning("Could not read learning intent %s: %s", key, exc)
+            return None
+        if not isinstance(raw, dict) or raw.get("key") != key:
+            return None
+        if raw.get("status") not in _LEARNING_STATUSES:
+            return None
+        return dict(raw)
+
+    def ensure_pending(
+        self, key: str, *, kind: str, identity: dict[str, object] | None = None
+    ) -> dict[str, Any]:
+        """Create a pending record once and return its current value."""
+        if not key or not kind:
+            raise ValueError("learning intent key and kind must be non-empty")
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            current = self.load(key)
+            if current is not None:
+                if current.get("kind") != kind:
+                    raise ValueError("learning intent key was reused for another kind")
+                return current
+            now = datetime.now(UTC).isoformat()
+            record = {
+                "key": key,
+                "kind": kind,
+                "status": "pending",
+                "attempts": 0,
+                "created_at": now,
+                "updated_at": now,
+                **dict(identity or {}),
+            }
+            self._write(key, record)
+            return record
+
+    def incomplete_for_issue(self, *, repo: str, issue: int) -> list[dict[str, Any]]:
+        """Return bounded nonterminal intent records for one issue."""
+        state_dir = self._state_dir_provider()
+        records: list[dict[str, Any]] = []
+        for path in sorted(state_dir.glob("learning-intent-*.json")):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, TypeError):
+                continue
+            if (
+                isinstance(raw, dict)
+                and raw.get("repo") == repo
+                and raw.get("issue") == issue
+                and raw.get("status") in {"pending", "claimed"}
+            ):
+                records.append(dict(raw))
+        return records
+
+    def disable(self, key: str) -> dict[str, Any]:
+        """Mark reconstructed nonterminal work disabled without host dispatch."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self.load(key)
+            if record is None:
+                raise KeyError(key)
+            if record["status"] not in {"pending", "claimed"}:
+                return record
+            record["status"] = "failed"
+            record["error"] = "learning_disabled"
+            record["updated_at"] = datetime.now(UTC).isoformat()
+            self._write(key, record)
+            return record
+
+    def claim(self, key: str) -> bool:
+        """Commit ``pending → claimed`` and return whether this call won."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self.load(key)
+            if record is None:
+                raise KeyError(key)
+            if record["status"] != "pending":
+                return False
+            record["status"] = "claimed"
+            record["attempts"] = int(record.get("attempts", 0)) + 1
+            record["updated_at"] = datetime.now(UTC).isoformat()
+            self._write(key, record)
+            return True
+
+    def finish(
+        self,
+        key: str,
+        *,
+        succeeded: bool,
+        error: str = "",
+        receipt_summary: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Commit a claimed intent to a terminal result."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self.load(key)
+            if record is None:
+                raise KeyError(key)
+            if record["status"] != "claimed":
+                raise ValueError(f"cannot finish learning intent from {record['status']}")
+            record["status"] = "succeeded" if succeeded else "failed"
+            record["updated_at"] = datetime.now(UTC).isoformat()
+            if error:
+                record["error"] = error[:1000]
+            if receipt_summary:
+                record["receipt_summary"] = dict(receipt_summary)
+            self._write(key, record)
+            return record
+
+    def retry(self, key: str, *, error: str) -> dict[str, Any]:
+        """Return a known failed claim to pending for a bounded retry."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self.load(key)
+            if record is None:
+                raise KeyError(key)
+            if record["status"] != "claimed":
+                raise ValueError(f"cannot retry learning intent from {record['status']}")
+            record["status"] = "pending"
+            record["updated_at"] = datetime.now(UTC).isoformat()
+            record["error"] = error[:1000]
+            self._write(key, record)
+            return record
+
+    def _write(self, key: str, record: dict[str, Any]) -> None:
+        write_secure(self.path(key), json.dumps(record, indent=2, sort_keys=True) + "\n")
 
 
 class ArmingStateStore:

--- a/hephaestus/automation/arming_state.py
+++ b/hephaestus/automation/arming_state.py
@@ -29,9 +29,14 @@ from typing import Any
 from hephaestus.io.utils import write_secure
 
 from ._review_utils import load_state_file
-from .learning_journal import LearningJournalError, LearningJournalStore
+from .learning_journal import LearningClaimRegistry, LearningJournalError, LearningJournalStore
 
-__all__ = ["ArmingStateStore", "LearningJournalError", "LearningJournalStore"]
+__all__ = [
+    "ArmingStateStore",
+    "LearningClaimRegistry",
+    "LearningJournalError",
+    "LearningJournalStore",
+]
 
 logger = logging.getLogger(__name__)
 

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -152,9 +152,23 @@ Examples:
         action="store_true",
         help="Skip the advise step before loop review",
     )
-    parser.add_argument("--learning-workers", type=positive_int, default=1)
-    parser.add_argument("--learning-queue-capacity", type=positive_int, default=1)
-    parser.add_argument("--no-learn", action="store_true")
+    parser.add_argument(
+        "--learning-workers",
+        type=positive_int,
+        default=1,
+        help="Independent auxiliary learning workers (default: 1)",
+    )
+    parser.add_argument(
+        "--learning-queue-capacity",
+        type=positive_int,
+        default=1,
+        help="Bounded auxiliary learning queue capacity (default: 1)",
+    )
+    parser.add_argument(
+        "--no-learn",
+        action="store_true",
+        help="Do not create or execute auxiliary learning intents",
+    )
     parser.add_argument(
         "--no-include-bot-prs",
         dest="include_bot_prs",

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -41,6 +41,7 @@ from hephaestus.cli.utils import (
     configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
+    positive_int,
 )
 from hephaestus.config.paths import resolve_projects_dir
 
@@ -151,8 +152,8 @@ Examples:
         action="store_true",
         help="Skip the advise step before loop review",
     )
-    parser.add_argument("--learning-workers", type=int, default=1)
-    parser.add_argument("--learning-queue-capacity", type=int, default=1)
+    parser.add_argument("--learning-workers", type=positive_int, default=1)
+    parser.add_argument("--learning-queue-capacity", type=positive_int, default=1)
     parser.add_argument("--no-learn", action="store_true")
     parser.add_argument(
         "--no-include-bot-prs",

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -151,6 +151,9 @@ Examples:
         action="store_true",
         help="Skip the advise step before loop review",
     )
+    parser.add_argument("--learning-workers", type=int, default=1)
+    parser.add_argument("--learning-queue-capacity", type=int, default=1)
+    parser.add_argument("--no-learn", action="store_true")
     parser.add_argument(
         "--no-include-bot-prs",
         dest="include_bot_prs",
@@ -252,9 +255,12 @@ def main() -> int:
             loops=1,
             # --max-workers maps to the pipeline worker-pool size.
             max_workers=args.max_workers,
+            learning_workers=args.learning_workers,
+            learning_queue_capacity=args.learning_queue_capacity,
             dry_run=args.dry_run,
             agent=agent,
             no_advise=args.no_advise,
+            enable_learn=not args.no_learn,
             drive_green_all=drive_green_all,
             include_bot_prs=args.include_bot_prs,
             include_all_authors=args.include_all_authors,

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -49,6 +49,7 @@ from hephaestus.cli.utils import (
     add_follow_up_timeout_arg,
     add_git_message_timeout_arg,
     add_learn_timeout_arg,
+    positive_int,
 )
 from hephaestus.config.paths import resolve_projects_dir
 from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
@@ -201,8 +202,8 @@ Examples:
         action="store_true",
         help="Disable /learn after implementation (enabled by default)",
     )
-    parser.add_argument("--learning-workers", type=int, default=1)
-    parser.add_argument("--learning-queue-capacity", type=int, default=1)
+    parser.add_argument("--learning-workers", type=positive_int, default=1)
+    parser.add_argument("--learning-queue-capacity", type=positive_int, default=1)
     parser.add_argument(
         "--no-follow-up",
         action="store_true",

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -201,6 +201,8 @@ Examples:
         action="store_true",
         help="Disable /learn after implementation (enabled by default)",
     )
+    parser.add_argument("--learning-workers", type=int, default=1)
+    parser.add_argument("--learning-queue-capacity", type=int, default=1)
     parser.add_argument(
         "--no-follow-up",
         action="store_true",
@@ -529,9 +531,12 @@ def main() -> int:
         loops=1,
         # --max-workers maps to the pipeline worker-pool size.
         max_workers=args.max_workers,
+        learning_workers=args.learning_workers,
+        learning_queue_capacity=args.learning_queue_capacity,
         dry_run=args.dry_run,
         agent=agent,
         no_advise=args.no_advise,
+        enable_learn=not args.no_learn,
         nitpick=args.nitpick,
         projects_dir=resolve_projects_dir(None, prefer_cwd_parent=True),
         json_out=args.json,

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -200,10 +200,20 @@ Examples:
     parser.add_argument(
         "--no-learn",
         action="store_true",
-        help="Disable /learn after implementation (enabled by default)",
+        help="Do not create or execute auxiliary learning intents",
     )
-    parser.add_argument("--learning-workers", type=positive_int, default=1)
-    parser.add_argument("--learning-queue-capacity", type=positive_int, default=1)
+    parser.add_argument(
+        "--learning-workers",
+        type=positive_int,
+        default=1,
+        help="Independent auxiliary learning workers (default: 1)",
+    )
+    parser.add_argument(
+        "--learning-queue-capacity",
+        type=positive_int,
+        default=1,
+        help="Bounded auxiliary learning queue capacity (default: 1)",
+    )
     parser.add_argument(
         "--no-follow-up",
         action="store_true",

--- a/hephaestus/automation/learning_journal.py
+++ b/hephaestus/automation/learning_journal.py
@@ -1,0 +1,249 @@
+"""Durable, cross-process journal for auxiliary learning intents."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager
+from datetime import UTC, datetime
+from hashlib import sha256
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from hephaestus.io.utils import write_secure
+from hephaestus.utils.file_lock import LockUnavailableError, file_lock
+
+logger = logging.getLogger(__name__)
+
+_STATUSES = frozenset({"pending", "claimed", "succeeded", "failed"})
+_REQUIRED_FIELDS = frozenset({"key", "kind", "status", "attempts", "created_at", "updated_at"})
+_RESERVED_FIELDS = _REQUIRED_FIELDS | frozenset({"error", "receipt_summary", "claim_owner"})
+
+
+class LearningJournalError(RuntimeError):
+    """Report unreadable or invalid durable learning evidence."""
+
+
+class LearningJournalStore:
+    """Persist strict, bounded state for auxiliary learning intents."""
+
+    def __init__(self, state_dir_provider: Callable[[], Path]) -> None:
+        """Use the current automation state directory on every operation."""
+        self._state_dir_provider = state_dir_provider
+        self._claim_locks: dict[str, AbstractContextManager[None]] = {}
+        self._claim_locks_guard = Lock()
+
+    @staticmethod
+    def _digest(key: str) -> str:
+        return sha256(key.encode("utf-8")).hexdigest()
+
+    def path(self, key: str) -> Path:
+        """Return the journal record path for ``key``."""
+        return self._state_dir_provider() / f"learning-intent-{self._digest(key)}.json"
+
+    def lock_path(self, key: str) -> Path:
+        """Return the stable sibling lock path for ``key``."""
+        return self.path(key).with_suffix(".lock")
+
+    def claim_lock_path(self, key: str) -> Path:
+        """Return the lock held for the complete external delivery attempt."""
+        return self.path(key).with_suffix(".claim.lock")
+
+    def load(self, key: str) -> dict[str, Any] | None:
+        """Read one valid record, or return ``None`` only when it is absent."""
+        path = self.path(key)
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        except json.JSONDecodeError as exc:
+            raise LearningJournalError(f"learning intent {key} has invalid JSON: {exc}") from exc
+        except (OSError, TypeError) as exc:
+            raise LearningJournalError(f"could not read learning intent {key}: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise LearningJournalError(f"learning intent {key} is not an object")
+        missing = _REQUIRED_FIELDS.difference(raw)
+        if missing:
+            names = ", ".join(sorted(missing))
+            raise LearningJournalError(f"learning intent {key} has missing fields: {names}")
+        if raw.get("key") != key:
+            raise LearningJournalError(f"learning intent {key} has a different key")
+        if raw.get("status") not in _STATUSES:
+            raise LearningJournalError(f"learning intent {key} has an invalid status")
+        if not isinstance(raw.get("kind"), str) or not raw["kind"]:
+            raise LearningJournalError(f"learning intent {key} has an invalid kind")
+        if not isinstance(raw.get("attempts"), int) or int(raw["attempts"]) < 0:
+            raise LearningJournalError(f"learning intent {key} has invalid attempts")
+        return dict(raw)
+
+    def ensure_pending(
+        self, key: str, *, kind: str, identity: dict[str, object] | None = None
+    ) -> dict[str, Any]:
+        """Create a pending record once and return its current value."""
+        if not key or not kind:
+            raise ValueError("learning intent key and kind must be non-empty")
+        identity_fields = dict(identity or {})
+        reserved = _RESERVED_FIELDS.intersection(identity_fields)
+        if reserved:
+            names = ", ".join(sorted(reserved))
+            raise ValueError(f"learning intent identity uses reserved fields: {names}")
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            current = self.load(key)
+            if current is not None:
+                if current.get("kind") != kind:
+                    raise ValueError("learning intent key was reused for another kind")
+                changed = False
+                for field, value in identity_fields.items():
+                    if field in current and current[field] != value:
+                        raise ValueError(f"learning intent identity changed field: {field}")
+                    if field not in current:
+                        current[field] = value
+                        changed = True
+                if changed:
+                    current["updated_at"] = datetime.now(UTC).isoformat()
+                    self._write(key, current)
+                return current
+            now = datetime.now(UTC).isoformat()
+            record = {
+                "key": key,
+                "kind": kind,
+                "status": "pending",
+                "attempts": 0,
+                "created_at": now,
+                "updated_at": now,
+                **identity_fields,
+            }
+            self._write(key, record)
+            return record
+
+    def incomplete_for_issue(self, *, repo: str, issue: int) -> list[dict[str, Any]]:
+        """Return bounded nonterminal intent records for one issue."""
+        records: list[dict[str, Any]] = []
+        for raw in self._scan_nonterminal(repo=repo):
+            if raw.get("issue") == issue:
+                records.append(raw)
+        return records
+
+    def incomplete_for_repo(self, *, repo: str) -> Iterator[dict[str, Any]]:
+        """Yield nonterminal records for one repository without a bulk list."""
+        yield from self._scan_nonterminal(repo=repo)
+
+    def _scan_nonterminal(self, *, repo: str) -> Iterator[dict[str, Any]]:
+        for path in sorted(self._state_dir_provider().glob("learning-intent-*.json")):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, TypeError) as exc:
+                logger.warning("Could not scan learning intent %s: %s", path.name, exc)
+                continue
+            if (
+                isinstance(raw, dict)
+                and raw.get("repo") == repo
+                and raw.get("status") in {"pending", "claimed"}
+            ):
+                yield dict(raw)
+
+    def disable(self, key: str) -> dict[str, Any]:
+        """Mark reconstructed nonterminal work disabled without host dispatch."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self.load(key)
+            if record is None:
+                raise KeyError(key)
+            if record["status"] not in {"pending", "claimed"}:
+                return record
+            record.update(
+                status="failed",
+                error="learning_disabled",
+                updated_at=datetime.now(UTC).isoformat(),
+            )
+            self._write(key, record)
+            return record
+
+    def claim(self, key: str) -> bool:
+        """Commit ``pending -> claimed`` and return whether this call won."""
+        claim_lock = file_lock(self.claim_lock_path(key), blocking=False, require_exclusive=True)
+        try:
+            claim_lock.__enter__()
+        except LockUnavailableError:
+            return False
+        keep_lock = False
+        try:
+            with file_lock(self.lock_path(key), require_exclusive=True):
+                record = self.load(key)
+                if record is None:
+                    raise KeyError(key)
+                if record["status"] != "pending":
+                    return False
+                record["status"] = "claimed"
+                record["attempts"] = int(record.get("attempts", 0)) + 1
+                record["updated_at"] = datetime.now(UTC).isoformat()
+                self._write(key, record)
+            with self._claim_locks_guard:
+                self._claim_locks[key] = claim_lock
+            keep_lock = True
+            return True
+        finally:
+            if not keep_lock:
+                claim_lock.__exit__(None, None, None)
+
+    def claim_is_active(self, key: str) -> bool:
+        """Return whether another live owner holds the delivery claim lock."""
+        probe = file_lock(self.claim_lock_path(key), blocking=False, require_exclusive=True)
+        try:
+            probe.__enter__()
+        except LockUnavailableError:
+            return True
+        probe.__exit__(None, None, None)
+        return False
+
+    def finish(
+        self,
+        key: str,
+        *,
+        succeeded: bool,
+        error: str = "",
+        receipt_summary: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Commit a claimed intent to a terminal result."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self._require_claimed(key)
+            record["status"] = "succeeded" if succeeded else "failed"
+            record["updated_at"] = datetime.now(UTC).isoformat()
+            if error:
+                record["error"] = error[:1000]
+            if receipt_summary:
+                record["receipt_summary"] = dict(receipt_summary)
+            self._write(key, record)
+        self._release_claim_lock(key)
+        return record
+
+    def retry(self, key: str, *, error: str) -> dict[str, Any]:
+        """Return a known failed claim to pending for a bounded retry."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self._require_claimed(key)
+            record.update(
+                status="pending",
+                updated_at=datetime.now(UTC).isoformat(),
+                error=error[:1000],
+            )
+            self._write(key, record)
+        self._release_claim_lock(key)
+        return record
+
+    def _require_claimed(self, key: str) -> dict[str, Any]:
+        record = self.load(key)
+        if record is None:
+            raise KeyError(key)
+        if record["status"] != "claimed":
+            raise ValueError(f"cannot finish learning intent from {record['status']}")
+        return record
+
+    def _release_claim_lock(self, key: str) -> None:
+        with self._claim_locks_guard:
+            claim_lock = self._claim_locks.pop(key, None)
+        if claim_lock is not None:
+            claim_lock.__exit__(None, None, None)
+
+    def _write(self, key: str, record: dict[str, Any]) -> None:
+        write_secure(self.path(key), json.dumps(record, indent=2, sort_keys=True) + "\n")

--- a/hephaestus/automation/learning_journal.py
+++ b/hephaestus/automation/learning_journal.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 
 _STATUSES = frozenset({"pending", "claimed", "succeeded", "failed"})
 _REQUIRED_FIELDS = frozenset({"key", "kind", "status", "attempts", "created_at", "updated_at"})
-_RESERVED_FIELDS = _REQUIRED_FIELDS | frozenset({"error", "receipt_summary", "claim_owner"})
+_RESERVED_FIELDS = _REQUIRED_FIELDS | frozenset(
+    {"error", "receipt_summary", "claim_owner", "cleanup_status", "cleanup_error"}
+)
 
 
 class LearningJournalError(RuntimeError):
@@ -76,6 +78,15 @@ class LearningJournalStore:
             raise LearningJournalError(f"learning intent {key} has an invalid kind")
         if not isinstance(raw.get("attempts"), int) or int(raw["attempts"]) < 0:
             raise LearningJournalError(f"learning intent {key} has invalid attempts")
+        cleanup_status = raw.get("cleanup_status")
+        if cleanup_status is not None and cleanup_status not in {
+            "pending",
+            "succeeded",
+            "failed",
+        }:
+            raise LearningJournalError(f"learning intent {key} has invalid cleanup status")
+        if "post_processing" in raw and not isinstance(raw["post_processing"], dict):
+            raise LearningJournalError(f"learning intent {key} has invalid post-processing data")
         return dict(raw)
 
     def ensure_pending(
@@ -101,6 +112,12 @@ class LearningJournalStore:
                     if field not in current:
                         current[field] = value
                         changed = True
+                if (
+                    isinstance(current.get("post_processing"), dict)
+                    and current.get("cleanup_status") is None
+                ):
+                    current["cleanup_status"] = "pending"
+                    changed = True
                 if changed:
                     current["updated_at"] = datetime.now(UTC).isoformat()
                     self._write(key, current)
@@ -115,6 +132,8 @@ class LearningJournalStore:
                 "updated_at": now,
                 **identity_fields,
             }
+            if "post_processing" in identity_fields:
+                record["cleanup_status"] = "pending"
             self._write(key, record)
             return record
 
@@ -140,7 +159,14 @@ class LearningJournalStore:
             if (
                 isinstance(raw, dict)
                 and raw.get("repo") == repo
-                and raw.get("status") in {"pending", "claimed"}
+                and (
+                    raw.get("status") in {"pending", "claimed"}
+                    or (
+                        isinstance(raw.get("post_processing"), dict)
+                        and raw.get("cleanup_status") != "succeeded"
+                        and raw.get("cleanup_status") != "failed"
+                    )
+                )
             ):
                 yield dict(raw)
 
@@ -197,6 +223,26 @@ class LearningJournalStore:
         probe.__exit__(None, None, None)
         return False
 
+    def fail_abandoned_claim(self, key: str, *, error: str) -> dict[str, Any] | None:
+        """Fail an abandoned claim, or return ``None`` if a live owner won."""
+        claim_lock = file_lock(self.claim_lock_path(key), blocking=False, require_exclusive=True)
+        try:
+            claim_lock.__enter__()
+        except LockUnavailableError:
+            return None
+        try:
+            with file_lock(self.lock_path(key), require_exclusive=True):
+                record = self._require_claimed(key)
+                record.update(
+                    status="failed",
+                    updated_at=datetime.now(UTC).isoformat(),
+                    error=error[:1000],
+                )
+                self._write(key, record)
+                return record
+        finally:
+            claim_lock.__exit__(None, None, None)
+
     def finish(
         self,
         key: str,
@@ -206,6 +252,8 @@ class LearningJournalStore:
         receipt_summary: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Commit a claimed intent to a terminal result."""
+        self._require_claimed(key)
+        self._require_local_claim(key)
         with file_lock(self.lock_path(key), require_exclusive=True):
             record = self._require_claimed(key)
             record["status"] = "succeeded" if succeeded else "failed"
@@ -220,6 +268,8 @@ class LearningJournalStore:
 
     def retry(self, key: str, *, error: str) -> dict[str, Any]:
         """Return a known failed claim to pending for a bounded retry."""
+        self._require_claimed(key)
+        self._require_local_claim(key)
         with file_lock(self.lock_path(key), require_exclusive=True):
             record = self._require_claimed(key)
             record.update(
@@ -230,6 +280,28 @@ class LearningJournalStore:
             self._write(key, record)
         self._release_claim_lock(key)
         return record
+
+    def finish_cleanup(self, key: str, *, succeeded: bool, error: str = "") -> dict[str, Any]:
+        """Record that terminal cleanup reached a bounded outcome."""
+        with file_lock(self.lock_path(key), require_exclusive=True):
+            record = self.load(key)
+            if record is None:
+                raise KeyError(key)
+            if not isinstance(record.get("post_processing"), dict):
+                return record
+            if record["status"] not in {"succeeded", "failed"}:
+                raise ValueError("learning must be terminal before cleanup")
+            record["cleanup_status"] = "succeeded" if succeeded else "failed"
+            record["updated_at"] = datetime.now(UTC).isoformat()
+            if error:
+                record["cleanup_error"] = error[:1000]
+            self._write(key, record)
+            return record
+
+    def _require_local_claim(self, key: str) -> None:
+        with self._claim_locks_guard:
+            if key not in self._claim_locks:
+                raise ValueError("learning intent claim is not owned by this process")
 
     def _require_claimed(self, key: str) -> dict[str, Any]:
         record = self.load(key)

--- a/hephaestus/automation/learning_journal.py
+++ b/hephaestus/automation/learning_journal.py
@@ -28,14 +28,29 @@ class LearningJournalError(RuntimeError):
     """Report unreadable or invalid durable learning evidence."""
 
 
+class LearningClaimRegistry:
+    """Retain process-owned claim locks across repository context eviction."""
+
+    def __init__(self) -> None:
+        """Create an empty thread-safe ownership registry."""
+        self.locks: dict[str, AbstractContextManager[None]] = {}
+        self.guard = Lock()
+
+
 class LearningJournalStore:
     """Persist strict, bounded state for auxiliary learning intents."""
 
-    def __init__(self, state_dir_provider: Callable[[], Path]) -> None:
+    def __init__(
+        self,
+        state_dir_provider: Callable[[], Path],
+        *,
+        claim_registry: LearningClaimRegistry | None = None,
+    ) -> None:
         """Use the current automation state directory on every operation."""
         self._state_dir_provider = state_dir_provider
-        self._claim_locks: dict[str, AbstractContextManager[None]] = {}
-        self._claim_locks_guard = Lock()
+        self._claim_registry = claim_registry or LearningClaimRegistry()
+        self._claim_locks = self._claim_registry.locks
+        self._claim_locks_guard = self._claim_registry.guard
 
     @staticmethod
     def _digest(key: str) -> str:
@@ -170,21 +185,29 @@ class LearningJournalStore:
             ):
                 yield dict(raw)
 
-    def disable(self, key: str) -> dict[str, Any]:
+    def disable(self, key: str) -> dict[str, Any] | None:
         """Mark reconstructed nonterminal work disabled without host dispatch."""
-        with file_lock(self.lock_path(key), require_exclusive=True):
-            record = self.load(key)
-            if record is None:
-                raise KeyError(key)
-            if record["status"] not in {"pending", "claimed"}:
+        claim_lock = file_lock(self.claim_lock_path(key), blocking=False, require_exclusive=True)
+        try:
+            claim_lock.__enter__()
+        except LockUnavailableError:
+            return None
+        try:
+            with file_lock(self.lock_path(key), require_exclusive=True):
+                record = self.load(key)
+                if record is None:
+                    raise KeyError(key)
+                if record["status"] not in {"pending", "claimed"}:
+                    return record
+                record.update(
+                    status="failed",
+                    error="learning_disabled",
+                    updated_at=datetime.now(UTC).isoformat(),
+                )
+                self._write(key, record)
                 return record
-            record.update(
-                status="failed",
-                error="learning_disabled",
-                updated_at=datetime.now(UTC).isoformat(),
-            )
-            self._write(key, record)
-            return record
+        finally:
+            claim_lock.__exit__(None, None, None)
 
     def claim(self, key: str) -> bool:
         """Commit ``pending -> claimed`` and return whether this call won."""
@@ -232,7 +255,11 @@ class LearningJournalStore:
             return None
         try:
             with file_lock(self.lock_path(key), require_exclusive=True):
-                record = self._require_claimed(key)
+                record = self.load(key)
+                if record is None:
+                    raise KeyError(key)
+                if record["status"] != "claimed":
+                    return record
                 record.update(
                     status="failed",
                     updated_at=datetime.now(UTC).isoformat(),

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -220,6 +220,8 @@ class LoopConfig:
     review_iterations: int | None = None
     max_workers: int = LOOP_DEFAULT_MAX_WORKERS
     parallel_repos: int = 1
+    learning_workers: int = 1
+    learning_queue_capacity: int = 1
     # Dataclass default covers ONLY the iteration phases (``ALL_PHASES`` =
     # plan, implement), deliberately excluding drive-green — a bare
     # ``LoopConfig()`` gets a quiet plan+implement run. The CLI ``--phases``
@@ -239,6 +241,7 @@ class LoopConfig:
     prs: list[int] = field(default_factory=list)
     dry_run: bool = False
     no_advise: bool = False
+    no_learn: bool = False
     nitpick: bool = False
     # Retained CLI/config compatibility option. It does not expand the queue's
     # linked-issue repository discovery into an unrelated open-PR sweep.
@@ -332,6 +335,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Repos processed in parallel per loop iteration (default: 1)",
     )
     p.add_argument(
+        "--learning-workers",
+        type=_parse_positive_int,
+        default=1,
+        help="Independent host-learning workers (default: 1)",
+    )
+    p.add_argument(
+        "--learning-queue-capacity",
+        type=_parse_positive_int,
+        default=1,
+        help="Bounded auxiliary learning queue capacity (default: 1)",
+    )
+    p.add_argument(
         "--issue-limit",
         type=_parse_positive_int,
         default=None,
@@ -373,6 +388,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--no-advise",
         action="store_true",
         help="Pass --no-advise to phases that support the advise preflight",
+    )
+    p.add_argument(
+        "--no-learn",
+        action="store_true",
+        help="Do not create or execute auxiliary learning intents",
     )
     p.add_argument(
         "--no-serialize-file-overlap",
@@ -775,6 +795,8 @@ def _build_pipeline_config(
         loops=cfg.loops,
         max_workers=cfg.max_workers,
         parallel_repos=cfg.parallel_repos,
+        learning_workers=cfg.learning_workers,
+        learning_queue_capacity=cfg.learning_queue_capacity,
         dry_run=cfg.dry_run,
         grace_s=30.0,  # Default grace period
         phase_timeout_s=cfg.phase_timeout_s,
@@ -788,6 +810,7 @@ def _build_pipeline_config(
         implementer_reasoning_effort=cfg.implementer_reasoning_effort,
         gh_extra_path_root=cfg.gh_extra_path_root,
         no_advise=cfg.no_advise,
+        enable_learn=not cfg.no_learn,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
         include_bot_prs=True,
@@ -939,6 +962,8 @@ def main(argv: list[str] | None = None) -> int:
         loops=args.loops,
         review_iterations=args.review_iterations,
         max_workers=args.max_workers,
+        learning_workers=args.learning_workers,
+        learning_queue_capacity=args.learning_queue_capacity,
         drive_green_loops=args.drive_green_loops,
         serialize_file_overlap=args.serialize_file_overlap,
         parallel_repos=args.parallel_repos,
@@ -949,6 +974,7 @@ def main(argv: list[str] | None = None) -> int:
         issue_limit=args.issue_limit,
         dry_run=args.dry_run,
         no_advise=args.no_advise,
+        no_learn=args.no_learn,
         nitpick=args.nitpick,
         drive_green_all=args.drive_green_all,
         run_pre_pr_tests=args.run_pre_pr_tests,

--- a/hephaestus/automation/mnemosyne_binding.py
+++ b/hephaestus/automation/mnemosyne_binding.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from hephaestus.automation.athena_contract import AthenaContractReceipt
 from hephaestus.github.mnemosyne_repo import MnemosyneTarget, resolve_mnemosyne_target
-from hephaestus.utils.helpers import NETWORK_TIMEOUT
+from hephaestus.utils.helpers import NETWORK_TIMEOUT, run_subprocess
 
 
 class MnemosyneBindingError(RuntimeError):
@@ -48,13 +48,12 @@ def default_mnemosyne_root() -> Path:
 
 
 def _run_git(cwd: Path, argv: tuple[str, ...], timeout_s: int) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ("git", *argv),
+    return run_subprocess(
+        ["git", *argv],
         cwd=cwd,
         check=False,
-        capture_output=True,
-        text=True,
         timeout=timeout_s,
+        track_process_group=True,
     )
 
 

--- a/hephaestus/automation/mnemosyne_corpus.py
+++ b/hephaestus/automation/mnemosyne_corpus.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from hephaestus.automation.athena_contract import AthenaContractReceipt
 from hephaestus.automation.mnemosyne_binding import MnemosyneBindingReceipt
-from hephaestus.utils.helpers import METADATA_TIMEOUT
+from hephaestus.utils.helpers import METADATA_TIMEOUT, run_subprocess
 
 
 class MnemosyneCorpusError(RuntimeError):
@@ -53,13 +53,12 @@ class MnemosyneCorpusResult:
 
 
 def _run_git(cwd: Path, argv: tuple[str, ...], timeout_s: int) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ("git", *argv),
+    return run_subprocess(
+        ["git", *argv],
         cwd=cwd,
         check=False,
-        capture_output=True,
-        text=True,
         timeout=timeout_s,
+        track_process_group=True,
     )
 
 

--- a/hephaestus/automation/mnemosyne_delivery.py
+++ b/hephaestus/automation/mnemosyne_delivery.py
@@ -9,7 +9,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Protocol
 
-from hephaestus.utils.helpers import NETWORK_TIMEOUT
+from hephaestus.utils.helpers import NETWORK_TIMEOUT, run_subprocess
 
 
 class LearnDeliveryError(RuntimeError):
@@ -86,13 +86,12 @@ class LearnDeliveryReceipt:
 
 
 def _run_git(cwd: Path, argv: tuple[str, ...], timeout_s: int) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ("git", *argv),
+    return run_subprocess(
+        ["git", *argv],
         cwd=cwd,
         check=False,
-        capture_output=True,
-        text=True,
         timeout=timeout_s,
+        track_process_group=True,
     )
 
 

--- a/hephaestus/automation/mnemosyne_skill_host.py
+++ b/hephaestus/automation/mnemosyne_skill_host.py
@@ -36,6 +36,8 @@ from hephaestus.automation.mnemosyne_delivery import (
 from hephaestus.automation.pipeline.athena_skill_jobs import AthenaSkillRequest, AthenaSkillResult
 from hephaestus.github.client import gh_call
 from hephaestus.io.utils import write_secure
+from hephaestus.utils import subprocess_registry
+from hephaestus.utils.helpers import run_subprocess
 
 
 class BindingService(Protocol):
@@ -89,6 +91,7 @@ class GitHubLearnDeliveryAdapter:
                 body,
             ],
             check=False,
+            track_process_group=True,
         )
         if result.returncode != 0:
             detail = (result.stderr or result.stdout or "").strip()
@@ -103,6 +106,7 @@ class GitHubLearnDeliveryAdapter:
         result = self._gh(
             ["pr", "view", str(number), "--repo", repository, "--json", "url,headRefOid"],
             check=False,
+            track_process_group=True,
         )
         if result.returncode != 0:
             detail = (result.stderr or result.stdout or "").strip()
@@ -133,6 +137,7 @@ class GitHubLearnDeliveryAdapter:
                 "url,state,baseRefName,headRefName,headRefOid,headRepository",
             ],
             check=False,
+            track_process_group=True,
         )
         if result.returncode != 0:
             detail = (result.stderr or result.stdout or "").strip()
@@ -298,12 +303,11 @@ class DefaultCorpusReader:
     def _subprocess_git_output(root: Path, argv: tuple[str, ...]) -> str:
         """Read one committed Git object while preserving fail-closed errors."""
         try:
-            result = subprocess.run(
-                ("git", *argv),
+            result = run_subprocess(
+                ["git", *argv],
                 cwd=root,
                 check=False,
-                capture_output=True,
-                text=True,
+                track_process_group=True,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             raise MnemosyneCorpusError(f"Mnemosyne corpus search failed: {exc}") from exc
@@ -502,6 +506,11 @@ class MnemosyneSkillHost:
             )
         except Exception as exc:
             return AthenaSkillResult(kind=str(request.kind), error=str(exc))
+
+    @staticmethod
+    def cancel() -> None:
+        """Stop active host-owned subprocess groups during forced shutdown."""
+        subprocess_registry.terminate_all()
 
     @staticmethod
     def _load_contract() -> AthenaContractReceipt:

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -4,7 +4,8 @@ Pure data and pure functions with ZERO I/O — no gh, no claude, no
 subprocess, no imports of github_api/claude_invoke. Part of epic #1809.
 
 Thread-safety: a WorkItem and its StageQueue are only ever touched by the
-coordinator thread. The single cross-thread channel is CompletionQueue.
+coordinator thread. The bounded main and auxiliary completion queues are the
+only cross-thread payload channels.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .athena_skill_jobs import AthenaSkillJob, AthenaSkillRequest, AthenaSkillResult
+    from .auxiliary_worker_pool import AuxiliaryWorkerPool
     from .coordinator import PipelineConfig, run_pipeline
     from .jobs import GIT_OPS, AgentJob, BuildTestJob, CompactJob, GitJob, JobHandle, JobResult
     from .queues import CompletionQueue, StageQueue
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
         StageName,
         StageOutcome,
     )
-    from .work_item import HistoryEvent, ItemKind, ItemResult, WorkItem
+    from .work_item import HistoryEvent, ItemKind, ItemResult, LearningIntent, WorkItem
     from .worker_pool import WorkerPool
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "AthenaSkillJob",
     "AthenaSkillRequest",
     "AthenaSkillResult",
+    "AuxiliaryWorkerPool",
     "BuildTestJob",
     "CompactJob",
     "CompletionQueue",
@@ -45,6 +47,7 @@ __all__ = [
     "ItemResult",
     "JobHandle",
     "JobResult",
+    "LearningIntent",
     "PipelineConfig",
     "PipelineScope",
     "Route",
@@ -61,6 +64,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "AthenaSkillJob": "hephaestus.automation.pipeline.athena_skill_jobs",
     "AthenaSkillRequest": "hephaestus.automation.pipeline.athena_skill_jobs",
     "AthenaSkillResult": "hephaestus.automation.pipeline.athena_skill_jobs",
+    "AuxiliaryWorkerPool": "hephaestus.automation.pipeline.auxiliary_worker_pool",
     "BuildTestJob": "hephaestus.automation.pipeline.jobs",
     "CompactJob": "hephaestus.automation.pipeline.jobs",
     "CompletionQueue": "hephaestus.automation.pipeline.queues",
@@ -70,6 +74,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "HistoryEvent": "hephaestus.automation.pipeline.work_item",
     "ItemKind": "hephaestus.automation.pipeline.work_item",
     "ItemResult": "hephaestus.automation.pipeline.work_item",
+    "LearningIntent": "hephaestus.automation.pipeline.work_item",
     "JobHandle": "hephaestus.automation.pipeline.jobs",
     "JobResult": "hephaestus.automation.pipeline.jobs",
     "PipelineConfig": "hephaestus.automation.pipeline.coordinator",

--- a/hephaestus/automation/pipeline/athena_executor_scope.py
+++ b/hephaestus/automation/pipeline/athena_executor_scope.py
@@ -12,10 +12,7 @@ def pipeline_requires_athena_executor(config: Any) -> bool:
     if config.dry_run:
         return False
     stages = config.scope.stages if config.scope is not None else frozenset(ROUTES)
-    return (
+    return bool(config.enable_learn) or (
         not config.no_advise
         and bool(stages.intersection({StageName.PLANNING, StageName.IMPLEMENTATION}))
-    ) or (
-        config.enable_learn
-        and bool(stages.intersection({StageName.PLAN_REVIEW, StageName.MERGE_WAIT}))
     )

--- a/hephaestus/automation/pipeline/auxiliary_worker_pool.py
+++ b/hephaestus/automation/pipeline/auxiliary_worker_pool.py
@@ -27,7 +27,7 @@ class AuxiliaryWorkerPool:
         size: int,
         shutdown: threading.Event,
         completion_q: queue.Queue[tuple[JobHandle, JobResult]],
-        athena_skill_executor: AthenaSkillExecutor,
+        athena_skill_executor: AthenaSkillExecutor | None,
         cleanup_runner: CleanupRunner | None = None,
     ) -> None:
         """Create a bounded host-only executor."""
@@ -57,6 +57,8 @@ class AuxiliaryWorkerPool:
         if isinstance(job, AthenaSkillJob):
             if job.request.kind != "learn":
                 raise TypeError("auxiliary worker pool accepts only Athena learn jobs")
+            if self._athena_skill_executor is None:
+                raise RuntimeError("auxiliary learning is disabled")
         elif isinstance(job, GitJob):
             if job.op not in _CLEANUP_OPS:
                 raise TypeError("auxiliary worker pool accepts only cleanup Git jobs")
@@ -73,6 +75,8 @@ class AuxiliaryWorkerPool:
             return JobResult(ok=False, interrupted=True, error="interrupted_before_start")
         try:
             if isinstance(job, AthenaSkillJob):
+                if self._athena_skill_executor is None:
+                    raise RuntimeError("auxiliary learning is disabled")
                 value = self._athena_skill_executor.execute(job.request)
                 result = JobResult(ok=value.ok, value=value, error=value.error)
             else:

--- a/hephaestus/automation/pipeline/auxiliary_worker_pool.py
+++ b/hephaestus/automation/pipeline/auxiliary_worker_pool.py
@@ -6,7 +6,7 @@ import queue
 import threading
 import time
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from dataclasses import replace
 
 from .athena_skill_jobs import AthenaSkillExecutor, AthenaSkillJob
@@ -44,6 +44,8 @@ class AuxiliaryWorkerPool:
         )
         self._completion_wakeup: threading.Event | None = None
         self._completion_saturation: threading.Event | None = None
+        self._futures: set[Future[JobResult]] = set()
+        self._futures_guard = threading.Lock()
 
     def set_completion_notifiers(
         self, *, wakeup: threading.Event, saturation: threading.Event
@@ -66,6 +68,8 @@ class AuxiliaryWorkerPool:
             raise TypeError(f"auxiliary worker pool does not accept {type(job).__name__}")
         handle = JobHandle(job=job, on_done_state=on_done_state)
         future = self._executor.submit(self._run, job)
+        with self._futures_guard:
+            self._futures.add(future)
         future.add_done_callback(lambda completed: self._publish(handle, completed))
         return handle
 
@@ -96,8 +100,16 @@ class AuxiliaryWorkerPool:
     def _publish(self, handle: JobHandle, future: Future[JobResult]) -> None:
         try:
             result = future.result()
+        except CancelledError:
+            result = JobResult(
+                ok=False,
+                interrupted=True,
+                error="interrupted_before_start",
+            )
         except Exception as exc:
             result = JobResult(ok=False, error=f"worker_crash: {type(exc).__name__}: {exc}")
+        with self._futures_guard:
+            self._futures.discard(future)
         try:
             self._completion_q.put_nowait((handle, result))
         except queue.Full:
@@ -114,4 +126,8 @@ class AuxiliaryWorkerPool:
         cancel = getattr(self._athena_skill_executor, "cancel", None)
         if callable(cancel):
             cancel()
+        with self._futures_guard:
+            futures = tuple(self._futures)
+        for future in futures:
+            future.cancel()
         self._executor.shutdown(wait=False, cancel_futures=True)

--- a/hephaestus/automation/pipeline/auxiliary_worker_pool.py
+++ b/hephaestus/automation/pipeline/auxiliary_worker_pool.py
@@ -92,7 +92,7 @@ class AuxiliaryWorkerPool:
     def _publish(self, handle: JobHandle, future: Future[JobResult]) -> None:
         try:
             result = future.result()
-        except BaseException as exc:
+        except Exception as exc:
             result = JobResult(ok=False, error=f"worker_crash: {type(exc).__name__}: {exc}")
         try:
             self._completion_q.put_nowait((handle, result))
@@ -107,4 +107,7 @@ class AuxiliaryWorkerPool:
         """Stop pending work and optionally mark active work interrupted."""
         if mark_interrupted:
             self._shutdown.set()
+        cancel = getattr(self._athena_skill_executor, "cancel", None)
+        if callable(cancel):
+            cancel()
         self._executor.shutdown(wait=False, cancel_futures=True)

--- a/hephaestus/automation/pipeline/auxiliary_worker_pool.py
+++ b/hephaestus/automation/pipeline/auxiliary_worker_pool.py
@@ -1,0 +1,110 @@
+"""Closed worker lane for host learning and terminal cleanup."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import replace
+
+from .athena_skill_jobs import AthenaSkillExecutor, AthenaSkillJob
+from .git_jobs import GitJob
+from .job_results import JobHandle, JobResult
+
+AuxiliaryJob = AthenaSkillJob | GitJob
+CleanupRunner = Callable[[GitJob], JobResult]
+_CLEANUP_OPS = frozenset({"remove_worktree", "release_branch_reservation"})
+
+
+class AuxiliaryWorkerPool:
+    """Execute a strict auxiliary-job allowlist on independent threads."""
+
+    def __init__(
+        self,
+        *,
+        size: int,
+        shutdown: threading.Event,
+        completion_q: queue.Queue[tuple[JobHandle, JobResult]],
+        athena_skill_executor: AthenaSkillExecutor,
+        cleanup_runner: CleanupRunner | None = None,
+    ) -> None:
+        """Create a bounded host-only executor."""
+        if size < 1:
+            raise ValueError("auxiliary worker size must be positive")
+        self._shutdown = shutdown
+        self._completion_q = completion_q
+        self.completion_q = completion_q
+        self._athena_skill_executor = athena_skill_executor
+        self._cleanup_runner = cleanup_runner
+        self._executor = ThreadPoolExecutor(
+            max_workers=size,
+            thread_name_prefix="hephaestus-learning-worker-",
+        )
+        self._completion_wakeup: threading.Event | None = None
+        self._completion_saturation: threading.Event | None = None
+
+    def set_completion_notifiers(
+        self, *, wakeup: threading.Event, saturation: threading.Event
+    ) -> None:
+        """Install coordinator latches without adding a data channel."""
+        self._completion_wakeup = wakeup
+        self._completion_saturation = saturation
+
+    def submit(self, job: object, on_done_state: str) -> JobHandle:
+        """Submit one allowlisted auxiliary job."""
+        if isinstance(job, AthenaSkillJob):
+            if job.request.kind != "learn":
+                raise TypeError("auxiliary worker pool accepts only Athena learn jobs")
+        elif isinstance(job, GitJob):
+            if job.op not in _CLEANUP_OPS:
+                raise TypeError("auxiliary worker pool accepts only cleanup Git jobs")
+        else:
+            raise TypeError(f"auxiliary worker pool does not accept {type(job).__name__}")
+        handle = JobHandle(job=job, on_done_state=on_done_state)
+        future = self._executor.submit(self._run, job)
+        future.add_done_callback(lambda completed: self._publish(handle, completed))
+        return handle
+
+    def _run(self, job: AuxiliaryJob) -> JobResult:
+        start = time.monotonic()
+        if self._shutdown.is_set():
+            return JobResult(ok=False, interrupted=True, error="interrupted_before_start")
+        try:
+            if isinstance(job, AthenaSkillJob):
+                value = self._athena_skill_executor.execute(job.request)
+                result = JobResult(ok=value.ok, value=value, error=value.error)
+            else:
+                if self._cleanup_runner is None:
+                    raise RuntimeError("cleanup job submitted without a cleanup runner")
+                result = self._cleanup_runner(job)
+        except Exception as exc:
+            result = JobResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+        if self._shutdown.is_set():
+            result = replace(result, ok=False, interrupted=True)
+        return replace(
+            result,
+            duration_s=time.monotonic() - start,
+            worker_id=threading.current_thread().name,
+        )
+
+    def _publish(self, handle: JobHandle, future: Future[JobResult]) -> None:
+        try:
+            result = future.result()
+        except BaseException as exc:
+            result = JobResult(ok=False, error=f"worker_crash: {type(exc).__name__}: {exc}")
+        try:
+            self._completion_q.put_nowait((handle, result))
+        except queue.Full:
+            if self._completion_saturation is not None:
+                self._completion_saturation.set()
+        finally:
+            if self._completion_wakeup is not None:
+                self._completion_wakeup.set()
+
+    def shutdown(self, *, mark_interrupted: bool = True) -> None:
+        """Stop pending work and optionally mark active work interrupted."""
+        if mark_interrupted:
+            self._shutdown.set()
+        self._executor.shutdown(wait=False, cancel_futures=True)

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -91,6 +91,7 @@ class Coordinator(
             maxsize=max(config.learning_queue_capacity, config.learning_workers)
         )
         athena_executor: Any | None = None
+        production_pool = pool is None
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
             # I/O-capable module and tests never need it.
@@ -139,7 +140,7 @@ class Coordinator(
                 saturation=self._completion_saturation,
             )
 
-        if auxiliary_pool is None and athena_executor is not None:
+        if auxiliary_pool is None and production_pool:
             from hephaestus.automation.pipeline.auxiliary_worker_pool import AuxiliaryWorkerPool
 
             auxiliary_pool = AuxiliaryWorkerPool(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -7,6 +7,8 @@ from dataclasses import replace
 from pathlib import Path
 
 from .coordinator_dispatch import ImplementationDispatcher
+from .coordinator_execution import ExecutionCoordinator
+from .coordinator_learning import LearningRecoveryCoordinator
 from .coordinator_runtime import CoordinatorRuntime
 from .coordinator_sources import SourceCoordinator
 from .coordinator_types import *
@@ -19,6 +21,8 @@ logger = logging.getLogger(__name__)
 _COORDINATOR_METRIC_NAMES = (
     "hephaestus_pipeline_queue_depth",
     "hephaestus_pipeline_inflight_jobs",
+    "hephaestus_pipeline_lane_queue_depth",
+    "hephaestus_pipeline_lane_inflight_jobs",
     "hephaestus_pipeline_inflight_per_repo",
     "hephaestus_pipeline_loops_total",
     "hephaestus_pipeline_stalled_ticks",
@@ -26,18 +30,26 @@ _COORDINATOR_METRIC_NAMES = (
     "hephaestus_pipeline_alert_active",
     "hephaestus_pipeline_jobs_total",
     "hephaestus_pipeline_agent_job_seconds_total",
+    "hephaestus_pipeline_auxiliary_job_seconds_total",
 )
 
 
-class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatcher):
+class Coordinator(
+    CoordinatorRuntime,
+    SourceCoordinator,
+    ImplementationDispatcher,
+    ExecutionCoordinator,
+    LearningRecoveryCoordinator,
+):
     """Assemble the coordinator's type, runtime, source, and dispatch seams."""
 
-    def __init__(
+    def __init__(  # noqa: C901 - assembles two closed worker lanes
         self,
         config: PipelineConfig,
         *,
         github: StageGitHub,
         pool: Any | None = None,
+        auxiliary_pool: Any | None = None,
         stages: dict[StageName, Stage] | None = None,
         github_factory: Callable[[str, Path], StageGitHub] | None = None,
         install_signals: bool = True,
@@ -63,6 +75,10 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
             raise ValueError("event_log_capacity must be positive")
         if config.terminal_detail_capacity < 1:
             raise ValueError("terminal_detail_capacity must be positive")
+        if config.learning_workers < 1:
+            raise ValueError("learning_workers must be positive")
+        if config.learning_queue_capacity < 1:
+            raise ValueError("learning_queue_capacity must be positive")
         self.shutdown = threading.Event()
         # These latches are the control plane for the bounded completion
         # queue.  They carry no WorkItem/JobResult payload and therefore
@@ -71,6 +87,10 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         self._completion_saturation = threading.Event()
         work_window = _work_window(config)
         self.completion_q: CompletionQueue = queue_mod.Queue(maxsize=work_window)
+        self.auxiliary_completion_q: CompletionQueue = queue_mod.Queue(
+            maxsize=max(config.learning_queue_capacity, config.learning_workers)
+        )
+        athena_executor: Any | None = None
         if pool is None:
             # Imported here, not module-top: WorkerPool is the pipeline's one
             # I/O-capable module and tests never need it.
@@ -119,11 +139,43 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
                 saturation=self._completion_saturation,
             )
 
+        if auxiliary_pool is None and athena_executor is not None:
+            from hephaestus.automation.pipeline.auxiliary_worker_pool import AuxiliaryWorkerPool
+
+            auxiliary_pool = AuxiliaryWorkerPool(
+                size=config.learning_workers,
+                shutdown=self.shutdown,
+                completion_q=self.auxiliary_completion_q,
+                athena_skill_executor=athena_executor,
+                cleanup_runner=getattr(pool, "_run_cleanup_git", None),
+            )
+        elif auxiliary_pool is None:
+            # Injected test pools keep their historical single-channel shape
+            # unless a test exercises the independent auxiliary lane.
+            auxiliary_pool = pool
+            self.auxiliary_completion_q = self.completion_q
+        else:
+            auxiliary_pool.completion_q = self.auxiliary_completion_q
+            if hasattr(auxiliary_pool, "_completion_q"):
+                auxiliary_pool._completion_q = self.auxiliary_completion_q
+        self.auxiliary_pool: Any = auxiliary_pool
+        self._auxiliary_pool_separate = auxiliary_pool is not pool
+        auxiliary_notifiers = getattr(auxiliary_pool, "set_completion_notifiers", None)
+        if self._auxiliary_pool_separate and callable(auxiliary_notifiers):
+            auxiliary_notifiers(
+                wakeup=self._completion_wakeup,
+                saturation=self._completion_saturation,
+            )
+
         self.queues: dict[StageName, StageQueue] = {
-            name: StageQueue(work_window) for name in StageName
+            name: StageQueue(
+                config.learning_queue_capacity if name is StageName.LEARNING else work_window
+            )
+            for name in StageName
         }
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
+        self.auxiliary_in_flight: dict[JobHandle, WorkItem] = {}
         # A holder path reported by Git becomes a safe supersession signal
         # only after a successful create-worktree completion registered it
         # here.  Paths discovered from Git alone can belong to a human or a
@@ -159,6 +211,7 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         # only after the finished sink completes.  The set is therefore
         # bounded by ``_work_window(config)``, not by the number of stages.
         self._live_work_permit_ids: set[int] = set()
+        self._learning_work_permit_ids: set[int] = set()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         # Recovery checkouts are intentionally distinct from failed-item
@@ -198,12 +251,13 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         # Route table for this run: the full ROUTES, or a scope-trimmed copy
         # (out-of-scope next/fail targets rewritten to FINISHED) when the
         # config pins a contiguous stage subset. Computed once — trimming is
-        # pure and the scope is immutable for the run's lifetime. FINISHED is
-        # the universal sink: ``trimmed_routes`` omits it unless it is in the
-        # scope set, so its terminal route is re-added here — every item
-        # eventually routes into FINISHED and _route must find it.
+        # pure and the scope is immutable for the run's lifetime. Learning is
+        # an implicit auxiliary detour and FINISHED is the universal sink, so
+        # both control routes remain available outside the selected main-lane
+        # scope.
         if config.scope is not None:
             self._routes = config.scope.trimmed_routes()
+            self._routes.setdefault(StageName.LEARNING, ROUTES[StageName.LEARNING])
             self._routes.setdefault(StageName.FINISHED, ROUTES[StageName.FINISHED])
         else:
             # Copy, not alias: ``ROUTES`` is a module-level shared table, so an
@@ -217,6 +271,9 @@ class Coordinator(CoordinatorRuntime, SourceCoordinator, ImplementationDispatche
         self._immediate = False
         self._agent_job_count = 0
         self._agent_job_time_s = 0.0
+        self._auxiliary_job_count = 0
+        self._auxiliary_job_time_s = 0.0
+        self._auxiliary_job_failure_count = 0
         self._loops_run = 0
         self._pass_work_count = 0
         self._progress = False

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -80,6 +80,7 @@ class Coordinator(
         if config.learning_queue_capacity < 1:
             raise ValueError("learning_queue_capacity must be positive")
         self.shutdown = threading.Event()
+        self._force_shutdown = threading.Event()
         # These latches are the control plane for the bounded completion
         # queue.  They carry no WorkItem/JobResult payload and therefore
         # cannot become a second, unbounded completion buffer.
@@ -145,7 +146,7 @@ class Coordinator(
 
             auxiliary_pool = AuxiliaryWorkerPool(
                 size=config.learning_workers,
-                shutdown=self.shutdown,
+                shutdown=self._force_shutdown,
                 completion_q=self.auxiliary_completion_q,
                 athena_skill_executor=athena_executor,
                 cleanup_runner=getattr(pool, "_run_cleanup_git", None),
@@ -308,6 +309,9 @@ class Coordinator(
         # retaining one accessor per repository.
         self._ctx_cache: OrderedDict[str, StageContext] = OrderedDict()
         self._ctx_cache_capacity = work_window
+        from hephaestus.automation.arming_state import LearningClaimRegistry
+
+        self._learning_claim_registry = LearningClaimRegistry()
 
     def _direct_issue_identity(
         self, repo: str, issue: int, run_nonce: str

--- a/hephaestus/automation/pipeline/coordinator_contract.py
+++ b/hephaestus/automation/pipeline/coordinator_contract.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         github: StageGitHub
         _github_factory: Callable[[str, Path], StageGitHub] | None
         shutdown: Event
+        _force_shutdown: Event
         completion_q: CompletionQueue
         pool: Any
         queues: dict[StageName, StageQueue]
@@ -73,6 +74,7 @@ if TYPE_CHECKING:
         _stage_config: _StageRunConfig
         _ctx_cache: OrderedDict[str, StageContext]
         _ctx_cache_capacity: int
+        _learning_claim_registry: Any
         _event_log_disabled: bool
         _observed_inflight_repos: set[str]
         _observed_circuit_breaker_states: dict[str, str]

--- a/hephaestus/automation/pipeline/coordinator_contract.py
+++ b/hephaestus/automation/pipeline/coordinator_contract.py
@@ -85,6 +85,8 @@ if TYPE_CHECKING:
         _seq: int
         _agent_job_count: int
         _agent_job_time_s: float
+        _auxiliary_job_count: int
+        _auxiliary_job_time_s: float
 
         @property
         def live_work_count(self) -> int:
@@ -96,7 +98,7 @@ if TYPE_CHECKING:
         def _record_event(self, event: str, *fields: Any) -> None:
             pass
 
-        def _try_acquire_work_permit(self, item: WorkItem) -> bool:
+        def _try_acquire_work_permit(self, item: WorkItem, stage: StageName | None = None) -> bool:
             pass
 
         def _release_work_permit(self, item: WorkItem) -> None:

--- a/hephaestus/automation/pipeline/coordinator_dispatch.py
+++ b/hephaestus/automation/pipeline/coordinator_dispatch.py
@@ -366,6 +366,10 @@ class ImplementationDispatcher(_CoordinatorHost):
 
     def _admit(self, item: WorkItem) -> bool:
         """Admission control: per-repo in-flight cap (O(1) Counter lookup)."""
+        if getattr(self, "_auxiliary_pool_separate", False) and self._is_auxiliary_stage(
+            item.stage
+        ):
+            return len(self.auxiliary_in_flight) < self.config.learning_workers
         return len(self.in_flight) < _work_window(self.config) and self.inflight_per_repo[
             item.repo
         ] < max(1, self.config.max_workers)

--- a/hephaestus/automation/pipeline/coordinator_execution.py
+++ b/hephaestus/automation/pipeline/coordinator_execution.py
@@ -77,7 +77,7 @@ class ExecutionCoordinator(_CoordinatorHost):
             journal.ensure_pending(
                 intent.key,
                 kind=intent.kind.value,
-                identity=intent.journal_identity(),
+                identity=item.learning_journal_identity(intent),
             )
 
     def _submit(self, item: WorkItem, request: JobRequest) -> None:
@@ -210,6 +210,24 @@ class ExecutionCoordinator(_CoordinatorHost):
             logger.exception(
                 "on_job_done poisoned item %s at %s", self._item_key(item), item.stage.value
             )
+            if item.stage is StageName.LEARNING:
+                item.payload.setdefault("learning_failures", []).append(
+                    {
+                        "key": "journal",
+                        "error": "journal_completion_failed",
+                    }
+                )
+                if item.post_processing is not None:
+                    self._handoff_item(
+                        item,
+                        StageName.FINISHED,
+                        enter=True,
+                        result=item.post_processing.result,
+                    )
+                    return
+                if item.learning_resume_stage is not None:
+                    self._handoff_item(item, item.learning_resume_stage, enter=True)
+                    return
             self._finish(item, passed=False, reason="poisoned: on_job_done raised")
             return
         self._register_pipeline_writer_worktree(item, handle.job, result)

--- a/hephaestus/automation/pipeline/coordinator_execution.py
+++ b/hephaestus/automation/pipeline/coordinator_execution.py
@@ -1,0 +1,260 @@
+"""Job submission and lane-permit ownership for the pipeline coordinator."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from .coordinator_contract import _CoordinatorHost
+from .coordinator_sessions import store_agent_session_result
+from .coordinator_types import *
+from .routing import AUXILIARY_PIPELINE_ORDER
+
+# This collaborator consumes the facade's shared type namespace by design.
+# ruff: noqa: F403, F405
+
+_PIPELINE_STAGE_LABELS = frozenset(stage.value for stage in StageName)
+_JOB_OUTCOME_LABELS = frozenset({"ok", "failed", "interrupted"})
+
+
+class ExecutionCoordinator(_CoordinatorHost):
+    """Own job dispatch and independent main/learning permit budgets."""
+
+    _auxiliary_job_failure_count: int
+
+    @property
+    def live_work_count(self) -> int:
+        """Return the number of nonterminal main-lane permits."""
+        return len(self._live_work_permit_ids)
+
+    @property
+    def learning_work_count(self) -> int:
+        """Return the number of nonterminal auxiliary permits."""
+        return len(self._learning_work_permit_ids)
+
+    def _try_acquire_work_permit(self, item: WorkItem, stage: StageName | None = None) -> bool:
+        """Reserve capacity in the lane that owns the target stage."""
+        item_id = id(item)
+        target = stage or item.stage
+        if self._is_auxiliary_stage(target):
+            if item_id in self._learning_work_permit_ids:
+                return True
+            if self.learning_work_count >= self.config.learning_queue_capacity:
+                return False
+            self._learning_work_permit_ids.add(item_id)
+            return True
+        if item_id in self._live_work_permit_ids:
+            return True
+        if self.live_work_count >= _work_window(self.config):
+            return False
+        self._live_work_permit_ids.add(item_id)
+        return True
+
+    def _release_work_permit(self, item: WorkItem) -> None:
+        """Release every lane permit held by an item."""
+        self._live_work_permit_ids.discard(id(item))
+        self._learning_work_permit_ids.discard(id(item))
+
+    def _lane_handoff_capacity(self, item: WorkItem, target: StageName) -> bool:
+        """Check destination capacity before source ownership is released."""
+        source_auxiliary = self._is_auxiliary_stage(item.stage)
+        target_auxiliary = self._is_auxiliary_stage(target)
+        if not source_auxiliary and target_auxiliary:
+            return self.learning_work_count < self.config.learning_queue_capacity
+        if source_auxiliary and not target_auxiliary:
+            return self.live_work_count < _work_window(self.config)
+        return True
+
+    @staticmethod
+    def _is_auxiliary_stage(stage: StageName) -> bool:
+        """Return whether a stage uses the auxiliary permit and worker lane."""
+        return stage in AUXILIARY_PIPELINE_ORDER
+
+    def _persist_learning_intents(self, item: WorkItem) -> None:
+        """Write every intent before a destination queue owns the item."""
+        journal = self._ctx_for_repo(item.repo).learning_journal
+        for intent in item.learning_intents:
+            journal.ensure_pending(
+                intent.key,
+                kind=intent.kind.value,
+                identity=intent.journal_identity(),
+            )
+
+    def _submit(self, item: WorkItem, request: JobRequest) -> None:
+        """Submit a frozen job to its lane and register its ownership."""
+        assert not self.config.dry_run, "dry-run must never submit jobs"  # noqa: S101
+        job: Any = request.job
+        if isinstance(job, AgentJob):
+            ok, delay = self._rate_budget_ok()
+            if not ok:
+                self._timer_park(item, delay)
+                return
+            if self.config.phase_timeout_s and self.config.phase_timeout_s > 0:
+                job = replace(job, timeout_s=int(self.config.phase_timeout_s))
+        claims = self._capture_implementation_file_claims(item)
+        auxiliary = self._auxiliary_pool_separate and self._is_auxiliary_stage(item.stage)
+        if auxiliary:
+            handle = self.auxiliary_pool.submit(job, request.on_done_state)
+            self.auxiliary_in_flight[handle] = item
+        else:
+            handle = self.pool.submit(
+                job,
+                request.on_done_state,
+                claim_key=self._item_key(item),
+                claim_stage=item.stage.value,
+            )
+            self.in_flight[handle] = item
+            self.inflight_per_repo[item.repo] += 1
+        if claims:
+            self._inflight_implementation_claims[handle] = claims
+        self._record_event(
+            "submit",
+            type(job).__name__,
+            self._item_key(item),
+            request.on_done_state,
+            {"lane": "auxiliary" if auxiliary else "main"},
+        )
+
+    def _rate_budget_ok(self) -> tuple[bool, float]:
+        """Return the non-blocking GitHub rate-budget decision."""
+        from hephaestus.automation.pipeline_github_transport import rate_budget_ok
+
+        return rate_budget_ok()
+
+    def _drain_completions(self) -> None:
+        """Drain all ready completions from both worker lanes."""
+        self._completion_wakeup.clear()
+        while True:
+            try:
+                handle, result = self.completion_q.get_nowait()
+            except queue_mod.Empty:
+                break
+            self._handle_completion(handle, result)
+        if self._auxiliary_pool_separate:
+            while True:
+                try:
+                    handle, result = self.auxiliary_completion_q.get_nowait()
+                except queue_mod.Empty:
+                    break
+                self._handle_completion(handle, result, auxiliary=True)
+        if self._completion_saturation.is_set():
+            self._record_event("completion_saturation")
+            raise RuntimeError("completion queue saturated")
+
+    def _wait_for_completion(self, timeout: float) -> None:
+        """Wait for a completion, saturation fault, or signal wake-up."""
+        if self.completion_q.empty() and not self._completion_saturation.is_set():
+            self._completion_wakeup.wait(timeout=timeout)
+        self._drain_completions()
+
+    def _handle_completion(  # noqa: C901 - one protocol serves both closed lanes
+        self, handle: JobHandle, result: JobResult, *, auxiliary: bool = False
+    ) -> None:
+        """Record and route one result from the lane that owned the job."""
+        self._progress = True
+        registry = self.auxiliary_in_flight if auxiliary else self.in_flight
+        item = registry.pop(handle, None)
+        self._inflight_implementation_claims.pop(handle, None)
+        if item is None:
+            self._record_event(
+                "complete_unknown",
+                type(handle.job).__name__,
+                handle.on_done_state,
+                self._job_result_event_fields(result),
+            )
+            logger.warning("completion for unknown handle (already torn down?): %s", handle)
+            return
+        self._record_event(
+            "complete",
+            type(handle.job).__name__,
+            self._item_key(item),
+            item.stage.value,
+            handle.on_done_state,
+            {
+                "descr": getattr(handle.job, "descr", ""),
+                "lane": "auxiliary" if auxiliary else "main",
+                **self._job_result_event_fields(result),
+            },
+        )
+        if not auxiliary:
+            self.inflight_per_repo[item.repo] -= 1
+            if self.inflight_per_repo[item.repo] <= 0:
+                del self.inflight_per_repo[item.repo]
+        if isinstance(handle.job, AgentJob):
+            self._agent_job_count += 1
+            self._agent_job_time_s += result.duration_s
+        if auxiliary:
+            self._auxiliary_job_count += 1
+            self._auxiliary_job_time_s += result.duration_s
+            if not result.ok:
+                self._auxiliary_job_failure_count += 1
+        self._record_completion_metrics(item, handle, result, auxiliary=auxiliary)
+
+        stage = self.stages[item.stage]
+        ctx = self._ctx_for(item)
+        if result.interrupted:
+            if item.stage is StageName.LEARNING and result.error == "interrupted_before_start":
+                cancelled = getattr(stage, "on_cancelled_before_start", None)
+                if callable(cancelled):
+                    cancelled(item, ctx)
+            self._park_resumable(item)
+            return
+        if isinstance(handle.job, AgentJob):
+            session_error = store_agent_session_result(item, handle.job, result)
+            if session_error is not None:
+                self._finish(item, passed=False, reason=session_error)
+                return
+        try:
+            stage.on_job_done(item, result, ctx)
+        except Exception:
+            logger.exception(
+                "on_job_done poisoned item %s at %s", self._item_key(item), item.stage.value
+            )
+            self._finish(item, passed=False, reason="poisoned: on_job_done raised")
+            return
+        self._register_pipeline_writer_worktree(item, handle.job, result)
+        item.state = (
+            handle.on_done_state.value
+            if isinstance(handle.on_done_state, StageName)
+            else handle.on_done_state
+        )
+        if self.shutdown.is_set():
+            self._park_resumable(item)
+            return
+        self._run_item(item)
+
+    def _record_completion_metrics(
+        self,
+        item: WorkItem,
+        handle: JobHandle,
+        result: JobResult,
+        *,
+        auxiliary: bool,
+    ) -> None:
+        """Update the bounded metric series for one completed job."""
+        if self._metrics_registry is None:
+            return
+        outcome = "interrupted" if result.interrupted else ("ok" if result.ok else "failed")
+        self._metrics_registry.counter(
+            "hephaestus_pipeline_jobs_total",
+            "Completed pipeline jobs by stage and outcome.",
+            allowed_labels={
+                "stage": _PIPELINE_STAGE_LABELS,
+                "outcome": _JOB_OUTCOME_LABELS,
+            },
+            series_cap=len(_PIPELINE_STAGE_LABELS) * len(_JOB_OUTCOME_LABELS),
+        ).inc(labels={"stage": item.stage.value, "outcome": outcome})
+        if isinstance(handle.job, AgentJob):
+            self._metrics_registry.counter(
+                "hephaestus_pipeline_agent_job_seconds_total",
+                "Cumulative agent job wall-clock seconds.",
+                allowed_labels={},
+                series_cap=1,
+            ).inc(max(result.duration_s, 0.0))
+        if auxiliary:
+            self._metrics_registry.counter(
+                "hephaestus_pipeline_auxiliary_job_seconds_total",
+                "Cumulative auxiliary-lane job wall-clock seconds.",
+                allowed_labels={},
+                series_cap=1,
+            ).inc(max(result.duration_s, 0.0))

--- a/hephaestus/automation/pipeline/coordinator_execution.py
+++ b/hephaestus/automation/pipeline/coordinator_execution.py
@@ -217,17 +217,8 @@ class ExecutionCoordinator(_CoordinatorHost):
                         "error": "journal_completion_failed",
                     }
                 )
-                if item.post_processing is not None:
-                    self._handoff_item(
-                        item,
-                        StageName.FINISHED,
-                        enter=True,
-                        result=item.post_processing.result,
-                    )
-                    return
-                if item.learning_resume_stage is not None:
-                    self._handoff_item(item, item.learning_resume_stage, enter=True)
-                    return
+                self._park_resumable(item)
+                return
             self._finish(item, passed=False, reason="poisoned: on_job_done raised")
             return
         self._register_pipeline_writer_worktree(item, handle.job, result)

--- a/hephaestus/automation/pipeline/coordinator_handoffs.py
+++ b/hephaestus/automation/pipeline/coordinator_handoffs.py
@@ -1,0 +1,80 @@
+"""Bounded cross-lane handoff recovery."""
+
+from typing import Any, Protocol, cast
+
+from .coordinator_types import StageQueueLease, _PendingHandoff
+
+
+class _HandoffHost(Protocol):
+    def _activate_handoff(self, *args: Any, **kwargs: Any) -> None: ...
+    def _record_event(self, *args: Any) -> None: ...
+    def _item_key(self, item: Any) -> str: ...
+    def _is_auxiliary_stage(self, stage: Any) -> bool: ...
+
+
+class PendingHandoffCoordinator:
+    """Resolve complementary queue handoffs without early lease release."""
+
+    _leases: dict[int, StageQueueLease]
+    _pending_handoffs: dict[int, _PendingHandoff]
+    queues: Any
+    _progress: bool
+
+    def _complete_pending_handoff_pair(
+        self,
+        first_id: int,
+        first: _PendingHandoff,
+        second_id: int,
+        second: _PendingHandoff,
+    ) -> bool:
+        host = cast(_HandoffHost, self)
+        leases = self._leases.get(first_id), self._leases.get(second_id)
+        if None in leases:
+            return False
+        first_lease, second_lease = leases
+        assert first_lease is not None and second_lease is not None  # noqa: S101
+        source1, source2 = self.queues[first.item.stage], self.queues[second.item.stage]
+        target1, target2 = self.queues[first.target], self.queues[second.target]
+        if target1 is source2 and target2 is source1:
+            accepted = first_lease.exchange(target1, second_lease, target2)
+        elif target1.can_offer() and (target2 is source1 or target2.can_offer()):
+            accepted = first_lease.handoff(target1) and second_lease.handoff(target2)
+        elif target2.can_offer() and (target1 is source2 or target1.can_offer()):
+            accepted = second_lease.handoff(target2) and first_lease.handoff(target1)
+        else:
+            return False
+        if not accepted:  # pragma: no cover
+            raise RuntimeError("handoff exchange lost capacity")
+        for item_id, pending in ((first_id, first), (second_id, second)):
+            self._leases.pop(item_id, None)
+            self._pending_handoffs.pop(item_id, None)
+            host._activate_handoff(
+                pending.item, pending.target, enter=pending.enter, result=pending.result
+            )
+            host._record_event(
+                "handoff_retry", pending.item.stage.value, host._item_key(pending.item)
+            )
+        self._progress = True
+        return True
+
+    def _drain_complementary_handoff_pairs(self) -> None:
+        host = cast(_HandoffHost, self)
+        entries = list(self._pending_handoffs.items())
+        for index, (first_id, first) in enumerate(entries):
+            if first_id not in self._pending_handoffs:
+                continue
+            source_aux = host._is_auxiliary_stage(first.item.stage)
+            target_aux = host._is_auxiliary_stage(first.target)
+            if source_aux == target_aux:
+                continue
+            for second_id, second in entries[index + 1 :]:
+                if second_id not in self._pending_handoffs:
+                    continue
+                complementary = (
+                    host._is_auxiliary_stage(second.item.stage) == target_aux
+                    and host._is_auxiliary_stage(second.target) == source_aux
+                )
+                if complementary and self._complete_pending_handoff_pair(
+                    first_id, first, second_id, second
+                ):
+                    break

--- a/hephaestus/automation/pipeline/coordinator_learning.py
+++ b/hephaestus/automation/pipeline/coordinator_learning.py
@@ -35,8 +35,7 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
         if not records:
             return
         if not self.config.enable_learn:
-            for record in records:
-                journal.disable(str(record["key"]))
+            self._disable_valid_records(records, journal)
             return
         restored: list[LearningIntent] = []
         for record in records:
@@ -44,21 +43,38 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
                 restored.append(LearningIntent.from_journal(record))
             except (KeyError, TypeError, ValueError) as exc:
                 logger.warning(
-                    "learning:%s#%s: invalid journal identity disabled: %s",
+                    "learning:%s#%s: invalid journal identity ignored: %s",
                     item.repo,
                     item.issue,
                     exc,
                 )
-                journal.disable(str(record["key"]))
         if not restored:
             return
         item.learning_intents = restored
         item.learning_resume_stage = primary_stage
         if primary_stage is StageName.FINISHED:
             item.payload["_learning_primary_reason"] = primary_reason
-            if item.result is not None:
+            terminal_record = next(
+                (record for record in records if "post_processing" in record),
+                records[0],
+            )
+            restored_terminal = item.restore_post_processing(terminal_record)
+            if item.result is not None and not restored_terminal:
                 item.compact_for_post_processing(item.result)
         item.stage = StageName.LEARNING
+
+    @staticmethod
+    def _disable_valid_records(
+        records: list[dict[str, Any]], journal: LearningJournalStore
+    ) -> None:
+        """Disable records that contain a usable deterministic key."""
+        for record in records:
+            key = record.get("key")
+            if isinstance(key, str) and key:
+                if record.get("status") == "claimed" and journal.claim_is_active(key):
+                    logger.info("learning:%s: active claim belongs to another loop", key)
+                    continue
+                journal.disable(key)
 
     def _adopt_legacy_post_merge_intent(
         self,

--- a/hephaestus/automation/pipeline/coordinator_learning.py
+++ b/hephaestus/automation/pipeline/coordinator_learning.py
@@ -17,7 +17,7 @@ from .work_item import LearningIntent
 class LearningRecoveryCoordinator(_CoordinatorHost):
     """Restore durable learning work before an item's primary route."""
 
-    def _restore_learning_intents(
+    def _restore_learning_intents(  # noqa: C901 - recovery validates durable mixed states
         self,
         item: WorkItem,
         primary_stage: StageName | None,
@@ -34,9 +34,6 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
             records = self._adopt_legacy_post_merge_intent(item, journal)
         if not records:
             return
-        if not self.config.enable_learn:
-            self._disable_valid_records(records, journal)
-            return
         restored: list[LearningIntent] = []
         for record in records:
             try:
@@ -50,6 +47,16 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
                 )
         if not restored:
             return
+        if not self.config.enable_learn:
+            disabled = self._disable_valid_records(records, journal)
+            if primary_stage is StageName.FINISHED:
+                terminal_record = next(
+                    (record for record in records if "post_processing" in record),
+                    records[0],
+                )
+                item.restore_post_processing(terminal_record)
+            if disabled:
+                return
         item.learning_intents = restored
         item.learning_resume_stage = primary_stage
         if primary_stage is StageName.FINISHED:
@@ -66,15 +73,16 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
     @staticmethod
     def _disable_valid_records(
         records: list[dict[str, Any]], journal: LearningJournalStore
-    ) -> None:
+    ) -> bool:
         """Disable records that contain a usable deterministic key."""
+        all_disabled = True
         for record in records:
             key = record.get("key")
-            if isinstance(key, str) and key:
-                if record.get("status") == "claimed" and journal.claim_is_active(key):
-                    logger.info("learning:%s: active claim belongs to another loop", key)
-                    continue
-                journal.disable(key)
+            if isinstance(key, str) and key and journal.disable(key) is None:
+                logger.info("learning:%s: active claim belongs to another loop", key)
+                all_disabled = False
+                continue
+        return all_disabled
 
     def _adopt_legacy_post_merge_intent(
         self,

--- a/hephaestus/automation/pipeline/coordinator_learning.py
+++ b/hephaestus/automation/pipeline/coordinator_learning.py
@@ -47,17 +47,20 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
                 )
         if not restored:
             return
+        item.learning_intents = restored
         if not self.config.enable_learn:
-            disabled = self._disable_valid_records(records, journal)
+            self._disable_valid_records(records, journal)
             if primary_stage is StageName.FINISHED:
                 terminal_record = next(
                     (record for record in records if "post_processing" in record),
                     records[0],
                 )
-                item.restore_post_processing(terminal_record)
-            if disabled:
-                return
-        item.learning_intents = restored
+                if "post_processing" in terminal_record and not self._restore_post_processing(
+                    item, terminal_record
+                ):
+                    return
+            item.learning_intents.clear()
+            return
         item.learning_resume_stage = primary_stage
         if primary_stage is StageName.FINISHED:
             item.payload["_learning_primary_reason"] = primary_reason
@@ -65,10 +68,35 @@ class LearningRecoveryCoordinator(_CoordinatorHost):
                 (record for record in records if "post_processing" in record),
                 records[0],
             )
-            restored_terminal = item.restore_post_processing(terminal_record)
+            restored_terminal = self._restore_post_processing(item, terminal_record)
+            if item.result is not None and not item.result.passed:
+                return
             if item.result is not None and not restored_terminal:
                 item.compact_for_post_processing(item.result)
         item.stage = StageName.LEARNING
+
+    @staticmethod
+    def _restore_post_processing(item: WorkItem, record: dict[str, Any]) -> bool:
+        """Restore one cleanup receipt or quarantine only its source item."""
+        try:
+            return item.restore_post_processing(record)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "learning:%s#%s: invalid post-processing state quarantined: %s",
+                item.repo,
+                item.issue,
+                exc,
+            )
+            item.learning_intents = []
+            item.learning_resume_stage = None
+            item.post_processing = None
+            item.result = ItemResult(
+                passed=False,
+                reason="invalid durable learning recovery state",
+                final_stage=StageName.LEARNING,
+            )
+            item.stage = StageName.FINISHED
+            return False
 
     @staticmethod
     def _disable_valid_records(

--- a/hephaestus/automation/pipeline/coordinator_learning.py
+++ b/hephaestus/automation/pipeline/coordinator_learning.py
@@ -1,0 +1,92 @@
+"""Durable learning-intent recovery for coordinator source items."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.arming_state import LearningJournalStore
+
+from .coordinator_contract import _CoordinatorHost
+from .coordinator_types import *
+from .work_item import LearningIntent
+
+# This collaborator consumes the facade's shared type namespace by design.
+# ruff: noqa: F403, F405
+
+
+class LearningRecoveryCoordinator(_CoordinatorHost):
+    """Restore durable learning work before an item's primary route."""
+
+    def _restore_learning_intents(
+        self,
+        item: WorkItem,
+        primary_stage: StageName | None,
+        primary_reason: str,
+    ) -> None:
+        """Route durable nonterminal learning records before normal work."""
+        if item.issue is None or primary_stage is None:
+            return
+        journal = self._ctx_for_repo(item.repo).learning_journal
+        if not isinstance(journal, LearningJournalStore):
+            return
+        records = journal.incomplete_for_issue(repo=item.repo, issue=item.issue)
+        if not records and primary_stage is StageName.FINISHED and item.pr is not None:
+            records = self._adopt_legacy_post_merge_intent(item, journal)
+        if not records:
+            return
+        if not self.config.enable_learn:
+            for record in records:
+                journal.disable(str(record["key"]))
+            return
+        restored: list[LearningIntent] = []
+        for record in records:
+            try:
+                restored.append(LearningIntent.from_journal(record))
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "learning:%s#%s: invalid journal identity disabled: %s",
+                    item.repo,
+                    item.issue,
+                    exc,
+                )
+                journal.disable(str(record["key"]))
+        if not restored:
+            return
+        item.learning_intents = restored
+        item.learning_resume_stage = primary_stage
+        if primary_stage is StageName.FINISHED:
+            item.payload["_learning_primary_reason"] = primary_reason
+            if item.result is not None:
+                item.compact_for_post_processing(item.result)
+        item.stage = StageName.LEARNING
+
+    def _adopt_legacy_post_merge_intent(
+        self,
+        item: WorkItem,
+        journal: LearningJournalStore,
+    ) -> list[dict[str, Any]]:
+        """Convert a merged legacy learning state into the new journal once."""
+        assert item.issue is not None and item.pr is not None  # noqa: S101
+        github = self._ctx_for_repo(item.repo).github
+        pr_state = github.gh_pr_state(item.pr) or {}
+        if str(pr_state.get("state") or "").upper() != "MERGED" and not pr_state.get("mergedAt"):
+            return []
+        if github.drive_green_learn_terminal(item.issue):
+            return []
+        intent = LearningIntent.post_merge(repo=item.repo, issue=item.issue, pr=item.pr)
+        record = journal.ensure_pending(
+            intent.key,
+            kind=intent.kind.value,
+            identity=intent.journal_identity(),
+        )
+        if record["status"] in {"succeeded", "failed"}:
+            return []
+        if github.drive_green_learn_inflight(item.issue):
+            if journal.claim(intent.key):
+                journal.finish(
+                    intent.key,
+                    succeeded=False,
+                    error="legacy_outcome_unknown",
+                )
+            return []
+        return [record]

--- a/hephaestus/automation/pipeline/coordinator_observability.py
+++ b/hephaestus/automation/pipeline/coordinator_observability.py
@@ -10,6 +10,7 @@ from typing import Any
 from hephaestus.observability.alerts import evaluate_alerts
 
 from .coordinator_types import _json_safe
+from .routing import AUXILIARY_PIPELINE_ORDER, MAIN_PIPELINE_ORDER
 
 
 def record_event(
@@ -54,10 +55,21 @@ def observability_snapshot(coordinator: Any, *, logger: logging.Logger) -> dict[
             logger.exception("circuit-breaker snapshot provider failed")
             snapshot_errors.append("circuit_breaker_snapshot_provider_failed")
 
+    queue_depths = {name.value: len(queue) for name, queue in coordinator.queues.items()}
+    lane_queue_depths = {
+        "main": sum(queue_depths[stage.value] for stage in MAIN_PIPELINE_ORDER),
+        "auxiliary": sum(queue_depths[stage.value] for stage in AUXILIARY_PIPELINE_ORDER),
+    }
+    inflight_by_lane = {
+        "main": len(coordinator.in_flight),
+        "auxiliary": len(coordinator.auxiliary_in_flight),
+    }
     snapshot = {
-        "queue_depths": {name.value: len(queue) for name, queue in coordinator.queues.items()},
+        "queue_depths": queue_depths,
+        "lane_queue_depths": lane_queue_depths,
         "inflight_per_repo": dict(coordinator.inflight_per_repo),
-        "inflight_jobs": len(coordinator.in_flight),
+        "inflight_by_lane": inflight_by_lane,
+        "inflight_jobs": sum(inflight_by_lane.values()),
         "circuit_breakers": circuit_breakers,
         "loops_run": coordinator._loops_run,
         "stalled_ticks": coordinator._stalled_ticks,

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -93,7 +93,10 @@ class CoordinatorRuntime(_CoordinatorHost):
                 now_fn=time.monotonic,
                 budget_fn=self._budget_for,
                 event_fn=self._record_stage_event,
-                learning_journal=LearningJournalStore(learning_state_dir),
+                learning_journal=LearningJournalStore(
+                    learning_state_dir,
+                    claim_registry=self._learning_claim_registry,
+                ),
                 branch_worktree_owner_status=self._branch_worktree_owner_status,
             )
             if len(self._ctx_cache) >= self._ctx_cache_capacity:
@@ -1288,6 +1291,7 @@ class CoordinatorRuntime(_CoordinatorHost):
     def _teardown_immediate(self) -> None:
         """Cancel the pool and synthesize interrupted results for in-flight items."""
         self.shutdown.set()
+        self._force_shutdown.set()
         self._shutdown_pool()
 
     def _shutdown_pool(self) -> None:
@@ -1316,6 +1320,11 @@ class CoordinatorRuntime(_CoordinatorHost):
                 self.auxiliary_pool.shutdown(mark_interrupted=self.shutdown.is_set())
             except Exception:  # pragma: no cover - defensive
                 logger.exception("auxiliary pool shutdown raised")
+        try:
+            self._drain_completions()
+        except RuntimeError as exc:
+            if str(exc) != "completion queue saturated":
+                raise
         for item in list(self.in_flight.values()):
             self._park_resumable(item)
         for item in list(self.auxiliary_in_flight.values()):

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -156,7 +156,7 @@ class CoordinatorRuntime(_CoordinatorHost):
         self._emit_lane_gauges(registry, snapshot)
         inflight_by_repo = registry.gauge(
             "hephaestus_pipeline_inflight_per_repo",
-            "Pipeline jobs currently in flight by repository.",
+            "Main-lane pipeline jobs currently in flight by repository.",
             allowed_labels={"repo": None},
             series_cap=_DYNAMIC_METRIC_SERIES_CAP,
         )
@@ -572,10 +572,17 @@ class CoordinatorRuntime(_CoordinatorHost):
             self._progress = True
             return True
 
-        pending = _PendingHandoff(target=target, enter=enter, result=result)
+        pending = _PendingHandoff(item=item, target=target, enter=enter, result=result)
         existing = self._pending_handoffs.setdefault(id(item), pending)
         if existing != pending:  # pragma: no cover - no item can route twice while leased
             raise RuntimeError(f"conflicting pending handoff for {self._item_key(item)}")
+        if self._is_auxiliary_stage(item.stage) and not self._is_auxiliary_stage(target):
+            # The bounded handoff record now owns the item. Release the source
+            # queue slot and auxiliary permit so a main-lane item can enter
+            # learning and release the main permit that this return needs.
+            # Keeping either source capacity creates a capacity-one cycle.
+            self._leases.pop(id(item)).release()
+            self._learning_work_permit_ids.discard(id(item))
         self._record_event(
             "handoff_pending",
             item.stage.value,
@@ -588,15 +595,18 @@ class CoordinatorRuntime(_CoordinatorHost):
         """Retry every retained route whose destination may have opened."""
         for item_id, pending in list(self._pending_handoffs.items()):
             lease = self._leases.get(item_id)
-            if lease is None:  # pragma: no cover - defensive bookkeeping repair
-                self._pending_handoffs.pop(item_id, None)
-                continue
-            item = lease.item
+            item = pending.item
             if not self._lane_handoff_capacity(item, pending.target):
                 continue
-            if not lease.handoff(self.queues[pending.target]):
+            accepted = (
+                lease.handoff(self.queues[pending.target])
+                if lease is not None
+                else self.queues[pending.target].offer(item)
+            )
+            if not accepted:
                 continue
-            self._leases.pop(item_id, None)
+            if lease is not None:
+                self._leases.pop(item_id, None)
             self._pending_handoffs.pop(item_id, None)
             self._activate_handoff(
                 item,
@@ -964,13 +974,13 @@ class CoordinatorRuntime(_CoordinatorHost):
             if item.stage is StageName.MERGE_WAIT and item.learning_intents:
                 primary_reason = outcome.note or "merged"
                 item.payload["_learning_primary_reason"] = primary_reason
-                self._persist_learning_intents(item)
                 terminal_result = ItemResult(
                     passed=True,
                     reason=primary_reason,
                     final_stage=StageName.MERGE_WAIT,
                 )
                 item.compact_for_post_processing(terminal_result)
+                self._persist_learning_intents(item)
                 self._handoff_item(
                     item,
                     StageName.LEARNING,
@@ -1300,6 +1310,7 @@ class CoordinatorRuntime(_CoordinatorHost):
         leftovers.extend(self.in_flight.values())
         leftovers.extend(self.auxiliary_in_flight.values())
         leftovers.extend(lease.item for lease in self._leases.values())
+        leftovers.extend(pending.item for pending in self._pending_handoffs.values())
         seen: set[int] = set()
         for item in leftovers:
             if id(item) in seen:

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -966,6 +966,16 @@ class CoordinatorRuntime(_CoordinatorHost):
         if disposition is Disposition.SKIP:
             self._finish(item, passed=False, reason=f"skip: {outcome.note}")
             return
+        if disposition is Disposition.EJECT:
+            item.result = ItemResult(
+                passed=True,
+                reason=f"ejected: {outcome.note}",
+                final_stage=item.stage,
+            )
+            self._record_terminal_result(item)
+            self._release_source_lease(item)
+            self._release_work_permit(item)
+            return
         if disposition is Disposition.BLOCKED:
             self._finish(item, passed=False, reason=f"blocked: {outcome.note}")
             return
@@ -979,8 +989,26 @@ class CoordinatorRuntime(_CoordinatorHost):
                     reason=primary_reason,
                     final_stage=StageName.MERGE_WAIT,
                 )
-                item.compact_for_post_processing(terminal_result)
-                self._persist_learning_intents(item)
+                try:
+                    item.compact_for_post_processing(terminal_result)
+                    self._persist_learning_intents(item)
+                except (OSError, RuntimeError, TypeError, ValueError) as exc:
+                    logger.warning(
+                        "merge_wait:%s: could not persist ancillary learning: %s",
+                        item.issue or item.repo,
+                        exc,
+                    )
+                    item.payload.setdefault("learning_failures", []).append(
+                        {"key": "post_merge", "error": str(exc)[:1000]}
+                    )
+                    item.learning_intents.clear()
+                    self._handoff_item(
+                        item,
+                        StageName.FINISHED,
+                        enter=True,
+                        result=terminal_result,
+                    )
+                    return
                 self._handoff_item(
                     item,
                     StageName.LEARNING,

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 import hephaestus.automation.pipeline.coordinator_observability as _observability
 
 from .coordinator_contract import _CoordinatorHost
-from .coordinator_sessions import store_agent_session_result
 from .coordinator_shutdown import shutdown_signal_message
 from .coordinator_types import *
 
@@ -33,6 +32,7 @@ logger = logging.getLogger("hephaestus.automation.pipeline.coordinator")
 _DYNAMIC_METRIC_SERIES_CAP = 100
 _PIPELINE_STAGE_LABELS = frozenset(stage.value for stage in StageName)
 _JOB_OUTCOME_LABELS = frozenset({"ok", "failed", "interrupted"})
+_LANE_LABELS = frozenset({"main", "auxiliary"})
 _BREAKER_STATE_LABELS = frozenset({"closed", "open", "half_open"})
 _ALERT_NAME_LABELS = frozenset({"circuit_breaker_open", "queue_depth_exceeds", "pipeline_stalled"})
 
@@ -44,6 +44,7 @@ class CoordinatorRuntime(_CoordinatorHost):
     _grace_deadline: float | None
     _observed_circuit_breaker_states: dict[str, str]
     _observed_inflight_repos: set[str]
+    _auxiliary_job_failure_count: int
     _pool_shut_down: bool
 
     def _default_stages(self) -> dict[StageName, Stage]:
@@ -55,6 +56,7 @@ class CoordinatorRuntime(_CoordinatorHost):
             StageName.IMPLEMENTATION: ImplementationStage(),
             StageName.PR_REVIEW: PrReviewStage(),
             StageName.MERGE_WAIT: MergeWaitStage(),
+            StageName.LEARNING: LearningStage(),
             StageName.FINISHED: FinishedStage(
                 self.ledger,
                 self.preserved,
@@ -69,6 +71,11 @@ class CoordinatorRuntime(_CoordinatorHost):
             self._ctx_cache.move_to_end(repo)
         else:
             root = _effective_repo_root(self.config, repo)
+            from hephaestus.automation.arming_state import LearningJournalStore
+
+            def learning_state_dir() -> Path:
+                return root / "build" / ".automation-state"
+
             ctx = StageContext(
                 config=self._stage_config,
                 org=self.config.org,
@@ -86,6 +93,7 @@ class CoordinatorRuntime(_CoordinatorHost):
                 now_fn=time.monotonic,
                 budget_fn=self._budget_for,
                 event_fn=self._record_stage_event,
+                learning_journal=LearningJournalStore(learning_state_dir),
                 branch_worktree_owner_status=self._branch_worktree_owner_status,
             )
             if len(self._ctx_cache) >= self._ctx_cache_capacity:
@@ -145,6 +153,7 @@ class CoordinatorRuntime(_CoordinatorHost):
             allowed_labels={},
             series_cap=1,
         ).set(snapshot["inflight_jobs"])
+        self._emit_lane_gauges(registry, snapshot)
         inflight_by_repo = registry.gauge(
             "hephaestus_pipeline_inflight_per_repo",
             "Pipeline jobs currently in flight by repository.",
@@ -166,6 +175,7 @@ class CoordinatorRuntime(_CoordinatorHost):
             allowed_labels={},
             series_cap=1,
         ).set(snapshot["loops_run"])
+
         registry.gauge(
             "hephaestus_pipeline_stalled_ticks",
             "Consecutive drain ticks without pipeline progress.",
@@ -220,6 +230,25 @@ class CoordinatorRuntime(_CoordinatorHost):
                 },
             )
 
+    @staticmethod
+    def _emit_lane_gauges(registry: Any, snapshot: dict[str, Any]) -> None:
+        """Update the two fixed-cardinality auxiliary-lane gauges."""
+        queue_gauge = registry.gauge(
+            "hephaestus_pipeline_lane_queue_depth",
+            "Queued pipeline work items by worker lane.",
+            allowed_labels={"lane": _LANE_LABELS},
+            series_cap=len(_LANE_LABELS),
+        )
+        inflight_gauge = registry.gauge(
+            "hephaestus_pipeline_lane_inflight_jobs",
+            "Pipeline jobs currently in flight by worker lane.",
+            allowed_labels={"lane": _LANE_LABELS},
+            series_cap=len(_LANE_LABELS),
+        )
+        for lane in _LANE_LABELS:
+            queue_gauge.set(snapshot["lane_queue_depths"][lane], labels={"lane": lane})
+            inflight_gauge.set(snapshot["inflight_by_lane"][lane], labels={"lane": lane})
+
     def _wake_completion_wait(self) -> None:
         """Wake the coordinator without writing a sentinel into its bounded queue."""
         self._completion_wakeup.set()
@@ -255,7 +284,7 @@ class CoordinatorRuntime(_CoordinatorHost):
                 self._emit_observability_tick()
                 if self.shutdown.is_set():
                     # Graceful: stop admitting; drain in-flight to RESUMABLE.
-                    if not self.in_flight:
+                    if not self.in_flight and not self.auxiliary_in_flight:
                         break
                     self._wait_for_completion(timeout=0.2)
                     continue
@@ -286,6 +315,9 @@ class CoordinatorRuntime(_CoordinatorHost):
                 agent_job_count=self._agent_job_count,
                 agent_job_time_s=self._agent_job_time_s,
                 wall_s=time.monotonic() - started,
+                auxiliary_job_count=self._auxiliary_job_count,
+                auxiliary_job_time_s=self._auxiliary_job_time_s,
+                auxiliary_job_failure_count=self._auxiliary_job_failure_count,
             )
             summary_items = self._effective_items()
             preserved = self._active_preserved_worktrees()
@@ -374,6 +406,7 @@ class CoordinatorRuntime(_CoordinatorHost):
             all(len(q) == 0 for q in self.queues.values())
             and not self.timers
             and not self.in_flight
+            and not self.auxiliary_in_flight
             and not self._leases
             and not self._pending_handoffs
             and self._direct_issue_source is None
@@ -381,25 +414,6 @@ class CoordinatorRuntime(_CoordinatorHost):
             and self._repo_entry_source is None
             and not self._repo_issue_sources
         )
-
-    @property
-    def live_work_count(self) -> int:
-        """Return the number of nonterminal work permits currently held."""
-        return len(self._live_work_permit_ids)
-
-    def _try_acquire_work_permit(self, item: WorkItem) -> bool:
-        """Reserve one global live-work slot for a newly admitted item."""
-        item_id = id(item)
-        if item_id in self._live_work_permit_ids:
-            return True
-        if self.live_work_count >= _work_window(self.config):
-            return False
-        self._live_work_permit_ids.add(item_id)
-        return True
-
-    def _release_work_permit(self, item: WorkItem) -> None:
-        """Release *item*'s permit after the terminal sink has completed."""
-        self._live_work_permit_ids.discard(id(item))
 
     def _record_terminal_result(self, item: WorkItem) -> None:
         """Aggregate one completed/resumable item and trim detailed retention.
@@ -490,7 +504,16 @@ class CoordinatorRuntime(_CoordinatorHost):
         result: ItemResult | None,
     ) -> None:
         """Publish a route only after its destination accepted the item."""
+        source = item.stage
         self._clear_implementation_file_claims_on_exit(item, target)
+        source_auxiliary = self._is_auxiliary_stage(source)
+        target_auxiliary = self._is_auxiliary_stage(target)
+        if not source_auxiliary and target_auxiliary:
+            self._live_work_permit_ids.discard(id(item))
+            self._learning_work_permit_ids.add(id(item))
+        elif source_auxiliary and not target_auxiliary:
+            self._learning_work_permit_ids.discard(id(item))
+            self._live_work_permit_ids.add(id(item))
         item.stage = target
         if enter:
             item.state = "ENTER"
@@ -519,7 +542,16 @@ class CoordinatorRuntime(_CoordinatorHost):
         if lease is None:
             if result is not None:
                 item.result = result
+            source = item.stage
             self._push_item(item, target, enter=enter)
+            source_auxiliary = self._is_auxiliary_stage(source)
+            target_auxiliary = self._is_auxiliary_stage(target)
+            if not source_auxiliary and target_auxiliary:
+                self._live_work_permit_ids.discard(id(item))
+                self._learning_work_permit_ids.add(id(item))
+            elif source_auxiliary and not target_auxiliary:
+                self._learning_work_permit_ids.discard(id(item))
+                self._live_work_permit_ids.add(id(item))
             return True
 
         if target is item.stage:
@@ -529,7 +561,11 @@ class CoordinatorRuntime(_CoordinatorHost):
                 raise RuntimeError("terminal result cannot route to the source stage")
             return self._restore_source_lease(item)
 
-        if lease.handoff(self.queues[target]):
+        if not self._lane_handoff_capacity(item, target):
+            accepted = False
+        else:
+            accepted = lease.handoff(self.queues[target])
+        if accepted:
             self._leases.pop(id(item), None)
             self._pending_handoffs.pop(id(item), None)
             self._activate_handoff(item, target, enter=enter, result=result)
@@ -556,6 +592,8 @@ class CoordinatorRuntime(_CoordinatorHost):
                 self._pending_handoffs.pop(item_id, None)
                 continue
             item = lease.item
+            if not self._lane_handoff_capacity(item, pending.target):
+                continue
             if not lease.handoff(self.queues[pending.target]):
                 continue
             self._leases.pop(item_id, None)
@@ -592,7 +630,7 @@ class CoordinatorRuntime(_CoordinatorHost):
         if self._progress:
             self._progress = False
             self._stalled_ticks = 0
-        elif not self.in_flight and not self.timers:
+        elif not self.in_flight and not self.auxiliary_in_flight and not self.timers:
             self._stalled_ticks += 1
             if self._stalled_ticks >= _compat("_STALL_TICKS_BEFORE_FORCE"):
                 self._force_run_one()
@@ -604,7 +642,9 @@ class CoordinatorRuntime(_CoordinatorHost):
 
     def _force_run_one(self) -> None:
         """Run the first item of the most-downstream non-empty queue."""
-        assert not self.in_flight, "force-run requires no in-flight work"  # noqa: S101
+        assert not self.in_flight and not self.auxiliary_in_flight, (  # noqa: S101
+            "force-run requires no in-flight work"
+        )
         self._stalled_ticks = 0
         for stage_name in _DRAIN_ORDER:
             q = self.queues[stage_name]
@@ -648,126 +688,6 @@ class CoordinatorRuntime(_CoordinatorHost):
                 return
             heapq.heappop(self.timers)
             self._progress = True
-
-    def _drain_completions(self) -> None:
-        """Drain ALL ready completions without blocking."""
-        # Clear before inspection.  A callback that publishes between this
-        # clear and the final get_nowait() either has its result drained now
-        # (leaving a harmless set latch) or sets the latch for the next wait.
-        self._completion_wakeup.clear()
-        while True:
-            try:
-                handle, result = self.completion_q.get_nowait()
-            except queue_mod.Empty:
-                break
-            self._handle_completion(handle, result)
-
-        if self._completion_saturation.is_set():
-            # This cannot occur when the C-in-flight invariant holds: each
-            # active job has one reserved slot in the C-sized completion
-            # queue.  A WorkerPool callback never blocks or spills when that
-            # invariant is violated; fail the run and finalize its still-live
-            # item resumably instead.  Crucially, this is not a signal.
-            self._record_event("completion_saturation")
-            raise RuntimeError("completion queue saturated")
-
-    def _wait_for_completion(self, timeout: float) -> None:
-        """Wait for a completion, a saturation fault, or a signal wake latch."""
-        # A test double may synchronously enqueue without owning the notifier;
-        # avoid an unnecessary idle wait in that compatible case.  Production
-        # callbacks set the event after every accepted completion.
-        if self.completion_q.empty() and not self._completion_saturation.is_set():
-            self._completion_wakeup.wait(timeout=timeout)
-        self._drain_completions()
-
-    def _handle_completion(self, handle: JobHandle, result: JobResult) -> None:
-        """Route one completed job back to its item.
-
-        Interrupted results park the item RESUMABLE — they never advance and
-        never reach ``on_job_done`` (base-protocol contract).
-        """
-        self._progress = True
-        item = self.in_flight.pop(handle, None)
-        self._inflight_implementation_claims.pop(handle, None)
-        if item is None:
-            self._record_event(
-                "complete_unknown",
-                type(handle.job).__name__,
-                handle.on_done_state,
-                self._job_result_event_fields(result),
-            )
-            logger.warning("completion for unknown handle (already torn down?): %s", handle)
-            return
-        self._record_event(
-            "complete",
-            type(handle.job).__name__,
-            self._item_key(item),
-            item.stage.value,
-            handle.on_done_state,
-            {
-                "descr": getattr(handle.job, "descr", ""),
-                **self._job_result_event_fields(result),
-            },
-        )
-        self.inflight_per_repo[item.repo] -= 1
-        if self.inflight_per_repo[item.repo] <= 0:
-            del self.inflight_per_repo[item.repo]
-        if isinstance(handle.job, AgentJob):
-            self._agent_job_count += 1
-            self._agent_job_time_s += result.duration_s
-        if self._metrics_registry is not None:
-            outcome = "interrupted" if result.interrupted else ("ok" if result.ok else "failed")
-            self._metrics_registry.counter(
-                "hephaestus_pipeline_jobs_total",
-                "Completed pipeline jobs by stage and outcome.",
-                allowed_labels={
-                    "stage": _PIPELINE_STAGE_LABELS,
-                    "outcome": _JOB_OUTCOME_LABELS,
-                },
-                series_cap=len(_PIPELINE_STAGE_LABELS) * len(_JOB_OUTCOME_LABELS),
-            ).inc(labels={"stage": item.stage.value, "outcome": outcome})
-            if isinstance(handle.job, AgentJob):
-                # Counter.inc rejects negative amounts; a monotonic-clock skew
-                # could yield a tiny negative duration, so clamp defensively.
-                self._metrics_registry.counter(
-                    "hephaestus_pipeline_agent_job_seconds_total",
-                    "Cumulative agent job wall-clock seconds.",
-                    allowed_labels={},
-                    series_cap=1,
-                ).inc(max(result.duration_s, 0.0))
-
-        if result.interrupted:
-            self._park_resumable(item)
-            return
-
-        if isinstance(handle.job, AgentJob):
-            session_error = store_agent_session_result(item, handle.job, result)
-            if session_error is not None:
-                self._finish(item, passed=False, reason=session_error)
-                return
-        stage = self.stages[item.stage]
-        ctx = self._ctx_for(item)
-        try:
-            stage.on_job_done(item, result, ctx)
-        except Exception:
-            logger.exception(
-                "on_job_done poisoned item %s at %s", self._item_key(item), item.stage.value
-            )
-            self._finish(item, passed=False, reason="poisoned: on_job_done raised")
-            return
-        self._register_pipeline_writer_worktree(item, handle.job, result)
-        item.state = (
-            handle.on_done_state.value
-            if isinstance(handle.on_done_state, StageName)
-            else handle.on_done_state
-        )
-        if self.shutdown.is_set():
-            # Graceful shutdown: the durable write for this completion is
-            # already journaled by on_job_done's owning stage; do not step
-            # further (stepping could submit new work). Park RESUMABLE.
-            self._park_resumable(item)
-            return
-        self._run_item(item)
 
     def _park_resumable(self, item: WorkItem) -> None:
         """Park *item* as RESUMABLE at its current stage (interrupt semantics).
@@ -965,57 +885,9 @@ class CoordinatorRuntime(_CoordinatorHost):
             )
         return result
 
-    def _submit(self, item: WorkItem, request: JobRequest) -> None:
-        """Submit the requested job; register in-flight bookkeeping.
-
-        Rate gate (non-blocking): an AgentJob submitted while the GraphQL
-        budget is low is timer-parked until the upstream reset instead
-        (``will_submit_agent`` does not exist on the merged stage protocol,
-        so the gate lives here at the submit chokepoint — the plan's
-        sanctioned fallback).
-        """
-        assert not self.config.dry_run, "dry-run must never submit jobs"  # noqa: S101
-        job: Any = request.job
-        if isinstance(job, AgentJob):
-            ok, delay = self._rate_budget_ok()
-            if not ok:
-                logger.info(
-                    "rate budget low; timer-parking %s for %.0fs (no sleep)",
-                    self._item_key(item),
-                    delay,
-                )
-                self._timer_park(item, delay)
-                return
-            if self.config.phase_timeout_s and self.config.phase_timeout_s > 0:
-                # --phase-timeout bounds each AGENT JOB, not a phase subprocess.
-                job = replace(job, timeout_s=int(self.config.phase_timeout_s))
-        implementation_claims = self._capture_implementation_file_claims(item)
-        handle = self.pool.submit(
-            job,
-            request.on_done_state,
-            claim_key=self._item_key(item),
-            claim_stage=item.stage.value,
-        )
-        self.in_flight[handle] = item
-        if implementation_claims:
-            self._inflight_implementation_claims[handle] = implementation_claims
-        self.inflight_per_repo[item.repo] += 1
-        self._record_event(
-            "submit",
-            type(job).__name__,
-            self._item_key(item),
-            request.on_done_state,
-        )
-
-    def _rate_budget_ok(self) -> tuple[bool, float]:
-        """Non-blocking rate-budget check (``(ok, park_delay_s)``)."""
-        # Imported lazily to keep coordinator imports zero-I/O. The transport
-        # proxy still resolves the historical façade patch seam.
-        from hephaestus.automation.pipeline_github_transport import rate_budget_ok
-
-        return rate_budget_ok()
-
-    def _route(self, item: WorkItem, outcome: StageOutcome) -> None:
+    def _route(  # noqa: C901 - disposition table includes an auxiliary detour
+        self, item: WorkItem, outcome: StageOutcome
+    ) -> None:
         """Apply the Disposition -> action table (plan #1817)."""
         if item.stage is StageName.REPO and item.payload.get(DIRECT_SCOPE_BOOTSTRAP_KEY, False):
             self._route_direct_scope_bootstrap(item, outcome)
@@ -1049,9 +921,26 @@ class CoordinatorRuntime(_CoordinatorHost):
 
         if disposition is Disposition.ADVANCE:
             self._seed_products(item)
-            target = route.next
+            if item.stage is StageName.PLAN_REVIEW and item.learning_intents:
+                # Preserve the scope-trimmed primary destination before the
+                # auxiliary detour. A planner-only run must return to its sink
+                # instead of escaping into implementation.
+                item.learning_resume_stage = route.next
+                self._persist_learning_intents(item)
+                target = StageName.LEARNING
+            else:
+                target = route.next
             if target is StageName.FINISHED:
-                self._finish(item, passed=True, reason=outcome.note or "advance")
+                reason = str(item.payload.pop("_learning_primary_reason", ""))
+                if item.post_processing is not None:
+                    self._handoff_item(
+                        item,
+                        StageName.FINISHED,
+                        enter=True,
+                        result=item.post_processing.result,
+                    )
+                else:
+                    self._finish(item, passed=True, reason=reason or outcome.note or "advance")
             else:
                 self._handoff_item(item, target, enter=True)
             return
@@ -1072,6 +961,23 @@ class CoordinatorRuntime(_CoordinatorHost):
             return
         if disposition is Disposition.FINISH_PASS:
             self._seed_products(item)
+            if item.stage is StageName.MERGE_WAIT and item.learning_intents:
+                primary_reason = outcome.note or "merged"
+                item.payload["_learning_primary_reason"] = primary_reason
+                self._persist_learning_intents(item)
+                terminal_result = ItemResult(
+                    passed=True,
+                    reason=primary_reason,
+                    final_stage=StageName.MERGE_WAIT,
+                )
+                item.compact_for_post_processing(terminal_result)
+                self._handoff_item(
+                    item,
+                    StageName.LEARNING,
+                    enter=True,
+                    result=terminal_result,
+                )
+                return
             self._finish(item, passed=True, reason=outcome.note or "pass")
             return
         # FINISH_FAIL (exhaustive over Disposition)
@@ -1367,9 +1273,17 @@ class CoordinatorRuntime(_CoordinatorHost):
             self.pool.shutdown(mark_interrupted=self.shutdown.is_set())
         except Exception:  # pragma: no cover - defensive
             logger.exception("pool shutdown raised")
+        if self._auxiliary_pool_separate:
+            try:
+                self.auxiliary_pool.shutdown(mark_interrupted=self.shutdown.is_set())
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("auxiliary pool shutdown raised")
         for item in list(self.in_flight.values()):
             self._park_resumable(item)
+        for item in list(self.auxiliary_in_flight.values()):
+            self._park_resumable(item)
         self.in_flight.clear()
+        self.auxiliary_in_flight.clear()
         self._inflight_implementation_claims.clear()
         self._implementation_file_claims.clear()
         self.inflight_per_repo.clear()
@@ -1384,6 +1298,7 @@ class CoordinatorRuntime(_CoordinatorHost):
                 continue
             leftovers.extend(q.snapshot())
         leftovers.extend(self.in_flight.values())
+        leftovers.extend(self.auxiliary_in_flight.values())
         leftovers.extend(lease.item for lease in self._leases.values())
         seen: set[int] = set()
         for item in leftovers:

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -4,10 +4,10 @@ from typing import Any, cast
 import hephaestus.automation.pipeline.coordinator_observability as _observability
 
 from .coordinator_contract import _CoordinatorHost
+from .coordinator_handoffs import PendingHandoffCoordinator
 from .coordinator_shutdown import shutdown_signal_message
 from .coordinator_types import *
 
-# This collaborator consumes the façade's shared type namespace by design.
 # ruff: noqa: F403, F405
 
 
@@ -37,7 +37,7 @@ _BREAKER_STATE_LABELS = frozenset({"closed", "open", "half_open"})
 _ALERT_NAME_LABELS = frozenset({"circuit_breaker_open", "queue_depth_exceeds", "pipeline_stalled"})
 
 
-class CoordinatorRuntime(_CoordinatorHost):
+class CoordinatorRuntime(PendingHandoffCoordinator, _CoordinatorHost):
     """Own the event loop, timers, completions, routing, and shutdown."""
 
     _event_log_disabled: bool
@@ -466,7 +466,7 @@ class CoordinatorRuntime(_CoordinatorHost):
         lease = self.queues[stage_name].claim_at(index)
         if lease is None:
             return None
-        item = lease.item
+        item = cast(WorkItem, lease.item)
         item_id = id(item)
         if item_id in self._leases:  # pragma: no cover - internal invariant
             lease.restore()
@@ -579,13 +579,6 @@ class CoordinatorRuntime(_CoordinatorHost):
         existing = self._pending_handoffs.setdefault(id(item), pending)
         if existing != pending:  # pragma: no cover - no item can route twice while leased
             raise RuntimeError(f"conflicting pending handoff for {self._item_key(item)}")
-        if self._is_auxiliary_stage(item.stage) and not self._is_auxiliary_stage(target):
-            # The bounded handoff record now owns the item. Release the source
-            # queue slot and auxiliary permit so a main-lane item can enter
-            # learning and release the main permit that this return needs.
-            # Keeping either source capacity creates a capacity-one cycle.
-            self._leases.pop(id(item)).release()
-            self._learning_work_permit_ids.discard(id(item))
         self._record_event(
             "handoff_pending",
             item.stage.value,
@@ -596,6 +589,7 @@ class CoordinatorRuntime(_CoordinatorHost):
 
     def _drain_pending_handoffs(self) -> None:
         """Retry every retained route whose destination may have opened."""
+        self._drain_complementary_handoff_pairs()
         for item_id, pending in list(self._pending_handoffs.items()):
             lease = self._leases.get(item_id)
             item = pending.item

--- a/hephaestus/automation/pipeline/coordinator_sources.py
+++ b/hephaestus/automation/pipeline/coordinator_sources.py
@@ -162,12 +162,12 @@ class SourceCoordinator(_CoordinatorHost):
                     self._pass_work_count += 1
                 if source.wave_lease is not None:
                     new_item.payload[WAVE_LEASE_PAYLOAD] = source.wave_lease
-                source.pending = None
-                if self._push_item(new_item, new_item.stage, enter=True):
+                if self._push_item(new_item, new_item.stage, enter=True, defer_if_full=True):
+                    source.pending = None
                     source.seeded_count += 1
                     self._progress = True
                     return True
-                self._progress = True
+                source.pending = metadata
                 return True
             except Exception as exc:
                 logger.warning("repo:%s: issue #%d classification failed: %s", repo, number, exc)
@@ -534,13 +534,16 @@ class SourceCoordinator(_CoordinatorHost):
                 continue
             if item is None:
                 continue
-            if self._push_item(item, item.stage, enter=True):
+            if self._push_item(item, item.stage, enter=True, defer_if_full=True):
                 pushed += 1
                 # Let the implementation drain establish ownership before a
                 # later source item is considered, otherwise two overlapping
                 # plans can be queued in the same bootstrap tick.
                 if overlap_enabled and item.stage is StageName.IMPLEMENTATION:
                     break
+            else:
+                source.issues.appendleft(issue)
+                break
         if not source.issues:
             self._direct_issue_source = None
         elif pushed == 0 and blocked_by_overlap and scanned == scan_limit:
@@ -585,8 +588,11 @@ class SourceCoordinator(_CoordinatorHost):
             self._restore_learning_intents(item, entry.stage, entry.reason)
             if source.wave_lease is not None:
                 item.payload[WAVE_LEASE_PAYLOAD] = source.wave_lease
-            if self._push_item(item, item.stage, enter=True):
+            if self._push_item(item, item.stage, enter=True, defer_if_full=True):
                 pushed += 1
+            else:
+                source.pending_pr = pr
+                break
         return pushed
 
     def _clamp_seed_stage_to_scope(

--- a/hephaestus/automation/pipeline/coordinator_sources.py
+++ b/hephaestus/automation/pipeline/coordinator_sources.py
@@ -429,9 +429,10 @@ class SourceCoordinator(_CoordinatorHost):
         if not self.config.issues:
             return
         open_issues = _admission._filter_open_issues(repo, self.config.issues)
+        unique_open_issues = list(dict.fromkeys(open_issues))
         self._direct_issue_source = _DirectIssueSource(
             repo=repo,
-            issues=deque(open_issues),
+            issues=deque(unique_open_issues),
             base_sha=base_sha,
             run_nonce=uuid.uuid4().hex,
             wave_lease=self._direct_wave_lease,

--- a/hephaestus/automation/pipeline/coordinator_sources.py
+++ b/hephaestus/automation/pipeline/coordinator_sources.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Any
 
 from .coordinator_contract import _CoordinatorHost
 from .coordinator_types import *
@@ -158,7 +157,8 @@ class SourceCoordinator(_CoordinatorHost):
                         reason=entry.reason,
                         final_stage=StageName.FINISHED,
                     )
-                elif new_item.stage is not StageName.REPO:
+                self._restore_learning_intents(new_item, entry.stage, entry.reason)
+                if new_item.stage not in {StageName.REPO, StageName.FINISHED, StageName.LEARNING}:
                     self._pass_work_count += 1
                 if source.wave_lease is not None:
                     new_item.payload[WAVE_LEASE_PAYLOAD] = source.wave_lease
@@ -218,6 +218,9 @@ class SourceCoordinator(_CoordinatorHost):
         for it in self.in_flight.values():
             if it.kind is ItemKind.ISSUE and it.issue is not None:
                 keys.add((it.repo, it.issue))
+        for it in self.auxiliary_in_flight.values():
+            if it.kind is ItemKind.ISSUE and it.issue is not None:
+                keys.add((it.repo, it.issue))
         for lease in self._leases.values():
             it = lease.item
             if it.kind is ItemKind.ISSUE and it.issue is not None:
@@ -263,7 +266,7 @@ class SourceCoordinator(_CoordinatorHost):
         ):
             logger.info("seed skipped: #%s already queued/in-flight in %s", item.issue, item.repo)
             return False
-        if is_new_item and not self._try_acquire_work_permit(item):
+        if is_new_item and not self._try_acquire_work_permit(item, stage):
             logger.debug(
                 "global live-work capacity reached (%d); deferring %s",
                 _work_window(self.config),
@@ -480,6 +483,7 @@ class SourceCoordinator(_CoordinatorHost):
             logger.info("seed excluded: %s", entry.reason)
             return None, False
         item = self._prepare_direct_item(entry, source.repo, source.base_sha, source.run_nonce)
+        self._restore_learning_intents(item, entry.stage, entry.reason)
         if existing_pr is not None:
             item.branch = branch
         if source.wave_lease is not None:
@@ -578,6 +582,7 @@ class SourceCoordinator(_CoordinatorHost):
                 continue
 
             item = self._prepare_direct_item(entry, source.repo, source.base_sha)
+            self._restore_learning_intents(item, entry.stage, entry.reason)
             if source.wave_lease is not None:
                 item.payload[WAVE_LEASE_PAYLOAD] = source.wave_lease
             if self._push_item(item, item.stage, enter=True):

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -6,7 +6,8 @@ The coordinator runs on the process main thread and owns all seven stage
 queues, the timer heap, the in-flight registry, all routing, and (through the
 :class:`~hephaestus.automation.pipeline_github.PipelineGitHub` accessor) every
 GitHub API mutation. A single worker pool executes agent, build/test, and
-git/network jobs; the ONLY cross-thread data channel is the completion queue.
+git/network jobs; the only cross-thread data channels are the bounded main and
+auxiliary completion queues.
 A separate event latch wakes the idle loop for both accepted completions and
 signals, so neither a worker callback nor a signal handler can block on a
 full queue.
@@ -218,7 +219,8 @@ _PROMPT_PREFLIGHT_TEMPLATE = "shared/untrusted_notice.j2"
 _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — reinstall: `uv sync`."
 
 # In-memory diagnostics are finite; the durable JSONL stream is a best-effort
-# diagnostic artifact only. GitHub state remains the restart authority.
+# diagnostic artifact only. GitHub facts, learning journals, arming state, and
+# issue-wave checkpoints are the restart authorities for their owned state.
 _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -405,17 +405,17 @@ class _Paths:
 
 @dataclass(frozen=True)
 class _PendingHandoff:
-    """A completed route retained by its source-stage lease.
+    """A completed route retained by a source lease or bounded handoff slot.
 
     ``StageQueueLease`` keeps the source slot occupied until the destination
     accepts the item.  The coordinator records only the next intent here; it
     deliberately does not mutate ``WorkItem.stage``, ``state``, history, or a
     terminal result until that destination-first admission succeeds.  There
     can be at most one pending handoff per active lease, so this is bounded by
-    the fixed capacity of the coordinator's stage queues rather than acting as
-    a spill buffer.
+    fixed stage-queue capacity rather than acting as a spill buffer.
     """
 
+    item: WorkItem
     target: StageName
     enter: bool
     result: ItemResult | None = None

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -6,9 +6,8 @@ The coordinator runs on the process main thread and owns all seven stage
 queues, the timer heap, the in-flight registry, all routing, and (through the
 :class:`~hephaestus.automation.pipeline_github.PipelineGitHub` accessor) every
 GitHub API mutation. A single worker pool executes agent, build/test, and
-git/network jobs; the only cross-thread data channels are the bounded main and
-auxiliary completion queues.
-A separate event latch wakes the idle loop for both accepted completions and
+git/network jobs; bounded main and auxiliary completion queues are the only
+cross-thread data channels. A separate event latch wakes the idle loop for accepted completions and
 signals, so neither a worker callback nor a signal handler can block on a
 full queue.
 
@@ -218,9 +217,8 @@ _FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
 _PROMPT_PREFLIGHT_TEMPLATE = "shared/untrusted_notice.j2"
 _PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — reinstall: `uv sync`."
 
-# In-memory diagnostics are finite; the durable JSONL stream is a best-effort
-# diagnostic artifact only. GitHub facts, learning journals, arming state, and
-# issue-wave checkpoints are the restart authorities for their owned state.
+# JSONL is diagnostic only. GitHub facts, learning journals, arming state, and issue-wave
+# checkpoints are the restart authorities for their owned state.
 _DEFAULT_EVENT_LOG_CAPACITY = 1_024
 _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -132,6 +132,7 @@ from hephaestus.automation.pipeline.stages import (
     FinishedStage,
     ImplementationStage,
     JobRequest,
+    LearningStage,
     MergeWaitStage,
     PlanningStage,
     PlanReviewStage,
@@ -167,7 +168,6 @@ from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO, STATE_PL
 from hephaestus.prompts import PromptCatalog
 
 logger = logging.getLogger(__name__)
-
 
 #: Warn when any stage.step() call exceeds this duration (seconds) — the
 #: stage protocol promises short (<~60s) main-thread steps. 15s proved too
@@ -228,6 +228,7 @@ _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05
 #: finished sink drains first of all so results are recorded promptly).
 _DRAIN_ORDER: tuple[StageName, ...] = (
     StageName.FINISHED,
+    StageName.LEARNING,
     StageName.MERGE_WAIT,
     StageName.PR_REVIEW,
     StageName.IMPLEMENTATION,
@@ -303,6 +304,8 @@ class PipelineConfig:
     loops: int = 1
     max_workers: int = 1
     parallel_repos: int = 1
+    learning_workers: int = 1
+    learning_queue_capacity: int = 1
     dry_run: bool = False
     grace_s: float = _DEFAULT_GRACE_S
     phase_timeout_s: float | None = None
@@ -355,9 +358,7 @@ class PipelineConfig:
     # when True, issues already at-or-past ``state:plan-go`` are re-routed to
     # PLANNING instead of being classified past the scope (and thus skipped).
     force: bool = False
-    # Optional staged issue-wave selector.  It is intentionally appended after
-    # the historical fields so existing positional construction keeps its
-    # third argument as ``repo_source_factory``.
+    # Appended so positional construction keeps ``repo_source_factory`` third.
     issue_limit: int | None = None
     enable_learn: bool = True
 
@@ -491,7 +492,7 @@ __all__ = [
     'DIRECT_SCOPE_BASE_SHA_KEY', 'DIRECT_SCOPE_BOOTSTRAP_KEY', 'DIRECT_SCOPE_WORKTREE_NONCE_KEY', 'PIPELINE_ORDER', 'PRE_PR_TEST_ARGV', 'ROUTES', 'STATE_IMPLEMENTATION_GO', 'STATE_PLAN_BLOCKED', 'WAVE_LEASE_PAYLOAD', 'WORKTREE_MATERIALIZED_KEY',  # noqa: E501
     '_DEFAULT_EVENT_LOG_CAPACITY', '_DEFAULT_GRACE_S', '_DEFAULT_TERMINAL_DETAIL_CAPACITY', '_DIRECT_ISSUE_ENTRY_STAGES', '_DRAIN_ORDER', '_FAIL_BACK_CAP', '_FILE_CLAIM_STAGES', '_FILE_OVERLAP_BLOCKED_CLAIMS_KEY', '_FILE_OVERLAP_DEFERRALS_KEY', '_FILE_OVERLAP_WARNING_THRESHOLD',  # noqa: E501
     '_IDLE_POLL_S', '_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD', '_MAX_STEPS_PER_TICK', '_PROMPT_PREFLIGHT_ERROR', '_PROMPT_PREFLIGHT_TEMPLATE', '_REALIZED_DIFF_CLAIM_STAGES', '_SOURCE_REGISTRY_RETRY_DELAY_S', '_STALL_TICKS_BEFORE_FORCE', '_STEP_WATCHDOG_S', 'AgentJob', 'Any', 'BranchWorktreeOwnerStatus', 'Callable',  # noqa: E501
-    'CompletionQueue', 'Continue', 'Counter', 'Disposition', 'FinishedStage', 'GitJob', 'ImplementationStage', 'IssueInfo', 'IssueWaveError', 'IssueWaveStore', 'ItemKind', 'ItemResult', 'Iterable', 'Iterator', 'JobHandle', 'JobRequest', 'JobResult', 'MergeWaitStage',  # noqa: E501
+    'CompletionQueue', 'Continue', 'Counter', 'Disposition', 'FinishedStage', 'GitJob', 'ImplementationStage', 'IssueInfo', 'IssueWaveError', 'IssueWaveStore', 'ItemKind', 'ItemResult', 'Iterable', 'Iterator', 'JobHandle', 'JobRequest', 'JobResult', 'LearningStage', 'MergeWaitStage',  # noqa: E501
     'OrderedDict', 'Path', 'PipelineConfig', 'PipelineScope', 'PlanReviewStage', 'PlanningStage', 'PrReviewStage', 'PreservedWorktree', 'PromptCatalog', 'RepoIssueSource', 'RepoStage', 'Route', 'RunStats', 'Stage', 'StageContext', 'StageEvent', 'StageGitHub', 'StageName',  # noqa: E501
     'StageOutcome', 'StageQueue', 'StageQueueLease', 'StageStepResult', 'TemplateNotFound', 'TerminalSummary', 'WaveLease', 'WorkItem', '_ActiveRepoIssueSource', '_DirectIssueSource', '_DirectPrSource', '_Paths', '_PendingHandoff', '_RepoEntrySource', '_StageRunConfig',  # noqa: E501
     '_admission', '_budget_lookup', '_effective_repo_root', '_json_safe', '_preflight_prompt_catalog', '_seeding', '_work_window', 'annotations', 'dataclass', 'deque', 'encode_stage_event', 'field', 'heapq', 'is_epic', 'is_full_commit_sha', 'is_inspection_only_detached_push_failure', 'json',  # noqa: E501

--- a/hephaestus/automation/pipeline/coordinator_types.py
+++ b/hephaestus/automation/pipeline/coordinator_types.py
@@ -2,14 +2,13 @@
 
 ## Semantics
 
-The coordinator runs on the process main thread and owns all seven stage
-queues, the timer heap, the in-flight registry, all routing, and (through the
+The coordinator main thread owns all eight queues, the timer heap, in-flight
+jobs, routing, and (through the
 :class:`~hephaestus.automation.pipeline_github.PipelineGitHub` accessor) every
-GitHub API mutation. A single worker pool executes agent, build/test, and
-git/network jobs; bounded main and auxiliary completion queues are the only
-cross-thread data channels. A separate event latch wakes the idle loop for accepted completions and
-signals, so neither a worker callback nor a signal handler can block on a
-full queue.
+GitHub API mutation. The main pool runs agent, test, Git, and network jobs. The
+auxiliary pool runs learning and terminal cleanup. Their bounded completion
+queues are the only cross-thread channels. An event latch wakes the loop for
+accepted completions and signals; callbacks and signal handlers never block on full queues.
 
 Per tick (epic #1809 "Coordinator event loop"):
 
@@ -18,8 +17,9 @@ Per tick (epic #1809 "Coordinator event loop"):
 2. wake expired timers (heapq) back into their stage queues;
 3. drain ALL ready completions — interrupted results park the item
    RESUMABLE and never advance (``on_job_done`` is never called for them);
-4. drain queues DOWNSTREAM-FIRST (finished → merge_wait → ... → repo; finish
-   work before admitting new) with admission control;
+4. drain queues DOWNSTREAM-FIRST (finished → learning → merge_wait → pr_review
+   → implementation → plan_review → planning → repo; finish work before
+   admitting new) with admission control;
 5. fully drained: re-seed discovery up to ``--loops``; explicit
    ``--issues``/``--prs`` selections drain once; otherwise block or converge.
 
@@ -224,8 +224,8 @@ _DEFAULT_TERMINAL_DETAIL_CAPACITY = 128
 _SOURCE_REGISTRY_RETRY_DELAY_S = 0.05
 
 #: Downstream-first drain order: finish work before admitting new (epic
-#: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
-#: finished sink drains first of all so results are recorded promptly).
+#: #1809 "drain queues downstream-first"; finished and auxiliary learning
+#: drain before the main pipeline so terminal work is recorded promptly).
 _DRAIN_ORDER: tuple[StageName, ...] = (
     StageName.FINISHED,
     StageName.LEARNING,

--- a/hephaestus/automation/pipeline/git_cleanup.py
+++ b/hephaestus/automation/pipeline/git_cleanup.py
@@ -111,24 +111,39 @@ def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager
         ):
             return JobResult(ok=False, error="worktree cleanup identity is invalid")
         expected_branch = job.kwargs.get("expected_branch")
+        expected_head = job.kwargs.get("expected_head")
         with file_lock(worktree_manager_type.git_metadata_lock_path(repo_root)):
-            if expected_branch is not None:
+            if expected_branch is not None or expected_head is not None:
                 record = _worktree_record(
                     worktree_path,
                     repo_root=repo_root,
                     timeout=job.timeout_s,
                     worktree_manager_type=worktree_manager_type,
                 )
-                if (
+                branch_changed = expected_branch is not None and (
                     not isinstance(expected_branch, str)
                     or not expected_branch
                     or record is None
                     or record.get("branch") != f"refs/heads/{expected_branch}"
-                ):
+                )
+                head_changed = expected_head is not None and (
+                    not _is_full_commit_sha(expected_head)
+                    or record is None
+                    or record.get("commit") != expected_head
+                )
+                if branch_changed or head_changed:
                     return JobResult(ok=False, error="worktree cleanup ownership changed")
+            status = run(
+                ["git", "status", "--porcelain", "--untracked-files=all"],
+                cwd=worktree_path,
+                timeout=job.timeout_s,
+            )
+            if status.stdout.strip():
+                return JobResult(
+                    ok=False,
+                    error="worktree cleanup refused a dirty checkout",
+                )
             command = ["git", "worktree", "remove", str(worktree_path)]
-            if job.kwargs.get("force"):
-                command.append("--force")
             run(command, cwd=repo_root, timeout=job.timeout_s)
             run(
                 ["git", "worktree", "prune"],

--- a/hephaestus/automation/pipeline/git_cleanup.py
+++ b/hephaestus/automation/pipeline/git_cleanup.py
@@ -21,9 +21,32 @@ from .job_results import JobResult
 def _is_full_commit_sha(value: object) -> bool:
     return (
         isinstance(value, str)
-        and len(value) == 40
+        and len(value) in (40, 64)
         and all(character in "0123456789abcdefABCDEF" for character in value)
     )
+
+
+def _is_expected_worktree_path(path: Path, *, repo_root: Path, issue_number: int) -> bool:
+    """Bind destructive cleanup to one managed issue worktree identity."""
+    if issue_number <= 0:
+        return False
+    try:
+        resolved = path.resolve()
+        root = repo_root.resolve()
+    except OSError:
+        return False
+    expected_names = (
+        f"issue-{issue_number}",
+        f"issue-{issue_number}-direct-",
+        f"review-pr-{issue_number}",
+    )
+    if (
+        resolved.name != expected_names[0]
+        and not resolved.name.startswith(expected_names[1])
+        and resolved.name != expected_names[2]
+    ):
+        return False
+    return resolved.parent in {root, root / "build" / ".worktrees"}
 
 
 def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager) -> JobResult:
@@ -56,6 +79,17 @@ def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager
     if job.kwargs.get("worktree_path"):
         worktree_path = Path(str(job.kwargs["worktree_path"]))
         repo_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
+        issue_number = job.kwargs.get("issue_number")
+        if (
+            isinstance(issue_number, bool)
+            or not isinstance(issue_number, int)
+            or not _is_expected_worktree_path(
+                worktree_path,
+                repo_root=repo_root,
+                issue_number=issue_number,
+            )
+        ):
+            return JobResult(ok=False, error="worktree cleanup identity is invalid")
         with file_lock(worktree_manager_type.git_metadata_lock_path(repo_root)):
             command = ["git", "worktree", "remove", str(worktree_path)]
             if job.kwargs.get("force"):

--- a/hephaestus/automation/pipeline/git_cleanup.py
+++ b/hephaestus/automation/pipeline/git_cleanup.py
@@ -35,15 +35,19 @@ def _is_expected_worktree_path(path: Path, *, repo_root: Path, issue_number: int
         root = repo_root.resolve()
     except OSError:
         return False
-    expected_names = (
-        f"issue-{issue_number}",
-        f"issue-{issue_number}-direct-",
-        f"review-pr-{issue_number}",
+    issue_name = f"issue-{issue_number}"
+    direct_prefix = f"{issue_name}-direct-"
+    review_name = f"review-pr-{issue_number}"
+    review_generation = resolved.name.removeprefix(f"{review_name}-")
+    is_review_path = resolved.name == review_name or (
+        resolved.name.startswith(f"{review_name}-")
+        and review_generation.isdecimal()
+        and int(review_generation) > 0
     )
     if (
-        resolved.name != expected_names[0]
-        and not resolved.name.startswith(expected_names[1])
-        and resolved.name != expected_names[2]
+        resolved.name != issue_name
+        and not resolved.name.startswith(direct_prefix)
+        and not is_review_path
     ):
         return False
     return resolved.parent in {root, root / "build" / ".worktrees"}
@@ -67,6 +71,29 @@ def _worktree_record(
         ),
         None,
     )
+
+
+def _ownership_changed(
+    record: dict[str, str] | None,
+    *,
+    expected_branch: object,
+    expected_head: object,
+    expected_detached: bool,
+) -> bool:
+    """Return whether the registered worktree differs from its cleanup proof."""
+    branch_changed = expected_branch is not None and (
+        not isinstance(expected_branch, str)
+        or not expected_branch
+        or record is None
+        or record.get("branch") != f"refs/heads/{expected_branch}"
+    )
+    head_changed = expected_head is not None and (
+        not _is_full_commit_sha(expected_head)
+        or record is None
+        or record.get("commit") != expected_head
+    )
+    detached_changed = expected_detached and (record is None or bool(record.get("branch")))
+    return branch_changed or head_changed or detached_changed
 
 
 def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager) -> JobResult:
@@ -100,6 +127,9 @@ def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager
         worktree_path = Path(str(job.kwargs["worktree_path"]))
         repo_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
         issue_number = job.kwargs.get("issue_number")
+        expected_branch = job.kwargs.get("expected_branch")
+        expected_head = job.kwargs.get("expected_head")
+        expected_detached = job.kwargs.get("expected_detached", False)
         if (
             isinstance(issue_number, bool)
             or not isinstance(issue_number, int)
@@ -108,31 +138,24 @@ def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager
                 repo_root=repo_root,
                 issue_number=issue_number,
             )
+            or (expected_branch is None and expected_head is None)
+            or not isinstance(expected_detached, bool)
         ):
             return JobResult(ok=False, error="worktree cleanup identity is invalid")
-        expected_branch = job.kwargs.get("expected_branch")
-        expected_head = job.kwargs.get("expected_head")
         with file_lock(worktree_manager_type.git_metadata_lock_path(repo_root)):
-            if expected_branch is not None or expected_head is not None:
-                record = _worktree_record(
-                    worktree_path,
-                    repo_root=repo_root,
-                    timeout=job.timeout_s,
-                    worktree_manager_type=worktree_manager_type,
-                )
-                branch_changed = expected_branch is not None and (
-                    not isinstance(expected_branch, str)
-                    or not expected_branch
-                    or record is None
-                    or record.get("branch") != f"refs/heads/{expected_branch}"
-                )
-                head_changed = expected_head is not None and (
-                    not _is_full_commit_sha(expected_head)
-                    or record is None
-                    or record.get("commit") != expected_head
-                )
-                if branch_changed or head_changed:
-                    return JobResult(ok=False, error="worktree cleanup ownership changed")
+            record = _worktree_record(
+                worktree_path,
+                repo_root=repo_root,
+                timeout=job.timeout_s,
+                worktree_manager_type=worktree_manager_type,
+            )
+            if _ownership_changed(
+                record,
+                expected_branch=expected_branch,
+                expected_head=expected_head,
+                expected_detached=expected_detached,
+            ):
+                return JobResult(ok=False, error="worktree cleanup ownership changed")
             status = run(
                 ["git", "status", "--porcelain", "--untracked-files=all"],
                 cwd=worktree_path,

--- a/hephaestus/automation/pipeline/git_cleanup.py
+++ b/hephaestus/automation/pipeline/git_cleanup.py
@@ -1,0 +1,93 @@
+"""Shared low-level cleanup operations for both pipeline worker lanes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation.git_utils import (
+    delete_local_branch_if_unchanged,
+    delete_reserved_branch_if_unchanged,
+    run,
+)
+from hephaestus.automation.worktree_manager import WorktreeManager
+from hephaestus.utils.file_lock import file_lock
+from hephaestus.utils.helpers import get_repo_root
+
+from .git_jobs import GitJob
+from .job_results import JobResult
+
+
+def _is_full_commit_sha(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 40
+        and all(character in "0123456789abcdefABCDEF" for character in value)
+    )
+
+
+def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager) -> JobResult:
+    """Run one validated worktree or reservation cleanup operation."""
+    if job.op == "release_branch_reservation":
+        branch_name = str(job.kwargs.get("branch") or "")
+        base_sha = str(job.kwargs.get("base_sha") or "")
+        repo_root_value = job.kwargs.get("repo_root")
+        repo_root = Path(str(repo_root_value)) if repo_root_value else None
+        if (
+            not branch_name
+            or not _is_full_commit_sha(base_sha)
+            or repo_root is None
+            or not repo_root.is_dir()
+        ):
+            return JobResult(
+                ok=False,
+                error="release_branch_reservation requires branch, base_sha, and repo_root",
+            )
+        released = delete_reserved_branch_if_unchanged(
+            branch_name,
+            base_sha,
+            repo_root,
+            timeout=job.timeout_s,
+        )
+        return JobResult(ok=True, value=released)
+
+    if job.op != "remove_worktree":
+        raise TypeError(f"unsupported cleanup Git operation: {job.op}")
+    if job.kwargs.get("worktree_path"):
+        worktree_path = Path(str(job.kwargs["worktree_path"]))
+        repo_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
+        with file_lock(worktree_manager_type.git_metadata_lock_path(repo_root)):
+            command = ["git", "worktree", "remove", str(worktree_path)]
+            if job.kwargs.get("force"):
+                command.append("--force")
+            run(command, cwd=repo_root, timeout=job.timeout_s)
+            run(
+                ["git", "worktree", "prune"],
+                cwd=repo_root,
+                check=False,
+                timeout=job.timeout_s,
+            )
+            local_cleanup = job.kwargs.get("local_branch_cleanup")
+            if local_cleanup is not None:
+                if not isinstance(local_cleanup, dict):
+                    return JobResult(ok=False, error="local branch cleanup receipt is invalid")
+                cleanup_branch = local_cleanup.get("branch")
+                expected_sha = str(local_cleanup.get("base_sha") or "")
+                if not isinstance(cleanup_branch, str) or not _is_full_commit_sha(expected_sha):
+                    return JobResult(ok=False, error="local branch cleanup receipt is invalid")
+                deleted = delete_local_branch_if_unchanged(
+                    cleanup_branch,
+                    expected_sha,
+                    repo_root,
+                    timeout=job.timeout_s,
+                )
+                return JobResult(ok=True, value={"local_branch_deleted": deleted})
+        return JobResult(ok=True)
+    fallback_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
+    fallback_kwargs = dict(job.kwargs)
+    fallback_kwargs.pop("repo_root", None)
+    worktree_manager_type(repo_root=fallback_root).remove_worktree(
+        **fallback_kwargs,
+        timeout=job.timeout_s,
+    )
+    return JobResult(ok=True)

--- a/hephaestus/automation/pipeline/git_cleanup.py
+++ b/hephaestus/automation/pipeline/git_cleanup.py
@@ -49,6 +49,26 @@ def _is_expected_worktree_path(path: Path, *, repo_root: Path, issue_number: int
     return resolved.parent in {root, root / "build" / ".worktrees"}
 
 
+def _worktree_record(
+    worktree_path: Path,
+    *,
+    repo_root: Path,
+    timeout: int,
+    worktree_manager_type: Any,
+) -> dict[str, str] | None:
+    """Return the registered record for an exact worktree path."""
+    target = worktree_path.resolve()
+    manager = worktree_manager_type(repo_root=repo_root)
+    return next(
+        (
+            record
+            for record in manager.list_worktrees(raise_on_error=True, timeout=timeout)
+            if record.get("path") and Path(record["path"]).resolve() == target
+        ),
+        None,
+    )
+
+
 def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager) -> JobResult:
     """Run one validated worktree or reservation cleanup operation."""
     if job.op == "release_branch_reservation":
@@ -90,7 +110,22 @@ def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager
             )
         ):
             return JobResult(ok=False, error="worktree cleanup identity is invalid")
+        expected_branch = job.kwargs.get("expected_branch")
         with file_lock(worktree_manager_type.git_metadata_lock_path(repo_root)):
+            if expected_branch is not None:
+                record = _worktree_record(
+                    worktree_path,
+                    repo_root=repo_root,
+                    timeout=job.timeout_s,
+                    worktree_manager_type=worktree_manager_type,
+                )
+                if (
+                    not isinstance(expected_branch, str)
+                    or not expected_branch
+                    or record is None
+                    or record.get("branch") != f"refs/heads/{expected_branch}"
+                ):
+                    return JobResult(ok=False, error="worktree cleanup ownership changed")
             command = ["git", "worktree", "remove", str(worktree_path)]
             if job.kwargs.get("force"):
                 command.append("--force")
@@ -107,7 +142,11 @@ def run_cleanup_job(job: GitJob, *, worktree_manager_type: Any = WorktreeManager
                     return JobResult(ok=False, error="local branch cleanup receipt is invalid")
                 cleanup_branch = local_cleanup.get("branch")
                 expected_sha = str(local_cleanup.get("base_sha") or "")
-                if not isinstance(cleanup_branch, str) or not _is_full_commit_sha(expected_sha):
+                if (
+                    not isinstance(cleanup_branch, str)
+                    or cleanup_branch != expected_branch
+                    or not _is_full_commit_sha(expected_sha)
+                ):
                     return JobResult(ok=False, error="local branch cleanup receipt is invalid")
                 deleted = delete_local_branch_if_unchanged(
                     cleanup_branch,

--- a/hephaestus/automation/pipeline/git_jobs.py
+++ b/hephaestus/automation/pipeline/git_jobs.py
@@ -1,0 +1,40 @@
+"""Provider-neutral Git job specifications for pipeline workers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+GIT_OPS: frozenset[str] = frozenset(
+    {
+        "clone",
+        "sync_checkout",
+        "verify_issue_wave_ancestry",
+        "create_worktree",
+        "verify_pr_review_checkout",
+        "remove_worktree",
+        "rebase",
+        "continue_rebase",
+        "push",
+        "commit_push",
+        "release_branch_reservation",
+    }
+)
+
+WORKTREE_MATERIALIZED_KEY = "worktree_materialized"
+
+
+@dataclass(frozen=True)
+class GitJob:
+    """Request one allowlisted Git operation."""
+
+    repo: str
+    op: str
+    timeout_s: int
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    descr: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject an operation outside the closed Git vocabulary."""
+        if self.op not in GIT_OPS:
+            raise ValueError(f"unknown git op {self.op!r}; expected one of {sorted(GIT_OPS)}")

--- a/hephaestus/automation/pipeline/job_results.py
+++ b/hephaestus/automation/pipeline/job_results.py
@@ -1,0 +1,32 @@
+"""Provider-neutral pipeline job completion types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .routing import StageName
+
+
+@dataclass(frozen=True)
+class JobResult:
+    """Result of a completed pipeline job."""
+
+    ok: bool
+    value: Any = None
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+    error: str | None = None
+    interrupted: bool = False
+    duration_s: float = 0.0
+    worker_id: str = ""
+    session_id: str | None = None
+    session_binding: Any = None
+
+
+@dataclass(frozen=True, eq=False)
+class JobHandle:
+    """Identity-based handle that correlates a job with its completion."""
+
+    job: Any
+    on_done_state: str | StageName

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -16,32 +16,20 @@ from typing import Any
 
 from hephaestus.agents.execution_policy import ExecutionRequest
 from hephaestus.agents.pi_session import AgentSessionBinding
-from hephaestus.automation.pipeline.routing import StageName
 
-from .athena_skill_jobs import AthenaSkillJob
-from .github_jobs import GitHubJob
+from .git_jobs import GIT_OPS, WORKTREE_MATERIALIZED_KEY, GitJob
+from .job_results import JobHandle, JobResult
 
-GIT_OPS: frozenset[str] = frozenset(
-    {
-        "clone",
-        "sync_checkout",
-        "verify_issue_wave_ancestry",
-        "create_worktree",
-        "verify_pr_review_checkout",
-        "remove_worktree",
-        "rebase",
-        "continue_rebase",
-        "push",
-        "commit_push",
-        "release_branch_reservation",
-    }
-)
-
-#: Structured failed ``create_worktree`` results set this only after a
-#: checkout was created but a later adopted-branch preparation step failed.
-#: The coordinator retains that physical checkout as first-writer evidence
-#: while its transient retry is pending.
-WORKTREE_MATERIALIZED_KEY = "worktree_materialized"
+__all__ = [
+    "GIT_OPS",
+    "WORKTREE_MATERIALIZED_KEY",
+    "AgentJob",
+    "BuildTestJob",
+    "CompactJob",
+    "GitJob",
+    "JobHandle",
+    "JobResult",
+]
 
 
 @dataclass(frozen=True)
@@ -107,27 +95,6 @@ class BuildTestJob:
 
 
 @dataclass(frozen=True)
-class GitJob:
-    """Job to perform a git operation.
-
-    Security: ``kwargs`` values are forwarded to git/worktree helpers that
-    shell out, so they MUST NOT carry untrusted (issue-body-derived) strings.
-    Only the coordinator may construct these jobs, from vetted values.
-    """
-
-    repo: str
-    op: str
-    timeout_s: int
-    kwargs: dict[str, Any] = field(default_factory=dict)
-    descr: str = ""
-
-    def __post_init__(self) -> None:
-        """Validate that op is a recognized git operation."""
-        if self.op not in GIT_OPS:
-            raise ValueError(f"unknown git op {self.op!r}; expected one of {sorted(GIT_OPS)}")
-
-
-@dataclass(frozen=True)
 class CompactJob:
     """Best-effort compaction of one resumable agent session.
 
@@ -151,35 +118,3 @@ class CompactJob:
     execution_request: ExecutionRequest | None = None
     session_binding: AgentSessionBinding | None = None
     descr: str = "compact_session"
-
-
-@dataclass(frozen=True)
-class JobResult:
-    """Result of a completed job."""
-
-    ok: bool
-    value: Any = None
-    stdout_tail: str = ""
-    stderr_tail: str = ""
-    error: str | None = None
-    interrupted: bool = False
-    duration_s: float = 0.0
-    worker_id: str = ""
-    session_id: str | None = None
-    session_binding: AgentSessionBinding | None = None
-
-
-@dataclass(frozen=True, eq=False)
-class JobHandle:
-    """Handle to a submitted job, used to correlate its completion.
-
-    Identity semantics (``eq=False``): each ``submit()`` mints a distinct
-    handle that hashes and compares by object identity, NOT by field value.
-    Two submissions of identical job specs therefore produce two distinct
-    handles, so the coordinator can key dicts/sets by handle without
-    collisions, and unhashable field values (``dict`` kwargs, callables)
-    never break hashing.
-    """
-
-    job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob | AthenaSkillJob
-    on_done_state: str | StageName

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -1,7 +1,8 @@
-"""Stage queues and cross-thread completion channel. Pure data, zero I/O (epic #1809).
+"""Stage queues and cross-thread completion channels. Pure data, zero I/O (epic #1809).
 
 The StageQueue is FIFO and deliberately not thread-safe — owned exclusively by
-the coordinator thread. The CompletionQueue is the only cross-thread channel.
+the coordinator thread. The main and auxiliary completion queues are the only
+cross-thread payload channels.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/pipeline/queues.py
+++ b/hephaestus/automation/pipeline/queues.py
@@ -62,6 +62,35 @@ class StageQueueLease:
         self._active = False
         return True
 
+    def exchange(
+        self,
+        destination: StageQueue,
+        peer: StageQueueLease,
+        peer_destination: StageQueue,
+    ) -> bool:
+        """Atomically exchange two complementary active source leases.
+
+        This coordinator-thread-only operation handles the capacity-one case
+        where each lease targets the other lease's full source queue. Invalid
+        or stale lease identities leave both queues unchanged.
+        """
+        if (
+            self is peer
+            or not self._active
+            or not peer._active
+            or destination is not peer._source
+            or peer_destination is not self._source
+            or not self._source._owns_lease(self.item, self._ticket)
+            or not peer._source._owns_lease(peer.item, peer._ticket)
+        ):
+            return False
+
+        self._source._replace_lease(self.item, self._ticket, peer.item)
+        peer._source._replace_lease(peer.item, peer._ticket, self.item)
+        self._active = False
+        peer._active = False
+        return True
+
     def release(self) -> None:
         """Release a lease when an external owner takes the item.
 
@@ -191,6 +220,10 @@ class StageQueue:
         """Restore one active lease in original FIFO order without opening capacity."""
         if self._leased.pop(id(item), None) != ticket:
             raise RuntimeError("StageQueue lease ticket mismatch")
+        self._insert_at_ticket(ticket, item)
+
+    def _insert_at_ticket(self, ticket: int, item: WorkItem) -> None:
+        """Insert one item at its reserved FIFO ticket."""
         index = next(
             (
                 position
@@ -200,6 +233,16 @@ class StageQueue:
             len(self._items),
         )
         self._items.insert(index, (ticket, item))
+
+    def _owns_lease(self, item: WorkItem, ticket: int) -> bool:
+        """Return whether this queue owns the exact active lease identity."""
+        return self._leased.get(id(item)) == ticket
+
+    def _replace_lease(self, item: WorkItem, ticket: int, replacement: WorkItem) -> None:
+        """Replace one validated leased slot without changing queue capacity."""
+        if self._leased.pop(id(item), None) != ticket:
+            raise RuntimeError("StageQueue lease ticket mismatch")
+        self._insert_at_ticket(ticket, replacement)
 
     def _release_lease(self, item: WorkItem, ticket: int) -> None:
         """Release one active lease after its item was admitted elsewhere."""

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -65,6 +65,7 @@ class Disposition(StrEnum):
     RETRY = "retry"
     FAIL_BACK = "fail_back"
     SKIP = "skip"
+    EJECT = "eject"
     BLOCKED = "blocked"
     # "PASS" trips ruff's hardcoded-password heuristic (S105); this is a
     # pipeline disposition, not a credential.

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -35,6 +35,7 @@ class StageName(StrEnum):
     IMPLEMENTATION = "implementation"
     PR_REVIEW = "pr_review"
     MERGE_WAIT = "merge_wait"
+    LEARNING = "learning"
     FINISHED = "finished"
 
 
@@ -42,7 +43,19 @@ class StageName(StrEnum):
 #: has no pipeline stage: normal review may collect its evidence for a binary
 #: verdict, but the loop does not change CI/CD and it never independently
 #: authorizes an approval.
-PIPELINE_ORDER: tuple[StageName, ...] = tuple(StageName)
+MAIN_PIPELINE_ORDER: tuple[StageName, ...] = (
+    StageName.REPO,
+    StageName.PLANNING,
+    StageName.PLAN_REVIEW,
+    StageName.IMPLEMENTATION,
+    StageName.PR_REVIEW,
+    StageName.MERGE_WAIT,
+)
+AUXILIARY_PIPELINE_ORDER: tuple[StageName, ...] = (
+    StageName.LEARNING,
+    StageName.FINISHED,
+)
+PIPELINE_ORDER: tuple[StageName, ...] = MAIN_PIPELINE_ORDER + AUXILIARY_PIPELINE_ORDER
 
 
 class Disposition(StrEnum):
@@ -146,6 +159,15 @@ ROUTES: dict[StageName, Route] = {
         },
         budgets={"merge": DEFAULT_DRIVE_GREEN_LOOPS},
     ),
+    StageName.LEARNING: Route(
+        next=StageName.FINISHED,
+        fail_routes={
+            "resume_implementation": StageName.IMPLEMENTATION,
+            "resume_plan_review": StageName.PLAN_REVIEW,
+            "*": StageName.FINISHED,
+        },
+        budgets={"learn": 2},
+    ),
     StageName.FINISHED: Route(next=StageName.FINISHED),
 }
 
@@ -184,7 +206,7 @@ class PipelineScope:
         """
         if not stages:
             raise ValueError("PipelineScope requires at least one stage")
-        ordered = [s for s in PIPELINE_ORDER if s in stages and s != StageName.FINISHED]
+        ordered = [s for s in MAIN_PIPELINE_ORDER if s in stages]
         # An ALL-FINISHED scope is by-design: ``_compute_trimmed_routes`` reduces
         # it to ``{StageName.FINISHED: ROUTES[StageName.FINISHED]}`` (a no-op
         # trim).  ``test_pipeline_scope_finished_only`` pins this contract, so
@@ -192,8 +214,8 @@ class PipelineScope:
         # universal-sink sentinel.   re-analysis tried to reject and
         # was reverted.
         if ordered:
-            first = PIPELINE_ORDER.index(ordered[0])
-            last = PIPELINE_ORDER.index(ordered[-1])
+            first = MAIN_PIPELINE_ORDER.index(ordered[0])
+            last = MAIN_PIPELINE_ORDER.index(ordered[-1])
             if last - first + 1 != len(ordered):
                 raise ValueError(
                     f"PipelineScope stages must be contiguous in pipeline order; "
@@ -222,21 +244,15 @@ class PipelineScope:
 
     def _compute_trimmed_routes(self) -> dict[StageName, Route]:
         result = {}
+        implicit = {StageName.LEARNING, StageName.FINISHED}
+        available = self.stages | implicit
         for stage, route in ROUTES.items():
-            if stage not in self.stages:
+            if stage not in available:
                 continue
 
-            new_next = (
-                route.next
-                if route.next in self.stages or route.next == StageName.FINISHED
-                else StageName.FINISHED
-            )
+            new_next = route.next if route.next in available else StageName.FINISHED
             new_fail_routes = {
-                key: (
-                    target
-                    if target in self.stages or target == StageName.FINISHED
-                    else StageName.FINISHED
-                )
+                key: (target if target in available else StageName.FINISHED)
                 for key, target in route.fail_routes.items()
             }
             result[stage] = Route(

--- a/hephaestus/automation/pipeline/stage_results.py
+++ b/hephaestus/automation/pipeline/stage_results.py
@@ -1,0 +1,21 @@
+"""Provider-neutral state-machine results shared by pipeline stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Continue:
+    """Advance to the next state without requesting a job."""
+
+    next_state: str
+
+
+@dataclass(frozen=True)
+class JobRequest:
+    """Request one frozen job and name its completion state."""
+
+    job: Any
+    on_done_state: str

--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -19,6 +19,7 @@ from .base import (
 )
 from .finished import FinishedStage
 from .implementation import ImplementationStage
+from .learning import LearningStage
 from .merge_wait import MergeWaitStage
 from .plan_review import PlanReviewStage
 from .planning import PlanningStage
@@ -32,6 +33,7 @@ __all__ = [
     "ImplementationStage",
     "ImplementationThreadReplyResult",
     "JobRequest",
+    "LearningStage",
     "MergeWaitStage",
     "PlanReviewStage",
     "PlanningStage",

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -65,6 +65,7 @@ from ..events import StageEvent
 from ..github_jobs import GitHubJob
 from ..jobs import AgentJob, BuildTestJob, CompactJob, GitJob, JobHandle, JobResult
 from ..routing import ROUTES, Disposition, StageName, StageOutcome
+from ..stage_results import Continue, JobRequest
 from ..work_item import ItemKind, WorkItem
 
 __all__ = [
@@ -496,29 +497,6 @@ class StageGitHub(Protocol):
         ...
 
 
-@dataclass(frozen=True)
-class Continue:
-    """Advance to the next state without requesting a job."""
-
-    next_state: str
-
-
-@dataclass(frozen=True)
-class JobRequest:
-    """Request a job be submitted to the worker pool.
-
-    Attributes:
-        job: The frozen job spec to submit (agent, build/test, git, GitHub, or
-            session compaction — the same union :class:`~..jobs.JobHandle` carries).
-        on_done_state: The state the coordinator moves the item to after the
-            job completes and ``on_job_done`` has run.
-
-    """
-
-    job: AgentJob | BuildTestJob | GitJob | GitHubJob | CompactJob | AthenaSkillJob
-    on_done_state: str
-
-
 type StepResult = "Continue | JobRequest | StageOutcome"
 type BranchWorktreeOwnerStatus = Literal["verified", "pending", "unverified"]
 
@@ -548,6 +526,7 @@ class StageContext:
     now_fn: Callable[[], float] | None = None  # injectable clock (tests pass a fake)
     budget_fn: Callable[[str], int] | None = None  # injected overrides; falls back to ROUTES
     event_fn: Callable[[StageEvent], None] | None = None
+    learning_journal: Any = None
     # A worktree-holder result is only a diagnostic fact from Git.  The
     # coordinator proves that it belongs to a live pipeline sibling before
     # implementation can treat a collision as redundant work.  Leaving this

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -205,7 +205,8 @@ class FinishedStage(Stage):
             if isinstance(reservation, dict):
                 branch_name = reservation.get("branch")
                 base_sha = reservation.get("base_sha")
-                if isinstance(branch_name, str) and is_full_commit_sha(base_sha):
+                owns_branch = isinstance(branch_name, str) and branch_name == item.branch
+                if owns_branch and is_full_commit_sha(base_sha):
                     # The branch contains no coordinator-published commit.
                     # Release only if its remote ref is still the exact base
                     # we reserved, so a later human/concurrent writer is
@@ -238,10 +239,12 @@ class FinishedStage(Stage):
                     )
                 else:
                     logger.warning(
-                        "finished:%s: invalid direct-scope reservation receipt; "
+                        "finished:%s: invalid or stale direct-scope reservation receipt; "
                         "not releasing branch",
                         item.issue or item.repo,
                     )
+                    item.payload["_learning_cleanup_succeeded"] = False
+                    item.payload["_learning_cleanup_error"] = "cleanup ownership changed"
             item.payload["_direct_scope_reservation_release_attempted"] = True
 
         if not item.worktree:
@@ -293,6 +296,7 @@ class FinishedStage(Stage):
             # human may edit it before this terminal cleanup runs. Refuse to
             # discard that late edit; on failure the worktree is preserved.
             "force": not is_direct_noop,
+            **({"expected_branch": item.branch} if item.branch else {}),
         }
         if is_direct_noop:
             kwargs["local_branch_cleanup"] = local_cleanup

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -9,11 +9,11 @@ Steps:
 1. [M] RECORD: append the item's :class:`~..work_item.ItemResult` to the run
    ledger (the coordinator injects its ledger list at construction — queue
    and ledger ownership stay with the coordinator).
-2. [W:G] CLEANUP: remove the implementation worktree on pass; on fail, preserve that writer
-   worktree for debugging and record it in the preserved list the end-of-run
-   summary prints. A direct-scope no-op is the exception: its remote reservation
-   has already been released, so cleanup attempts a non-forced removal of its
-   known-clean worktree and local branch; a late dirty edit is preserved.
+2. [W:G] CLEANUP: after all durable learning records are terminal, remove a clean
+   implementation worktree on pass. On fail, or while learning is pending,
+   preserve that writer worktree and record it in the preserved list that the
+   end-of-run summary prints. Cleanup never forces removal. A direct-scope no-op
+   also removes its local branch only when its ownership receipt still matches.
 
 Verdicts: terminal — no outgoing routes (the coordinator drops the item
 when the sink emits its final outcome).
@@ -197,9 +197,13 @@ class FinishedStage(Stage):
                     exc,
                 )
 
-    def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
+    def _cleanup(  # noqa: C901 - cleanup validates independent durable receipts
+        self, item: WorkItem, ctx: StageContext
+    ) -> StepResult:
         """Clean or preserve the writer worktree."""
         recovery_worktrees = self._record_recovery_worktrees(item, ctx)
+        if item.worktree and not self._learning_is_terminal(item, ctx):
+            return self._preserve_pending_learning_worktree(item)
         reservation = item.payload.get(DIRECT_SCOPE_RESERVATION_KEY)
         if not item.payload.get("_direct_scope_reservation_release_attempted", False):
             if isinstance(reservation, dict):
@@ -295,9 +299,14 @@ class FinishedStage(Stage):
             # A no-op direct scope is known-clean at commit/push time, but a
             # human may edit it before this terminal cleanup runs. Refuse to
             # discard that late edit; on failure the worktree is preserved.
-            "force": not is_direct_noop,
+            # Learning has finished, but a user can still edit the checkout.
+            # Cleanup must preserve those edits instead of forcing removal.
+            "force": False,
             **({"expected_branch": item.branch} if item.branch else {}),
         }
+        expected_head = item.payload.get("_worktree_cleanup_head_sha")
+        if is_full_commit_sha(expected_head):
+            kwargs["expected_head"] = expected_head
         if is_direct_noop:
             kwargs["local_branch_cleanup"] = local_cleanup
             item.payload["_direct_scope_noop_cleanup_inflight"] = True
@@ -311,6 +320,41 @@ class FinishedStage(Stage):
             descr=f"remove worktree {item.worktree}",
         )
         return JobRequest(job=job, on_done_state="DONE")
+
+    def _preserve_pending_learning_worktree(self, item: WorkItem) -> Continue:
+        """Preserve a writer checkout until all learning work is terminal."""
+        entry = (item.repo, item.issue or item.pr or 0, item.worktree)
+        if entry not in self._preserved:
+            self._preserved.append(entry)
+        item.payload["_learning_cleanup_succeeded"] = False
+        item.payload["_learning_cleanup_error"] = "learning is not terminal"
+        logger.warning(
+            "finished:%s: preserving worktree until learning is terminal: %s",
+            item.issue or item.repo,
+            item.worktree,
+        )
+        return Continue(next_state="DONE")
+
+    @staticmethod
+    def _learning_is_terminal(item: WorkItem, ctx: StageContext) -> bool:
+        """Return whether all cleanup-bound learning records are terminal."""
+        if item.post_processing is None:
+            return True
+        journal = ctx.learning_journal
+        if journal is None:
+            return False
+        for key in item.post_processing.intent_keys:
+            try:
+                record = journal.load(key)
+            except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+                return False
+            if not isinstance(record, dict) or record.get("status") not in {
+                "succeeded",
+                "failed",
+                "disabled",
+            }:
+                return False
+        return True
 
     def _record_recovery_worktrees(self, item: WorkItem, ctx: StageContext) -> set[str]:
         """Record receipt-backed recoveries and return their concrete paths."""

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -321,19 +321,17 @@ class FinishedStage(Stage):
         )
         return JobRequest(job=job, on_done_state="DONE")
 
-    def _preserve_pending_learning_worktree(self, item: WorkItem) -> Continue:
-        """Preserve a writer checkout until all learning work is terminal."""
+    def _preserve_pending_learning_worktree(self, item: WorkItem) -> StageOutcome:
+        """Eject a writer checkout until all learning work is terminal."""
         entry = (item.repo, item.issue or item.pr or 0, item.worktree)
         if entry not in self._preserved:
             self._preserved.append(entry)
-        item.payload["_learning_cleanup_succeeded"] = False
-        item.payload["_learning_cleanup_error"] = "learning is not terminal"
         logger.warning(
             "finished:%s: preserving worktree until learning is terminal: %s",
             item.issue or item.repo,
             item.worktree,
         )
-        return Continue(next_state="DONE")
+        return StageOutcome(Disposition.EJECT, "learning_cleanup_pending")
 
     @staticmethod
     def _learning_is_terminal(item: WorkItem, ctx: StageContext) -> bool:

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -355,6 +355,8 @@ class FinishedStage(Stage):
                 >= _RESERVATION_RELEASE_RETRY_CAP
             ):
                 item.payload["_direct_scope_reservation_release_attempted"] = True
+                item.payload["_learning_cleanup_succeeded"] = False
+                item.payload["_learning_cleanup_error"] = result.error
                 logger.warning(
                     "finished:%s: direct-scope reservation release failed after retries: %s",
                     item.issue or item.repo,

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -1,6 +1,6 @@
 """Finished stage: record outcomes and clean up worktrees (epic #1809).
 
-Binding contract: docs/architecture.md §5.7 "finished".
+Binding contract: docs/architecture.md §5.8 "finished".
 
 The universal sink. States: ENTER -> RECORD -> CLEANUP -> DONE.
 
@@ -170,9 +170,32 @@ class FinishedStage(Stage):
             return self._cleanup(item, ctx)
 
         if item.state == "DONE":
+            self._record_cleanup_terminal(item, ctx)
             return StageOutcome(Disposition.FINISH_PASS, note="done")
 
         return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
+
+    @staticmethod
+    def _record_cleanup_terminal(item: WorkItem, ctx: StageContext) -> None:
+        """Close durable cleanup obligations after the sink reaches DONE."""
+        if item.post_processing is None:
+            return
+        succeeded = bool(item.payload.pop("_learning_cleanup_succeeded", True))
+        error = str(item.payload.pop("_learning_cleanup_error", ""))
+        for key in item.post_processing.intent_keys:
+            try:
+                ctx.learning_journal.finish_cleanup(
+                    key,
+                    succeeded=succeeded,
+                    error=error,
+                )
+            except (KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "finished:%s: could not record cleanup completion for %s: %s",
+                    item.issue or item.repo,
+                    key,
+                    exc,
+                )
 
     def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Clean or preserve the writer worktree."""
@@ -265,6 +288,7 @@ class FinishedStage(Stage):
         kwargs: dict[str, object] = {
             "worktree_path": item.worktree,
             "repo_root": str(ctx.paths.repo_root),
+            "issue_number": item.issue or item.pr or 0,
             # A no-op direct scope is known-clean at commit/push time, but a
             # human may edit it before this terminal cleanup runs. Refuse to
             # discard that late edit; on failure the worktree is preserved.
@@ -338,6 +362,8 @@ class FinishedStage(Stage):
                 )
             return
         if not result.ok:
+            item.payload["_learning_cleanup_succeeded"] = False
+            item.payload["_learning_cleanup_error"] = result.error
             if item.payload.pop("_direct_scope_noop_cleanup_inflight", False):
                 entry = (item.repo, item.issue or item.pr or 0, item.worktree)
                 if entry not in self._preserved:

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -1385,6 +1385,9 @@ class ImplementationStage(Stage):
         """Record commit+push success, no-commit skip, or git failure."""
         if result.ok:
             receipt = result.value if isinstance(result.value, dict) else {}
+            receipt_head = receipt.get("head_sha")
+            if is_full_commit_sha(receipt_head):
+                item.payload["_worktree_cleanup_head_sha"] = receipt_head
             pushed = receipt.get("pushed") is True if receipt else bool(result.value)
             if not pushed:
                 item.payload["no_commits"] = True

--- a/hephaestus/automation/pipeline/stages/learning.py
+++ b/hephaestus/automation/pipeline/stages/learning.py
@@ -67,6 +67,7 @@ class LearningStage:
             return skip
         if not journal.claim(intent.key):
             return Continue(next_state=CLAIM)
+        item.payload["_learning_claimed_intent_key"] = intent.key
 
         payload: dict[str, object] = {
             "issue_number": intent.issue,
@@ -98,7 +99,7 @@ class LearningStage:
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
         """Record success or apply the bounded retry policy."""
-        intent = self._claimed_intent(item, ctx)
+        intent = self._locally_claimed_intent(item)
         if intent is None:
             return
         succeeded = bool(
@@ -132,7 +133,7 @@ class LearningStage:
 
     def on_cancelled_before_start(self, item: WorkItem, ctx: Any) -> None:
         """Return a claim to pending when the host provably did not run."""
-        intent = self._claimed_intent(item, ctx)
+        intent = self._locally_claimed_intent(item)
         if intent is not None:
             self._journal(ctx).retry(intent.key, error="interrupted_before_start")
 
@@ -154,13 +155,12 @@ class LearningStage:
                 return intent
         return None
 
-    def _claimed_intent(self, item: WorkItem, ctx: Any) -> LearningIntent | None:
-        journal = self._journal(ctx)
-        for intent in item.learning_intents:
-            record = journal.load(intent.key)
-            if record is not None and record["status"] == "claimed":
-                return intent
-        return None
+    @staticmethod
+    def _locally_claimed_intent(item: WorkItem) -> LearningIntent | None:
+        key = item.payload.pop("_learning_claimed_intent_key", None)
+        if not isinstance(key, str):
+            return None
+        return next((intent for intent in item.learning_intents if intent.key == key), None)
 
     def _claim_or_skip(
         self,
@@ -169,13 +169,19 @@ class LearningStage:
         record: dict[str, Any],
         journal: LearningJournalStore,
         ctx: Any,
-    ) -> Continue | None:
+    ) -> Continue | StageOutcome | None:
         """Handle terminal, ambiguous, and stale-plan records before claim."""
         if record["status"] == "claimed":
             if journal.claim_is_active(intent.key):
-                item.payload.setdefault("learning_external_claims", []).append(intent.key)
-                return Continue(next_state=CLAIM)
-            journal.finish(intent.key, succeeded=False, error="outcome_unknown")
+                return StageOutcome(
+                    Disposition.EJECT,
+                    "learning_claim_owned_elsewhere",
+                )
+            if journal.fail_abandoned_claim(intent.key, error="outcome_unknown") is None:
+                return StageOutcome(
+                    Disposition.EJECT,
+                    "learning_claim_owned_elsewhere",
+                )
             item.payload.setdefault("learning_failures", []).append(
                 {"key": intent.key, "error": "outcome_unknown"}
             )

--- a/hephaestus/automation/pipeline/stages/learning.py
+++ b/hephaestus/automation/pipeline/stages/learning.py
@@ -145,7 +145,10 @@ class LearningStage:
 
     def _next_intent(self, item: WorkItem, ctx: Any) -> LearningIntent | None:
         journal = self._journal(ctx)
+        external_claims = set(item.payload.get("learning_external_claims", []))
         for intent in item.learning_intents:
+            if intent.key in external_claims:
+                continue
             record = journal.load(intent.key)
             if record is None or record["status"] not in {"succeeded", "failed"}:
                 return intent
@@ -169,6 +172,9 @@ class LearningStage:
     ) -> Continue | None:
         """Handle terminal, ambiguous, and stale-plan records before claim."""
         if record["status"] == "claimed":
+            if journal.claim_is_active(intent.key):
+                item.payload.setdefault("learning_external_claims", []).append(intent.key)
+                return Continue(next_state=CLAIM)
             journal.finish(intent.key, succeeded=False, error="outcome_unknown")
             item.payload.setdefault("learning_failures", []).append(
                 {"key": intent.key, "error": "outcome_unknown"}

--- a/hephaestus/automation/pipeline/stages/learning.py
+++ b/hephaestus/automation/pipeline/stages/learning.py
@@ -8,6 +8,7 @@ from typing import Any
 from hephaestus.automation.agent_config import learn_claude_timeout
 from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.mnemosyne_delivery import valid_delivery_receipt
+from hephaestus.automation.review_journal import journal_snapshot, plan_fingerprint
 from hephaestus.automation.state_labels import STATE_PLAN_GO, is_exclusive_plan_state
 
 from ..athena_skill_jobs import AthenaSkillJob, AthenaSkillRequest, AthenaSkillResult
@@ -177,14 +178,16 @@ class LearningStage:
                     Disposition.EJECT,
                     "learning_claim_owned_elsewhere",
                 )
-            if journal.fail_abandoned_claim(intent.key, error="outcome_unknown") is None:
+            abandoned = journal.fail_abandoned_claim(intent.key, error="outcome_unknown")
+            if abandoned is None:
                 return StageOutcome(
                     Disposition.EJECT,
                     "learning_claim_owned_elsewhere",
                 )
-            item.payload.setdefault("learning_failures", []).append(
-                {"key": intent.key, "error": "outcome_unknown"}
-            )
+            if abandoned.get("status") == "failed" and abandoned.get("error") == "outcome_unknown":
+                item.payload.setdefault("learning_failures", []).append(
+                    {"key": intent.key, "error": "outcome_unknown"}
+                )
             return Continue(next_state=CLAIM)
         if record["status"] in {"succeeded", "failed"}:
             return Continue(next_state=CLAIM)
@@ -213,4 +216,14 @@ class LearningStage:
             for label in issue.get("labels", [])
             if isinstance(label, dict)
         ]
-        return is_exclusive_plan_state(labels, STATE_PLAN_GO)
+        if not is_exclusive_plan_state(labels, STATE_PLAN_GO):
+            return False
+        try:
+            snapshot = journal_snapshot(ctx.github.issue_comments(intent.issue))
+        except Exception:
+            return None
+        return bool(
+            snapshot.current_plan
+            and snapshot.revision == intent.plan_revision
+            and plan_fingerprint(snapshot.current_plan) == intent.plan_fingerprint
+        )

--- a/hephaestus/automation/pipeline/stages/learning.py
+++ b/hephaestus/automation/pipeline/stages/learning.py
@@ -1,0 +1,204 @@
+"""Auxiliary learning stage with durable, ancillary outcomes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation.agent_config import learn_claude_timeout
+from hephaestus.automation.arming_state import LearningJournalStore
+from hephaestus.automation.mnemosyne_delivery import valid_delivery_receipt
+from hephaestus.automation.state_labels import STATE_PLAN_GO, is_exclusive_plan_state
+
+from ..athena_skill_jobs import AthenaSkillJob, AthenaSkillRequest, AthenaSkillResult
+from ..job_results import JobResult
+from ..routing import Disposition, StageName, StageOutcome
+from ..stage_results import Continue, JobRequest
+from ..work_item import LearningIntent, WorkItem
+
+StepResult = Continue | JobRequest | StageOutcome
+
+ENTER = "ENTER"
+CLAIM = "CLAIM"
+RESULT = "RESULT"
+
+
+class LearningStage:
+    """Claim and execute learning intents outside the main worker lane."""
+
+    kind = StageName.LEARNING
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> StageOutcome | None:
+        """Persist all in-memory intents before any host call."""
+        journal = self._journal(ctx)
+        for intent in item.learning_intents:
+            journal.ensure_pending(
+                intent.key,
+                kind=intent.kind.value,
+                identity=intent.journal_identity(),
+            )
+        if not item.state:
+            item.state = ENTER
+        return None
+
+    def step(self, item: WorkItem, ctx: Any) -> StepResult:
+        """Run one durable intent at a time."""
+        if item.state == ENTER:
+            return Continue(next_state=CLAIM)
+        if item.state == RESULT:
+            return Continue(next_state=CLAIM)
+        if item.state != CLAIM:
+            return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+        intent = self._next_intent(item, ctx)
+        if intent is None:
+            if item.learning_resume_stage is StageName.IMPLEMENTATION:
+                return StageOutcome(Disposition.FAIL_BACK, "resume_implementation")
+            if item.learning_resume_stage is StageName.PLAN_REVIEW:
+                return StageOutcome(Disposition.FAIL_BACK, "resume_plan_review")
+            return StageOutcome(Disposition.ADVANCE, "learning terminal")
+
+        journal = self._journal(ctx)
+        record = journal.load(intent.key)
+        if record is None:
+            record = journal.ensure_pending(intent.key, kind=intent.kind.value)
+        skip = self._claim_or_skip(item, intent, record, journal, ctx)
+        if skip is not None:
+            return skip
+        if not journal.claim(intent.key):
+            return Continue(next_state=CLAIM)
+
+        payload: dict[str, object] = {
+            "issue_number": intent.issue,
+            "intent_key": intent.key,
+            "intent_kind": intent.kind.value,
+        }
+        delivery = item.payload.get("learn_delivery")
+        if isinstance(delivery, dict):
+            payload["learn_delivery"] = dict(delivery)
+        return JobRequest(
+            AthenaSkillJob(
+                request=AthenaSkillRequest(
+                    kind="learn",
+                    repo=item.repo,
+                    issue=intent.issue,
+                    agent=str(getattr(ctx.config, "agent", "") or "claude"),
+                    model=str(
+                        getattr(ctx.config, "implementer_model", "")
+                        or getattr(ctx.config, "model", "")
+                    ),
+                    cwd=Path(item.worktree or str(ctx.paths.worktree)),
+                    timeout_s=learn_claude_timeout(),
+                    payload=payload,
+                ),
+                descr=f"auxiliary_learn_{intent.kind.value}",
+            ),
+            on_done_state=RESULT,
+        )
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        """Record success or apply the bounded retry policy."""
+        intent = self._claimed_intent(item, ctx)
+        if intent is None:
+            return
+        succeeded = bool(
+            result.ok
+            and isinstance(result.value, AthenaSkillResult)
+            and result.value.ok
+            and valid_delivery_receipt(result.value.delivery_receipt)
+        )
+        error = "" if succeeded else (result.error or "invalid Athena learn result")
+        receipt = result.value.delivery_receipt if succeeded else None
+        journal = self._journal(ctx)
+        record = journal.load(intent.key)
+        attempts = int(record.get("attempts", 0)) if record is not None else 0
+        if not succeeded and attempts < ctx.budget("learn"):
+            journal.retry(intent.key, error=error)
+            return
+        journal.finish(
+            intent.key,
+            succeeded=succeeded,
+            error=error,
+            receipt_summary=(
+                {"pr_number": receipt.get("pr_number"), "pr_url": receipt.get("pr_url")}
+                if isinstance(receipt, dict)
+                else None
+            ),
+        )
+        if not succeeded:
+            item.payload.setdefault("learning_failures", []).append(
+                {"key": intent.key, "error": error[:1000]}
+            )
+
+    def on_cancelled_before_start(self, item: WorkItem, ctx: Any) -> None:
+        """Return a claim to pending when the host provably did not run."""
+        intent = self._claimed_intent(item, ctx)
+        if intent is not None:
+            self._journal(ctx).retry(intent.key, error="interrupted_before_start")
+
+    @staticmethod
+    def _journal(ctx: Any) -> LearningJournalStore:
+        journal = ctx.learning_journal
+        if not isinstance(journal, LearningJournalStore):
+            raise RuntimeError("learning stage requires a LearningJournalStore")
+        return journal
+
+    def _next_intent(self, item: WorkItem, ctx: Any) -> LearningIntent | None:
+        journal = self._journal(ctx)
+        for intent in item.learning_intents:
+            record = journal.load(intent.key)
+            if record is None or record["status"] not in {"succeeded", "failed"}:
+                return intent
+        return None
+
+    def _claimed_intent(self, item: WorkItem, ctx: Any) -> LearningIntent | None:
+        journal = self._journal(ctx)
+        for intent in item.learning_intents:
+            record = journal.load(intent.key)
+            if record is not None and record["status"] == "claimed":
+                return intent
+        return None
+
+    def _claim_or_skip(
+        self,
+        item: WorkItem,
+        intent: LearningIntent,
+        record: dict[str, Any],
+        journal: LearningJournalStore,
+        ctx: Any,
+    ) -> Continue | None:
+        """Handle terminal, ambiguous, and stale-plan records before claim."""
+        if record["status"] == "claimed":
+            journal.finish(intent.key, succeeded=False, error="outcome_unknown")
+            item.payload.setdefault("learning_failures", []).append(
+                {"key": intent.key, "error": "outcome_unknown"}
+            )
+            return Continue(next_state=CLAIM)
+        if record["status"] in {"succeeded", "failed"}:
+            return Continue(next_state=CLAIM)
+        if intent.kind.value != "approved_plan":
+            return None
+        plan_state = self._approved_plan_state(intent, ctx)
+        if plan_state is True:
+            return None
+        error = "plan_state_changed" if plan_state is False else "plan_state_unverified"
+        if journal.claim(intent.key):
+            journal.finish(intent.key, succeeded=False, error=error)
+        if plan_state is False:
+            item.learning_resume_stage = StageName.PLAN_REVIEW
+        item.payload.setdefault("learning_failures", []).append({"key": intent.key, "error": error})
+        return Continue(next_state=CLAIM)
+
+    @staticmethod
+    def _approved_plan_state(intent: LearningIntent, ctx: Any) -> bool | None:
+        """Return live approval, confirmed change, or an unavailable read."""
+        try:
+            issue = ctx.github.gh_issue_json(intent.issue)
+        except Exception:
+            return None
+        labels = [
+            str(label.get("name", ""))
+            for label in issue.get("labels", [])
+            if isinstance(label, dict)
+        ]
+        return is_exclusive_plan_state(labels, STATE_PLAN_GO)

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -611,23 +611,30 @@ class MergeWaitStage(Stage):
         if intent not in item.learning_intents:
             item.learning_intents.append(intent)
         if isinstance(ctx.learning_journal, LearningJournalStore):
-            record = ctx.learning_journal.ensure_pending(
-                intent.key,
-                kind=intent.kind.value,
-                identity=intent.journal_identity(),
-            )
-            if (
-                ctx.github.drive_green_learn_inflight(item.issue)
-                and record["status"] == "pending"
-                and ctx.learning_journal.claim(intent.key)
-            ):
-                ctx.learning_journal.finish(
+            try:
+                record = ctx.learning_journal.ensure_pending(
                     intent.key,
-                    succeeded=False,
-                    error="legacy_outcome_unknown",
+                    kind=intent.kind.value,
+                    identity=intent.journal_identity(),
                 )
+                if (
+                    ctx.github.drive_green_learn_inflight(item.issue)
+                    and record["status"] == "pending"
+                    and ctx.learning_journal.claim(intent.key)
+                ):
+                    ctx.learning_journal.finish(
+                        intent.key,
+                        succeeded=False,
+                        error="legacy_outcome_unknown",
+                    )
+                    item.payload.setdefault("learning_failures", []).append(
+                        {"key": intent.key, "error": "legacy_outcome_unknown"}
+                    )
+            except (OSError, RuntimeError, TypeError, ValueError):
+                logger.exception("merge_wait:%s: could not persist learning intent", item.issue)
+                item.learning_intents.remove(intent)
                 item.payload.setdefault("learning_failures", []).append(
-                    {"key": intent.key, "error": "legacy_outcome_unknown"}
+                    {"key": intent.key, "error": "learning_intent_persist_failed"}
                 )
         elif ctx.github.drive_green_learn_inflight(item.issue):
             item.learning_intents.remove(intent)

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -12,15 +12,10 @@ The implemented mini-state graph is:
   reviewed-head proof and the PR-level implementation-GO label; readiness may
   retry ``MERGE`` within its bounded wait.
 - A PR observed as already merged, or a conditional merge freshly confirmed as
-  merged, enters ``_route_merged``. It exits directly with ``FINISH_PASS``
-  when learning is disabled or already terminal, or follows
-  ``MERGE -> LEARN_WAIT -> MW_FINISH -> FINISH_PASS`` when one post-merge
-  learning job must run.
-- The already-merged path can exit ``FINISH_FAIL`` when a learning result is
-  already in flight or unknown, its claim fails, or result persistence fails.
-  Live admission, readiness, and conditional-merge failures likewise exit
-  safely (or fail back to fresh PR review when the head-bound proof is absent
-  or stale).
+  merged, emits one immutable post-merge learning intent. The coordinator
+  transfers that intent to the auxiliary lane after the confirmed pass.
+- Live admission, readiness, and conditional-merge failures exit safely or
+  fail back to fresh PR review when the head-bound proof is absent or stale.
 """
 
 from __future__ import annotations
@@ -29,38 +24,33 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hephaestus.automation.agent_config import implementer_model, learn_claude_timeout
+from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.issue_waves import (
     WAVE_LEASE_PAYLOAD,
     IssueWaveError,
     IssueWaveStore,
     WaveLease,
 )
-from hephaestus.automation.mnemosyne_delivery import valid_delivery_receipt
 
 from ..github_jobs import (
     GitHubJob,
     MergeWaitCycleCompleted,
     RunMergeWaitCycleRequest,
 )
+from ..work_item import LearningIntent
 from .base import (
-    AthenaSkillJob,
-    AthenaSkillRequest,
-    AthenaSkillResult,
     Continue,
     Disposition,
     JobRequest,
     JobResult,
     Stage,
     StageContext,
+    StageName,
     StageOutcome,
     StepResult,
     WorkItem,
     _is_confirmed_open_unarmed,
     _terminal_pr_outcome,
-    _worktree_path,
-    agent_provider,
-    stage_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -68,7 +58,6 @@ logger = logging.getLogger(__name__)
 ENTER = "ENTER"
 MERGE = "MERGE"
 MERGE_APPLY = "MERGE_APPLY"
-LEARN_WAIT = "LEARN_WAIT"
 MW_FINISH = "MW_FINISH"
 FINISH = MW_FINISH
 
@@ -118,11 +107,7 @@ class MergeWaitStage(Stage):
             return self._merge(item, ctx)
         if item.state == MERGE_APPLY:
             return self._merge_apply(item, ctx)
-        if item.state == LEARN_WAIT:
-            return self._request_learn(item, ctx)
         if item.state == MW_FINISH:
-            if item.payload.pop("learn_result_persistence_failed", None):
-                return StageOutcome(Disposition.FINISH_FAIL, "learn_result_persistence_failed")
             return StageOutcome(Disposition.FINISH_PASS, "merged")
         logger.warning("merge_wait:%s: unknown state %r", item.issue, item.state)
         return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
@@ -615,44 +600,42 @@ class MergeWaitStage(Stage):
         return StageOutcome(Disposition.RETRY, "merge_readiness_wait")
 
     def _route_merged(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Dispatch the existing deduplicated post-merge learning step."""
+        """Record post-merge learning without changing confirmed merge success."""
         if item.issue is None or not getattr(ctx.config, "enable_learn", True):
             return StageOutcome(Disposition.FINISH_PASS, "merged")
         if ctx.github.drive_green_learn_terminal(item.issue):
             return StageOutcome(Disposition.FINISH_PASS, "merged")
-        if ctx.github.drive_green_learn_inflight(item.issue):
-            logger.error("merge_wait:%d: post-merge learning outcome is unknown", item.issue)
-            return StageOutcome(Disposition.FINISH_FAIL, "learn_outcome_unknown")
-        return Continue(next_state=LEARN_WAIT)
-
-    def _request_learn(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Dispatch the existing post-merge learning job exactly once."""
-        if item.issue is None or item.pr is None:
+        if item.pr is None:
             return StageOutcome(Disposition.FINISH_FAIL, "missing_learn_scope")
-        try:
-            claimed = ctx.github.claim_drive_green_learn(item.issue, item.pr)
-        except Exception as exc:
-            logger.error("merge_wait:%d: failed to claim /learn dispatch: %s", item.issue, exc)
-            return StageOutcome(Disposition.FINISH_FAIL, "learn_claim_failed")
-        if not claimed:
-            return StageOutcome(Disposition.FINISH_FAIL, "learn_outcome_unknown")
-        job = AthenaSkillJob(
-            request=AthenaSkillRequest(
-                kind="learn",
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "implementer", implementer_model),
-                cwd=_worktree_path(item, ctx),
-                timeout_s=learn_claude_timeout(),
-                payload={"issue_number": item.issue, "pr_number": item.pr},
-            ),
-            descr="drive_green_learn",
-        )
-        return JobRequest(job, on_done_state=MW_FINISH)
+        intent = LearningIntent.post_merge(repo=item.repo, issue=item.issue, pr=item.pr)
+        if intent not in item.learning_intents:
+            item.learning_intents.append(intent)
+        if isinstance(ctx.learning_journal, LearningJournalStore):
+            record = ctx.learning_journal.ensure_pending(
+                intent.key,
+                kind=intent.kind.value,
+                identity=intent.journal_identity(),
+            )
+            if (
+                ctx.github.drive_green_learn_inflight(item.issue)
+                and record["status"] == "pending"
+                and ctx.learning_journal.claim(intent.key)
+            ):
+                ctx.learning_journal.finish(
+                    intent.key,
+                    succeeded=False,
+                    error="legacy_outcome_unknown",
+                )
+                item.payload.setdefault("learning_failures", []).append(
+                    {"key": intent.key, "error": "legacy_outcome_unknown"}
+                )
+        elif ctx.github.drive_green_learn_inflight(item.issue):
+            item.learning_intents.remove(intent)
+        item.learning_resume_stage = StageName.FINISHED
+        return StageOutcome(Disposition.FINISH_PASS, "merged")
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
-        """Persist the post-merge learning result without changing merge outcome."""
+        """Store one immutable merge-cycle receipt."""
         if item.state == MERGE:
             if not result.ok:
                 item.payload[_MERGE_CYCLE_RECEIPT_ERROR] = result.error or "merge cycle failed"
@@ -665,20 +648,3 @@ class MergeWaitStage(Stage):
                 return
             item.payload[_MERGE_CYCLE_RECEIPT] = receipt
             return
-        if item.state != LEARN_WAIT or item.issue is None:
-            return
-        if not (
-            result.ok
-            and isinstance(result.value, AthenaSkillResult)
-            and result.value.ok
-            and valid_delivery_receipt(result.value.delivery_receipt)
-        ):
-            item.payload["athena_learn_error"] = result.error or "invalid Athena learn result"
-            return
-        item.payload["athena_learn_receipt"] = result.value.receipt
-        item.payload["athena_learn_delivery_receipt"] = result.value.delivery_receipt
-        try:
-            ctx.github.mark_drive_green_learn_result(item.issue, succeeded=True)
-        except Exception as exc:
-            logger.error("merge_wait:%d: failed to persist /learn result: %s", item.issue, exc)
-            item.payload["learn_result_persistence_failed"] = True

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -683,12 +683,6 @@ class PlanReviewStage(Stage):
         """Apply GO, record auxiliary learning, and release the main stage."""
         assert item.issue is not None  # noqa: S101 - _eval narrows the issue
         logger.info("plan_review:%d: GO verdict; applying label and advancing", item.issue)
-        self._write_verdict_labels(item.issue, ctx, is_go=True)
-        if not is_exclusive_plan_state(
-            _require_issue_labels(item, ctx),
-            STATE_PLAN_GO,
-        ):
-            return StageOutcome(Disposition.RETRY, "plan-go label was not confirmed")
         if ctx.config.enable_learn:
             plan_text = str(item.payload.get("plan_text") or "")
             intent = LearningIntent.approved_plan(
@@ -706,6 +700,12 @@ class PlanReviewStage(Stage):
                     identity=intent.journal_identity(),
                 )
             item.learning_resume_stage = StageName.IMPLEMENTATION
+        self._write_verdict_labels(item.issue, ctx, is_go=True)
+        if not is_exclusive_plan_state(
+            _require_issue_labels(item, ctx),
+            STATE_PLAN_GO,
+        ):
+            return StageOutcome(Disposition.RETRY, "plan-go label was not confirmed")
         return StageOutcome(Disposition.ADVANCE, "plan approved")
 
     @staticmethod

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -6,8 +6,7 @@ binding contract). It fully owns the review/amend/learn loop that the legacy
 planner review loop used to run before ``hephaestus-plan-issues`` was
 re-pointed at the pipeline (#1820):
 
-- States: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT -> (loop) -> LEARN_WAIT
-  -> PLAN_FINISH.
+- States: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT -> (loop) -> ADVANCE.
 - Budgets: ``plan_review_iter`` = 3 (max review iterations per cycle),
   ``plan_cycles`` = 2 (max plan->review->amend cycles before giving up).
 - Iteration accounting: ``item.attempts["plan_review_iter"]`` is the
@@ -63,13 +62,12 @@ from hephaestus.agents.execution_policy import (
     SessionLifecycle,
 )
 from hephaestus.automation.agent_config import (
-    learn_claude_timeout,
     plan_reviewer_claude_timeout,
     planner_claude_timeout,
     planner_model,
     reviewer_model,
 )
-from hephaestus.automation.mnemosyne_delivery import valid_delivery_receipt
+from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.prompts._shared import fence_content
 from hephaestus.automation.prompts.planning import (
     get_plan_loop_review_prompt,
@@ -83,6 +81,7 @@ from hephaestus.automation.review_journal import (
     current_plan_context,
     journal_snapshot,
     parse_plan_review_state,
+    plan_fingerprint,
     render_current_review,
 )
 from hephaestus.automation.review_types import ReviewVerdict
@@ -99,17 +98,16 @@ from hephaestus.automation.state_labels import (
 from hephaestus.prompts import PromptCatalog
 
 from ..plan_journal import publish_plan_revision, reconcile_plan_journal
+from ..work_item import LearningIntent
 from .base import (
     AgentJob,
-    AthenaSkillJob,
-    AthenaSkillRequest,
-    AthenaSkillResult,
     Continue,
     Disposition,
     JobRequest,
     JobResult,
     Stage,
     StageContext,
+    StageName,
     StageOutcome,
     StepResult,
     WorkItem,
@@ -126,9 +124,6 @@ ENTER = "ENTER"
 REVIEW_WAIT = "REVIEW_WAIT"
 EVAL = "EVAL"
 AMEND_WAIT = "AMEND_WAIT"
-LEARN_WAIT = "LEARN_WAIT"
-PLAN_FINISH = "PLAN_FINISH"
-FINISH = PLAN_FINISH
 
 #: Max CONSECUTIVE reviewer-infrastructure failures (ERROR verdicts or
 #: failed/valueless review jobs) tolerated before the item FINISH_FAILs.
@@ -296,8 +291,8 @@ class PlanReviewStage(Stage):
       in ``item.payload["review_verdict"]``.
     - EVAL [M]: real verdicts (GO/NOGO/BLOCKED) advance both iteration
       counters; ERROR/missing verdicts never do. GO -> durably apply
-      ``state:plan-go`` (write BEFORE the advancing outcome) then learn
-      step or ADVANCE; NOGO within the cycle-relative iteration budget ->
+      ``state:plan-go`` (write BEFORE the advancing outcome), emit an immutable
+      learning intent, then ADVANCE; NOGO within the cycle-relative iteration budget ->
       durably apply ``state:plan-no-go`` and enter AMEND_WAIT within budget,
       or FAIL_BACK("nogo") while plan cycles remain;
       BLOCKED applies and confirms ``state:plan-blocked`` first, publishes its
@@ -307,9 +302,6 @@ class PlanReviewStage(Stage):
       ``REVIEW_ERROR_RETRY_CAP`` consecutive failures, then FINISH_FAIL).
     - AMEND_WAIT: submit the planner amend job (:func:`build_amend_prompt`
       carries the reviewer feedback block), loop to REVIEW_WAIT.
-    - LEARN_WAIT (GO only, gated by ``enable_learn``): submit the learn job,
-      then ADVANCE.
-
     Fail routes (ROUTES): "nogo" -> planning, "plan_cycles_exhausted" ->
     finished(fail).
     """
@@ -510,42 +502,8 @@ class PlanReviewStage(Stage):
             )
             return JobRequest(job, on_done_state="REVIEW_WAIT")
 
-        if item.state == "LEARN_WAIT":
-            logger.info("plan_review:%d: requesting learn job", item.issue)
-            learn_job = AthenaSkillJob(
-                request=AthenaSkillRequest(
-                    kind="learn",
-                    repo=item.repo,
-                    issue=item.issue,
-                    agent=agent_provider(ctx),
-                    model=stage_model(ctx, "planner", planner_model),
-                    cwd=ctx.paths.worktree,
-                    timeout_s=learn_claude_timeout(),
-                    payload={"context": item.payload.get("plan_text", "")},
-                ),
-                descr="learn",
-            )
-            return JobRequest(learn_job, on_done_state=PLAN_FINISH)
-
-        if item.state == PLAN_FINISH:
-            return self._finish_after_learning(item, ctx)
-
         logger.warning("plan_review:%d: unknown state %r", item.issue, item.state)
         return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
-
-    @staticmethod
-    def _finish_after_learning(item: WorkItem, ctx: StageContext) -> StageOutcome:
-        """Advance only while the approved label remains live and exclusive."""
-        if not valid_delivery_receipt(item.payload.get("athena_learn_delivery_receipt")):
-            return StageOutcome(Disposition.FINISH_FAIL, "learn_delivery_missing")
-        live_labels = _require_issue_labels(item, ctx)
-        if not is_exclusive_plan_state(live_labels, STATE_PLAN_GO):
-            return StageOutcome(
-                Disposition.RETRY,
-                "exclusive plan-go label was not confirmed after learning",
-            )
-        logger.info("plan_review:%d: learn completed; advancing", item.issue)
-        return StageOutcome(Disposition.ADVANCE, "plan approved and learned")
 
     def _eval(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """EVAL [M]: decide the next action from the parsed reviewer verdict.
@@ -722,7 +680,7 @@ class PlanReviewStage(Stage):
         return outcome
 
     def _complete_go(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Apply and confirm GO before learn or implementation routing."""
+        """Apply GO, record auxiliary learning, and release the main stage."""
         assert item.issue is not None  # noqa: S101 - _eval narrows the issue
         logger.info("plan_review:%d: GO verdict; applying label and advancing", item.issue)
         self._write_verdict_labels(item.issue, ctx, is_go=True)
@@ -732,8 +690,23 @@ class PlanReviewStage(Stage):
         ):
             return StageOutcome(Disposition.RETRY, "plan-go label was not confirmed")
         if ctx.config.enable_learn:
-            return Continue(next_state="LEARN_WAIT")
-        return StageOutcome(Disposition.ADVANCE, "plan approved (learn disabled)")
+            plan_text = str(item.payload.get("plan_text") or "")
+            intent = LearningIntent.approved_plan(
+                repo=item.repo,
+                issue=item.issue,
+                plan_revision=int(item.payload.get("plan_revision") or 0),
+                plan_fingerprint=plan_fingerprint(plan_text) if plan_text else "",
+            )
+            if intent not in item.learning_intents:
+                item.learning_intents.append(intent)
+            if isinstance(ctx.learning_journal, LearningJournalStore):
+                ctx.learning_journal.ensure_pending(
+                    intent.key,
+                    kind=intent.kind.value,
+                    identity=intent.journal_identity(),
+                )
+            item.learning_resume_stage = StageName.IMPLEMENTATION
+        return StageOutcome(Disposition.ADVANCE, "plan approved")
 
     @staticmethod
     def _write_verdict_labels(issue_number: int, ctx: StageContext, *, is_go: bool) -> None:
@@ -764,11 +737,6 @@ class PlanReviewStage(Stage):
             ctx: Stage context.
 
         """
-        if item.state == "LEARN_WAIT" and not result.ok:
-            item.payload["athena_learn_error"] = result.error or "learn failed"
-            logger.warning("plan_review:%s: learn failed: %s", item.issue, result.error)
-            return
-
         if not result.ok:
             reason = _safe_agent_failure_reason(result.error)
             diagnostic = _safe_agent_failure_diagnostic(result.stderr_tail)
@@ -781,14 +749,6 @@ class PlanReviewStage(Stage):
                 )
             else:
                 logger.warning("plan_review:%s: job failed: %s", item.issue, reason)
-            return
-
-        if item.state == "LEARN_WAIT":
-            if not isinstance(result.value, AthenaSkillResult) or not result.value.ok:
-                item.payload["athena_learn_error"] = "invalid Athena learn result"
-                return
-            item.payload["athena_learn_receipt"] = result.value.receipt
-            item.payload["athena_learn_delivery_receipt"] = result.value.delivery_receipt
             return
 
         if result.value is not None:
@@ -829,6 +789,3 @@ class PlanReviewStage(Stage):
                     ctx.github.edit_labels(item.issue, add=add, remove=remove)
                     item.payload["needs_plan_transition_pending"] = True
                     item.payload.pop("no_progress_reason", None)
-            # LEARN_WAIT intentionally has no branch: the learn job's output
-            # is a side effect for the Mnemosyne skill store, not a payload
-            # value any later state consumes.

--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -284,6 +284,7 @@ class PrReviewJobs(_PrReviewHost):
         base_branch = str(review_context.get("pr_base_branch") or "main")
         item.payload.update(review_context)
         item.payload["review_checkout_expected_head"] = expected_head
+        item.payload["review_worktree_expected_head"] = expected_head
         item.payload["review_checkout_pending"] = True
         job = GitJob(
             repo=item.repo,
@@ -792,13 +793,15 @@ class PrReviewJobs(_PrReviewHost):
         if not isinstance(review_worktree, str) or not review_worktree:
             return StageOutcome(Disposition.FINISH_FAIL, "review_worktree_cleanup_invalid")
         if item.payload.pop("review_worktree_cleanup_error", None):
-            # Keep the disposable checkout visible to Finished's diagnostic
-            # preservation path.  The writer remains separately recorded and
-            # cannot be confused for reviewer evidence.
             item.worktree = review_worktree
             return StageOutcome(Disposition.FINISH_FAIL, "review_worktree_cleanup_failed")
         cleanup_state = item.payload.get("review_worktree_cleanup_done")
         if cleanup_state == "pending":
+            expected_head = item.payload.get("review_worktree_expected_head")
+            if not is_full_commit_sha(expected_head):
+                return StageOutcome(
+                    Disposition.FINISH_FAIL, "review_worktree_cleanup_identity_invalid"
+                )
             job = GitJob(
                 repo=item.repo,
                 op="remove_worktree",
@@ -807,6 +810,8 @@ class PrReviewJobs(_PrReviewHost):
                     "worktree_path": review_worktree,
                     "repo_root": str(ctx.paths.repo_root),
                     "issue_number": item.issue or item.pr or 0,
+                    "expected_head": expected_head,
+                    "expected_detached": True,
                     "force": False,
                 },
                 descr="remove_read_only_review_worktree",
@@ -814,7 +819,6 @@ class PrReviewJobs(_PrReviewHost):
             return JobRequest(job, on_done_state=CLEANUP_REVIEW_WORKTREE_WAIT)
         if cleanup_state is not True:
             return StageOutcome(Disposition.FINISH_FAIL, "review_worktree_cleanup_state_invalid")
-
         outcome_value = item.payload.pop("review_worktree_cleanup_outcome", None)
         note = str(item.payload.pop("review_worktree_cleanup_note", "") or "")
         try:
@@ -822,9 +826,6 @@ class PrReviewJobs(_PrReviewHost):
         except ValueError:
             return StageOutcome(Disposition.FINISH_FAIL, "review_worktree_cleanup_outcome_invalid")
         if disposition is Disposition.RETRY:
-            # A retry requires a new detached snapshot.  Do not requeue the
-            # already-consumed cleanup state, and do not temporarily expose a
-            # retained implementation checkout as reviewer input.
             item.worktree = ""
             if item.payload.get("writer_worktree"):
                 item.payload["reviewer_checkout_needed"] = True
@@ -832,9 +833,10 @@ class PrReviewJobs(_PrReviewHost):
         else:
             self._restore_writer_worktree(item)
         item.payload.pop("review_worktree", None)
-        item.payload.pop("direct_pr_worktree", None)
-        item.payload.pop("direct_pr_worktree_dirty", None)
+        for key in ("direct_pr_worktree", "direct_pr_worktree_dirty"):
+            item.payload.pop(key, None)
         item.payload.pop("review_worktree_cleanup_done", None)
+        item.payload.pop("review_worktree_expected_head", None)
         return StageOutcome(disposition, note)
 
     def on_job_done(  # noqa: C901

--- a/hephaestus/automation/pipeline/stages/pr_review_jobs.py
+++ b/hephaestus/automation/pipeline/stages/pr_review_jobs.py
@@ -806,6 +806,7 @@ class PrReviewJobs(_PrReviewHost):
                 kwargs={
                     "worktree_path": review_worktree,
                     "repo_root": str(ctx.paths.repo_root),
+                    "issue_number": item.issue or item.pr or 0,
                     "force": False,
                 },
                 descr="remove_read_only_review_worktree",

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -32,11 +32,13 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
+from itertools import chain
 from pathlib import Path
 from typing import Any, TypeGuard
 
 import hephaestus.automation.loop_repo_manager as _repo_manager
 import hephaestus.automation.pipeline.seeding as _seeding
+from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.issue_waves import (
     WAVE_LEASE_PAYLOAD,
     IssueWaveError,
@@ -453,7 +455,9 @@ class RepoStage(Stage):
     def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """[M] Initialize a bounded metadata source; do not classify eagerly."""
         try:
-            source = RepoIssueSource(_repo_manager._iter_open_issue_meta(ctx.org, item.repo))
+            open_issues = _repo_manager._iter_open_issue_meta(ctx.org, item.repo)
+            recovered = self._iter_closed_learning_meta(item.repo, ctx)
+            source = RepoIssueSource(chain(open_issues, recovered))
         except Exception as exc:
             logger.warning("repo:%s: discovery failed: %s", item.repo, exc)
             return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
@@ -466,6 +470,29 @@ class RepoStage(Stage):
 
         item.payload["_repo_issue_source"] = source
         return Continue(next_state="SOURCE")
+
+    @staticmethod
+    def _iter_closed_learning_meta(repo: str, ctx: StageContext) -> Iterator[dict[str, object]]:
+        """Yield closed issues that still own durable learning work."""
+        journal = ctx.learning_journal
+        if not isinstance(journal, LearningJournalStore):
+            return
+        for record in journal.incomplete_for_repo(repo=repo):
+            issue = record.get("issue")
+            if isinstance(issue, bool) or not isinstance(issue, int):
+                continue
+            issue_data = ctx.github.gh_issue_json(issue)
+            if str(issue_data.get("state") or "").upper() != "CLOSED":
+                continue
+            yield {
+                "number": issue,
+                "labels": [
+                    str(label.get("name") or "")
+                    for label in issue_data.get("labels", [])
+                    if isinstance(label, dict)
+                ],
+                "title": str(issue_data.get("title") or "durable learning recovery"),
+            }
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Record checkout preparation success/failure (state still CLONE_WAIT).

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -33,6 +33,9 @@ class RunStats:
     agent_job_count: int
     agent_job_time_s: float
     wall_s: float
+    auxiliary_job_count: int = 0
+    auxiliary_job_time_s: float = 0.0
+    auxiliary_job_failure_count: int = 0
 
     @property
     def interrupted(self) -> bool:
@@ -260,6 +263,12 @@ def print_summary(
         stats.wall_s,
         stats.interrupted,
     )
+    logger.info(
+        "  auxiliary jobs: %d (%.1fs total, %d failed)",
+        stats.auxiliary_job_count,
+        stats.auxiliary_job_time_s,
+        stats.auxiliary_job_failure_count,
+    )
 
     for line in format_preserved_worktrees(preserved, sys.argv[0]):
         logger.info("%s", line)
@@ -279,6 +288,9 @@ def print_summary(
             loops_run=stats.loops_run,
             agent_jobs=stats.agent_job_count,
             agent_job_time_s=round(stats.agent_job_time_s, 1),
+            auxiliary_jobs=stats.auxiliary_job_count,
+            auxiliary_job_time_s=round(stats.auxiliary_job_time_s, 1),
+            auxiliary_job_failures=stats.auxiliary_job_failure_count,
             wall_s=round(stats.wall_s, 1),
             resumable=resumable,
             preserved_worktrees=[[number, path] for _, number, path in preserved],

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -1,7 +1,8 @@
 """Work item and history tracking. Pure data, zero I/O (epic #1809).
 
 Thread-safety: a WorkItem and its associated StageQueue are only ever touched
-by the coordinator thread. The single cross-thread channel is CompletionQueue.
+by the coordinator thread. The bounded main and auxiliary completion queues
+are the only cross-thread payload channels.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -199,6 +199,66 @@ class WorkItem:
     post_processing: PostProcessingRecord | None = None
     result: ItemResult | None = None
 
+    def learning_journal_identity(self, intent: LearningIntent) -> dict[str, object]:
+        """Return restart identity plus bounded terminal cleanup state."""
+        identity = intent.journal_identity()
+        if self.post_processing is None:
+            return identity
+        result = self.post_processing.result
+        identity["post_processing"] = {
+            "worktree": self.worktree,
+            "branch": self.branch,
+            "resume_stage": self.post_processing.resume_stage.value,
+            "cleanup_payload": dict(self.post_processing.cleanup_payload),
+            "result": {
+                "passed": result.passed,
+                "reason": result.reason,
+                "final_stage": result.final_stage.value,
+            },
+        }
+        return identity
+
+    def restore_post_processing(self, record: dict[str, Any]) -> bool:
+        """Restore validated terminal cleanup state from a journal record."""
+        raw = record.get("post_processing")
+        if not isinstance(raw, dict):
+            return False
+        cleanup = raw.get("cleanup_payload")
+        result_raw = raw.get("result")
+        if not isinstance(cleanup, dict) or not isinstance(result_raw, dict):
+            raise ValueError("invalid post-processing journal state")
+        unknown = set(cleanup).difference(_POST_PROCESSING_PAYLOAD_KEYS)
+        if unknown:
+            raise ValueError("post-processing journal has unsupported cleanup fields")
+        passed = result_raw.get("passed")
+        reason = result_raw.get("reason")
+        final_stage = result_raw.get("final_stage")
+        resume_stage_raw = raw.get("resume_stage")
+        if (
+            not isinstance(passed, bool)
+            or not isinstance(reason, str)
+            or not isinstance(final_stage, str)
+            or not isinstance(resume_stage_raw, str)
+        ):
+            raise ValueError("post-processing journal has invalid result fields")
+        result = ItemResult(
+            passed=passed,
+            reason=reason,
+            final_stage=StageName(final_stage),
+        )
+        resume_stage = StageName(resume_stage_raw)
+        self.worktree = str(raw.get("worktree") or "")
+        self.branch = str(raw.get("branch") or "")
+        self.payload.update(cleanup)
+        self.result = result
+        self.post_processing = PostProcessingRecord(
+            result=result,
+            resume_stage=resume_stage,
+            intent_keys=tuple(intent.key for intent in self.learning_intents),
+            cleanup_payload=dict(cleanup),
+        )
+        return True
+
     def compact_for_post_processing(self, result: ItemResult) -> None:
         """Drop stage-local payload after terminal main work completes."""
         cleanup_payload = {

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -6,13 +6,13 @@ by the coordinator thread. The single cross-thread channel is CompletionQueue.
 
 from __future__ import annotations
 
+import json
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from hashlib import sha256
 from typing import Any
-
-from hephaestus.agents.pi_session import AgentSessionBinding
 
 from .routing import StageName, budget_keys
 
@@ -39,6 +39,111 @@ class ItemKind(StrEnum):
     REPO = "repo"
     ISSUE = "issue"
     PR = "pr"
+
+
+class LearningIntentKind(StrEnum):
+    """Supported auxiliary learning sources."""
+
+    APPROVED_PLAN = "approved_plan"
+    POST_MERGE = "post_merge"
+
+
+@dataclass(frozen=True)
+class LearningIntent:
+    """Immutable identity and bounded input for one learning operation."""
+
+    kind: LearningIntentKind
+    repo: str
+    issue: int
+    pr: int | None = None
+    plan_revision: int | None = None
+    plan_fingerprint: str = ""
+
+    @property
+    def key(self) -> str:
+        """Return a deterministic identity key without persisting content."""
+        identity = {
+            "issue": self.issue,
+            "kind": self.kind.value,
+            "plan_fingerprint": self.plan_fingerprint,
+            "plan_revision": self.plan_revision,
+            "pr": self.pr,
+            "repo": self.repo,
+        }
+        digest = sha256(json.dumps(identity, sort_keys=True).encode("utf-8")).hexdigest()
+        return f"{self.kind.value}:{digest}"
+
+    def journal_identity(self) -> dict[str, object]:
+        """Return the bounded identity fields needed for restart recovery."""
+        return {
+            "repo": self.repo,
+            "issue": self.issue,
+            "pr": self.pr,
+            "plan_revision": self.plan_revision,
+            "plan_fingerprint": self.plan_fingerprint,
+        }
+
+    @classmethod
+    def from_journal(cls, record: dict[str, Any]) -> LearningIntent:
+        """Rebuild an intent from a validated journal record."""
+        intent = cls(
+            kind=LearningIntentKind(str(record["kind"])),
+            repo=str(record["repo"]),
+            issue=int(record["issue"]),
+            pr=int(record["pr"]) if record.get("pr") is not None else None,
+            plan_revision=(
+                int(record["plan_revision"]) if record.get("plan_revision") is not None else None
+            ),
+            plan_fingerprint=str(record.get("plan_fingerprint", "")),
+        )
+        if intent.key != record.get("key"):
+            raise ValueError("learning journal identity does not match its key")
+        return intent
+
+    @classmethod
+    def approved_plan(
+        cls,
+        *,
+        repo: str,
+        issue: int,
+        plan_revision: int,
+        plan_fingerprint: str,
+    ) -> LearningIntent:
+        """Build an approved-plan learning identity."""
+        return cls(
+            kind=LearningIntentKind.APPROVED_PLAN,
+            repo=repo,
+            issue=issue,
+            plan_revision=plan_revision,
+            plan_fingerprint=plan_fingerprint,
+        )
+
+    @classmethod
+    def post_merge(cls, *, repo: str, issue: int, pr: int) -> LearningIntent:
+        """Build a post-merge learning identity."""
+        return cls(kind=LearningIntentKind.POST_MERGE, repo=repo, issue=issue, pr=pr)
+
+
+_POST_PROCESSING_PAYLOAD_KEYS = frozenset(
+    {
+        "_direct_scope_local_branch_cleanup",
+        "_direct_scope_reservation",
+        "_learning_primary_reason",
+        "_wave_lease",
+        "detached_push_failure",
+        "learning_failures",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PostProcessingRecord:
+    """Compact terminal state retained by the auxiliary lane."""
+
+    result: ItemResult
+    resume_stage: StageName
+    intent_keys: tuple[str, ...]
+    cleanup_payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -86,10 +191,28 @@ class WorkItem:
     session_ids: dict[str, str] = field(default_factory=dict)
     # Pi bindings are deliberately separate from legacy raw session ids: they
     # bind a provider session to its worktree, role, and model fingerprint.
-    session_bindings: dict[str, AgentSessionBinding] = field(default_factory=dict)
+    session_bindings: dict[str, Any] = field(default_factory=dict)
     labels_cache: dict[str, bool] = field(default_factory=dict)
     payload: dict[str, Any] = field(default_factory=dict)
+    learning_intents: list[LearningIntent] = field(default_factory=list)
+    learning_resume_stage: StageName | None = None
+    post_processing: PostProcessingRecord | None = None
     result: ItemResult | None = None
+
+    def compact_for_post_processing(self, result: ItemResult) -> None:
+        """Drop stage-local payload after terminal main work completes."""
+        cleanup_payload = {
+            key: value
+            for key, value in self.payload.items()
+            if key in _POST_PROCESSING_PAYLOAD_KEYS
+        }
+        self.payload = cleanup_payload
+        self.post_processing = PostProcessingRecord(
+            result=result,
+            resume_stage=StageName.FINISHED,
+            intent_keys=tuple(intent.key for intent in self.learning_intents),
+            cleanup_payload=dict(cleanup_payload),
+        )
 
     def add_history_event(self, stage: StageName, state: str, note: str = "") -> None:
         """Record a stage transition in the history (capped at HISTORY_CAP events)."""

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -130,6 +130,7 @@ _POST_PROCESSING_PAYLOAD_KEYS = frozenset(
         "_direct_scope_local_branch_cleanup",
         "_direct_scope_reservation",
         "_learning_primary_reason",
+        "_worktree_cleanup_head_sha",
         "_wave_lease",
         "detached_push_failure",
         "learning_failures",

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2031,6 +2031,12 @@ class WorkerPool:
                 stderr_tail=(exc.stderr or "")[-_TAIL:],
             )
 
+    def _run_cleanup_git(self, job: GitJob) -> JobResult:
+        """Run one cleanup job through the existing serialized Git boundary."""
+        if job.op not in {"remove_worktree", "release_branch_reservation"}:
+            raise TypeError(f"unsupported cleanup Git operation: {job.op}")
+        return self._run_git(job)
+
     def _dispatch_git_op(self, job: GitJob) -> JobResult:  # noqa: C901
         """Dispatch a git operation to its handler.
 
@@ -2044,7 +2050,9 @@ class WorkerPool:
             return self._git_verify_pr_review_checkout(job)
 
         elif job.op == "remove_worktree":
-            return self._git_remove_worktree(job)
+            from .git_cleanup import run_cleanup_job
+
+            return run_cleanup_job(job, worktree_manager_type=WorktreeManager)
 
         elif job.op == "rebase":
             return self._git_rebase(job)
@@ -2063,27 +2071,9 @@ class WorkerPool:
             return self._git_commit_push(job)
 
         elif job.op == "release_branch_reservation":
-            branch_name = str(job.kwargs.get("branch") or "")
-            base_sha = job.kwargs.get("base_sha")
-            repo_root_value = job.kwargs.get("repo_root")
-            repo_root = Path(str(repo_root_value)) if repo_root_value else None
-            if (
-                not branch_name
-                or not _is_full_commit_sha(base_sha)
-                or repo_root is None
-                or not repo_root.is_dir()
-            ):
-                return JobResult(
-                    ok=False,
-                    error="release_branch_reservation requires branch, base_sha, and repo_root",
-                )
-            released = git_utils.delete_reserved_branch_if_unchanged(
-                branch_name,
-                base_sha,
-                repo_root,
-                timeout=job.timeout_s,
-            )
-            return JobResult(ok=True, value=released)
+            from .git_cleanup import run_cleanup_job
+
+            return run_cleanup_job(job, worktree_manager_type=WorktreeManager)
 
         elif job.op == "clone":
             # gh repo clone <repo> <dest>
@@ -3260,45 +3250,9 @@ class WorkerPool:
 
     def _git_remove_worktree(self, job: GitJob) -> JobResult:
         """Remove a worktree by known path, or fall back to manager state."""
-        if job.kwargs.get("worktree_path"):
-            worktree_path = Path(str(job.kwargs["worktree_path"]))
-            repo_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
-            # This is the same lock create_worktree takes. Keep it across
-            # removal, prune, and local cleanup so pipeline workers cannot
-            # attach the branch between those operations. The final
-            # ``git branch -d`` check also refuses an externally checked-out
-            # branch.
-            with file_lock(WorktreeManager.git_metadata_lock_path(repo_root)):
-                cmd = ["git", "worktree", "remove", str(worktree_path)]
-                if job.kwargs.get("force"):
-                    cmd.append("--force")
-                git_utils.run(cmd, cwd=repo_root, timeout=job.timeout_s)
-                git_utils.run(
-                    ["git", "worktree", "prune"],
-                    cwd=repo_root,
-                    check=False,
-                    timeout=job.timeout_s,
-                )
-                local_cleanup = job.kwargs.get("local_branch_cleanup")
-                if local_cleanup is not None:
-                    if not isinstance(local_cleanup, dict):
-                        return JobResult(ok=False, error="local branch cleanup receipt is invalid")
-                    branch_name = local_cleanup.get("branch")
-                    expected_sha = local_cleanup.get("base_sha")
-                    if not isinstance(branch_name, str) or not _is_full_commit_sha(expected_sha):
-                        return JobResult(ok=False, error="local branch cleanup receipt is invalid")
-                    deleted = git_utils.delete_local_branch_if_unchanged(
-                        branch_name,
-                        expected_sha,
-                        repo_root,
-                        timeout=job.timeout_s,
-                    )
-                    return JobResult(ok=True, value={"local_branch_deleted": deleted})
-            return JobResult(ok=True)
-        fallback_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
-        manager = WorktreeManager(repo_root=fallback_root)
-        manager.remove_worktree(**job.kwargs, timeout=job.timeout_s)
-        return JobResult(ok=True)
+        from .git_cleanup import run_cleanup_job
+
+        return run_cleanup_job(job, worktree_manager_type=WorktreeManager)
 
     def _git_commit_push(self, job: GitJob) -> JobResult:
         """Commit pending changes in a worktree, then push its branch.

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -131,9 +131,23 @@ Examples:
         action="store_true",
         help="Skip the advise step (don't search team knowledge base before planning)",
     )
-    parser.add_argument("--learning-workers", type=positive_int, default=1)
-    parser.add_argument("--learning-queue-capacity", type=positive_int, default=1)
-    parser.add_argument("--no-learn", action="store_true")
+    parser.add_argument(
+        "--learning-workers",
+        type=positive_int,
+        default=1,
+        help="Independent auxiliary learning workers (default: 1)",
+    )
+    parser.add_argument(
+        "--learning-queue-capacity",
+        type=positive_int,
+        default=1,
+        help="Bounded auxiliary learning queue capacity (default: 1)",
+    )
+    parser.add_argument(
+        "--no-learn",
+        action="store_true",
+        help="Do not create or execute auxiliary learning intents",
+    )
     add_agent_timeout_arg(parser)
     add_advise_timeout_arg(parser)
     add_git_message_timeout_arg(parser)

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -130,6 +130,9 @@ Examples:
         action="store_true",
         help="Skip the advise step (don't search team knowledge base before planning)",
     )
+    parser.add_argument("--learning-workers", type=int, default=1)
+    parser.add_argument("--learning-queue-capacity", type=int, default=1)
+    parser.add_argument("--no-learn", action="store_true")
     add_agent_timeout_arg(parser)
     add_advise_timeout_arg(parser)
     add_git_message_timeout_arg(parser)
@@ -235,9 +238,12 @@ def main() -> int:
         loops=1,
         # --parallel maps to the pipeline worker-pool size.
         max_workers=args.parallel,
+        learning_workers=args.learning_workers,
+        learning_queue_capacity=args.learning_queue_capacity,
         dry_run=args.dry_run,
         agent=agent,
         no_advise=args.no_advise,
+        enable_learn=not args.no_learn,
         projects_dir=resolve_projects_dir(None, prefer_cwd_parent=True),
         json_out=args.json,
         scope=PipelineScope(_PLANNER_SCOPE_STAGES),

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -32,6 +32,7 @@ from hephaestus.cli.utils import (
     configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
+    positive_int,
 )
 from hephaestus.config.paths import resolve_projects_dir
 
@@ -130,8 +131,8 @@ Examples:
         action="store_true",
         help="Skip the advise step (don't search team knowledge base before planning)",
     )
-    parser.add_argument("--learning-workers", type=int, default=1)
-    parser.add_argument("--learning-queue-capacity", type=int, default=1)
+    parser.add_argument("--learning-workers", type=positive_int, default=1)
+    parser.add_argument("--learning-queue-capacity", type=positive_int, default=1)
     parser.add_argument("--no-learn", action="store_true")
     add_agent_timeout_arg(parser)
     add_advise_timeout_arg(parser)

--- a/hephaestus/automation/subprocess_registry.py
+++ b/hephaestus/automation/subprocess_registry.py
@@ -1,122 +1,20 @@
-"""Thread-safe registry of live agent subprocess groups (#2059).
-
-The pipeline worker pool runs each agent (``claude``) invocation on a
-``ThreadPoolExecutor`` thread that blocks in :func:`subprocess.run`/``Popen``.
-``ThreadPoolExecutor.shutdown(cancel_futures=True)`` cancels only *un-started*
-futures; a job already blocked in ``communicate()`` keeps running to completion
-or timeout, holding a non-daemon worker thread and (via the interpreter's
-``atexit`` join) the whole process open — the ~19-minute leak reported in #2059.
-
-This registry lets the spawning code publish each live child's process-group id
-so a teardown path (``WorkerPool.shutdown``) can send it ``SIGTERM`` and free
-the worker promptly. It is a *shared* seam: :mod:`hephaestus.automation.claude_invoke`
-registers, the worker pool terminates. Registration is opt-in via
-:func:`track_process_group` (a context manager) so non-pipeline callers are
-unaffected.
-
-Windows has no process groups / ``killpg``; there registration is a no-op and
-:func:`terminate_all` returns 0 (the pool falls back to its prior behavior).
-"""
+"""Compatibility alias for the library-owned subprocess registry."""
 
 from __future__ import annotations
 
-import logging
-import os
-import signal
-import threading
-from collections.abc import Iterator
-from contextlib import contextmanager
+import sys
+from typing import TYPE_CHECKING
 
-logger = logging.getLogger(__name__)
+from hephaestus.utils import subprocess_registry as _implementation
 
-#: True when the platform supports POSIX process groups + killpg.
-_HAVE_KILLPG = hasattr(os, "killpg") and hasattr(os, "getpgid")
-
-_lock = threading.Lock()
-#: Live child process-group ids currently tracked.
-_live_pgids: set[int] = set()
-
-
-def supported() -> bool:
-    """Return True when process-group tracking/termination is available."""
-    return _HAVE_KILLPG
-
-
-def _register(pgid: int) -> None:
-    with _lock:
-        _live_pgids.add(pgid)
-
-
-def _unregister(pgid: int) -> None:
-    with _lock:
-        _live_pgids.discard(pgid)
-
-
-@contextmanager
-def track_process_group(pid: int) -> Iterator[None]:
-    """Track *pid*'s process group for the duration of the ``with`` block.
-
-    *pid* must be the leader of its own process group (spawn the child with
-    ``start_new_session=True`` so its pgid equals its pid). On unsupported
-    platforms this is a no-op. The group is always unregistered on exit, so a
-    child that finishes normally is never left in the registry.
-
-    Args:
-        pid: The child process id (also its process-group id).
-
-    """
-    if not _HAVE_KILLPG:
-        yield
-        return
-    try:
-        pgid = os.getpgid(pid)
-    except (ProcessLookupError, OSError):
-        # Child already gone (raced to exit) — nothing to track.
-        yield
-        return
-    _register(pgid)
-    try:
-        yield
-    finally:
-        _unregister(pgid)
-
-
-def terminate_all(sig: int = signal.SIGTERM) -> int:
-    """Signal every tracked process group and clear the registry.
-
-    Idempotent and safe to call with nothing tracked (returns 0). Groups whose
-    leader has already exited are skipped without error. Returns the number of
-    groups signalled — the worker pool logs this on teardown so a leak is
-    visible.
-
-    Args:
-        sig: The signal to deliver (default ``SIGTERM``).
-
-    Returns:
-        The count of process groups that were signalled.
-
-    """
-    if not _HAVE_KILLPG:
-        return 0
-    with _lock:
-        pgids = list(_live_pgids)
-        _live_pgids.clear()
-    signalled = 0
-    for pgid in pgids:
-        try:
-            os.killpg(pgid, sig)
-            signalled += 1
-        except ProcessLookupError:
-            # Group already gone — fine.
-            continue
-        except OSError as exc:  # pragma: no cover - defensive
-            logger.warning("failed to signal process group %s: %s", pgid, exc)
-    if signalled:
-        logger.info("terminated %d in-flight agent process group(s) on teardown", signalled)
-    return signalled
-
-
-def live_count() -> int:
-    """Return the number of currently tracked process groups (for tests/diagnostics)."""
-    with _lock:
-        return len(_live_pgids)
+if TYPE_CHECKING:
+    from hephaestus.utils.subprocess_registry import (
+        _register as _register,
+        _unregister as _unregister,
+        live_count as live_count,
+        supported as supported,
+        terminate_all as terminate_all,
+        track_process_group as track_process_group,
+    )
+else:
+    sys.modules[__name__] = _implementation

--- a/hephaestus/automation/subprocess_registry.py
+++ b/hephaestus/automation/subprocess_registry.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING
 from hephaestus.utils import subprocess_registry as _implementation
 
 if TYPE_CHECKING:
-    from hephaestus.utils.subprocess_registry import (
-        _register as _register,
-        _unregister as _unregister,
-        live_count as live_count,
-        supported as supported,
-        terminate_all as terminate_all,
-        track_process_group as track_process_group,
-    )
+    from collections.abc import Callable
+    from contextlib import AbstractContextManager
+
+    _register: Callable[[int], None]
+    _unregister: Callable[[int], None]
+    live_count: Callable[[], int]
+    supported: Callable[[], bool]
+    terminate_all: Callable[..., int]
+    track_process_group: Callable[[int], AbstractContextManager[None]]
 else:
     sys.modules[__name__] = _implementation

--- a/hephaestus/cli/__init__.py
+++ b/hephaestus/cli/__init__.py
@@ -24,7 +24,6 @@ from hephaestus.cli.utils import (
     emit_json_status,
     format_output,
     format_table,
-    positive_int,
     register_command,
     resolve_repo_root,
 )
@@ -53,7 +52,6 @@ __all__ = [
     "emit_json_status",
     "format_output",
     "format_table",
-    "positive_int",
     "register_command",
     "resolve_repo_root",
 ]

--- a/hephaestus/cli/__init__.py
+++ b/hephaestus/cli/__init__.py
@@ -24,6 +24,7 @@ from hephaestus.cli.utils import (
     emit_json_status,
     format_output,
     format_table,
+    positive_int,
     register_command,
     resolve_repo_root,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "emit_json_status",
     "format_output",
     "format_table",
+    "positive_int",
     "register_command",
     "resolve_repo_root",
 ]

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -49,7 +49,6 @@ __all__ = [
     "emit_json_status",
     "format_output",
     "format_table",
-    "positive_int",
     "register_command",
     "resolve_repo_root",
 ]

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -49,6 +49,7 @@ __all__ = [
     "emit_json_status",
     "format_output",
     "format_table",
+    "positive_int",
     "register_command",
     "resolve_repo_root",
 ]
@@ -309,7 +310,7 @@ def _finite_float(value: str) -> float:
     return parsed
 
 
-def _positive_int(value: str) -> int:
+def positive_int(value: str) -> int:
     """Parse a strictly positive integer for timeout CLI options."""
     try:
         parsed = int(value)
@@ -318,6 +319,9 @@ def _positive_int(value: str) -> int:
     if parsed <= 0:
         raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
     return parsed
+
+
+_positive_int = positive_int
 
 
 def _non_negative_float(value: str) -> float:

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -403,6 +403,7 @@ def _gh_call_impl(
     log_on_error: bool = True,
     timeout: int | None = None,
     env: Mapping[str, str] | None = None,
+    track_process_group: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Implement gh CLI call with rate limit handling (circuit breaker will wrap this).
 
@@ -417,6 +418,7 @@ def _gh_call_impl(
             foreign-authored comment that the caller recovers via a shadow post).
         timeout: Optional per-call timeout override. Defaults to
             :func:`gh_cli_timeout`.
+        track_process_group: Make the child available to host shutdown.
 
     Returns:
         CompletedProcess instance
@@ -437,6 +439,7 @@ def _gh_call_impl(
                 timeout=timeout if timeout is not None else gh_cli_timeout(),
                 log_on_error=log_on_error,
                 env=dict(env) if env is not None else None,
+                track_process_group=track_process_group,
             )
             return result
         except subprocess.CalledProcessError as e:
@@ -511,6 +514,7 @@ def _gh_call(
     log_on_error: bool = True,
     timeout: int | None = None,
     env: Mapping[str, str] | None = None,
+    track_process_group: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Call gh CLI with rate limit handling and circuit breaker protection.
 
@@ -551,6 +555,8 @@ def _gh_call(
         }
         if env is not None:
             kwargs["env"] = env
+        if track_process_group:
+            kwargs["track_process_group"] = True
         return _GH_BREAKER.call(_gh_call_impl, args, **kwargs)
     except CircuitBreakerOpenError as exc:
         # Translate to a domain exception (RuntimeError subclass) so existing

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -180,12 +180,13 @@ def _tail_for_log(value: str, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
 
 def run_subprocess(
     cmd: list[str],
-    cwd: str | None = None,
+    cwd: str | Path | None = None,
     timeout: int | None = None,
     check: bool = True,
     dry_run: bool = False,
     log_on_error: bool = True,
     env: dict[str, str] | None = None,
+    track_process_group: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run subprocess command with proper error handling.
 
@@ -199,6 +200,8 @@ def run_subprocess(
             Use when failure is expected and already handled by the caller.
         env: Optional environment dict to pass to subprocess.run().
             If provided, replaces the current process environment.
+        track_process_group: Run the child in a tracked POSIX process group so
+            an owning host can stop active work during forced shutdown.
 
     Returns:
         Completed process object
@@ -221,16 +224,50 @@ def run_subprocess(
         effective_env["GH_TRACE_ID"] = cid
 
     try:
-        result = subprocess.run(
-            cmd,
-            cwd=cwd,
-            stdin=subprocess.DEVNULL,
-            capture_output=True,
-            text=True,
-            check=check,
-            timeout=timeout,
-            env=effective_env,
-        )
+        if track_process_group:
+            from hephaestus.utils import subprocess_registry
+
+            process = subprocess.Popen(
+                cmd,
+                cwd=cwd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=effective_env,
+                start_new_session=True,
+            )
+            with subprocess_registry.track_process_group(process.pid):
+                try:
+                    stdout, stderr = process.communicate(timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    stdout, stderr = process.communicate()
+                    raise subprocess.TimeoutExpired(
+                        cmd,
+                        float(timeout or 0),
+                        output=stdout,
+                        stderr=stderr,
+                    ) from None
+            result = subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+            if check and result.returncode:
+                raise subprocess.CalledProcessError(
+                    result.returncode,
+                    cmd,
+                    output=result.stdout,
+                    stderr=result.stderr,
+                )
+        else:
+            result = subprocess.run(
+                cmd,
+                cwd=cwd,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                check=check,
+                timeout=timeout,
+                env=effective_env,
+            )
         return result
     except subprocess.TimeoutExpired:
         if log_on_error:

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -5,9 +5,11 @@ General utility functions that don't fit in other specific modules.
 
 import os
 import re
+import signal
 import subprocess
 import sys
 import unicodedata
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -178,10 +180,60 @@ def _tail_for_log(value: str, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
     return f"...({omitted} earlier chars){value[-limit:]}"
 
 
+def _run_tracked_process_group(
+    cmd: list[str],
+    *,
+    cwd: str | Path | None,
+    timeout: float | None,
+    check: bool,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run one command and terminate its full process group on timeout."""
+    from hephaestus.utils import subprocess_registry
+
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        start_new_session=True,
+    )
+    with subprocess_registry.track_process_group(process.pid):
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGTERM)
+            try:
+                stdout, stderr = process.communicate(timeout=1)
+            except subprocess.TimeoutExpired:
+                with suppress(ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGKILL)
+                stdout, stderr = process.communicate(timeout=1)
+            raise subprocess.TimeoutExpired(
+                cmd,
+                float(timeout or 0),
+                output=stdout,
+                stderr=stderr,
+            ) from None
+    result = subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+    if check and result.returncode:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            cmd,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+    return result
+
+
 def run_subprocess(
     cmd: list[str],
     cwd: str | Path | None = None,
-    timeout: int | None = None,
+    timeout: float | None = None,
     check: bool = True,
     dry_run: bool = False,
     log_on_error: bool = True,
@@ -225,38 +277,13 @@ def run_subprocess(
 
     try:
         if track_process_group:
-            from hephaestus.utils import subprocess_registry
-
-            process = subprocess.Popen(
+            result = _run_tracked_process_group(
                 cmd,
                 cwd=cwd,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
+                timeout=timeout,
+                check=check,
                 env=effective_env,
-                start_new_session=True,
             )
-            with subprocess_registry.track_process_group(process.pid):
-                try:
-                    stdout, stderr = process.communicate(timeout=timeout)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    stdout, stderr = process.communicate()
-                    raise subprocess.TimeoutExpired(
-                        cmd,
-                        float(timeout or 0),
-                        output=stdout,
-                        stderr=stderr,
-                    ) from None
-            result = subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
-            if check and result.returncode:
-                raise subprocess.CalledProcessError(
-                    result.returncode,
-                    cmd,
-                    output=result.stdout,
-                    stderr=result.stderr,
-                )
         else:
             result = subprocess.run(
                 cmd,

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -191,6 +191,18 @@ def _run_tracked_process_group(
     """Run one command and terminate its full process group on timeout."""
     from hephaestus.utils import subprocess_registry
 
+    if not subprocess_registry.supported():
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=timeout,
+            env=env,
+        )
+
     process = subprocess.Popen(
         cmd,
         cwd=cwd,

--- a/hephaestus/utils/subprocess_registry.py
+++ b/hephaestus/utils/subprocess_registry.py
@@ -1,0 +1,78 @@
+"""Track subprocess groups that a host can terminate during shutdown."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+_HAVE_KILLPG = hasattr(os, "killpg") and hasattr(os, "getpgid")
+_lock = threading.Lock()
+_live_pgids: set[int] = set()
+
+
+def supported() -> bool:
+    """Return true when POSIX process-group termination is available."""
+    return _HAVE_KILLPG
+
+
+def _register(pgid: int) -> None:
+    """Register one process group for compatibility with direct tests."""
+    with _lock:
+        _live_pgids.add(pgid)
+
+
+def _unregister(pgid: int) -> None:
+    """Remove one process group from the registry."""
+    with _lock:
+        _live_pgids.discard(pgid)
+
+
+@contextmanager
+def track_process_group(pid: int) -> Iterator[None]:
+    """Track a child that is the leader of its own process group."""
+    if not _HAVE_KILLPG:
+        yield
+        return
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        yield
+        return
+    _register(pgid)
+    try:
+        yield
+    finally:
+        _unregister(pgid)
+
+
+def terminate_all(sig: int = signal.SIGTERM) -> int:
+    """Signal all tracked process groups and return the signal count."""
+    if not _HAVE_KILLPG:
+        return 0
+    with _lock:
+        pgids = list(_live_pgids)
+        _live_pgids.clear()
+    signalled = 0
+    for pgid in pgids:
+        try:
+            os.killpg(pgid, sig)
+            signalled += 1
+        except ProcessLookupError:
+            continue
+        except OSError as exc:  # pragma: no cover - defensive logging
+            logger.warning("failed to signal process group %s: %s", pgid, exc)
+    if signalled:
+        logger.info("terminated %d in-flight subprocess group(s)", signalled)
+    return signalled
+
+
+def live_count() -> int:
+    """Return the number of tracked process groups."""
+    with _lock:
+        return len(_live_pgids)

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 
 from hephaestus.agents import runtime as agent_runtime
+from hephaestus.agents.execution_policy import ExecutionPolicyError
 
 PI_SMOKE_COMMAND_PREFIX = [
     "pi",
@@ -2042,7 +2043,7 @@ def test_run_agent_text_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) ->
         patch("hephaestus.agents.runtime.run_pi_text") as run_pi_text,
     ):
         with pytest.raises(
-            agent_runtime.ExecutionPolicyError,
+            ExecutionPolicyError,
             match="Pi automation requires an ExecutionRequest",
         ):
             agent_runtime.run_agent_text("pi", "prompt", cwd=tmp_path, timeout=30)
@@ -2057,7 +2058,7 @@ def test_run_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Path)
         patch("hephaestus.agents.runtime.run_pi_session") as run_pi_session,
     ):
         with pytest.raises(
-            agent_runtime.ExecutionPolicyError,
+            ExecutionPolicyError,
             match="Pi automation requires an ExecutionRequest",
         ):
             agent_runtime.run_agent_session("pi", "prompt", cwd=tmp_path, timeout=30)
@@ -2072,7 +2073,7 @@ def test_resume_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Pa
         patch("hephaestus.agents.runtime.resume_pi_session") as resume_pi_session,
     ):
         with pytest.raises(
-            agent_runtime.ExecutionPolicyError,
+            ExecutionPolicyError,
             match="Pi automation requires an ExecutionRequest",
         ):
             agent_runtime.resume_agent_session(

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -2037,7 +2037,10 @@ def test_agent_json_stdout_wraps_direct_agent_text() -> None:
 
 def test_run_agent_text_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) -> None:
     """The shared text boundary requires a scoped execution request."""
-    with patch("hephaestus.agents.runtime.run_pi_text") as run_pi_text:
+    with (
+        patch("hephaestus.agents.runtime._require_pi_automation_admission"),
+        patch("hephaestus.agents.runtime.run_pi_text") as run_pi_text,
+    ):
         with pytest.raises(
             agent_runtime.ExecutionPolicyError,
             match="Pi automation requires an ExecutionRequest",
@@ -2049,7 +2052,10 @@ def test_run_agent_text_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) ->
 
 def test_run_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) -> None:
     """The shared session boundary requires a scoped execution request."""
-    with patch("hephaestus.agents.runtime.run_pi_session") as run_pi_session:
+    with (
+        patch("hephaestus.agents.runtime._require_pi_automation_admission"),
+        patch("hephaestus.agents.runtime.run_pi_session") as run_pi_session,
+    ):
         with pytest.raises(
             agent_runtime.ExecutionPolicyError,
             match="Pi automation requires an ExecutionRequest",
@@ -2061,7 +2067,10 @@ def test_run_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Path)
 
 def test_resume_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) -> None:
     """The shared resume boundary requires a scoped execution request."""
-    with patch("hephaestus.agents.runtime.resume_pi_session") as resume_pi_session:
+    with (
+        patch("hephaestus.agents.runtime._require_pi_automation_admission"),
+        patch("hephaestus.agents.runtime.resume_pi_session") as resume_pi_session,
+    ):
         with pytest.raises(
             agent_runtime.ExecutionPolicyError,
             match="Pi automation requires an ExecutionRequest",

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -1123,7 +1123,13 @@ def test_run_pi_text_rejects_unadmitted_execution(tmp_path: Path) -> None:
 
 def test_private_pi_helpers_reject_unadmitted_execution(tmp_path: Path) -> None:
     """Reflective private-helper access cannot bypass the Pi admission boundary."""
-    with patch("subprocess.run") as run:
+    with (
+        patch("subprocess.run") as run,
+        patch(
+            "hephaestus.agents.runtime._require_pi_automation_admission",
+            side_effect=RuntimeError("Pi automation preflight is unavailable"),
+        ),
+    ):
         with pytest.raises(RuntimeError, match="Pi automation preflight is unavailable"):
             agent_runtime._invoke_pi_session(
                 "prompt",
@@ -2030,27 +2036,36 @@ def test_agent_json_stdout_wraps_direct_agent_text() -> None:
 
 
 def test_run_agent_text_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) -> None:
-    """The shared text boundary cannot bypass Pi admission through direct use."""
+    """The shared text boundary requires a scoped execution request."""
     with patch("hephaestus.agents.runtime.run_pi_text") as run_pi_text:
-        with pytest.raises(RuntimeError, match="Pi automation preflight is unavailable"):
+        with pytest.raises(
+            agent_runtime.ExecutionPolicyError,
+            match="Pi automation requires an ExecutionRequest",
+        ):
             agent_runtime.run_agent_text("pi", "prompt", cwd=tmp_path, timeout=30)
 
     run_pi_text.assert_not_called()
 
 
 def test_run_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) -> None:
-    """The shared session boundary cannot bypass Pi admission through direct use."""
+    """The shared session boundary requires a scoped execution request."""
     with patch("hephaestus.agents.runtime.run_pi_session") as run_pi_session:
-        with pytest.raises(RuntimeError, match="Pi automation preflight is unavailable"):
+        with pytest.raises(
+            agent_runtime.ExecutionPolicyError,
+            match="Pi automation requires an ExecutionRequest",
+        ):
             agent_runtime.run_agent_session("pi", "prompt", cwd=tmp_path, timeout=30)
 
     run_pi_session.assert_not_called()
 
 
 def test_resume_agent_session_rejects_unadmitted_pi_before_dispatch(tmp_path: Path) -> None:
-    """The shared resume boundary cannot bypass Pi admission through direct use."""
+    """The shared resume boundary requires a scoped execution request."""
     with patch("hephaestus.agents.runtime.resume_pi_session") as resume_pi_session:
-        with pytest.raises(RuntimeError, match="Pi automation preflight is unavailable"):
+        with pytest.raises(
+            agent_runtime.ExecutionPolicyError,
+            match="Pi automation requires an ExecutionRequest",
+        ):
             agent_runtime.resume_agent_session(
                 "pi",
                 "pi-session-123",

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -657,6 +657,7 @@ def make_ctx() -> Callable[..., StageContext]:
         now_fn: Callable[[], float] | None = None,
         budget_fn: Callable[[str], int] | None = None,
         event_fn: Callable[[StageEvent], None] | None = None,
+        learning_journal: Any = None,
         branch_worktree_owner_status: (
             Callable[[WorkItem, str, str], BranchWorktreeOwnerStatus] | None
         ) = None,
@@ -676,6 +677,7 @@ def make_ctx() -> Callable[..., StageContext]:
             now_fn=now_fn if now_fn is not None else default_now_fn,
             budget_fn=budget_fn if budget_fn is not None else _budget_fn,
             event_fn=event_fn,
+            learning_journal=learning_journal,
             branch_worktree_owner_status=branch_worktree_owner_status,
         )
 

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -105,7 +105,7 @@ class TestStepResultTypes:
 
     def test_job_request_carries_on_done_state(self) -> None:
         """JobRequest names the state entered after on_job_done."""
-        request = JobRequest(job=None, on_done_state="EVAL")  # type: ignore[arg-type]
+        request = JobRequest(job=None, on_done_state="EVAL")
         assert request.on_done_state == "EVAL"
 
 

--- a/tests/unit/automation/pipeline/stages/test_stage_cross.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_cross.py
@@ -234,6 +234,7 @@ class TestPostReviewRebaseReusesRestoredWriter:
             {
                 "writer_worktree": "/tmp/implementation-writer",
                 "review_worktree": "/tmp/detached-review",
+                "review_worktree_expected_head": "a" * 40,
             }
         )
 

--- a/tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from hephaestus.automation.pipeline.stages import merge_wait, plan_review, pr_review
+from hephaestus.automation.pipeline.stages import merge_wait, pr_review
 
 
 def test_active_finish_tokens_are_stage_qualified() -> None:
     """Only stages with active finish states expose their qualified tokens."""
-    assert plan_review.PLAN_FINISH == "PLAN_FINISH"
     assert merge_wait.MW_FINISH == "MW_FINISH"
     assert not hasattr(pr_review, "PR_FINISH")
     assert not hasattr(pr_review, "FINISH")

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -20,7 +21,12 @@ from hephaestus.automation.pipeline.routing import Disposition, StageName
 from hephaestus.automation.pipeline.stages import finished as finished_module
 from hephaestus.automation.pipeline.stages.base import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.finished import FinishedStage
-from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+from hephaestus.automation.pipeline.work_item import (
+    ItemKind,
+    ItemResult,
+    PostProcessingRecord,
+    WorkItem,
+)
 
 # tests/unit/automation/pipeline/stages/ -> parents[5] = repo root
 ROOT = Path(__file__).resolve().parents[5]
@@ -147,6 +153,8 @@ class TestCleanup:
     ) -> None:
         ctx = make_ctx()
         item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-fix"
+        item.payload["_worktree_cleanup_head_sha"] = "a" * 40
 
         result = stage.step(item, ctx)
 
@@ -156,9 +164,37 @@ class TestCleanup:
             "worktree_path": "/wt/issue-42",
             "repo_root": str(ctx.paths.repo_root),
             "issue_number": 42,
-            "force": True,
+            "force": False,
+            "expected_branch": "42-fix",
+            "expected_head": "a" * 40,
         }
         assert result.on_done_state == "DONE"
+
+    def test_pending_learning_preserves_worktree_before_cleanup(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[str, int, str]],
+        make_ctx: Any,
+    ) -> None:
+        """Finished cannot remove a writer worktree before learning is terminal."""
+        ctx = make_ctx(
+            learning_journal=SimpleNamespace(
+                load=lambda key: {"status": "pending"} if key == "post_merge:pending" else None
+            )
+        )
+        item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.post_processing = PostProcessingRecord(
+            result=item.result,
+            resume_stage=StageName.FINISHED,
+            intent_keys=("post_merge:pending",),
+            cleanup_payload={},
+        )
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state="DONE")
+        assert preserved == [("repo-a", 42, "/wt/issue-42")]
+        assert item.payload["_learning_cleanup_succeeded"] is False
+        assert item.payload["_learning_cleanup_error"] == "learning is not terminal"
 
     def test_fresh_review_completion_retains_only_receipt_backed_recovery_checkouts(
         self,

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -183,6 +183,7 @@ class TestCleanup:
             )
         )
         item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        assert item.result is not None
         item.post_processing = PostProcessingRecord(
             result=item.result,
             resume_stage=StageName.FINISHED,
@@ -191,10 +192,11 @@ class TestCleanup:
         )
         result = stage.step(item, ctx)
 
-        assert result == Continue(next_state="DONE")
+        assert result == StageOutcome(Disposition.EJECT, "learning_cleanup_pending")
         assert preserved == [("repo-a", 42, "/wt/issue-42")]
-        assert item.payload["_learning_cleanup_succeeded"] is False
-        assert item.payload["_learning_cleanup_error"] == "learning is not terminal"
+        assert "_learning_cleanup_succeeded" not in item.payload
+        assert "_learning_cleanup_error" not in item.payload
+        assert item.state == "CLEANUP"
 
     def test_fresh_review_completion_retains_only_receipt_backed_recovery_checkouts(
         self,

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -155,6 +155,7 @@ class TestCleanup:
         assert result.job.kwargs == {
             "worktree_path": "/wt/issue-42",
             "repo_root": str(ctx.paths.repo_root),
+            "issue_number": 42,
             "force": True,
         }
         assert result.on_done_state == "DONE"
@@ -373,6 +374,7 @@ class TestCleanup:
         assert result.job.kwargs == {
             "worktree_path": "/wt/issue-42",
             "repo_root": str(ctx.paths.repo_root),
+            "issue_number": 42,
             "force": False,
             "local_branch_cleanup": {
                 "branch": "42-auto-impl",

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -334,6 +334,11 @@ class TestCleanup:
         assert isinstance(second.job, GitJob)
         assert second.job.op == "release_branch_reservation"
 
+        stage.on_job_done(item, JobResult(ok=False, error="still unavailable"), ctx)
+
+        assert item.payload["_learning_cleanup_succeeded"] is False
+        assert item.payload["_learning_cleanup_error"] == "still unavailable"
+
     def test_noop_local_branch_cleanup_is_coupled_to_worktree_removal(
         self, stage: FinishedStage, make_ctx: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -251,6 +251,7 @@ class TestCleanup:
     ) -> None:
         ctx = make_ctx()
         item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
 
         stage.step(item, ctx)
         item.state = "CLEANUP"
@@ -267,6 +268,7 @@ class TestCleanup:
         """A terminal failure cannot strand a deterministic branch at its base SHA."""
         ctx = make_ctx()
         item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
         item.payload["_direct_scope_reservation"] = {
             "branch": "42-auto-impl",
             "base_sha": "a" * 40,
@@ -296,6 +298,7 @@ class TestCleanup:
         """The release runs for every unpublished direct item, including a passing no-op."""
         ctx = make_ctx()
         item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
         item.payload["_direct_scope_reservation"] = {
             "branch": "42-auto-impl",
             "base_sha": "a" * 40,
@@ -313,12 +316,31 @@ class TestCleanup:
         assert isinstance(second.job, GitJob)
         assert second.job.op == "remove_worktree"
 
+    def test_reservation_cleanup_rejects_a_different_item_branch(
+        self, stage: FinishedStage, make_ctx: Any
+    ) -> None:
+        """A damaged receipt cannot release an unrelated same-SHA branch."""
+        item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-owned"
+        item.payload["_direct_scope_reservation"] = {
+            "branch": "unrelated",
+            "base_sha": "a" * 40,
+        }
+
+        result = stage.step(item, make_ctx())
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DONE"
+        assert item.payload["_learning_cleanup_succeeded"] is False
+        assert item.payload["_learning_cleanup_error"] == "cleanup ownership changed"
+
     def test_failed_reservation_release_retries_before_terminal_cleanup(
         self, stage: FinishedStage, make_ctx: Any
     ) -> None:
         """An operational lease failure is retried instead of being misclassified as stale."""
         ctx = make_ctx()
         item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
         item.payload["_direct_scope_reservation"] = {
             "branch": "42-auto-impl",
             "base_sha": "a" * 40,
@@ -345,6 +367,7 @@ class TestCleanup:
         """A direct no-op removes its local deterministic branch after detaching it."""
         ctx = make_ctx()
         item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
         item.payload["_direct_scope_local_branch_cleanup"] = {
             "branch": "42-auto-impl",
             "base_sha": "a" * 40,
@@ -366,6 +389,7 @@ class TestCleanup:
         """A skipped no-op must not strand the deterministic local branch."""
         ctx = make_ctx()
         item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
         item.payload["_direct_scope_local_branch_cleanup"] = {
             "branch": "42-auto-impl",
             "base_sha": "a" * 40,
@@ -381,6 +405,7 @@ class TestCleanup:
             "repo_root": str(ctx.paths.repo_root),
             "issue_number": 42,
             "force": False,
+            "expected_branch": "42-auto-impl",
             "local_branch_cleanup": {
                 "branch": "42-auto-impl",
                 "base_sha": "a" * 40,
@@ -395,6 +420,7 @@ class TestCleanup:
     ) -> None:
         """A late human edit blocks no-op cleanup without being discarded."""
         item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+        item.branch = "42-auto-impl"
         item.payload["_direct_scope_local_branch_cleanup"] = {
             "branch": "42-auto-impl",
             "base_sha": "a" * 40,

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import hephaestus.automation.pipeline.stages as stages
 from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.pipeline.athena_skill_jobs import (
     AthenaSkillJob,
@@ -13,7 +12,12 @@ from hephaestus.automation.pipeline.athena_skill_jobs import (
 )
 from hephaestus.automation.pipeline.jobs import JobResult
 from hephaestus.automation.pipeline.routing import StageName
-from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages import (
+    Continue,
+    JobRequest,
+    LearningStage,
+    StageOutcome,
+)
 from hephaestus.automation.pipeline.stages.base import Disposition
 from hephaestus.automation.pipeline.work_item import LearningIntent
 from hephaestus.automation.state_labels import STATE_PLAN_GO
@@ -24,7 +28,7 @@ def test_learning_stage_owns_claim_and_submits_only_host_job(
     tmp_path: Path, make_ctx: Any, make_work_item: Any
 ) -> None:
     """The auxiliary stage claims durable work and emits only AthenaSkillJob."""
-    assert hasattr(stages, "LearningStage")
+    assert LearningStage is not None
     journal = LearningJournalStore(lambda: tmp_path)
     ctx = make_ctx(
         learning_journal=journal,
@@ -41,7 +45,7 @@ def test_learning_stage_owns_claim_and_submits_only_host_job(
     )
     item.learning_resume_stage = StageName.IMPLEMENTATION
 
-    stage = stages.LearningStage()
+    stage = LearningStage()
     assert stage.on_enter(item, ctx) is None
     entered = stage.step(item, ctx)
     assert entered == Continue(next_state="CLAIM")
@@ -75,7 +79,7 @@ def _claimed_learning(
         )
     )
     item.learning_resume_stage = StageName.IMPLEMENTATION
-    stage = stages.LearningStage()
+    stage = LearningStage()
     stage.on_enter(item, ctx)
     item.state = "CLAIM"
     assert isinstance(stage.step(item, ctx), JobRequest)
@@ -173,7 +177,7 @@ def test_live_claim_is_ejected_without_terminalizing_owner(
     owner.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
     assert owner.claim(intent.key)
 
-    stage = stages.LearningStage()
+    stage = LearningStage()
     assert stage.step(item, ctx) == Continue(next_state="CLAIM")
     assert stage.step(item, ctx) == StageOutcome(
         Disposition.FAIL_BACK,
@@ -220,7 +224,7 @@ def test_cleanup_barrier_waits_for_every_intent(
         ]
     )
     item.learning_resume_stage = StageName.FINISHED
-    stage = stages.LearningStage()
+    stage = LearningStage()
     stage.on_enter(item, ctx)
     item.state = "CLAIM"
     first = stage.step(item, ctx)
@@ -250,7 +254,7 @@ def test_stale_plan_authority_skips_host_and_returns_to_review(
     )
     item.learning_intents.append(intent)
     item.learning_resume_stage = StageName.IMPLEMENTATION
-    stage = stages.LearningStage()
+    stage = LearningStage()
     stage.on_enter(item, ctx)
 
     item.state = "CLAIM"
@@ -280,7 +284,7 @@ def test_unavailable_plan_read_is_ancillary_and_does_not_block_implementation(
     )
     item.learning_intents.append(intent)
     item.learning_resume_stage = StageName.IMPLEMENTATION
-    stage = stages.LearningStage()
+    stage = LearningStage()
     stage.on_enter(item, ctx)
 
     item.state = "CLAIM"

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -231,8 +231,10 @@ def test_completion_is_bound_to_the_locally_submitted_intent(
         ctx,
     )
 
-    assert observer.load(external.key)["status"] == "claimed"
-    assert observer.load(local.key)["status"] == "succeeded"
+    external_record = observer.load(external.key)
+    local_record = observer.load(local.key)
+    assert external_record is not None and external_record["status"] == "claimed"
+    assert local_record is not None and local_record["status"] == "succeeded"
     owner.finish(external.key, succeeded=True)
 
 

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -137,17 +137,53 @@ def test_valid_receipt_terminalizes_learning_success(
     assert record["receipt_summary"]["pr_number"] == 1
 
 
-def test_restart_does_not_repeat_unknown_claim(
+def test_restart_does_not_repeat_inactive_unknown_claim(
     tmp_path: Path, make_ctx: Any, make_work_item: Any
 ) -> None:
     """A restart marks an ambiguous claim failed instead of repeating it."""
     stage, item, ctx, journal = _claimed_learning(tmp_path, make_ctx, make_work_item)
+    journal._release_claim_lock(item.learning_intents[0].key)
     item.state = "CLAIM"
 
     assert stage.step(item, ctx) == Continue(next_state="CLAIM")
     record = journal.load(item.learning_intents[0].key)
     assert record is not None and record["status"] == "failed"
     assert item.payload["learning_failures"][0]["error"] == "outcome_unknown"
+
+
+def test_live_claim_is_ejected_without_terminalizing_owner(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A second loop does not change a claim held by a live owner."""
+    owner = LearningJournalStore(lambda: tmp_path)
+    observer = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(
+        learning_journal=observer,
+        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+    )
+    item = make_work_item(issue=2705, state="CLAIM")
+    intent = LearningIntent.approved_plan(
+        repo=item.repo,
+        issue=2705,
+        plan_revision=8,
+        plan_fingerprint="abc",
+    )
+    item.learning_intents.append(intent)
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+    owner.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
+    assert owner.claim(intent.key)
+
+    stage = stages.LearningStage()
+    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
+    assert stage.step(item, ctx) == StageOutcome(
+        Disposition.FAIL_BACK,
+        "resume_implementation",
+    )
+
+    record = observer.load(intent.key)
+    assert record is not None and record["status"] == "claimed"
+    assert item.payload["learning_external_claims"] == [intent.key]
+    owner.finish(intent.key, succeeded=True)
 
 
 def test_cancellation_before_host_start_returns_claim_to_pending(

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -1,0 +1,256 @@
+"""Behavior tests for the auxiliary learning stage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import hephaestus.automation.pipeline.stages as stages
+from hephaestus.automation.arming_state import LearningJournalStore
+from hephaestus.automation.pipeline.athena_skill_jobs import (
+    AthenaSkillJob,
+    AthenaSkillResult,
+)
+from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.base import Disposition
+from hephaestus.automation.pipeline.work_item import LearningIntent
+from hephaestus.automation.state_labels import STATE_PLAN_GO
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def test_learning_stage_owns_claim_and_submits_only_host_job(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """The auxiliary stage claims durable work and emits only AthenaSkillJob."""
+    assert hasattr(stages, "LearningStage")
+    journal = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(
+        learning_journal=journal,
+        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+    )
+    item = make_work_item(issue=2705, state="ENTER")
+    item.learning_intents.append(
+        LearningIntent.approved_plan(
+            repo=item.repo,
+            issue=2705,
+            plan_revision=8,
+            plan_fingerprint="abc",
+        )
+    )
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+
+    stage = stages.LearningStage()
+    assert stage.on_enter(item, ctx) is None
+    entered = stage.step(item, ctx)
+    assert entered == Continue(next_state="CLAIM")
+    item.state = entered.next_state
+
+    request = stage.step(item, ctx)
+
+    assert isinstance(request, JobRequest)
+    assert isinstance(request.job, AthenaSkillJob)
+    assert request.job.request.kind == "learn"
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None and record["status"] == "claimed"
+
+
+def _claimed_learning(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any, *, budget: int = 2
+) -> tuple[Any, Any, Any, LearningJournalStore]:
+    journal = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(
+        learning_journal=journal,
+        budget_fn=lambda _name: budget,
+        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+    )
+    item = make_work_item(issue=2705, state="ENTER")
+    item.learning_intents.append(
+        LearningIntent.approved_plan(
+            repo=item.repo,
+            issue=2705,
+            plan_revision=8,
+            plan_fingerprint="abc",
+        )
+    )
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+    stage = stages.LearningStage()
+    stage.on_enter(item, ctx)
+    item.state = "CLAIM"
+    assert isinstance(stage.step(item, ctx), JobRequest)
+    return stage, item, ctx, journal
+
+
+def test_known_failure_retries_within_learning_budget(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A known failed host result returns the intent to pending once."""
+    stage, item, ctx, journal = _claimed_learning(tmp_path, make_ctx, make_work_item)
+
+    stage.on_job_done(item, JobResult(ok=False, error="host unavailable"), ctx)
+
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None
+    assert record["status"] == "pending"
+    assert record["attempts"] == 1
+    assert item.payload.get("learning_failures") is None
+
+
+def test_exhausted_learning_retry_is_ancillary_failure(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """An exhausted learning failure does not fail the primary issue."""
+    stage, item, ctx, journal = _claimed_learning(tmp_path, make_ctx, make_work_item, budget=1)
+
+    stage.on_job_done(item, JobResult(ok=False, error="host unavailable"), ctx)
+    item.state = "RESULT"
+    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
+    item.state = "CLAIM"
+    assert stage.step(item, ctx) == StageOutcome(Disposition.FAIL_BACK, "resume_implementation")
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None and record["status"] == "failed"
+    assert item.payload["learning_failures"][0]["error"] == "host unavailable"
+
+
+def test_valid_receipt_terminalizes_learning_success(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A PR readback receipt is the only successful terminal result."""
+    stage, item, ctx, journal = _claimed_learning(tmp_path, make_ctx, make_work_item)
+    sha = "a" * 40
+    result = AthenaSkillResult(
+        kind="learn",
+        delivery_receipt={
+            "pr_url": "https://github.com/HomericIntelligence/Mnemosyne/pull/1",
+            "pr_number": 1,
+            "commit_sha": sha,
+            "readback_head_sha": sha,
+        },
+    )
+
+    stage.on_job_done(item, JobResult(ok=True, value=result), ctx)
+
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None
+    assert record["status"] == "succeeded"
+    assert record["receipt_summary"]["pr_number"] == 1
+
+
+def test_restart_does_not_repeat_unknown_claim(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A restart marks an ambiguous claim failed instead of repeating it."""
+    stage, item, ctx, journal = _claimed_learning(tmp_path, make_ctx, make_work_item)
+    item.state = "CLAIM"
+
+    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None and record["status"] == "failed"
+    assert item.payload["learning_failures"][0]["error"] == "outcome_unknown"
+
+
+def test_cancellation_before_host_start_returns_claim_to_pending(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A proven pre-start cancellation remains safe to retry after restart."""
+    stage, item, ctx, journal = _claimed_learning(tmp_path, make_ctx, make_work_item)
+
+    stage.on_cancelled_before_start(item, ctx)
+
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None
+    assert record["status"] == "pending"
+    assert record["error"] == "interrupted_before_start"
+
+
+def test_cleanup_barrier_waits_for_every_intent(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """The stage does not advance until every associated intent is terminal."""
+    journal = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(
+        learning_journal=journal,
+        budget_fn=lambda _name: 1,
+        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+    )
+    item = make_work_item(issue=2705, state="ENTER")
+    item.learning_intents.extend(
+        [
+            LearningIntent.approved_plan(
+                repo=item.repo, issue=2705, plan_revision=8, plan_fingerprint="abc"
+            ),
+            LearningIntent.post_merge(repo=item.repo, issue=2705, pr=99),
+        ]
+    )
+    item.learning_resume_stage = StageName.FINISHED
+    stage = stages.LearningStage()
+    stage.on_enter(item, ctx)
+    item.state = "CLAIM"
+    first = stage.step(item, ctx)
+    assert isinstance(first, JobRequest)
+    stage.on_job_done(item, JobResult(ok=False, error="first failed"), ctx)
+
+    item.state = "CLAIM"
+    second = stage.step(item, ctx)
+    assert isinstance(second, JobRequest)
+    assert isinstance(second.job, AthenaSkillJob)
+    assert second.job.request.payload["intent_kind"] == "post_merge"
+    stage.on_job_done(item, JobResult(ok=False, error="second failed"), ctx)
+
+    item.state = "CLAIM"
+    assert stage.step(item, ctx) == StageOutcome(Disposition.ADVANCE, "learning terminal")
+
+
+def test_stale_plan_authority_skips_host_and_returns_to_review(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A removed plan-GO label prevents stale learning and implementation."""
+    journal = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(learning_journal=journal, github=FakeStageGitHub())
+    item = make_work_item(issue=2705, state="ENTER")
+    intent = LearningIntent.approved_plan(
+        repo=item.repo, issue=2705, plan_revision=8, plan_fingerprint="abc"
+    )
+    item.learning_intents.append(intent)
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+    stage = stages.LearningStage()
+    stage.on_enter(item, ctx)
+
+    item.state = "CLAIM"
+    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
+    record = journal.load(intent.key)
+    assert record is not None
+    assert record["status"] == "failed"
+    assert record["error"] == "plan_state_changed"
+
+    assert stage.step(item, ctx) == StageOutcome(Disposition.FAIL_BACK, "resume_plan_review")
+
+
+def test_unavailable_plan_read_is_ancillary_and_does_not_block_implementation(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A failed authority read skips host delivery but keeps the primary route."""
+
+    class UnavailableGitHub(FakeStageGitHub):
+        def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+            raise RuntimeError("GitHub unavailable")
+
+    journal = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(learning_journal=journal, github=UnavailableGitHub())
+    item = make_work_item(issue=2705, state="ENTER")
+    intent = LearningIntent.approved_plan(
+        repo=item.repo, issue=2705, plan_revision=8, plan_fingerprint="abc"
+    )
+    item.learning_intents.append(intent)
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+    stage = stages.LearningStage()
+    stage.on_enter(item, ctx)
+
+    item.state = "CLAIM"
+    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
+    record = journal.load(intent.key)
+    assert record is not None
+    assert record["status"] == "failed"
+    assert record["error"] == "plan_state_unverified"
+    assert stage.step(item, ctx) == StageOutcome(Disposition.FAIL_BACK, "resume_implementation")

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -20,8 +20,18 @@ from hephaestus.automation.pipeline.stages import (
 )
 from hephaestus.automation.pipeline.stages.base import Disposition
 from hephaestus.automation.pipeline.work_item import LearningIntent
+from hephaestus.automation.review_journal import plan_fingerprint, render_current_plan
 from hephaestus.automation.state_labels import STATE_PLAN_GO
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+_APPROVED_PLAN = "Use the approved plan."
+_APPROVED_FINGERPRINT = plan_fingerprint(_APPROVED_PLAN)
+
+
+def _approved_github(issue: int = 2705, revision: int = 8) -> FakeStageGitHub:
+    github = FakeStageGitHub(labels=[STATE_PLAN_GO])
+    github.comments[issue] = [render_current_plan(_APPROVED_PLAN, revision=revision)]
+    return github
 
 
 def test_learning_stage_owns_claim_and_submits_only_host_job(
@@ -32,7 +42,7 @@ def test_learning_stage_owns_claim_and_submits_only_host_job(
     journal = LearningJournalStore(lambda: tmp_path)
     ctx = make_ctx(
         learning_journal=journal,
-        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        github=_approved_github(),
     )
     item = make_work_item(issue=2705, state="ENTER")
     item.learning_intents.append(
@@ -40,7 +50,7 @@ def test_learning_stage_owns_claim_and_submits_only_host_job(
             repo=item.repo,
             issue=2705,
             plan_revision=8,
-            plan_fingerprint="abc",
+            plan_fingerprint=_APPROVED_FINGERPRINT,
         )
     )
     item.learning_resume_stage = StageName.IMPLEMENTATION
@@ -67,7 +77,7 @@ def _claimed_learning(
     ctx = make_ctx(
         learning_journal=journal,
         budget_fn=lambda _name: budget,
-        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        github=_approved_github(),
     )
     item = make_work_item(issue=2705, state="ENTER")
     item.learning_intents.append(
@@ -75,7 +85,7 @@ def _claimed_learning(
             repo=item.repo,
             issue=2705,
             plan_revision=8,
-            plan_fingerprint="abc",
+            plan_fingerprint=_APPROVED_FINGERPRINT,
         )
     )
     item.learning_resume_stage = StageName.IMPLEMENTATION
@@ -163,7 +173,7 @@ def test_live_claim_is_ejected_without_terminalizing_owner(
     observer = LearningJournalStore(lambda: tmp_path)
     ctx = make_ctx(
         learning_journal=observer,
-        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        github=_approved_github(),
     )
     item = make_work_item(issue=2705, state="CLAIM")
     intent = LearningIntent.approved_plan(
@@ -260,13 +270,16 @@ def test_cleanup_barrier_waits_for_every_intent(
     ctx = make_ctx(
         learning_journal=journal,
         budget_fn=lambda _name: 1,
-        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        github=_approved_github(),
     )
     item = make_work_item(issue=2705, state="ENTER")
     item.learning_intents.extend(
         [
             LearningIntent.approved_plan(
-                repo=item.repo, issue=2705, plan_revision=8, plan_fingerprint="abc"
+                repo=item.repo,
+                issue=2705,
+                plan_revision=8,
+                plan_fingerprint=_APPROVED_FINGERPRINT,
             ),
             LearningIntent.post_merge(repo=item.repo, issue=2705, pr=99),
         ]
@@ -313,6 +326,34 @@ def test_stale_plan_authority_skips_host_and_returns_to_review(
     assert record["error"] == "plan_state_changed"
 
     assert stage.step(item, ctx) == StageOutcome(Disposition.FAIL_BACK, "resume_plan_review")
+
+
+def test_changed_plan_revision_invalidates_old_learning_intent(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A GO label cannot approve learning for a replaced plan revision."""
+    current_plan = render_current_plan("Use the current plan.", revision=9)
+    github = FakeStageGitHub(labels=[STATE_PLAN_GO])
+    github.comments[2705] = [current_plan]
+    journal = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(learning_journal=journal, github=github)
+    item = make_work_item(issue=2705, state="ENTER")
+    intent = LearningIntent.approved_plan(
+        repo=item.repo,
+        issue=2705,
+        plan_revision=8,
+        plan_fingerprint=plan_fingerprint("Use the old plan."),
+    )
+    item.learning_intents.append(intent)
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+    stage = LearningStage()
+    stage.on_enter(item, ctx)
+    item.state = "CLAIM"
+
+    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
+    record = journal.load(intent.key)
+    assert record is not None and record["error"] == "plan_state_changed"
+    assert item.learning_resume_stage is StageName.PLAN_REVIEW
 
 
 def test_unavailable_plan_read_is_ancillary_and_does_not_block_implementation(

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -178,16 +178,62 @@ def test_live_claim_is_ejected_without_terminalizing_owner(
     assert owner.claim(intent.key)
 
     stage = LearningStage()
-    assert stage.step(item, ctx) == Continue(next_state="CLAIM")
     assert stage.step(item, ctx) == StageOutcome(
-        Disposition.FAIL_BACK,
-        "resume_implementation",
+        Disposition.EJECT,
+        "learning_claim_owned_elsewhere",
     )
 
     record = observer.load(intent.key)
     assert record is not None and record["status"] == "claimed"
-    assert item.payload["learning_external_claims"] == [intent.key]
     owner.finish(intent.key, succeeded=True)
+
+
+def test_completion_is_bound_to_the_locally_submitted_intent(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A local completion cannot terminalize another process's live claim."""
+    owner = LearningJournalStore(lambda: tmp_path)
+    observer = LearningJournalStore(lambda: tmp_path)
+    ctx = make_ctx(learning_journal=observer, budget_fn=lambda _name: 1)
+    item = make_work_item(issue=2705, state="CLAIM")
+    external = LearningIntent.post_merge(repo=item.repo, issue=2705, pr=1)
+    local = LearningIntent.post_merge(repo=item.repo, issue=2705, pr=2)
+    item.learning_intents.extend([external, local])
+    item.learning_resume_stage = StageName.FINISHED
+    for intent in item.learning_intents:
+        observer.ensure_pending(
+            intent.key,
+            kind=intent.kind.value,
+            identity=intent.journal_identity(),
+        )
+    assert owner.claim(external.key)
+    item.payload["learning_external_claims"] = [external.key]
+
+    stage = LearningStage()
+    request = stage.step(item, ctx)
+    assert isinstance(request, JobRequest)
+    assert request.job.request.payload["intent_key"] == local.key
+    sha = "a" * 40
+    stage.on_job_done(
+        item,
+        JobResult(
+            ok=True,
+            value=AthenaSkillResult(
+                kind="learn",
+                delivery_receipt={
+                    "pr_url": "https://github.com/HomericIntelligence/Mnemosyne/pull/1",
+                    "pr_number": 1,
+                    "commit_sha": sha,
+                    "readback_head_sha": sha,
+                },
+            ),
+        ),
+        ctx,
+    )
+
+    assert observer.load(external.key)["status"] == "claimed"
+    assert observer.load(local.key)["status"] == "succeeded"
+    owner.finish(external.key, succeeded=True)
 
 
 def test_cancellation_before_host_start_returns_claim_to_pending(

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -625,6 +625,27 @@ def test_merged_emits_post_merge_intent_without_job(
     assert github.merge_attempts == []
 
 
+def test_post_merge_journal_failure_is_ancillary(make_ctx: Any, make_work_item: Any) -> None:
+    """A journal failure after merge confirmation cannot change merge success."""
+    from hephaestus.automation.arming_state import LearningJournalStore
+
+    class BrokenJournal(LearningJournalStore):
+        def ensure_pending(self, *_args: object, **_kwargs: object) -> None:
+            raise OSError("journal unavailable")
+
+    github = _ConditionalGitHub(states=[{"state": "MERGED"}])
+    item = _reviewed_item(make_work_item)
+
+    result = _complete_merge_cycle(
+        MergeWaitStage(),
+        item,
+        make_ctx(github=github, learning_journal=BrokenJournal(lambda: Path("."))),
+    )
+
+    assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert item.payload["learning_failures"][0]["error"] == "learning_intent_persist_failed"
+
+
 def test_legacy_inflight_learning_is_not_dispatched_again(
     tmp_path: Path, make_ctx: Any, make_work_item: Any
 ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -12,11 +13,11 @@ from hephaestus.automation.pipeline.jobs import JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName
 from hephaestus.automation.pipeline.stages import (
     ConditionalMergeResult,
-    Continue,
     JobRequest,
     StageOutcome,
 )
 from hephaestus.automation.pipeline.stages.merge_wait import MergeWaitStage
+from hephaestus.automation.pipeline.work_item import LearningIntent
 from hephaestus.automation.pipeline_github_jobs import PipelineGitHubJobRunner
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -603,18 +604,48 @@ def test_already_merged_retry_never_attempts_a_second_merge(
     assert github.merge_attempts == []
 
 
-def test_already_merged_retry_preserves_post_merge_learning(
-    make_ctx: Any, make_work_item: Any
+def test_merged_emits_post_merge_intent_without_job(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
 ) -> None:
-    """A retry that discovers a merge keeps the existing exactly-once learn path."""
+    """A confirmed merge records auxiliary work without blocking merge success."""
+    from hephaestus.automation.arming_state import LearningJournalStore
+
     github = _ConditionalGitHub(states=[{"state": "MERGED"}])
+    item = _reviewed_item(make_work_item)
+    journal = LearningJournalStore(lambda: tmp_path)
 
     result = _complete_merge_cycle(
-        MergeWaitStage(), _reviewed_item(make_work_item), make_ctx(github=github)
+        MergeWaitStage(), item, make_ctx(github=github, learning_journal=journal)
     )
 
-    assert result == Continue(next_state="LEARN_WAIT")
+    assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+    assert item.learning_intents == [LearningIntent.post_merge(repo=item.repo, issue=1, pr=12)]
+    record = journal.load(item.learning_intents[0].key)
+    assert record is not None and record["status"] == "pending"
     assert github.merge_attempts == []
+
+
+def test_legacy_inflight_learning_is_not_dispatched_again(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A legacy ambiguous claim becomes an ancillary terminal journal result."""
+    from hephaestus.automation.arming_state import LearningJournalStore
+
+    github = _ConditionalGitHub(states=[{"state": "MERGED"}])
+    github.learn_claims.add(1)
+    item = _reviewed_item(make_work_item)
+    journal = LearningJournalStore(lambda: tmp_path)
+
+    result = _complete_merge_cycle(
+        MergeWaitStage(), item, make_ctx(github=github, learning_journal=journal)
+    )
+
+    assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+    intent = LearningIntent.post_merge(repo=item.repo, issue=1, pr=12)
+    record = journal.load(intent.key)
+    assert record is not None
+    assert record["status"] == "failed"
+    assert record["error"] == "legacy_outcome_unknown"
 
 
 def test_ambiguous_transport_reconciles_a_merged_pr_without_duplicate_put(

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -630,7 +630,13 @@ def test_post_merge_journal_failure_is_ancillary(make_ctx: Any, make_work_item: 
     from hephaestus.automation.arming_state import LearningJournalStore
 
     class BrokenJournal(LearningJournalStore):
-        def ensure_pending(self, *_args: object, **_kwargs: object) -> None:
+        def ensure_pending(
+            self,
+            key: str,
+            *,
+            kind: str,
+            identity: dict[str, object] | None = None,
+        ) -> dict[str, Any]:
             raise OSError("journal unavailable")
 
     github = _ConditionalGitHub(states=[{"state": "MERGED"}])

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome, plan_review
@@ -1193,6 +1194,40 @@ class TestDurableWriteOrdering:
         # Mutations are recorded at the moment the advancing outcome exists.
         assert github.mutation_log[0][0] == "gh_issue_upsert_comment"
         assert github.mutation_log[1][0] == "edit_labels"
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+
+    def test_learning_intent_is_durable_before_plan_go_label(
+        self, tmp_path: Path, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A crash after plan-GO cannot lose its approved-plan learning intent."""
+        events: list[str] = []
+
+        class OrderedJournal(LearningJournalStore):
+            def ensure_pending(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+                events.append("journal")
+                return super().ensure_pending(*args, **kwargs)
+
+        class OrderedGitHub(FakeStageGitHub):
+            def edit_labels(self, issue_number: int, *, add: list[str], remove: list[str]) -> None:
+                events.append("label")
+                super().edit_labels(issue_number, add=add, remove=remove)
+
+        journal = OrderedJournal(lambda: tmp_path)
+        github = OrderedGitHub()
+        ctx = make_ctx(github=github, learning_journal=journal)
+        item = make_work_item(issue=11, state="EVAL")
+        item.payload.update(
+            {
+                "review_verdict": _verdict("GO"),
+                "plan_text": "Implement the durable learning lane.",
+                "plan_revision": 4,
+            }
+        )
+
+        result = PlanReviewStage().step(item, ctx)
+
+        assert events == ["journal", "label"]
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
 

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-from hephaestus.automation.pipeline.athena_skill_jobs import AthenaSkillJob
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome, plan_review
 from hephaestus.automation.pipeline.stages.plan_review import (
-    PLAN_FINISH,
     REVIEW_ERROR_RETRY_CAP,
     PlanReviewStage,
     build_amend_prompt,
 )
+from hephaestus.automation.pipeline.work_item import LearningIntent
 from hephaestus.automation.prompts._shared import get_untrusted_notice
 from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.protocol import (
@@ -550,21 +550,37 @@ class TestPlanReviewStageStep:
         assert result.disposition == Disposition.RETRY
         assert github.labels[205] == {initial_label, target_label}
 
-    def test_eval_go_with_learn_continues_to_learn(
-        self, make_ctx: Any, make_work_item: Any
+    def test_go_emits_approved_plan_intent_without_job(
+        self, tmp_path: Path, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """GO with learn enabled writes the label then continues to LEARN_WAIT."""
+        """GO records learning work and releases the main stage at once."""
+        from hephaestus.automation.arming_state import LearningJournalStore
+        from hephaestus.automation.review_journal import plan_fingerprint
+
         stage = PlanReviewStage()
         github = FakeStageGitHub()
-        ctx = make_ctx(github=github)
+        journal = LearningJournalStore(lambda: tmp_path)
+        ctx = make_ctx(github=github, learning_journal=journal)
         ctx.config.enable_learn = True
         item = make_work_item(issue=3, state="EVAL")
+        item.payload["plan_text"] = "# Approved plan\n\nImplement the queue."
+        item.payload["plan_revision"] = 8
         item.payload["review_verdict"] = _verdict("GO")
 
         result = stage.step(item, ctx)
 
-        assert isinstance(result, Continue)
-        assert result.next_state == "LEARN_WAIT"
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert item.learning_intents == [
+            LearningIntent.approved_plan(
+                repo=item.repo,
+                issue=3,
+                plan_revision=8,
+                plan_fingerprint=plan_fingerprint(item.payload["plan_text"]),
+            )
+        ]
+        record = journal.load(item.learning_intents[0].key)
+        assert record is not None and record["status"] == "pending"
         assert STATE_PLAN_GO in github.labels[3]
 
     def test_eval_nogo_within_budget_amends(self, make_ctx: Any, make_work_item: Any) -> None:
@@ -738,64 +754,21 @@ class TestPlanReviewStageStep:
             "plan_history": "",
         }
 
-    def test_learn_wait_requests_learn(self, make_ctx: Any, make_work_item: Any) -> None:
-        """LEARN_WAIT submits the learn job carrying the approved plan."""
+    def test_plan_review_never_submits_learning_job(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The main plan-review stage records intent but does not run learning."""
         stage = PlanReviewStage()
-        ctx = make_ctx()
-        item = make_work_item(issue=11, state="LEARN_WAIT")
+        ctx = make_ctx(github=FakeStageGitHub())
+        item = make_work_item(issue=11, state="EVAL")
         item.payload["plan_text"] = "# My Plan\n..."
-
-        result = stage.step(item, ctx)
-
-        assert isinstance(result, JobRequest)
-        assert isinstance(result.job, AthenaSkillJob)  # narrow the job union
-        assert result.on_done_state == PLAN_FINISH
-        assert result.job.descr == "learn"
-        assert result.job.request.kind == "learn"
-        assert result.job.request.payload == {"context": "# My Plan\n..."}
-
-    def test_finish_advances(self, make_ctx: Any, make_work_item: Any) -> None:
-        """PLAN_FINISH advances only while the live GO label remains exclusive."""
-        stage = PlanReviewStage()
-        ctx = make_ctx(github=FakeStageGitHub(labels=[STATE_PLAN_GO]))
-        item = make_work_item(issue=12, state=PLAN_FINISH)
-        item.payload["athena_learn_delivery_receipt"] = _valid_delivery_receipt()
+        item.payload["review_verdict"] = _verdict("GO")
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
-
-    def test_finish_stops_if_operator_blocks_during_learn(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """A BLOCKED label applied after GO prevents the final stage transition."""
-        stage = PlanReviewStage()
-        github = FakeStageGitHub(labels=[STATE_PLAN_BLOCKED])
-        ctx = make_ctx(github=github)
-        item = make_work_item(issue=120, state=PLAN_FINISH)
-        item.payload["athena_learn_delivery_receipt"] = _valid_delivery_receipt()
-
-        result = stage.step(item, ctx)
-
-        assert isinstance(result, StageOutcome)
-        assert result.disposition == Disposition.BLOCKED
-        assert github.labels[120] == {STATE_PLAN_BLOCKED}
-
-    def test_finish_cannot_advance_without_exclusive_live_go(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """Cached or historical GO is insufficient after the learn job."""
-        stage = PlanReviewStage()
-        github = FakeStageGitHub(labels=[STATE_PLAN_GO, STATE_PLAN_NO_GO])
-        ctx = make_ctx(github=github)
-        item = make_work_item(issue=121, state=PLAN_FINISH)
-        item.payload["athena_learn_delivery_receipt"] = _valid_delivery_receipt()
-
-        result = stage.step(item, ctx)
-
-        assert isinstance(result, StageOutcome)
-        assert result.disposition == Disposition.RETRY
+        assert not isinstance(result, JobRequest)
 
     def test_unknown_state_fails(self, make_ctx: Any, make_work_item: Any) -> None:
         """An unknown state finishes failed instead of looping silently."""
@@ -1606,8 +1579,7 @@ class TestReviewFlowWithFakePool:
     def test_full_walk_enter_to_advance(self, make_ctx: Any, make_work_item: Any) -> None:
         """Full pool-driven walk of the whole stage.
 
-        ENTER -> REVIEW -> EVAL(NOGO) -> AMEND -> REVIEW -> EVAL(GO) ->
-        LEARN -> PLAN_FINISH -> ADVANCE.
+        ENTER -> REVIEW -> EVAL(NOGO) -> AMEND -> REVIEW -> EVAL(GO) -> ADVANCE.
         """
         from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 
@@ -1624,7 +1596,6 @@ class TestReviewFlowWithFakePool:
             JobResult(ok=True, value=_verdict("NOGO")),  # review round 1
             JobResult(ok=True, value="# Plan v2"),  # amend
             JobResult(ok=True, value=_verdict("GO")),  # review round 2
-            JobResult(ok=True, value="learn bullets"),  # learn
         )
 
         assert stage.on_enter(item, ctx) is None
@@ -1650,8 +1621,8 @@ class TestReviewFlowWithFakePool:
         # The amended plan and both counters reflect the two real rounds.
         assert item.payload["plan_text"] == "# Plan v2"
         assert item.attempts["plan_review_iter"] == 2
-        # All four jobs ran, in order.
-        assert [h.job.descr for h in pool.submitted] == ["review", "amend", "review", "learn"]
+        # Learning is now auxiliary, so the main stage runs only its three jobs.
+        assert [h.job.descr for h in pool.submitted] == ["review", "amend", "review"]
         # Durable amended-plan write happens before the GO label write and ADVANCE outcome.
         assert github.mutation_log == [
             ("gh_issue_upsert_comment", (21, PLAN_REVIEW_CANONICAL_MARKER)),

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -521,6 +521,7 @@ class TestPrReviewStageOnEnter:
             {
                 "review_checkout_ready": True,
                 "review_checkout_expected_head": "a" * 40,
+                "review_worktree_expected_head": "a" * 40,
                 "pr_diff": "",
             }
         )
@@ -543,6 +544,7 @@ class TestPrReviewStageOnEnter:
             {
                 "review_worktree": item.worktree,
                 "review_checkout_expected_head": "a" * 40,
+                "review_worktree_expected_head": "a" * 40,
                 "review_checkout_ready": True,
                 "reviewed_pr_head_sha": "a" * 40,
                 "reviewed_pr_proof_generation": 7,
@@ -868,6 +870,7 @@ class TestPrReviewStageStep:
         item.payload.update(
             {
                 "review_worktree": item.worktree,
+                "review_worktree_expected_head": "a" * 40,
                 "review_worktree_cleanup_done": "pending",
                 "review_worktree_cleanup_outcome": Disposition.FAIL_BACK.value,
                 "review_worktree_cleanup_note": "implementation_remediation",
@@ -878,6 +881,8 @@ class TestPrReviewStageStep:
         assert isinstance(removal, JobRequest)
         assert isinstance(removal.job, GitJob)
         assert removal.job.op == "remove_worktree"
+        assert removal.job.kwargs["expected_head"] == "a" * 40
+        assert removal.job.kwargs["expected_detached"] is True
         stage.on_job_done(item, JobResult(ok=True), ctx)
 
         assert stage.step(item, ctx) == StageOutcome(
@@ -904,6 +909,7 @@ class TestPrReviewStageStep:
                 "existing_pr": True,
                 "writer_worktree": "/tmp/implementation-writer",
                 "review_worktree": item.worktree,
+                "review_worktree_expected_head": "a" * 40,
                 "review_worktree_cleanup_done": "pending",
                 "review_worktree_cleanup_outcome": Disposition.RETRY.value,
                 "review_worktree_cleanup_note": "review audit format failure",

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -17,13 +17,14 @@ from unittest.mock import MagicMock
 import pytest
 
 import hephaestus.automation.loop_repo_manager as loop_repo_manager_mod
+from hephaestus.automation.arming_state import LearningJournalStore
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.jobs import GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName
 from hephaestus.automation.pipeline.seeding import IssueFacts
 from hephaestus.automation.pipeline.stages.base import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.repo import RepoStage, product_to_work_item
-from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, LearningIntent, WorkItem
 
 from .conftest import FakeStageGitHub
 
@@ -367,6 +368,44 @@ class TestDiscover:
         assert classified == []
         assert "products" not in repo_item.payload
         assert "seeded_count" not in repo_item.payload
+
+    def test_discovery_stream_includes_closed_issue_with_pending_learning(
+        self,
+        tmp_path: Path,
+        repo_item: WorkItem,
+        make_ctx: Callable[..., Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Closed issues remain discoverable while their journal work is pending."""
+        monkeypatch.setattr(
+            loop_repo_manager_mod,
+            "_iter_open_issue_meta",
+            lambda _org, _repo: iter(()),
+        )
+        journal = LearningJournalStore(lambda: tmp_path)
+        intent = LearningIntent.post_merge(repo="repo-a", issue=2705, pr=99)
+        journal.ensure_pending(
+            intent.key,
+            kind=intent.kind.value,
+            identity=intent.journal_identity(),
+        )
+        github = FakeStageGitHub(issue_state="CLOSED", issue_title="Merged work")
+        ctx = make_ctx(
+            paths=_RepoPaths(tmp_path),
+            github=github,
+            learning_journal=journal,
+        )
+        repo_item.state = "DISCOVER"
+
+        result = RepoStage().step(repo_item, ctx)
+
+        assert isinstance(result, Continue)
+        source = repo_item.payload["_repo_issue_source"]
+        assert next(source.metadata) == {
+            "number": 2705,
+            "labels": [],
+            "title": "Merged work",
+        }
 
     def test_discover_does_not_mutate_before_source_consumption(
         self,

--- a/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
+++ b/tests/unit/automation/pipeline/test_agent_allowed_tools_scoping.py
@@ -53,8 +53,7 @@ EXPECTED_SCOPES = {
 EXPECTED_ATHENA_SKILLS = {
     ("stages/planning.py", "step", "advise"),
     ("stages/implementation.py", "_advise_wait", "advise"),
-    ("stages/plan_review.py", "step", "learn"),
-    ("stages/merge_wait.py", "_request_learn", "learn"),
+    ("stages/learning.py", "step", "learn"),
 }
 
 

--- a/tests/unit/automation/pipeline/test_auxiliary_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_auxiliary_worker_pool.py
@@ -1,0 +1,82 @@
+"""Behavior tests for the closed auxiliary worker pool."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.util
+import queue
+import threading
+from pathlib import Path
+
+import pytest
+
+from hephaestus.automation.pipeline.athena_skill_jobs import (
+    AthenaSkillJob,
+    AthenaSkillRequest,
+    AthenaSkillResult,
+)
+from hephaestus.automation.pipeline.jobs import AgentJob
+
+
+class _Host:
+    def execute(self, request: AthenaSkillRequest) -> AthenaSkillResult:
+        return AthenaSkillResult(
+            kind=str(request.kind), receipt={"worker": threading.current_thread().name}
+        )
+
+
+def test_learning_workers_are_distinct_and_reject_generic_agents(tmp_path: Path) -> None:
+    """The lane has distinct workers and no generic agent dispatch surface."""
+    assert (
+        importlib.util.find_spec("hephaestus.automation.pipeline.auxiliary_worker_pool") is not None
+    )
+    auxiliary = importlib.import_module("hephaestus.automation.pipeline.auxiliary_worker_pool")
+    completions: queue.Queue = queue.Queue(maxsize=1)
+    pool = auxiliary.AuxiliaryWorkerPool(
+        size=1,
+        shutdown=threading.Event(),
+        completion_q=completions,
+        athena_skill_executor=_Host(),
+    )
+    request = AthenaSkillRequest(
+        kind="learn",
+        repo="Hephaestus",
+        issue=2705,
+        agent="codex",
+        model="",
+        cwd=tmp_path,
+        timeout_s=10,
+    )
+    handle = pool.submit(AthenaSkillJob(request=request), "DONE")
+    done, result = completions.get(timeout=2)
+
+    assert done is handle
+    assert result.ok
+    assert result.value.receipt["worker"].startswith("hephaestus-learning-worker-")
+    with pytest.raises(TypeError, match="does not accept"):
+        pool.submit(AgentJob("r", 1, "codex", "", lambda: "", tmp_path, 1), "DONE")
+    pool.shutdown(mark_interrupted=False)
+
+
+def test_learning_dependency_graph_excludes_agent_runtime_and_pi() -> None:
+    """The closed auxiliary module has no provider or generic-worker import."""
+    spec = importlib.util.find_spec("hephaestus.automation.pipeline.auxiliary_worker_pool")
+    assert spec is not None and spec.origin is not None
+    module_path = Path(spec.origin)
+    imported = {
+        alias.name
+        for node in ast.walk(ast.parse(module_path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module or ""
+        for node in ast.walk(ast.parse(module_path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom)
+    )
+
+    assert not any(
+        "worker_pool" in name and "auxiliary_worker_pool" not in name for name in imported
+    )
+    assert not any("agents.runtime" in name or "pi_" in name for name in imported)

--- a/tests/unit/automation/pipeline/test_auxiliary_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_auxiliary_worker_pool.py
@@ -7,6 +7,7 @@ import importlib
 import importlib.util
 import queue
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -87,3 +88,80 @@ def test_learning_dependency_graph_excludes_agent_runtime_and_pi() -> None:
         "worker_pool" in name and "auxiliary_worker_pool" not in name for name in imported
     )
     assert not any("agents.runtime" in name or "pi_" in name for name in imported)
+
+
+def test_graceful_coordinator_signal_does_not_rewrite_completed_result(tmp_path: Path) -> None:
+    """A graceful stop lets active host work publish its real result."""
+    auxiliary = importlib.import_module("hephaestus.automation.pipeline.auxiliary_worker_pool")
+    graceful = threading.Event()
+    forced = threading.Event()
+    completions: queue.Queue = queue.Queue(maxsize=1)
+
+    class BlockingHost(_Host):
+        def execute(self, request: AthenaSkillRequest) -> AthenaSkillResult:
+            graceful.wait(timeout=1)
+            time.sleep(0.01)
+            return super().execute(request)
+
+    pool = auxiliary.AuxiliaryWorkerPool(
+        size=1,
+        shutdown=forced,
+        completion_q=completions,
+        athena_skill_executor=BlockingHost(),
+    )
+    request = AthenaSkillRequest(
+        kind="learn",
+        repo="Hephaestus",
+        issue=1,
+        agent="codex",
+        model="",
+        cwd=tmp_path,
+        timeout_s=10,
+    )
+    pool.submit(AthenaSkillJob(request=request), "DONE")
+    graceful.set()
+    _handle, result = completions.get(timeout=2)
+
+    assert result.ok
+    assert not result.interrupted
+    pool.shutdown(mark_interrupted=False)
+
+
+def test_forced_shutdown_publishes_cancelled_queued_job(tmp_path: Path) -> None:
+    """A queued host job becomes an explicit resumable completion."""
+    auxiliary = importlib.import_module("hephaestus.automation.pipeline.auxiliary_worker_pool")
+    forced = threading.Event()
+    completions: queue.Queue = queue.Queue(maxsize=2)
+
+    class BlockingHost(_Host):
+        def __init__(self) -> None:
+            self.started = threading.Event()
+            self.release = threading.Event()
+
+        def execute(self, request: AthenaSkillRequest) -> AthenaSkillResult:
+            self.started.set()
+            self.release.wait(timeout=2)
+            return super().execute(request)
+
+    host = BlockingHost()
+    pool = auxiliary.AuxiliaryWorkerPool(
+        size=1, shutdown=forced, completion_q=completions, athena_skill_executor=host
+    )
+    request = AthenaSkillRequest(
+        kind="learn",
+        repo="Hephaestus",
+        issue=1,
+        agent="codex",
+        model="",
+        cwd=tmp_path,
+        timeout_s=10,
+    )
+    pool.submit(AthenaSkillJob(request=request), "DONE")
+    pool.submit(AthenaSkillJob(request=request), "DONE")
+    assert host.started.wait(timeout=1)
+
+    pool.shutdown()
+    host.release.set()
+    results = [completions.get(timeout=2)[1], completions.get(timeout=2)[1]]
+
+    assert any(result.error == "interrupted_before_start" for result in results)

--- a/tests/unit/automation/pipeline/test_auxiliary_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_auxiliary_worker_pool.py
@@ -7,6 +7,7 @@ import importlib
 import importlib.util
 import queue
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -53,7 +54,13 @@ def test_learning_workers_are_distinct_and_reject_generic_agents(tmp_path: Path)
 
     assert done is handle
     assert result.ok
-    assert result.value.receipt["worker"].startswith("hephaestus-learning-worker-")
+    learning_worker = result.value.receipt["worker"]
+    assert learning_worker.startswith("hephaestus-learning-worker-")
+    with ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="hephaestus-pipeline-worker-"
+    ) as main:
+        main_worker = main.submit(lambda: threading.current_thread().name).result()
+    assert learning_worker != main_worker
     with pytest.raises(TypeError, match="does not accept"):
         pool.submit(AgentJob("r", 1, "codex", "", lambda: "", tmp_path, 1), "DONE")
     pool.shutdown(mark_interrupted=False)

--- a/tests/unit/automation/pipeline/test_backpressure.py
+++ b/tests/unit/automation/pipeline/test_backpressure.py
@@ -12,6 +12,7 @@ import pytest
 
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
 from hephaestus.automation.pipeline.jobs import JobHandle
+from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -56,10 +57,10 @@ def _config(
     )
 
 
-def test_coordinator_uses_one_capacity_for_all_queues_and_worker_pool(
+def test_coordinator_uses_independent_main_and_learning_capacities(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Every coordinator-owned queue and its worker pool use C exactly."""
+    """Main queues use C while learning uses its own bounded capacity."""
     from hephaestus.automation.pipeline import worker_pool as worker_pool_mod
 
     monkeypatch.setattr(worker_pool_mod, "WorkerPool", _RecordingWorkerPool)
@@ -68,8 +69,13 @@ def test_coordinator_uses_one_capacity_for_all_queues_and_worker_pool(
 
     coordinator = Coordinator(config, github=FakeStageGitHub(), install_signals=False)
 
-    assert {queue.capacity for queue in coordinator.queues.values()} == {capacity}
+    main_capacities = {
+        queue.capacity for stage, queue in coordinator.queues.items() if stage.value != "learning"
+    }
+    assert main_capacities == {capacity}
+    assert coordinator.queues[StageName.LEARNING].capacity == config.learning_queue_capacity
     assert coordinator.completion_q.maxsize == capacity
+    assert coordinator.auxiliary_completion_q.maxsize == config.learning_queue_capacity
     assert coordinator.pool.size == capacity
     assert coordinator.pool.completion_q is coordinator.completion_q
     assert coordinator.pool.gh_extra_path_root is None

--- a/tests/unit/automation/pipeline/test_backpressure_repo_source.py
+++ b/tests/unit/automation/pipeline/test_backpressure_repo_source.py
@@ -283,16 +283,22 @@ def test_repo_sources_round_robin_across_repositories_at_capacity_two(
 
     assert coordinator.run() == 0
 
-    assert events == [
+    assert events[:4] == [
         ("classify", 101),
         ("classify", 201),
         ("complete", 101),
         ("complete", 201),
-        ("classify", 102),
-        ("classify", 202),
-        ("complete", 102),
-        ("complete", 202),
     ]
+    assert sorted(events[4:]) == sorted(
+        [
+            ("classify", 102),
+            ("classify", 202),
+            ("complete", 102),
+            ("complete", 202),
+        ]
+    )
+    for issue in (102, 202):
+        assert events.index(("classify", issue)) < events.index(("complete", issue))
     assert coordinator._all_idle()
     assert coordinator.live_work_count == 0
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -3094,6 +3094,7 @@ class TestDurableEventLog:
                 "duration_s": 0.0,
                 "error": None,
                 "interrupted": False,
+                "lane": "main",
                 "ok": True,
             },
         ]
@@ -3319,10 +3320,11 @@ class TestPipelineScopeWiring:
             config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
         )
 
-        # Only the two in-scope stages plus the always-present FINISHED sink.
+        # Auxiliary learning and the FINISHED sink are implicit in every scope.
         assert set(coordinator._routes) == {
             StageName.PLANNING,
             StageName.PLAN_REVIEW,
+            StageName.LEARNING,
             StageName.FINISHED,
         }
         # PLANNING.next (PLAN_REVIEW) stays in scope; PLAN_REVIEW.next

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -410,6 +410,33 @@ class TestQuiescence:
         assert item.branch == ""
         assert item.payload["existing_pr"] is True
 
+    def test_duplicate_explicit_issue_is_ejected_from_source_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repeated explicit issue cannot run after its first copy finishes."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[617, 617],
+            loops=1,
+            projects_dir=tmp_path,
+        )
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(labels=["state:plan-go"]),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._begin_direct_issue_source("repo-a", "a" * 40)
+
+        assert coordinator._drain_direct_issue_source() == 1
+        assert coordinator._direct_issue_source is None
+        assert [item.issue for item in coordinator.items] == [617]
+
     def test_direct_issue_source_rotates_overlap_and_admits_independent_work(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -2945,6 +2945,58 @@ class TestDurableEventLog:
         assert "hephaestus_pipeline_stalled_ticks 2" in rendered
         assert "hephaestus_pipeline_loops_total 0" in rendered
 
+    def test_auxiliary_lane_exports_nonzero_depth_inflight_failure_and_time(
+        self, tmp_path: Path
+    ) -> None:
+        """Auxiliary queue, ownership, duration, and failure stay observable."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                metrics_port=9123,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            auxiliary_pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator.queues[StageName.PLANNING].push(_issue_item(10, StageName.PLANNING))
+        coordinator.queues[StageName.LEARNING].push(_issue_item(11, StageName.LEARNING))
+        _fake_in_flight_item(coordinator, _issue_item(12, StageName.IMPLEMENTATION))
+        auxiliary_item = _issue_item(13, StageName.LEARNING)
+        auxiliary_handle = JobHandle(
+            job=GitJob(repo="repo-a", op="push", timeout_s=1),
+            on_done_state="DONE",
+        )
+        coordinator.auxiliary_in_flight[auxiliary_handle] = auxiliary_item
+        coordinator.stages[StageName.LEARNING] = StubStage()
+
+        snapshot = coordinator._observability_snapshot()
+        assert snapshot["lane_queue_depths"] == {"main": 1, "auxiliary": 1}
+        assert snapshot["inflight_by_lane"] == {"main": 1, "auxiliary": 1}
+        coordinator._emit_observability_tick()
+
+        assert coordinator._metrics_registry is not None
+        rendered = coordinator._metrics_registry.render_prometheus()
+        assert 'hephaestus_pipeline_lane_queue_depth{lane="main"} 1' in rendered
+        assert 'hephaestus_pipeline_lane_queue_depth{lane="auxiliary"} 1' in rendered
+        assert 'hephaestus_pipeline_lane_inflight_jobs{lane="main"} 1' in rendered
+        assert 'hephaestus_pipeline_lane_inflight_jobs{lane="auxiliary"} 1' in rendered
+
+        coordinator.shutdown.set()
+        coordinator._handle_completion(
+            auxiliary_handle,
+            JobResult(ok=False, error="delivery failed", duration_s=2.5),
+            auxiliary=True,
+        )
+
+        rendered = coordinator._metrics_registry.render_prometheus()
+        assert 'hephaestus_pipeline_jobs_total{outcome="failed",stage="learning"} 1' in rendered
+        assert "hephaestus_pipeline_auxiliary_job_seconds_total 2.5" in rendered
+        assert coordinator._auxiliary_job_count == 1
+        assert coordinator._auxiliary_job_failure_count == 1
+
     def test_completion_increments_jobs_total_by_stage_and_outcome(self, tmp_path: Path) -> None:
         """Each completed job increments the jobs_total counter by outcome."""
         coordinator = Coordinator(

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -33,7 +33,12 @@ from hephaestus.automation.pipeline.stages.base import (
 from hephaestus.automation.pipeline.stages.implementation import ImplementationStage
 from hephaestus.automation.pipeline.stages.plan_review import PlanReviewStage
 from hephaestus.automation.pipeline.stages.planning import PlanningStage
-from hephaestus.automation.pipeline.work_item import ItemKind, LearningIntent, WorkItem
+from hephaestus.automation.pipeline.work_item import (
+    ItemKind,
+    ItemResult,
+    LearningIntent,
+    WorkItem,
+)
 from hephaestus.automation.review_types import ReviewVerdict
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
@@ -130,6 +135,26 @@ class GracefulSignalCompletionPool(FakeWorkerPool):
 
 class SecondSignalPool(FakeWorkerPool):
     """Send two SIGTERMs during submit and leave the job in flight."""
+
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
+        del kwargs
+        handle = JobHandle(job=job, on_done_state=on_done_state)
+        self.submitted.append(handle)
+        _raise_sigterm()
+        _raise_sigterm()
+        return handle
+
+
+class GracefulAuxiliarySignalPool(FakeWorkerPool):
+    """Send one SIGTERM while an auxiliary learning request is active."""
+
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
+        _raise_sigterm()
+        return super().submit(job, on_done_state, **kwargs)
+
+
+class ForcedAuxiliarySignalPool(FakeWorkerPool):
+    """Send two SIGTERMs and leave an auxiliary learning request active."""
 
     def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
         del kwargs
@@ -307,29 +332,20 @@ class TestInterruptSemantics:
             "press Ctrl+C again to force teardown"
         )
 
-    @pytest.mark.parametrize("signal_count", [1, 2])
-    def test_signal_parks_auxiliary_learning_and_restart_recovers_it(
-        self,
-        signal_count: int,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
+    def test_graceful_signal_drains_active_learning_and_restart_recovers_cleanup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Graceful and forced shutdown keep durable learning resumable."""
+        """Graceful shutdown records active learning before restart cleanup."""
         _capture_signal_handlers(monkeypatch)
+        auxiliary_pool = GracefulAuxiliarySignalPool()
         coordinator = Coordinator(
             PipelineConfig(org="org", repos=[], projects_dir=tmp_path),
             github=FakeStageGitHub(),
             pool=FakeWorkerPool(),
-            auxiliary_pool=FakeWorkerPool(),
+            auxiliary_pool=auxiliary_pool,
             install_signals=False,
         )
         intent = LearningIntent.post_merge(repo="repo-a", issue=81, pr=181)
-        journal = coordinator._ctx_for_repo("repo-a").learning_journal
-        journal.ensure_pending(
-            intent.key,
-            kind=intent.kind.value,
-            identity=intent.journal_identity(),
-        )
         item = WorkItem(
             repo="repo-a",
             kind=ItemKind.ISSUE,
@@ -338,19 +354,25 @@ class TestInterruptSemantics:
             stage=StageName.LEARNING,
         )
         item.learning_intents.append(intent)
-        item.learning_resume_stage = StageName.FINISHED
+        item.compact_for_post_processing(
+            ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+        )
+        journal = coordinator._ctx_for_repo("repo-a").learning_journal
+        journal.ensure_pending(
+            intent.key,
+            kind=intent.kind.value,
+            identity=item.learning_journal_identity(intent),
+        )
         assert coordinator._push_item(item, StageName.LEARNING, enter=True)
         coordinator._install_signal_handlers()
-        handler = signal_mod.getsignal(signal_mod.SIGINT)
-        assert callable(handler)
-        for _ in range(signal_count):
-            handler(signal_mod.SIGINT, None)
 
         assert coordinator.run() == 130
+        assert len(auxiliary_pool.submitted) == 1
         assert item.result is not None
         assert item.result.reason == "resumable at learning"
         record = journal.load(intent.key)
-        assert record is not None and record["status"] == "pending"
+        assert record is not None and record["status"] == "succeeded"
+        assert record["cleanup_status"] == "pending"
 
         restarted = Coordinator(
             PipelineConfig(org="org", repos=[], projects_dir=tmp_path),
@@ -364,6 +386,76 @@ class TestInterruptSemantics:
 
         assert recovered.stage is StageName.LEARNING
         assert recovered.learning_intents == [intent]
+        assert recovered.post_processing is not None
+        assert recovered.post_processing.result.reason == "merged"
+
+    def test_second_signal_parks_active_learning_and_restart_marks_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forced shutdown preserves an active claim for restart recovery."""
+        _capture_signal_handlers(monkeypatch)
+        auxiliary_pool = ForcedAuxiliarySignalPool()
+        coordinator = Coordinator(
+            PipelineConfig(org="org", repos=[], projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            auxiliary_pool=auxiliary_pool,
+            install_signals=False,
+        )
+        intent = LearningIntent.post_merge(repo="repo-a", issue=82, pr=182)
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=82,
+            pr=182,
+            stage=StageName.LEARNING,
+        )
+        item.learning_intents.append(intent)
+        item.compact_for_post_processing(
+            ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+        )
+        journal = coordinator._ctx_for_repo("repo-a").learning_journal
+        journal.ensure_pending(
+            intent.key,
+            kind=intent.kind.value,
+            identity=item.learning_journal_identity(intent),
+        )
+        assert coordinator._push_item(item, StageName.LEARNING, enter=True)
+        coordinator._install_signal_handlers()
+
+        assert coordinator.run() == 130
+        assert len(auxiliary_pool.submitted) == 1
+        assert item.result is not None
+        assert item.result.reason == "resumable at learning"
+        record = journal.load(intent.key)
+        assert record is not None and record["status"] == "claimed"
+
+        # Simulate process exit. The operating system releases this lock before
+        # a new coordinator reconstructs the durable item.
+        journal._release_claim_lock(intent.key)
+        restarted = Coordinator(
+            PipelineConfig(org="org", repos=[], projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            auxiliary_pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        recovered = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=82, pr=182)
+        restarted._restore_learning_intents(recovered, StageName.FINISHED, "merged")
+        assert recovered.stage is StageName.LEARNING
+        assert restarted._push_item(recovered, StageName.LEARNING, enter=True)
+
+        assert restarted.run() == 0
+        recovered_record = restarted._ctx_for_repo("repo-a").learning_journal.load(intent.key)
+        assert recovered_record is not None
+        assert recovered_record["status"] == "failed"
+        assert recovered_record["error"] == "outcome_unknown"
+        assert recovered_record["cleanup_status"] == "succeeded"
+        assert recovered.result == ItemResult(
+            passed=True,
+            reason="merged",
+            final_stage=StageName.MERGE_WAIT,
+        )
 
 
 class TestNormalTeardownExitSemantics:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -33,7 +33,7 @@ from hephaestus.automation.pipeline.stages.base import (
 from hephaestus.automation.pipeline.stages.implementation import ImplementationStage
 from hephaestus.automation.pipeline.stages.plan_review import PlanReviewStage
 from hephaestus.automation.pipeline.stages.planning import PlanningStage
-from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, LearningIntent, WorkItem
 from hephaestus.automation.review_types import ReviewVerdict
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
@@ -306,6 +306,64 @@ class TestInterruptSemantics:
             "Ctrl+C received: timed graceful shutdown started (17s); "
             "press Ctrl+C again to force teardown"
         )
+
+    @pytest.mark.parametrize("signal_count", [1, 2])
+    def test_signal_parks_auxiliary_learning_and_restart_recovers_it(
+        self,
+        signal_count: int,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Graceful and forced shutdown keep durable learning resumable."""
+        _capture_signal_handlers(monkeypatch)
+        coordinator = Coordinator(
+            PipelineConfig(org="org", repos=[], projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            auxiliary_pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        intent = LearningIntent.post_merge(repo="repo-a", issue=81, pr=181)
+        journal = coordinator._ctx_for_repo("repo-a").learning_journal
+        journal.ensure_pending(
+            intent.key,
+            kind=intent.kind.value,
+            identity=intent.journal_identity(),
+        )
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.ISSUE,
+            issue=81,
+            pr=181,
+            stage=StageName.LEARNING,
+        )
+        item.learning_intents.append(intent)
+        item.learning_resume_stage = StageName.FINISHED
+        assert coordinator._push_item(item, StageName.LEARNING, enter=True)
+        coordinator._install_signal_handlers()
+        handler = signal_mod.getsignal(signal_mod.SIGINT)
+        assert callable(handler)
+        for _ in range(signal_count):
+            handler(signal_mod.SIGINT, None)
+
+        assert coordinator.run() == 130
+        assert item.result is not None
+        assert item.result.reason == "resumable at learning"
+        record = journal.load(intent.key)
+        assert record is not None and record["status"] == "pending"
+
+        restarted = Coordinator(
+            PipelineConfig(org="org", repos=[], projects_dir=tmp_path),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            auxiliary_pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        recovered = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=81, pr=181)
+        restarted._restore_learning_intents(recovered, StageName.FINISHED, "merged")
+
+        assert recovered.stage is StageName.LEARNING
+        assert recovered.learning_intents == [intent]
 
 
 class TestNormalTeardownExitSemantics:

--- a/tests/unit/automation/pipeline/test_global_live_work_permits.py
+++ b/tests/unit/automation/pipeline/test_global_live_work_permits.py
@@ -60,15 +60,17 @@ def test_global_permit_refuses_c_plus_one_across_distinct_stage_queues(tmp_path:
     assert coordinator.live_work_count == 1
     assert id(second) not in coordinator._seen_item_ids
 
-    # Routing to the finished sink retains the permit: cleanup/ledger work is
-    # still nonterminal. Only the sink's terminal outcome makes a slot free.
+    # Routing to the auxiliary finished sink transfers permit ownership. The
+    # main lane can admit new work while cleanup remains nonterminal.
     assert coordinator._claim_item(StageName.PLANNING) is first
     coordinator._finish(first, passed=True, reason="done")
-    assert coordinator.live_work_count == 1
-    _complete_finished_item(coordinator, first)
     assert coordinator.live_work_count == 0
+    assert coordinator.learning_work_count == 1
 
     assert coordinator._push_item(second, StageName.PLAN_REVIEW, enter=True) is True
+    assert coordinator.live_work_count == 1
+    _complete_finished_item(coordinator, first)
+    assert coordinator.learning_work_count == 0
     assert coordinator.live_work_count == 1
 
 

--- a/tests/unit/automation/pipeline/test_learning_intent.py
+++ b/tests/unit/automation/pipeline/test_learning_intent.py
@@ -1,0 +1,42 @@
+"""Behavior tests for immutable learning intents."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import hephaestus.automation.pipeline.work_item as work_item
+
+
+def test_learning_intent_key_is_stable_and_immutable() -> None:
+    """Equivalent identities produce one stable key and cannot be changed."""
+    assert hasattr(work_item, "LearningIntent")
+    first = work_item.LearningIntent.approved_plan(
+        repo="Hephaestus", issue=2705, plan_revision=8, plan_fingerprint="abc"
+    )
+    second = work_item.LearningIntent.approved_plan(
+        repo="Hephaestus", issue=2705, plan_revision=8, plan_fingerprint="abc"
+    )
+
+    assert first.key == second.key
+    try:
+        first.issue = 1  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:
+        raise AssertionError("LearningIntent must be immutable")
+
+
+def test_learning_intent_rejects_tampered_journal_identity() -> None:
+    """Recovery cannot bind a stored key to different intent metadata."""
+    intent = work_item.LearningIntent.post_merge(repo="Hephaestus", issue=2705, pr=12)
+    record = {
+        "key": intent.key,
+        "kind": intent.kind.value,
+        **intent.journal_identity(),
+        "pr": 13,
+    }
+
+    with pytest.raises(ValueError, match="identity"):
+        work_item.LearningIntent.from_journal(record)

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -374,6 +374,88 @@ def test_merged_discovery_skips_terminal_learning_intent(tmp_path: Path) -> None
     assert item.learning_intents == []
 
 
+def test_restart_restores_cleanup_after_learning_became_terminal(tmp_path: Path) -> None:
+    """Restart retains cleanup after learn succeeds but before Finished completes."""
+    repo_root = tmp_path / "repo"
+    worktree = repo_root / "build" / ".worktrees" / "issue-2705"
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            repo_roots={"repo": repo_root},
+        ),
+        github=FakeStageGitHub(pr_state={"state": "MERGED"}),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    original = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.MERGE_WAIT,
+        worktree=str(worktree),
+        branch="2705-fix",
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    original.learning_intents.append(intent)
+    original.compact_for_post_processing(
+        ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+    )
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(
+        intent.key,
+        kind=intent.kind.value,
+        identity=original.learning_journal_identity(intent),
+    )
+    assert journal.claim(intent.key)
+    journal.finish(intent.key, succeeded=True)
+    recovered = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.FINISHED,
+    )
+
+    coordinator._restore_learning_intents(recovered, StageName.FINISHED, "already merged")
+
+    assert recovered.stage is StageName.LEARNING
+    assert recovered.worktree == str(worktree)
+    assert recovered.branch == "2705-fix"
+    assert recovered.post_processing is not None
+    assert recovered.post_processing.result.passed
+
+
+def test_no_learn_and_no_advise_keep_cleanup_on_separate_pool(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Disabling host skills does not collapse cleanup into the main pool."""
+    import hephaestus.automation.mnemosyne_skill_host as host_module
+
+    monkeypatch.setattr(
+        host_module,
+        "MnemosyneSkillHost",
+        lambda: (_ for _ in ()).throw(AssertionError("host must not be constructed")),
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            enable_learn=False,
+            no_advise=True,
+        ),
+        github=FakeStageGitHub(),
+        install_signals=False,
+    )
+
+    assert coordinator.auxiliary_pool is not coordinator.pool
+    assert coordinator._auxiliary_pool_separate
+    coordinator._shutdown_pool()
+
+
 def test_no_learn_disables_recovered_intent_and_keeps_primary_route(tmp_path: Path) -> None:
     """The no-learn switch records a terminal skip without a host request."""
     coordinator = Coordinator(
@@ -400,6 +482,42 @@ def test_no_learn_disables_recovered_intent_and_keeps_primary_route(tmp_path: Pa
     assert record is not None
     assert record["status"] == "failed"
     assert record["error"] == "learning_disabled"
+
+
+def test_post_merge_persistence_failure_keeps_confirmed_result(tmp_path: Path) -> None:
+    """Late auxiliary persistence cannot poison a confirmed merge result."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    item = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.MERGE_WAIT,
+    )
+    item.learning_intents.append(LearningIntent.post_merge(repo="repo", issue=2705, pr=12))
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+
+    def fail_persistence(*_args: object, **_kwargs: object) -> None:
+        raise OSError("journal unavailable")
+
+    journal.ensure_pending = fail_persistence  # type: ignore[method-assign]
+
+    coordinator._route(item, StageOutcome(Disposition.FINISH_PASS, "merged"))
+
+    assert item.stage is StageName.FINISHED
+    assert item.result == ItemResult(
+        passed=True,
+        reason="merged",
+        final_stage=StageName.MERGE_WAIT,
+    )
+    assert item.learning_intents == []
+    assert item.payload["learning_failures"][0]["key"] == "post_merge"
 
 
 class _BlockingLearningHost:

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -196,6 +196,7 @@ def test_scoped_plan_learning_resumes_at_scoped_sink(tmp_path: Path) -> None:
 def test_restart_reconstructs_pending_intent_before_primary_stage(tmp_path: Path) -> None:
     """A new coordinator routes a durable pending claim back to learning."""
     repo_root = tmp_path / "repo"
+    github = FakeStageGitHub(pr_state={"state": "MERGED"})
     coordinator = Coordinator(
         PipelineConfig(
             org="org",
@@ -203,12 +204,12 @@ def test_restart_reconstructs_pending_intent_before_primary_stage(tmp_path: Path
             projects_dir=tmp_path,
             repo_roots={"repo": repo_root},
         ),
-        github=FakeStageGitHub(pr_state={"state": "MERGED"}),
+        github=github,
         pool=FakeWorkerPool(),
         install_signals=False,
     )
     approved_plan = "Use the approved plan."
-    coordinator.github.comments[1] = [render_current_plan(approved_plan, revision=1)]
+    github.comments[1] = [render_current_plan(approved_plan, revision=1)]
     intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
     journal = coordinator._ctx_for_repo("repo").learning_journal
     journal.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
@@ -606,6 +607,7 @@ def test_single_main_worker_progresses_while_learning_is_blocked(
         completion_q=completions,
         athena_skill_executor=host,
     )
+    github = FakeStageGitHub(labels=[STATE_PLAN_GO])
     coordinator = Coordinator(
         PipelineConfig(
             org="org",
@@ -615,13 +617,13 @@ def test_single_main_worker_progresses_while_learning_is_blocked(
             learning_queue_capacity=1,
             projects_dir=tmp_path,
         ),
-        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        github=github,
         pool=FakeWorkerPool(),
         auxiliary_pool=auxiliary,
         install_signals=False,
     )
     approved_plan = "Use the approved plan."
-    coordinator.github.comments[1] = [render_current_plan(approved_plan, revision=1)]
+    github.comments[1] = [render_current_plan(approved_plan, revision=1)]
     learning = WorkItem(
         repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.LEARNING, state="ENTER"
     )

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -145,15 +145,91 @@ def test_opposite_lane_handoffs_do_not_deadlock_at_capacity_one(tmp_path: Path) 
     assert coordinator._claim_item(StageName.PLAN_REVIEW) is entering
 
     assert not coordinator._handoff_item(returning, StageName.IMPLEMENTATION, enter=True)
-    assert coordinator.learning_work_count == 0
-    assert coordinator._handoff_item(entering, StageName.LEARNING, enter=True)
-    assert coordinator.live_work_count == 0
+    assert coordinator.learning_work_count == 1
+    assert not coordinator._handoff_item(entering, StageName.LEARNING, enter=True)
+    assert coordinator.live_work_count == 1
 
     coordinator._drain_pending_handoffs()
 
     assert returning.stage is StageName.IMPLEMENTATION
+    assert entering.stage is StageName.LEARNING
     assert id(returning) not in coordinator._pending_handoffs
+    assert id(entering) not in coordinator._pending_handoffs
     assert coordinator.live_work_count == 1
+    assert coordinator.learning_work_count == 1
+
+
+def test_exact_stage_opposite_lane_handoffs_exchange_at_capacity_one(tmp_path: Path) -> None:
+    """Full source queues exchange complementary leased items without a spill."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            max_workers=1,
+            learning_workers=1,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    returning = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.LEARNING)
+    entering = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLAN_REVIEW)
+    assert coordinator._push_item(returning, StageName.LEARNING, enter=True)
+    assert coordinator._push_item(entering, StageName.PLAN_REVIEW, enter=True)
+    assert coordinator._claim_item(StageName.LEARNING) is returning
+    assert coordinator._claim_item(StageName.PLAN_REVIEW) is entering
+
+    assert not coordinator._handoff_item(returning, StageName.PLAN_REVIEW, enter=True)
+    assert not coordinator._handoff_item(entering, StageName.LEARNING, enter=True)
+
+    coordinator._drain_pending_handoffs()
+
+    assert coordinator.queues[StageName.PLAN_REVIEW].snapshot() == [returning]
+    assert coordinator.queues[StageName.LEARNING].snapshot() == [entering]
+    assert not coordinator._leases
+    assert not coordinator._pending_handoffs
+    assert coordinator.live_work_count == coordinator.learning_work_count == 1
+
+
+def test_repeated_opposite_lane_recovery_stays_bounded_by_active_leases(tmp_path: Path) -> None:
+    """Repeated capacity-one exchanges never create permitless pending work."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            max_workers=1,
+            learning_workers=1,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    main = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLANNING)
+    auxiliary = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2, stage=StageName.LEARNING)
+    assert coordinator._push_item(main, StageName.PLANNING, enter=True)
+    assert coordinator._push_item(auxiliary, StageName.LEARNING, enter=True)
+
+    for cycle in range(3):
+        assert coordinator._claim_item(main.stage) is main
+        assert coordinator._claim_item(auxiliary.stage) is auxiliary
+        auxiliary_target = StageName.IMPLEMENTATION if cycle % 2 == 0 else StageName.PLANNING
+        assert not coordinator._handoff_item(auxiliary, auxiliary_target, enter=True)
+        assert not coordinator._handoff_item(main, StageName.LEARNING, enter=True)
+        assert len(coordinator._pending_handoffs) == len(coordinator._leases) == 2
+        assert coordinator.live_work_count == coordinator.learning_work_count == 1
+
+        coordinator._drain_pending_handoffs()
+
+        assert not coordinator._pending_handoffs
+        assert not coordinator._leases
+        assert coordinator.live_work_count == coordinator.learning_work_count == 1
+        main, auxiliary = auxiliary, main
 
 
 def test_scoped_plan_learning_resumes_at_scoped_sink(tmp_path: Path) -> None:
@@ -541,6 +617,46 @@ def test_no_learn_restores_terminal_cleanup_before_disabling(tmp_path: Path) -> 
     assert terminal["cleanup_status"] == "succeeded"
 
 
+def test_pending_learning_ejection_keeps_cleanup_recoverable(tmp_path: Path) -> None:
+    """Finished leaves the cleanup receipt pending until learning is terminal."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    item = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.FINISHED,
+        state="CLEANUP",
+        worktree="build/.worktrees/issue-2705",
+        branch="2705-fix",
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    item.learning_intents.append(intent)
+    item.compact_for_post_processing(
+        ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+    )
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(
+        intent.key, kind=intent.kind.value, identity=item.learning_journal_identity(intent)
+    )
+
+    finished = coordinator.stages[StageName.FINISHED]
+    outcome = finished.step(item, coordinator._ctx_for_repo("repo"))
+
+    assert outcome == StageOutcome(Disposition.EJECT, "learning_cleanup_pending")
+    coordinator._route(item, outcome)
+    record = journal.load(intent.key)
+    assert record is not None
+    assert record["status"] == "pending"
+    assert record["cleanup_status"] == "pending"
+    assert item.worktree == "build/.worktrees/issue-2705"
+
+
 def test_malformed_post_processing_quarantines_only_one_issue(tmp_path: Path) -> None:
     """One damaged cleanup receipt does not stop later repository discovery."""
     coordinator = Coordinator(
@@ -604,7 +720,7 @@ def test_post_merge_persistence_failure_keeps_confirmed_result(tmp_path: Path) -
     def fail_persistence(*_args: object, **_kwargs: object) -> None:
         raise OSError("journal unavailable")
 
-    journal.ensure_pending = fail_persistence
+    cast(Any, journal).ensure_pending = fail_persistence
 
     coordinator._route(item, StageOutcome(Disposition.FINISH_PASS, "merged"))
 
@@ -712,7 +828,7 @@ def test_single_main_worker_progresses_while_learning_is_blocked(
         def on_job_done(self, _item: WorkItem, _result: JobResult, _ctx: object) -> None:
             raise AssertionError("progress stage submits no job")
 
-    coordinator.stages[StageName.PLANNING] = ProgressStage()  # type: ignore[assignment]
+    coordinator.stages[StageName.PLANNING] = ProgressStage()
     coordinator._run_item(unrelated)
     assert progressed.is_set()
     assert unrelated.result is not None
@@ -865,8 +981,88 @@ def test_learning_completion_exception_parks_before_cleanup(tmp_path: Path) -> N
     assert coordinator._terminal_summary.dispositions["resumable"] == 1
 
 
-def test_learning_completion_capacity_covers_all_learning_workers(tmp_path: Path) -> None:
-    """A small backlog setting cannot make valid completions disappear."""
+class _CompletionRecordingStage:
+    """Record completion delivery without starting more work."""
+
+    def __init__(self) -> None:
+        self.completed: list[int] = []
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: object) -> None:
+        del result, ctx
+        self.completed.append(item.issue or 0)
+
+
+def _queue_dual_lane_completions(
+    coordinator: Coordinator, tmp_path: Path
+) -> tuple[_CompletionRecordingStage, _CompletionRecordingStage]:
+    """Publish one owned result to each coordinator completion channel."""
+    main_stage = _CompletionRecordingStage()
+    auxiliary_stage = _CompletionRecordingStage()
+    coordinator.stages[StageName.PLANNING] = main_stage  # type: ignore[assignment]
+    coordinator.stages[StageName.LEARNING] = auxiliary_stage  # type: ignore[assignment]
+
+    main_item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLANNING)
+    main_handle = JobHandle(
+        job=GitJob(repo="repo", op="push", timeout_s=1),
+        on_done_state="DONE",
+    )
+    coordinator.in_flight[main_handle] = main_item
+    coordinator.inflight_per_repo[main_item.repo] = 1
+
+    auxiliary_item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2, stage=StageName.LEARNING)
+    auxiliary_handle = JobHandle(
+        job=AthenaSkillJob(
+            request=AthenaSkillRequest(
+                kind="learn",
+                repo="repo",
+                issue=2,
+                agent="codex",
+                model="default",
+                cwd=tmp_path,
+                timeout_s=60,
+            )
+        ),
+        on_done_state="DONE",
+    )
+    coordinator.auxiliary_in_flight[auxiliary_handle] = auxiliary_item
+
+    coordinator.completion_q.put((main_handle, JobResult(ok=True, duration_s=0.5)))
+    coordinator.auxiliary_completion_q.put(
+        (auxiliary_handle, JobResult(ok=False, error="delivery failed", duration_s=0.75))
+    )
+    return main_stage, auxiliary_stage
+
+
+def test_dual_completion_channels_drain_all_published_results(tmp_path: Path) -> None:
+    """One drain handles ready main and auxiliary results without loss."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    main_stage, auxiliary_stage = _queue_dual_lane_completions(coordinator, tmp_path)
+    coordinator.shutdown.set()
+
+    coordinator._drain_completions()
+
+    assert main_stage.completed == [1]
+    assert auxiliary_stage.completed == [2]
+    assert not coordinator.in_flight
+    assert not coordinator.auxiliary_in_flight
+    assert coordinator.completion_q.empty()
+    assert coordinator.auxiliary_completion_q.empty()
+    assert coordinator._auxiliary_job_count == 1
+    assert coordinator._auxiliary_job_failure_count == 1
+
+
+def test_dual_completion_saturation_drains_results_before_fault(tmp_path: Path) -> None:
+    """A saturation fault cannot discard results already in either channel."""
     coordinator = Coordinator(
         PipelineConfig(
             org="org",
@@ -880,5 +1076,18 @@ def test_learning_completion_capacity_covers_all_learning_workers(tmp_path: Path
         auxiliary_pool=FakeWorkerPool(),
         install_signals=False,
     )
+    main_stage, auxiliary_stage = _queue_dual_lane_completions(coordinator, tmp_path)
+    coordinator.shutdown.set()
+    coordinator._completion_saturation.set()
 
+    with pytest.raises(RuntimeError, match="completion queue saturated"):
+        coordinator._drain_completions()
+
+    assert main_stage.completed == [1]
+    assert auxiliary_stage.completed == [2]
+    assert not coordinator.in_flight
+    assert not coordinator.auxiliary_in_flight
+    assert coordinator.completion_q.empty()
+    assert coordinator.auxiliary_completion_q.empty()
+    assert any(event[0] == "completion_saturation" for event in coordinator.event_log)
     assert coordinator.auxiliary_completion_q.maxsize == 3

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -784,6 +784,8 @@ def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: 
         install_signals=False,
     )
     item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, pr=7, stage=StageName.MERGE_WAIT)
+    item.worktree = str(tmp_path / "repo" / "build" / ".worktrees" / "issue-1")
+    item.branch = "1-fix"
     item.payload.update({"pr_diff": "large raw diff", "review_audit": {"large": "value"}})
     item.learning_intents.append(LearningIntent.post_merge(repo="repo", issue=1, pr=7))
 
@@ -796,6 +798,8 @@ def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: 
     assert item.post_processing is not None
     assert item.post_processing.result.passed
     assert item.post_processing.result.final_stage is StageName.MERGE_WAIT
+    assert item.worktree.endswith("issue-1")
+    assert item.branch == "1-fix"
 
     item.payload["learning_failures"] = [{"key": "intent", "error": "host failed"}]
     coordinator._route(item, StageOutcome(Disposition.ADVANCE, "learning terminal"))
@@ -805,6 +809,7 @@ def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: 
     assert item.result.passed
     assert item.result.reason == "merged"
     assert item.result.final_stage is StageName.MERGE_WAIT
+    assert item.worktree.endswith("issue-1")
 
 
 def test_learning_completion_exception_parks_before_cleanup(tmp_path: Path) -> None:

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -526,8 +526,60 @@ def test_no_learn_restores_terminal_cleanup_before_disabling(tmp_path: Path) -> 
     coordinator._restore_learning_intents(recovered, StageName.FINISHED, "already merged")
 
     assert recovered.post_processing is not None
+    assert recovered.post_processing.intent_keys == (intent.key,)
     assert recovered.worktree == original.worktree
     assert recovered.branch == original.branch
+
+    recovered.state = "DONE"
+    finished = coordinator.stages[StageName.FINISHED]
+    assert finished.step(recovered, coordinator._ctx_for_repo("repo")) == StageOutcome(
+        Disposition.FINISH_PASS,
+        "done",
+    )
+    terminal = journal.load(intent.key)
+    assert terminal is not None
+    assert terminal["cleanup_status"] == "succeeded"
+
+
+def test_malformed_post_processing_quarantines_only_one_issue(tmp_path: Path) -> None:
+    """One damaged cleanup receipt does not stop later repository discovery."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(
+        intent.key,
+        kind=intent.kind.value,
+        identity={
+            **intent.journal_identity(),
+            "post_processing": {
+                "worktree": "",
+                "branch": "",
+                "resume_stage": StageName.FINISHED.value,
+                "cleanup_payload": {},
+                "result": {
+                    "passed": "false",
+                    "reason": "bad",
+                    "final_stage": StageName.MERGE_WAIT.value,
+                },
+            },
+        },
+    )
+    damaged = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2705)
+    healthy = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2706)
+
+    coordinator._restore_learning_intents(damaged, StageName.FINISHED, "merged")
+    coordinator._restore_learning_intents(healthy, StageName.PLANNING, "open")
+
+    assert damaged.stage is StageName.FINISHED
+    assert damaged.result is not None
+    assert not damaged.result.passed
+    assert damaged.result.reason == "invalid durable learning recovery state"
+    assert healthy.stage is StageName.REPO
 
 
 def test_post_merge_persistence_failure_keeps_confirmed_result(tmp_path: Path) -> None:
@@ -646,6 +698,27 @@ def test_single_main_worker_progresses_while_learning_is_blocked(
     assert coordinator._push_item(unrelated, StageName.PLANNING, enter=True)
     assert coordinator.live_work_count == 1
     assert coordinator.learning_work_count == 1
+    assert coordinator._claim_item(StageName.PLANNING) is unrelated
+    progressed = threading.Event()
+
+    class ProgressStage:
+        def on_enter(self, _item: WorkItem, _ctx: object) -> StageOutcome:
+            progressed.set()
+            return StageOutcome(Disposition.EJECT, "unrelated completed")
+
+        def step(self, _item: WorkItem, _ctx: object) -> StageOutcome:
+            raise AssertionError("on_enter completes the unrelated item")
+
+        def on_job_done(self, _item: WorkItem, _result: JobResult, _ctx: object) -> None:
+            raise AssertionError("progress stage submits no job")
+
+    coordinator.stages[StageName.PLANNING] = ProgressStage()  # type: ignore[assignment]
+    coordinator._run_item(unrelated)
+    assert progressed.is_set()
+    assert unrelated.result is not None
+    assert unrelated.result.passed
+    assert unrelated.result.reason == "ejected: unrelated completed"
+    assert not host.release.is_set()
 
     host.release.set()
     done, result = coordinator.auxiliary_completion_q.get(timeout=2)

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -506,7 +506,7 @@ def test_post_merge_persistence_failure_keeps_confirmed_result(tmp_path: Path) -
     def fail_persistence(*_args: object, **_kwargs: object) -> None:
         raise OSError("journal unavailable")
 
-    journal.ensure_pending = fail_persistence  # type: ignore[method-assign]
+    journal.ensure_pending = fail_persistence
 
     coordinator._route(item, StageOutcome(Disposition.FINISH_PASS, "merged"))
 

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -3,19 +3,31 @@
 from __future__ import annotations
 
 import inspect
+import json
 import queue
+import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 import hephaestus.agents.runtime as agent_runtime
-from hephaestus.automation.pipeline.athena_skill_jobs import AthenaSkillResult
+from hephaestus.automation.pipeline.athena_skill_jobs import (
+    AthenaSkillJob,
+    AthenaSkillRequest,
+    AthenaSkillResult,
+)
 from hephaestus.automation.pipeline.auxiliary_worker_pool import AuxiliaryWorkerPool
 from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.job_results import JobResult
 from hephaestus.automation.pipeline.jobs import GitJob, JobHandle
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
-from hephaestus.automation.pipeline.work_item import ItemKind, LearningIntent, WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, LearningIntent, WorkItem
 from hephaestus.automation.state_labels import STATE_PLAN_GO
+from hephaestus.utils import subprocess_registry
+from hephaestus.utils.helpers import run_subprocess
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -98,6 +110,51 @@ def test_learning_cleanup_does_not_wait_for_main_capacity(tmp_path: Path) -> Non
     assert coordinator._admit(learning)
 
 
+def test_opposite_lane_handoffs_do_not_deadlock_at_capacity_one(tmp_path: Path) -> None:
+    """An auxiliary return lets a main item enter the full auxiliary lane."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            max_workers=1,
+            learning_workers=1,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    returning = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=1,
+        stage=StageName.LEARNING,
+    )
+    entering = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2,
+        stage=StageName.PLAN_REVIEW,
+    )
+    assert coordinator._push_item(returning, StageName.LEARNING, enter=True)
+    assert coordinator._push_item(entering, StageName.PLAN_REVIEW, enter=True)
+    assert coordinator._claim_item(StageName.LEARNING) is returning
+    assert coordinator._claim_item(StageName.PLAN_REVIEW) is entering
+
+    assert not coordinator._handoff_item(returning, StageName.IMPLEMENTATION, enter=True)
+    assert coordinator.learning_work_count == 0
+    assert coordinator._handoff_item(entering, StageName.LEARNING, enter=True)
+    assert coordinator.live_work_count == 0
+
+    coordinator._drain_pending_handoffs()
+
+    assert returning.stage is StageName.IMPLEMENTATION
+    assert id(returning) not in coordinator._pending_handoffs
+    assert coordinator.live_work_count == 1
+
+
 def test_scoped_plan_learning_resumes_at_scoped_sink(tmp_path: Path) -> None:
     """A planning-only run does not escape its selected stage scope."""
     from hephaestus.automation.pipeline.routing import PipelineScope
@@ -154,6 +211,115 @@ def test_restart_reconstructs_pending_intent_before_primary_stage(tmp_path: Path
     assert item.stage is StageName.LEARNING
     assert item.learning_intents == [intent]
     assert item.learning_resume_stage is StageName.FINISHED
+
+
+def test_restart_restores_post_merge_cleanup_obligation(tmp_path: Path) -> None:
+    """A new item recovers the branch, worktree, and confirmed merge result."""
+    repo_root = tmp_path / "repo"
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            repo_roots={"repo": repo_root},
+        ),
+        github=FakeStageGitHub(pr_state={"state": "MERGED"}),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    original = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.MERGE_WAIT,
+        worktree="build/.worktrees/issue-2705",
+        branch="2705-fix",
+    )
+    original.payload["_direct_scope_local_branch_cleanup"] = True
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    original.learning_intents.append(intent)
+    original.compact_for_post_processing(
+        ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+    )
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(
+        intent.key,
+        kind=intent.kind.value,
+        identity=original.learning_journal_identity(intent),
+    )
+    recovered = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.FINISHED,
+    )
+
+    coordinator._restore_learning_intents(recovered, StageName.FINISHED, "already merged")
+
+    assert recovered.worktree == original.worktree
+    assert recovered.branch == original.branch
+    assert recovered.post_processing is not None
+    assert recovered.post_processing.result.passed
+    assert recovered.payload["_direct_scope_local_branch_cleanup"] is True
+
+
+def test_post_merge_recovery_rejects_non_boolean_result() -> None:
+    """Recovery rejects text that could invert a stored merge result."""
+    item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2705)
+    record = {
+        "post_processing": {
+            "worktree": "",
+            "branch": "",
+            "resume_stage": StageName.FINISHED.value,
+            "cleanup_payload": {},
+            "result": {
+                "passed": "false",
+                "reason": "failed",
+                "final_stage": StageName.MERGE_WAIT.value,
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="invalid result fields"):
+        item.restore_post_processing(record)
+
+
+def test_malformed_recovery_record_does_not_poison_source_item(tmp_path: Path) -> None:
+    """A journal object without a key is reported and left untouched."""
+    repo_root = tmp_path / "repo"
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            repo_roots={"repo": repo_root},
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    malformed = journal.path("unknown")
+    malformed.parent.mkdir(parents=True, exist_ok=True)
+    malformed.write_text(
+        json.dumps(
+            {
+                "repo": "repo",
+                "issue": 2705,
+                "status": "pending",
+                "kind": "post_merge",
+            }
+        ),
+        encoding="utf-8",
+    )
+    item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2705, stage=StageName.PLANNING)
+
+    coordinator._restore_learning_intents(item, StageName.PLANNING, "primary")
+
+    assert item.stage is StageName.PLANNING
+    assert malformed.exists()
 
 
 def test_merged_legacy_item_reconstructs_missing_post_merge_intent(tmp_path: Path) -> None:
@@ -315,6 +481,55 @@ def test_single_main_worker_progresses_while_learning_is_blocked(
     auxiliary.shutdown(mark_interrupted=False)
 
 
+@pytest.mark.skipif(not subprocess_registry.supported(), reason="requires POSIX process groups")
+def test_forced_auxiliary_shutdown_stops_active_host_process() -> None:
+    """Forced shutdown ends active host work and releases its worker thread."""
+
+    class ProcessHost:
+        def execute(self, request: object) -> AthenaSkillResult:
+            del request
+            run_subprocess(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                check=False,
+                timeout=60,
+                track_process_group=True,
+            )
+            return AthenaSkillResult(kind="learn", error="interrupted")
+
+        def cancel(self) -> None:
+            subprocess_registry.terminate_all()
+
+    completions: queue.Queue = queue.Queue(maxsize=1)
+    pool = AuxiliaryWorkerPool(
+        size=1,
+        shutdown=threading.Event(),
+        completion_q=completions,
+        athena_skill_executor=ProcessHost(),
+    )
+    request = AthenaSkillJob(
+        request=AthenaSkillRequest(
+            kind="learn",
+            repo="repo",
+            issue=1,
+            agent="codex",
+            model="default",
+            cwd=Path.cwd(),
+            timeout_s=60,
+        )
+    )
+    pool.submit(request, "DONE")
+    deadline = time.monotonic() + 3
+    while subprocess_registry.live_count() == 0 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert subprocess_registry.live_count() == 1
+
+    pool.shutdown()
+
+    _handle, result = completions.get(timeout=3)
+    assert result.interrupted
+    assert subprocess_registry.live_count() == 0
+
+
 def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: Path) -> None:
     """Post-merge learning drops review data and keeps the merge outcome."""
     coordinator = Coordinator(
@@ -345,6 +560,55 @@ def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: 
     assert item.result.passed
     assert item.result.reason == "merged"
     assert item.result.final_stage is StageName.MERGE_WAIT
+
+
+def test_learning_completion_exception_preserves_confirmed_merge(tmp_path: Path) -> None:
+    """A journal callback error cannot rewrite a confirmed merge as failed."""
+
+    class RaisingStage:
+        def on_job_done(self, item: WorkItem, result: object, ctx: object) -> None:
+            del item, result, ctx
+            raise OSError("journal unavailable")
+
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    item = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=1,
+        pr=7,
+        stage=StageName.LEARNING,
+    )
+    primary = ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+    item.learning_intents.append(LearningIntent.post_merge(repo="repo", issue=1, pr=7))
+    item.compact_for_post_processing(primary)
+    assert coordinator._push_item(item, StageName.LEARNING, enter=True)
+    assert coordinator._claim_item(StageName.LEARNING) is item
+    request = AthenaSkillJob(
+        request=AthenaSkillRequest(
+            kind="learn",
+            repo="repo",
+            issue=1,
+            agent="codex",
+            model="default",
+            cwd=tmp_path,
+            timeout_s=60,
+        )
+    )
+    handle = JobHandle(job=request, on_done_state="RESULT")
+    coordinator.auxiliary_in_flight[handle] = item
+    coordinator.stages[StageName.LEARNING] = RaisingStage()  # type: ignore[assignment]
+
+    coordinator._handle_completion(handle, JobResult(ok=False, error="disk"), auxiliary=True)
+
+    assert item.stage is StageName.FINISHED
+    assert item.result == primary
+    assert item.payload["learning_failures"][0]["error"] == "journal_completion_failed"
 
 
 def test_learning_completion_capacity_covers_all_learning_workers(tmp_path: Path) -> None:

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -1,0 +1,366 @@
+"""Coordinator behavior tests for the independent learning lane."""
+
+from __future__ import annotations
+
+import inspect
+import queue
+import threading
+from pathlib import Path
+from typing import Any
+
+import hephaestus.agents.runtime as agent_runtime
+from hephaestus.automation.pipeline.athena_skill_jobs import AthenaSkillResult
+from hephaestus.automation.pipeline.auxiliary_worker_pool import AuxiliaryWorkerPool
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import GitJob, JobHandle
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.work_item import ItemKind, LearningIntent, WorkItem
+from hephaestus.automation.state_labels import STATE_PLAN_GO
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def test_coordinator_exposes_independent_learning_capacity(tmp_path: Path) -> None:
+    """Learning capacity is configured separately from the main work window."""
+    assert "auxiliary_pool" in inspect.signature(Coordinator).parameters
+    config = PipelineConfig(
+        org="org",
+        repos=["repo"],
+        max_workers=1,
+        learning_workers=2,
+        learning_queue_capacity=3,
+        projects_dir=tmp_path,
+    )
+    assert config.learning_workers == 2
+    assert config.learning_queue_capacity == 3
+
+
+def test_single_main_worker_progresses_while_learning_is_queued(tmp_path: Path) -> None:
+    """A learning handoff releases the only main permit for unrelated work."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            max_workers=1,
+            learning_workers=1,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    learning = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLAN_REVIEW)
+    unrelated = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLANNING)
+    assert coordinator._push_item(learning, StageName.PLAN_REVIEW, enter=True)
+    assert coordinator._claim_item(StageName.PLAN_REVIEW) is learning
+
+    assert coordinator._handoff_item(learning, StageName.LEARNING, enter=True)
+
+    assert coordinator.live_work_count == 0
+    assert coordinator.learning_work_count == 1
+    assert coordinator._push_item(unrelated, StageName.PLANNING, enter=True)
+
+
+def test_learning_cleanup_does_not_wait_for_main_capacity(tmp_path: Path) -> None:
+    """The learning-to-finished handoff keeps its auxiliary permit."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            max_workers=1,
+            learning_workers=1,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    learning = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.LEARNING)
+    unrelated = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLANNING)
+    assert coordinator._push_item(learning, StageName.LEARNING, enter=True)
+    assert coordinator._push_item(unrelated, StageName.PLANNING, enter=True)
+    assert coordinator._claim_item(StageName.LEARNING) is learning
+
+    assert coordinator._handoff_item(learning, StageName.FINISHED, enter=True)
+
+    main_handle = JobHandle(
+        job=GitJob(repo="repo", op="push", timeout_s=1),
+        on_done_state="DONE",
+    )
+    coordinator.in_flight[main_handle] = unrelated
+    coordinator.inflight_per_repo["repo"] = 1
+    assert coordinator.live_work_count == 1
+    assert coordinator.learning_work_count == 1
+    assert len(coordinator.queues[StageName.FINISHED]) == 1
+    assert coordinator._admit(learning)
+
+
+def test_scoped_plan_learning_resumes_at_scoped_sink(tmp_path: Path) -> None:
+    """A planning-only run does not escape its selected stage scope."""
+    from hephaestus.automation.pipeline.routing import PipelineScope
+
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            scope=PipelineScope(frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})),
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLAN_REVIEW)
+    item.learning_intents.append(
+        LearningIntent.approved_plan(repo="repo", issue=1, plan_revision=1, plan_fingerprint="abc")
+    )
+
+    coordinator._route(item, StageOutcome(Disposition.ADVANCE, "plan approved"))
+
+    assert item.stage is StageName.LEARNING
+    assert item.learning_resume_stage is StageName.FINISHED
+
+    coordinator._route(item, StageOutcome(Disposition.ADVANCE, "learning terminal"))
+
+    assert item.stage is StageName.FINISHED
+    assert item.result is not None
+    assert item.result.passed
+
+
+def test_restart_reconstructs_pending_intent_before_primary_stage(tmp_path: Path) -> None:
+    """A new coordinator routes a durable pending claim back to learning."""
+    repo_root = tmp_path / "repo"
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            repo_roots={"repo": repo_root},
+        ),
+        github=FakeStageGitHub(pr_state={"state": "MERGED"}),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
+    item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2705, stage=StageName.FINISHED)
+
+    coordinator._restore_learning_intents(item, StageName.FINISHED, "already merged")
+
+    assert item.stage is StageName.LEARNING
+    assert item.learning_intents == [intent]
+    assert item.learning_resume_stage is StageName.FINISHED
+
+
+def test_merged_legacy_item_reconstructs_missing_post_merge_intent(tmp_path: Path) -> None:
+    """A merged item without a new journal record enters learning once."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(pr_state={"state": "MERGED"}),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    item = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.FINISHED,
+    )
+
+    coordinator._restore_learning_intents(item, StageName.FINISHED, "already merged")
+
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    assert item.stage is StageName.LEARNING
+    assert item.learning_intents == [intent]
+    record = coordinator._ctx_for_repo("repo").learning_journal.load(intent.key)
+    assert record is not None and record["status"] == "pending"
+
+
+def test_merged_discovery_skips_terminal_learning_intent(tmp_path: Path) -> None:
+    """Repeated discovery does not rebuild a completed auxiliary detour."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(pr_state={"state": "MERGED"}),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
+    assert journal.claim(intent.key)
+    journal.finish(intent.key, succeeded=True)
+    item = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.FINISHED,
+    )
+
+    coordinator._restore_learning_intents(item, StageName.FINISHED, "already merged")
+
+    assert item.stage is StageName.FINISHED
+    assert item.learning_intents == []
+
+
+def test_no_learn_disables_recovered_intent_and_keeps_primary_route(tmp_path: Path) -> None:
+    """The no-learn switch records a terminal skip without a host request."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            projects_dir=tmp_path,
+            enable_learn=False,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
+    item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2705, stage=StageName.FINISHED)
+
+    coordinator._restore_learning_intents(item, StageName.FINISHED, "already merged")
+
+    assert item.stage is StageName.FINISHED
+    assert item.learning_intents == []
+    record = journal.load(intent.key)
+    assert record is not None
+    assert record["status"] == "failed"
+    assert record["error"] == "learning_disabled"
+
+
+class _BlockingLearningHost:
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def execute(self, request: object) -> AthenaSkillResult:
+        self.started.set()
+        assert self.release.wait(timeout=2)
+        sha = "a" * 40
+        return AthenaSkillResult(
+            kind="learn",
+            delivery_receipt={
+                "pr_url": "https://github.com/HomericIntelligence/Mnemosyne/pull/1",
+                "pr_number": 1,
+                "commit_sha": sha,
+                "readback_head_sha": sha,
+            },
+        )
+
+
+def test_single_main_worker_progresses_while_learning_is_blocked(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """A blocked host call does not retain the one main-lane permit."""
+
+    def _harness_forbidden(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("learning called an agent harness")
+
+    monkeypatch.setattr(agent_runtime, "run_agent_text", _harness_forbidden)
+    monkeypatch.setattr(agent_runtime, "run_agent_session", _harness_forbidden)
+    monkeypatch.setattr(agent_runtime, "run_pi_text", _harness_forbidden)
+    monkeypatch.setattr(agent_runtime, "run_pi_session", _harness_forbidden)
+    monkeypatch.setattr(agent_runtime, "preflight_pi_environment", _harness_forbidden)
+    host = _BlockingLearningHost()
+    completions: queue.Queue = queue.Queue(maxsize=1)
+    auxiliary = AuxiliaryWorkerPool(
+        size=1,
+        shutdown=threading.Event(),
+        completion_q=completions,
+        athena_skill_executor=host,
+    )
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            max_workers=1,
+            learning_workers=1,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(labels=[STATE_PLAN_GO]),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=auxiliary,
+        install_signals=False,
+    )
+    learning = WorkItem(
+        repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.LEARNING, state="ENTER"
+    )
+    learning.learning_intents.append(
+        LearningIntent.approved_plan(repo="repo", issue=1, plan_revision=1, plan_fingerprint="abc")
+    )
+    learning.learning_resume_stage = StageName.IMPLEMENTATION
+    assert coordinator._push_item(learning, StageName.LEARNING, enter=True)
+    claimed = coordinator._claim_item(StageName.LEARNING)
+    assert claimed is learning
+    coordinator._run_item(learning)
+    assert host.started.wait(timeout=2)
+
+    unrelated = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLANNING)
+    assert coordinator._push_item(unrelated, StageName.PLANNING, enter=True)
+    assert coordinator.live_work_count == 1
+    assert coordinator.learning_work_count == 1
+
+    host.release.set()
+    done, result = coordinator.auxiliary_completion_q.get(timeout=2)
+    coordinator._handle_completion(done, result, auxiliary=True)
+    auxiliary.shutdown(mark_interrupted=False)
+
+
+def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: Path) -> None:
+    """Post-merge learning drops review data and keeps the merge outcome."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, pr=7, stage=StageName.MERGE_WAIT)
+    item.payload.update({"pr_diff": "large raw diff", "review_audit": {"large": "value"}})
+    item.learning_intents.append(LearningIntent.post_merge(repo="repo", issue=1, pr=7))
+
+    coordinator._route(item, StageOutcome(Disposition.FINISH_PASS, "merged"))
+
+    assert item.stage is StageName.LEARNING
+    assert item.payload["_learning_primary_reason"] == "merged"
+    assert "pr_diff" not in item.payload
+    assert "review_audit" not in item.payload
+    assert item.post_processing is not None
+    assert item.post_processing.result.passed
+    assert item.post_processing.result.final_stage is StageName.MERGE_WAIT
+
+    item.payload["learning_failures"] = [{"key": "intent", "error": "host failed"}]
+    coordinator._route(item, StageOutcome(Disposition.ADVANCE, "learning terminal"))
+
+    assert item.stage is StageName.FINISHED
+    assert item.result is not None
+    assert item.result.passed
+    assert item.result.reason == "merged"
+    assert item.result.final_stage is StageName.MERGE_WAIT
+
+
+def test_learning_completion_capacity_covers_all_learning_workers(tmp_path: Path) -> None:
+    """A small backlog setting cannot make valid completions disappear."""
+    coordinator = Coordinator(
+        PipelineConfig(
+            org="org",
+            repos=["repo"],
+            learning_workers=3,
+            learning_queue_capacity=1,
+            projects_dir=tmp_path,
+        ),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        auxiliary_pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+
+    assert coordinator.auxiliary_completion_q.maxsize == 3

--- a/tests/unit/automation/pipeline/test_learning_lane.py
+++ b/tests/unit/automation/pipeline/test_learning_lane.py
@@ -25,6 +25,7 @@ from hephaestus.automation.pipeline.job_results import JobResult
 from hephaestus.automation.pipeline.jobs import GitJob, JobHandle
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, LearningIntent, WorkItem
+from hephaestus.automation.review_journal import plan_fingerprint, render_current_plan
 from hephaestus.automation.state_labels import STATE_PLAN_GO
 from hephaestus.utils import subprocess_registry
 from hephaestus.utils.helpers import run_subprocess
@@ -172,7 +173,12 @@ def test_scoped_plan_learning_resumes_at_scoped_sink(tmp_path: Path) -> None:
     )
     item = WorkItem(repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLAN_REVIEW)
     item.learning_intents.append(
-        LearningIntent.approved_plan(repo="repo", issue=1, plan_revision=1, plan_fingerprint="abc")
+        LearningIntent.approved_plan(
+            repo="repo",
+            issue=1,
+            plan_revision=1,
+            plan_fingerprint="abc",
+        )
     )
 
     coordinator._route(item, StageOutcome(Disposition.ADVANCE, "plan approved"))
@@ -201,6 +207,8 @@ def test_restart_reconstructs_pending_intent_before_primary_stage(tmp_path: Path
         pool=FakeWorkerPool(),
         install_signals=False,
     )
+    approved_plan = "Use the approved plan."
+    coordinator.github.comments[1] = [render_current_plan(approved_plan, revision=1)]
     intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
     journal = coordinator._ctx_for_repo("repo").learning_journal
     journal.ensure_pending(intent.key, kind=intent.kind.value, identity=intent.journal_identity())
@@ -484,6 +492,43 @@ def test_no_learn_disables_recovered_intent_and_keeps_primary_route(tmp_path: Pa
     assert record["error"] == "learning_disabled"
 
 
+def test_no_learn_restores_terminal_cleanup_before_disabling(tmp_path: Path) -> None:
+    """The no-learn switch preserves worktree cleanup from the journal."""
+    coordinator = Coordinator(
+        PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path, enable_learn=False),
+        github=FakeStageGitHub(),
+        pool=FakeWorkerPool(),
+        install_signals=False,
+    )
+    original = WorkItem(
+        repo="repo",
+        kind=ItemKind.ISSUE,
+        issue=2705,
+        pr=12,
+        stage=StageName.MERGE_WAIT,
+        worktree="build/.worktrees/issue-2705",
+        branch="2705-fix",
+    )
+    intent = LearningIntent.post_merge(repo="repo", issue=2705, pr=12)
+    original.learning_intents.append(intent)
+    original.compact_for_post_processing(
+        ItemResult(passed=True, reason="merged", final_stage=StageName.MERGE_WAIT)
+    )
+    journal = coordinator._ctx_for_repo("repo").learning_journal
+    journal.ensure_pending(
+        intent.key, kind=intent.kind.value, identity=original.learning_journal_identity(intent)
+    )
+    recovered = WorkItem(
+        repo="repo", kind=ItemKind.ISSUE, issue=2705, pr=12, stage=StageName.FINISHED
+    )
+
+    coordinator._restore_learning_intents(recovered, StageName.FINISHED, "already merged")
+
+    assert recovered.post_processing is not None
+    assert recovered.worktree == original.worktree
+    assert recovered.branch == original.branch
+
+
 def test_post_merge_persistence_failure_keeps_confirmed_result(tmp_path: Path) -> None:
     """Late auxiliary persistence cannot poison a confirmed merge result."""
     coordinator = Coordinator(
@@ -575,11 +620,18 @@ def test_single_main_worker_progresses_while_learning_is_blocked(
         auxiliary_pool=auxiliary,
         install_signals=False,
     )
+    approved_plan = "Use the approved plan."
+    coordinator.github.comments[1] = [render_current_plan(approved_plan, revision=1)]
     learning = WorkItem(
         repo="repo", kind=ItemKind.ISSUE, issue=1, stage=StageName.LEARNING, state="ENTER"
     )
     learning.learning_intents.append(
-        LearningIntent.approved_plan(repo="repo", issue=1, plan_revision=1, plan_fingerprint="abc")
+        LearningIntent.approved_plan(
+            repo="repo",
+            issue=1,
+            plan_revision=1,
+            plan_fingerprint=plan_fingerprint(approved_plan),
+        )
     )
     learning.learning_resume_stage = StageName.IMPLEMENTATION
     assert coordinator._push_item(learning, StageName.LEARNING, enter=True)
@@ -680,8 +732,8 @@ def test_terminal_handoff_compacts_payload_and_preserves_merge_result(tmp_path: 
     assert item.result.final_stage is StageName.MERGE_WAIT
 
 
-def test_learning_completion_exception_preserves_confirmed_merge(tmp_path: Path) -> None:
-    """A journal callback error cannot rewrite a confirmed merge as failed."""
+def test_learning_completion_exception_parks_before_cleanup(tmp_path: Path) -> None:
+    """A journal callback error preserves the claim and defers cleanup."""
 
     class RaisingStage:
         def on_job_done(self, item: WorkItem, result: object, ctx: object) -> None:
@@ -724,9 +776,13 @@ def test_learning_completion_exception_preserves_confirmed_merge(tmp_path: Path)
 
     coordinator._handle_completion(handle, JobResult(ok=False, error="disk"), auxiliary=True)
 
-    assert item.stage is StageName.FINISHED
-    assert item.result == primary
+    assert item.stage is StageName.LEARNING
+    assert item.post_processing is not None
+    assert item.post_processing.result == primary
+    assert item.result is not None and item.result.reason == "resumable at learning"
     assert item.payload["learning_failures"][0]["error"] == "journal_completion_failed"
+    assert item in coordinator.items
+    assert coordinator._terminal_summary.dispositions["resumable"] == 1
 
 
 def test_learning_completion_capacity_covers_all_learning_workers(tmp_path: Path) -> None:

--- a/tests/unit/automation/pipeline/test_pipeline_architecture.py
+++ b/tests/unit/automation/pipeline/test_pipeline_architecture.py
@@ -80,7 +80,12 @@ _ALLOWLIST: frozenset[str] = frozenset()
 # Worker-side modules: code that executes ON worker threads. These may not
 # import github_api or pr_manager at all (not even non-mutator helpers) so
 # that gh_call/run/skip_epics-style mutators can never sneak in.
-_WORKER_SIDE_MODULES = ("worker_pool.py", "jobs.py")
+_WORKER_SIDE_MODULES = (
+    "auxiliary_worker_pool.py",
+    "git_cleanup.py",
+    "jobs.py",
+    "worker_pool.py",
+)
 _FORBIDDEN_WORKER_MODULES = ("github_api", "pr_manager")
 
 

--- a/tests/unit/automation/pipeline/test_queue_leases.py
+++ b/tests/unit/automation/pipeline/test_queue_leases.py
@@ -174,6 +174,49 @@ class TestStageQueueLeases:
         assert popped_item is item
         assert destination.occupancy == 0
 
+    def test_complementary_leases_exchange_full_source_queues_atomically(self) -> None:
+        """Two active leases can swap full source queues without a spill slot."""
+        left = StageQueue(capacity=1)
+        right = StageQueue(capacity=1)
+        left_item = _item("left")
+        right_item = _item("right")
+        left.push(left_item)
+        right.push(right_item)
+        left_lease = left.claim()
+        right_lease = right.claim()
+        assert left_lease is not None
+        assert right_lease is not None
+
+        assert left_lease.exchange(right, right_lease, left)
+
+        assert left.snapshot() == [right_item]
+        assert right.snapshot() == [left_item]
+        assert left.occupancy == right.occupancy == 1
+        assert not left_lease.handoff(right)
+        assert not right_lease.handoff(left)
+
+    def test_exchange_rejects_noncomplementary_destinations_without_mutation(self) -> None:
+        """Exchange fails closed unless each destination is the peer source."""
+        left = StageQueue(capacity=1)
+        right = StageQueue(capacity=1)
+        other = StageQueue(capacity=1)
+        left_item = _item("left")
+        right_item = _item("right")
+        left.push(left_item)
+        right.push(right_item)
+        left_lease = left.claim()
+        right_lease = right.claim()
+        assert left_lease is not None
+        assert right_lease is not None
+
+        assert not left_lease.exchange(other, right_lease, left)
+
+        assert left.occupancy == right.occupancy == 1
+        left_lease.restore()
+        right_lease.restore()
+        assert left.snapshot() == [left_item]
+        assert right.snapshot() == [right_item]
+
     def test_empty_claim_is_explicit(self) -> None:
         """An empty source queue reports no lease instead of raising or inventing work."""
         source = StageQueue(capacity=1)

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -27,6 +27,7 @@ class TestStageName:
             "implementation",
             "pr_review",
             "merge_wait",
+            "learning",
             "finished",
         }
         assert {s.value for s in StageName} == expected
@@ -153,6 +154,14 @@ class TestROUTES:
         expected = set(StageName)
         assert stages == expected
 
+    def test_learning_is_an_implicit_auxiliary_route(self) -> None:
+        """Learning is available but does not break main-scope contiguity."""
+        assert ROUTES[StageName.LEARNING].next is StageName.FINISHED
+        scope = PipelineScope(frozenset({StageName.PLANNING, StageName.PLAN_REVIEW}))
+        routes = scope.trimmed_routes()
+        assert StageName.LEARNING in routes
+        assert routes[StageName.LEARNING].next is StageName.FINISHED
+
     def test_routes_structure(self) -> None:
         """Each ROUTES entry is a Route dataclass."""
         for _stage, route in ROUTES.items():
@@ -230,6 +239,15 @@ class TestROUTES:
                 },
                 budgets={"merge": routing.DEFAULT_DRIVE_GREEN_LOOPS},
             ),
+            StageName.LEARNING: Route(
+                next=StageName.FINISHED,
+                fail_routes={
+                    "resume_implementation": StageName.IMPLEMENTATION,
+                    "resume_plan_review": StageName.PLAN_REVIEW,
+                    "*": StageName.FINISHED,
+                },
+                budgets={"learn": 2},
+            ),
             StageName.FINISHED: Route(next=StageName.FINISHED),
         }
         assert expected == ROUTES
@@ -275,7 +293,9 @@ class TestPipelineScope:
         scope = PipelineScope(stages)
         trimmed = scope.trimmed_routes()
 
-        assert len(trimmed) == 4
+        assert len(trimmed) == 6
+        assert StageName.LEARNING in trimmed
+        assert StageName.FINISHED in trimmed
         assert StageName.REPO not in trimmed
         assert StageName.MERGE_WAIT not in trimmed
 
@@ -353,4 +373,5 @@ class TestPipelineScope:
         """A FINISHED-only scope is valid (empty ordered prefix) and terminal."""
         scope = PipelineScope(frozenset({StageName.FINISHED}))
         trimmed = scope.trimmed_routes()
-        assert trimmed == {StageName.FINISHED: ROUTES[StageName.FINISHED]}
+        assert set(trimmed) == {StageName.LEARNING, StageName.FINISHED}
+        assert trimmed[StageName.FINISHED] == ROUTES[StageName.FINISHED]

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -54,6 +54,7 @@ class TestDisposition:
             "retry",
             "fail_back",
             "skip",
+            "eject",
             "blocked",
             "finish_pass",
             "finish_fail",

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -21,7 +21,7 @@ from hephaestus.automation.pipeline import (
     StageName,
     WorkItem,
 )
-from hephaestus.automation.pipeline.routing import PIPELINE_ORDER, budget_keys
+from hephaestus.automation.pipeline.routing import MAIN_PIPELINE_ORDER, budget_keys
 from hephaestus.automation.pipeline.work_item import ItemKind
 
 NON_TERMINAL = [s for s in StageName if s != StageName.FINISHED]
@@ -60,6 +60,8 @@ _REASON_BUDGET: dict[str, str | None] = {
     "reviewed_head_drift": None,
     "merge_conflicting": None,
     "post_review_rebase_required": None,
+    "resume_implementation": None,
+    "resume_plan_review": None,
     "missing_worktree": None,
     "no_pr": None,
     # #2054 terminalizes every open merge-wait item after containment.
@@ -196,7 +198,7 @@ def test_budget_exhaustion_is_always_finite(budget_key: str) -> None:
 @st.composite
 def contiguous_scopes(draw: st.DrawFn) -> frozenset[StageName]:
     """Generate contiguous, non-empty stage subsets in pipeline order."""
-    non_finished = [s for s in PIPELINE_ORDER if s != StageName.FINISHED]
+    non_finished = list(MAIN_PIPELINE_ORDER)
     start = draw(st.integers(min_value=0, max_value=len(non_finished) - 1))
     end = draw(st.integers(min_value=start, max_value=len(non_finished) - 1))
     include_finished = draw(st.booleans())
@@ -211,9 +213,9 @@ def contiguous_scopes(draw: st.DrawFn) -> frozenset[StageName]:
 def test_scope_closure_over_generated_subsets(stages: frozenset[StageName]) -> None:
     """(d) Every trimmed route targets scope ∪ {FINISHED} for ANY contiguous scope."""
     scope = PipelineScope(stages)
-    allowed = set(stages) | {StageName.FINISHED}
+    allowed = set(stages) | {StageName.LEARNING, StageName.FINISHED}
     for stage, route in scope.trimmed_routes().items():
-        assert stage in stages
+        assert stage in allowed
         assert route.next in allowed
         for target in route.fail_routes.values():
             assert target in allowed

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -141,13 +141,24 @@ class TestPrintSummaryRows:
 
         with caplog.at_level(logging.INFO):
             print_summary(
-                items, _stats(loops_run=2, agent_job_count=5, wall_s=99.5), [], json_out=False
+                items,
+                _stats(
+                    loops_run=2,
+                    agent_job_count=5,
+                    wall_s=99.5,
+                    auxiliary_job_count=2,
+                    auxiliary_job_time_s=3.5,
+                    auxiliary_job_failure_count=1,
+                ),
+                [],
+                json_out=False,
             )
 
         text = caplog.text
         assert "'pass': 2" in text
         assert "'fail': 1" in text
         assert "agent jobs: 5" in text
+        assert "auxiliary jobs: 2 (3.5s total, 1 failed)" in text
         assert "loops: 2" in text
         assert "wall: 99.5s" in text
 
@@ -235,7 +246,13 @@ class TestJsonEnvelope:
 
         print_summary(
             items,
-            _stats(exit_code=130, loops_run=3),
+            _stats(
+                exit_code=130,
+                loops_run=3,
+                auxiliary_job_count=2,
+                auxiliary_job_time_s=3.5,
+                auxiliary_job_failure_count=1,
+            ),
             [("repo-a", 2, "/wt/2")],
             json_out=True,
         )
@@ -246,6 +263,9 @@ class TestJsonEnvelope:
         assert envelope["message"] == "pipeline interrupted"
         assert envelope["dispositions"] == {"pass": 1, "resumable": 1}
         assert envelope["loops_run"] == 3
+        assert envelope["auxiliary_jobs"] == 2
+        assert envelope["auxiliary_job_time_s"] == 3.5
+        assert envelope["auxiliary_job_failures"] == 1
         assert envelope["resumable"] == ["repo-a#2@pr_review"]
         assert envelope["preserved_worktrees"] == [[2, "/wt/2"]]
         assert envelope["recovery_worktrees"] == []

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2771,6 +2771,7 @@ class TestGitOps:
             kwargs={
                 "worktree_path": str(tmp_path / "issue-7"),
                 "repo_root": str(tmp_path),
+                "issue_number": 7,
                 "force": True,
             },
         )
@@ -2791,6 +2792,32 @@ class TestGitOps:
         )
         assert result.ok is True
 
+    def test_remove_worktree_rejects_path_outside_issue_identity(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Recovered cleanup cannot remove a path for another identity."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / "issue-8"),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "force": True,
+            },
+        )
+        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup identity is invalid"
+        mock_run.assert_not_called()
+
     def test_remove_worktree_conditionally_releases_noop_local_branch(
         self,
         pool: WorkerPool,
@@ -2806,6 +2833,7 @@ class TestGitOps:
             kwargs={
                 "worktree_path": str(tmp_path / "issue-7"),
                 "repo_root": str(tmp_path),
+                "issue_number": 7,
                 "force": True,
                 "local_branch_cleanup": {"branch": "7-auto", "base_sha": pin},
             },
@@ -3548,6 +3576,30 @@ class TestGitOps:
 
         assert result.ok is True
         assert result.value is False
+        release.assert_called_once_with("7-auto", pin, tmp_path, timeout=60)
+
+    def test_release_branch_reservation_accepts_sha256_object_id(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Cleanup supports repositories that use SHA-256 object IDs."""
+        pin = "a" * 64
+        job = GitJob(
+            repo="test/repo",
+            op="release_branch_reservation",
+            timeout_s=60,
+            kwargs={"branch": "7-auto", "base_sha": pin, "repo_root": str(tmp_path)},
+        )
+        with patch(
+            "hephaestus.automation.pipeline.git_cleanup.delete_reserved_branch_if_unchanged",
+            return_value=True,
+        ) as release:
+            pool.submit(job, StageName.FINISHED)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok
         release.assert_called_once_with("7-auto", pin, tmp_path, timeout=60)
 
     def test_commit_push_extracts_explicit_keys(

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2772,15 +2772,16 @@ class TestGitOps:
                 "worktree_path": str(tmp_path / "issue-7"),
                 "repo_root": str(tmp_path),
                 "issue_number": 7,
-                "force": True,
+                "force": False,
             },
         )
         with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+            mock_run.return_value.stdout = ""
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
         mock_run.assert_any_call(
-            ["git", "worktree", "remove", str(tmp_path / "issue-7"), "--force"],
+            ["git", "worktree", "remove", str(tmp_path / "issue-7")],
             cwd=tmp_path,
             timeout=60,
         )
@@ -2791,6 +2792,37 @@ class TestGitOps:
             timeout=60,
         )
         assert result.ok is True
+
+    def test_remove_worktree_rejects_dirty_checkout(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Cleanup preserves tracked and untracked work after learning."""
+        worktree = tmp_path / "issue-7"
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(worktree),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "force": False,
+            },
+        )
+        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+            mock_run.return_value.stdout = "?? learning-notes.md\n"
+            pool.submit(job, StageName.FINISHED)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup refused a dirty checkout"
+        assert not any(
+            call.args and call.args[0][:3] == ["git", "worktree", "remove"]
+            for call in mock_run.call_args_list
+        )
 
     def test_remove_worktree_rejects_path_outside_issue_identity(
         self,
@@ -2858,6 +2890,47 @@ class TestGitOps:
         assert result.error == "worktree cleanup ownership changed"
         mock_run.assert_not_called()
 
+    def test_remove_worktree_rejects_replacement_head(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Delayed cleanup cannot remove a checkout that moved to a new commit."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / "issue-7"),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "expected_branch": "7-auto",
+                "expected_head": "a" * 40,
+                "force": False,
+            },
+        )
+        records = [
+            {
+                "path": str(tmp_path / "issue-7"),
+                "branch": "refs/heads/7-auto",
+                "commit": "b" * 40,
+            }
+        ]
+        with (
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run,
+        ):
+            pool.submit(job, StageName.FINISHED)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup ownership changed"
+        mock_run.assert_not_called()
+
     def test_remove_worktree_conditionally_releases_noop_local_branch(
         self,
         pool: WorkerPool,
@@ -2887,7 +2960,7 @@ class TestGitOps:
             }
         ]
         with (
-            patch("hephaestus.automation.pipeline.git_cleanup.run"),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as run,
             patch(
                 "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
                 return_value=records,
@@ -2897,6 +2970,7 @@ class TestGitOps:
                 return_value=True,
             ) as release,
         ):
+            run.return_value.stdout = ""
             pool.submit(job, StageName.FINISHED)
             _, result = completion_q.get(timeout=10)
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2774,7 +2774,7 @@ class TestGitOps:
                 "force": True,
             },
         )
-        with patch(f"{_WP}.git_utils.run") as mock_run:
+        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
@@ -2811,9 +2811,10 @@ class TestGitOps:
             },
         )
         with (
-            patch(f"{_WP}.git_utils.run"),
+            patch("hephaestus.automation.pipeline.git_cleanup.run"),
             patch(
-                f"{_WP}.git_utils.delete_local_branch_if_unchanged", return_value=True
+                "hephaestus.automation.pipeline.git_cleanup.delete_local_branch_if_unchanged",
+                return_value=True,
             ) as release,
         ):
             pool.submit(job, StageName.FINISHED)
@@ -3539,7 +3540,7 @@ class TestGitOps:
             },
         )
         with patch(
-            "hephaestus.automation.git_utils.delete_reserved_branch_if_unchanged",
+            "hephaestus.automation.pipeline.git_cleanup.delete_reserved_branch_if_unchanged",
             return_value=False,
         ) as release:
             pool.submit(job, StageName.FINISHED)

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2772,10 +2772,19 @@ class TestGitOps:
                 "worktree_path": str(tmp_path / "issue-7"),
                 "repo_root": str(tmp_path),
                 "issue_number": 7,
+                "expected_head": "a" * 40,
+                "expected_detached": True,
                 "force": False,
             },
         )
-        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+        records = [{"path": str(tmp_path / "issue-7"), "commit": "a" * 40}]
+        with (
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run,
+        ):
             mock_run.return_value.stdout = ""
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
@@ -2809,10 +2818,19 @@ class TestGitOps:
                 "worktree_path": str(worktree),
                 "repo_root": str(tmp_path),
                 "issue_number": 7,
+                "expected_head": "a" * 40,
+                "expected_detached": True,
                 "force": False,
             },
         )
-        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+        records = [{"path": str(worktree), "commit": "a" * 40}]
+        with (
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run,
+        ):
             mock_run.return_value.stdout = "?? learning-notes.md\n"
             pool.submit(job, StageName.FINISHED)
             _, result = completion_q.get(timeout=10)
@@ -2823,6 +2841,140 @@ class TestGitOps:
             call.args and call.args[0][:3] == ["git", "worktree", "remove"]
             for call in mock_run.call_args_list
         )
+
+    def test_remove_worktree_requires_ownership_proof(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Path cleanup cannot remove a checkout without a bound branch or head."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / "review-pr-7"),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+            },
+        )
+        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup identity is invalid"
+        mock_run.assert_not_called()
+
+    def test_remove_generated_detached_review_worktree(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A positive numeric review generation is a valid managed path."""
+        worktree = tmp_path / "review-pr-7-2"
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(worktree),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "expected_head": "a" * 40,
+                "expected_detached": True,
+            },
+        )
+        records = [{"path": str(worktree), "commit": "a" * 40}]
+        with (
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run,
+        ):
+            mock_run.return_value.stdout = ""
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        mock_run.assert_any_call(
+            ["git", "worktree", "remove", str(worktree)],
+            cwd=tmp_path,
+            timeout=60,
+        )
+
+    def test_remove_detached_review_rejects_branch_attachment(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Detached cleanup preserves a replacement attached to a branch."""
+        worktree = tmp_path / "review-pr-7-1"
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(worktree),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "expected_head": "a" * 40,
+                "expected_detached": True,
+            },
+        )
+        records = [
+            {
+                "path": str(worktree),
+                "commit": "a" * 40,
+                "branch": "refs/heads/human-work",
+            }
+        ]
+        with (
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run,
+        ):
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup ownership changed"
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("name", ["review-pr-7-0", "review-pr-7-next", "review-pr-7--1"])
+    def test_remove_review_worktree_rejects_invalid_generation(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+        name: str,
+    ) -> None:
+        """Only a positive numeric review generation is admitted."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / name),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "expected_head": "a" * 40,
+                "expected_detached": True,
+            },
+        )
+        with patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run:
+            pool.submit(job, StageName.PR_REVIEW)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup identity is invalid"
+        mock_run.assert_not_called()
 
     def test_remove_worktree_rejects_path_outside_issue_identity(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2818,6 +2818,46 @@ class TestGitOps:
         assert result.error == "worktree cleanup identity is invalid"
         mock_run.assert_not_called()
 
+    def test_remove_worktree_rejects_replacement_branch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Recovered cleanup cannot remove a replacement worktree at the expected path."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / "issue-7"),
+                "repo_root": str(tmp_path),
+                "issue_number": 7,
+                "expected_branch": "7-auto",
+                "force": True,
+            },
+        )
+        records = [
+            {
+                "path": str(tmp_path / "issue-7"),
+                "branch": "refs/heads/human-work",
+                "commit": "a" * 40,
+            }
+        ]
+        with (
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
+            patch("hephaestus.automation.pipeline.git_cleanup.run") as mock_run,
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "worktree cleanup ownership changed"
+        mock_run.assert_not_called()
+
     def test_remove_worktree_conditionally_releases_noop_local_branch(
         self,
         pool: WorkerPool,
@@ -2835,11 +2875,23 @@ class TestGitOps:
                 "repo_root": str(tmp_path),
                 "issue_number": 7,
                 "force": True,
+                "expected_branch": "7-auto",
                 "local_branch_cleanup": {"branch": "7-auto", "base_sha": pin},
             },
         )
+        records = [
+            {
+                "path": str(tmp_path / "issue-7"),
+                "branch": "refs/heads/7-auto",
+                "commit": pin,
+            }
+        ]
         with (
             patch("hephaestus.automation.pipeline.git_cleanup.run"),
+            patch(
+                "hephaestus.automation.pipeline.git_cleanup.WorktreeManager.list_worktrees",
+                return_value=records,
+            ),
             patch(
                 "hephaestus.automation.pipeline.git_cleanup.delete_local_branch_if_unchanged",
                 return_value=True,

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -37,9 +37,10 @@ _FORBIDDEN_PREFIXES = (
 )
 
 # Modules exempt from the zero-I/O guard entirely.
-# worker_pool.py is the ONLY place that executes jobs (agent, git, build/test),
-# so it must import I/O modules; all other workers offload to it.
-_ALLOWLIST = frozenset({"worker_pool.py"})
+# These closed worker-side modules execute I/O. The main pool owns general
+# jobs. The auxiliary pool owns host learning and cleanup only. git_cleanup
+# is the shared low-level implementation of its two accepted Git operations.
+_ALLOWLIST = frozenset({"auxiliary_worker_pool.py", "git_cleanup.py", "worker_pool.py"})
 
 # Capability-scoped exemptions: seeding.py and admission.py are the sanctioned
 # "thin fetch over github_api" layer (epic #1809 PR-4): they READ GitHub facts
@@ -145,10 +146,9 @@ def test_pipeline_modules_have_zero_io_imports() -> None:
     inside function bodies), not just at the top level. This catches
     conditional and lazy imports that a text-scan would miss.
 
-    Exceptions: worker_pool.py is the only place that executes jobs
-    (agent, git, build/test), so it must import I/O modules; seeding.py and
-    admission.py get a capability-scoped exemption for their sanctioned
-    read seams only (see ``_CAPABILITY_EXEMPT``).
+    Exceptions: the two closed worker pools and the shared cleanup helper
+    execute I/O. Seeding and admission get a capability-scoped exemption for
+    their sanctioned read seams only (see ``_CAPABILITY_EXEMPT``).
     """
     violations: list[str] = []
     # rglob so future pipeline/ subpackages (e.g. stages/) stay guarded.

--- a/tests/unit/automation/test_arming_state.py
+++ b/tests/unit/automation/test_arming_state.py
@@ -8,6 +8,7 @@ inline ``_load/_save/_clear_arming_state`` methods provided.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -95,3 +96,15 @@ def test_clear_existing_removes_file(tmp_path: Path) -> None:
     assert store.path(11).exists()
     store.clear(11)
     assert not store.path(11).exists()
+
+
+def test_clear_failure_warns_without_raising(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A cleanup I/O failure remains best-effort and visible."""
+    store = _store(tmp_path)
+
+    with patch.object(Path, "unlink", side_effect=OSError("busy")), caplog.at_level("WARNING"):
+        store.clear(11)
+
+    assert "Could not delete arming record" in caplog.text

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -892,6 +892,22 @@ def test_parser_action_specs_are_preserved(
     assert _sorted_specs(_specs(factory())) == _sorted_specs(expected)
 
 
+@pytest.mark.parametrize(
+    "factory",
+    [planner._build_parser, implementer._build_parser, ci_driver._build_parser],
+)
+@pytest.mark.parametrize("flag", ["--learning-workers", "--learning-queue-capacity"])
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_learning_capacity_flags_require_positive_values(
+    factory: Callable[[], argparse.ArgumentParser], flag: str, value: str
+) -> None:
+    """All queue wrappers reject invalid learning capacity at parse time."""
+    with pytest.raises(SystemExit) as error:
+        factory().parse_args([flag, value])
+
+    assert error.value.code == 2
+
+
 def test_ci_driver_help_describes_loop_owned_review() -> None:
     """The historical driver advertises loop-owned review and arming."""
     description = ci_driver._build_parser().description or ""

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -293,6 +293,14 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "no_advise",
             "Skip the advise step (don't search team knowledge base before planning)",
         ),
+        _action_spec(("--learning-workers",), "learning_workers", "_StoreAction", 1),
+        _action_spec(
+            ("--learning-queue-capacity",),
+            "learning_queue_capacity",
+            "_StoreAction",
+            1,
+        ),
+        _action_spec(("--no-learn",), "no_learn", "_StoreTrueAction", False, nargs=0),
         _timeout_spec(
             "--agent-timeout",
             "agent_timeout",
@@ -429,6 +437,14 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "learn_timeout",
             "Timeout for the /learn agent session (default: 7200).",
         ),
+        _action_spec(("--learning-workers",), "learning_workers", "_StoreAction", 1),
+        _action_spec(
+            ("--learning-queue-capacity",),
+            "learning_queue_capacity",
+            "_StoreAction",
+            1,
+        ),
+        _action_spec(("--no-learn",), "no_learn", "_StoreTrueAction", False, nargs=0),
         *_github_throttle_specs(),
         _json_spec(),
         _version_spec(),
@@ -483,6 +499,13 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "--no-learn",
             "no_learn",
             "Disable /learn after implementation (enabled by default)",
+        ),
+        _action_spec(("--learning-workers",), "learning_workers", "_StoreAction", 1),
+        _action_spec(
+            ("--learning-queue-capacity",),
+            "learning_queue_capacity",
+            "_StoreAction",
+            1,
         ),
         _store_true(
             "--no-follow-up",
@@ -575,6 +598,20 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             help_text="Repos processed in parallel per loop iteration (default: 1)",
         ),
         _action_spec(
+            ("--learning-workers",),
+            "learning_workers",
+            "_StoreAction",
+            1,
+            help_text="Independent host-learning workers (default: 1)",
+        ),
+        _action_spec(
+            ("--learning-queue-capacity",),
+            "learning_queue_capacity",
+            "_StoreAction",
+            1,
+            help_text="Bounded auxiliary learning queue capacity (default: 1)",
+        ),
+        _action_spec(
             ("--issue-limit",),
             "issue_limit",
             "_StoreAction",
@@ -621,6 +658,11 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "--no-advise",
             "no_advise",
             "Pass --no-advise to phases that support the advise preflight",
+        ),
+        _store_true(
+            "--no-learn",
+            "no_learn",
+            "Do not create or execute auxiliary learning intents",
         ),
         _action_spec(
             ("--no-serialize-file-overlap",),

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -908,6 +908,24 @@ def test_learning_capacity_flags_require_positive_values(
     assert error.value.code == 2
 
 
+@pytest.mark.parametrize(
+    "factory",
+    [planner._build_parser, implementer._build_parser, ci_driver._build_parser],
+)
+@pytest.mark.parametrize(
+    "flag",
+    ["--learning-workers", "--learning-queue-capacity", "--no-learn"],
+)
+def test_learning_options_have_visible_help(
+    factory: Callable[[], argparse.ArgumentParser], flag: str
+) -> None:
+    """Each wrapper explains its auxiliary learning controls to operators."""
+    action = factory()._option_string_actions[flag]
+
+    assert action.help not in (None, argparse.SUPPRESS)
+    assert str(action.help).strip()
+
+
 def test_ci_driver_help_describes_loop_owned_review() -> None:
     """The historical driver advertises loop-owned review and arming."""
     description = ci_driver._build_parser().description or ""

--- a/tests/unit/automation/test_learning_journal.py
+++ b/tests/unit/automation/test_learning_journal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -59,3 +60,54 @@ def test_learning_journal_rejects_invalid_terminal_transition(tmp_path: Path) ->
 
     with pytest.raises(ValueError, match="cannot finish"):
         store.finish("key", succeeded=True)
+
+
+def test_learning_journal_does_not_overwrite_corrupt_record(tmp_path: Path) -> None:
+    """A present invalid record is evidence, not an absent intent."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    path = store.path("key")
+    path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(arming_state.LearningJournalError, match="invalid JSON"):
+        store.ensure_pending("key", kind="approved_plan")
+
+    assert path.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_learning_journal_identity_cannot_replace_reserved_fields(tmp_path: Path) -> None:
+    """Caller identity cannot change journal protocol fields."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+
+    with pytest.raises(ValueError, match="reserved"):
+        store.ensure_pending(
+            "key",
+            kind="approved_plan",
+            identity={"key": "other", "status": "succeeded"},
+        )
+
+    assert store.load("key") is None
+
+
+def test_learning_journal_exposes_live_claim_until_finish(tmp_path: Path) -> None:
+    """A retained claim lock proves that the owning process is still active."""
+    owner = arming_state.LearningJournalStore(lambda: tmp_path)
+    observer = arming_state.LearningJournalStore(lambda: tmp_path)
+    owner.ensure_pending("key", kind="approved_plan")
+
+    assert owner.claim("key") is True
+    assert observer.claim_is_active("key") is True
+
+    owner.finish("key", succeeded=True)
+    assert observer.claim_is_active("key") is False
+
+
+def test_learning_journal_validates_required_identity(tmp_path: Path) -> None:
+    """A syntactically valid but incomplete record is corrupt evidence."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    store.path("key").write_text(
+        json.dumps({"key": "key", "kind": "approved_plan", "status": "pending"}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(arming_state.LearningJournalError, match="missing fields"):
+        store.load("key")

--- a/tests/unit/automation/test_learning_journal.py
+++ b/tests/unit/automation/test_learning_journal.py
@@ -1,0 +1,61 @@
+"""Behavior tests for durable auxiliary-learning intent state."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+import hephaestus.automation.arming_state as arming_state
+
+
+def test_learning_journal_commits_only_one_claim(tmp_path: Path) -> None:
+    """A durable pending intent can be claimed exactly once."""
+    assert hasattr(arming_state, "LearningJournalStore")
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    store.ensure_pending("approved-plan-key", kind="approved_plan")
+
+    assert store.claim("approved-plan-key") is True
+    assert store.claim("approved-plan-key") is False
+    record = store.load("approved-plan-key")
+    assert record is not None and record["status"] == "claimed"
+
+
+def test_learning_journal_reconstructs_and_disables_one_issue(tmp_path: Path) -> None:
+    """Recovery lists only matching nonterminal identity records."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    identity = {"repo": "Hephaestus", "issue": 2705, "pr": 12}
+    store.ensure_pending("post-merge-key", kind="post_merge", identity=identity)
+    store.ensure_pending(
+        "other-key", kind="post_merge", identity={"repo": "Hephaestus", "issue": 1}
+    )
+
+    records = store.incomplete_for_issue(repo="Hephaestus", issue=2705)
+
+    assert [record["key"] for record in records] == ["post-merge-key"]
+    store.disable("post-merge-key")
+    record = store.load("post-merge-key")
+    assert record is not None and record["status"] == "failed"
+    assert store.incomplete_for_issue(repo="Hephaestus", issue=2705) == []
+
+
+def test_learning_journal_concurrent_claim_has_one_winner(tmp_path: Path) -> None:
+    """The lock makes concurrent claim attempts exactly once."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    store.ensure_pending("key", kind="approved_plan")
+
+    with ThreadPoolExecutor(max_workers=8) as workers:
+        results = list(workers.map(lambda _index: store.claim("key"), range(32)))
+
+    assert results.count(True) == 1
+    assert results.count(False) == 31
+
+
+def test_learning_journal_rejects_invalid_terminal_transition(tmp_path: Path) -> None:
+    """A pending record cannot become terminal without a committed claim."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    store.ensure_pending("key", kind="approved_plan")
+
+    with pytest.raises(ValueError, match="cannot finish"):
+        store.finish("key", succeeded=True)

--- a/tests/unit/automation/test_learning_journal.py
+++ b/tests/unit/automation/test_learning_journal.py
@@ -74,6 +74,31 @@ def test_learning_journal_does_not_overwrite_corrupt_record(tmp_path: Path) -> N
     assert path.read_text(encoding="utf-8") == "{not-json"
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("cleanup_status", "unknown", "invalid cleanup status"),
+        ("post_processing", "not-an-object", "invalid post-processing data"),
+    ],
+)
+def test_learning_journal_rejects_invalid_cleanup_state(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    """Recovery rejects malformed cleanup state before it can delete files."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    store.ensure_pending("key", kind="post_merge")
+    path = store.path("key")
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record[field] = value
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(arming_state.LearningJournalError, match=message):
+        store.load("key")
+
+
 def test_learning_journal_identity_cannot_replace_reserved_fields(tmp_path: Path) -> None:
     """Caller identity cannot change journal protocol fields."""
     store = arming_state.LearningJournalStore(lambda: tmp_path)
@@ -99,6 +124,39 @@ def test_learning_journal_exposes_live_claim_until_finish(tmp_path: Path) -> Non
 
     owner.finish("key", succeeded=True)
     assert observer.claim_is_active("key") is False
+
+
+def test_learning_journal_requires_local_claim_ownership_to_finish(tmp_path: Path) -> None:
+    """One process cannot finish another process's claimed delivery."""
+    owner = arming_state.LearningJournalStore(lambda: tmp_path)
+    observer = arming_state.LearningJournalStore(lambda: tmp_path)
+    owner.ensure_pending("key", kind="approved_plan")
+    assert owner.claim("key")
+
+    with pytest.raises(ValueError, match="owned by this process"):
+        observer.finish("key", succeeded=True)
+
+    owner.finish("key", succeeded=True)
+
+
+def test_terminal_learning_keeps_cleanup_recoverable(tmp_path: Path) -> None:
+    """A terminal learn result remains discoverable until cleanup completes."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    identity = {
+        "repo": "Hephaestus",
+        "issue": 2705,
+        "post_processing": {"result": {"passed": True}},
+    }
+    store.ensure_pending("key", kind="post_merge", identity=identity)
+    assert store.claim("key")
+    store.finish("key", succeeded=True)
+
+    assert [
+        record["key"] for record in store.incomplete_for_issue(repo="Hephaestus", issue=2705)
+    ] == ["key"]
+
+    store.finish_cleanup("key", succeeded=True)
+    assert store.incomplete_for_issue(repo="Hephaestus", issue=2705) == []
 
 
 def test_learning_journal_validates_required_identity(tmp_path: Path) -> None:

--- a/tests/unit/automation/test_learning_journal.py
+++ b/tests/unit/automation/test_learning_journal.py
@@ -139,6 +139,45 @@ def test_learning_journal_requires_local_claim_ownership_to_finish(tmp_path: Pat
     owner.finish("key", succeeded=True)
 
 
+def test_shared_claim_registry_survives_store_reconstruction(tmp_path: Path) -> None:
+    """An evicted repository context does not lose its live claim owner."""
+    registry = arming_state.LearningClaimRegistry()
+    owner = arming_state.LearningJournalStore(lambda: tmp_path, claim_registry=registry)
+    replacement = arming_state.LearningJournalStore(lambda: tmp_path, claim_registry=registry)
+    owner.ensure_pending("key", kind="approved_plan")
+    assert owner.claim("key")
+
+    replacement.finish("key", succeeded=True)
+
+    record = replacement.load("key")
+    assert record is not None and record["status"] == "succeeded"
+
+
+def test_disable_does_not_overwrite_a_live_claim(tmp_path: Path) -> None:
+    """The no-learn path cannot replace an active delivery result."""
+    owner = arming_state.LearningJournalStore(lambda: tmp_path)
+    observer = arming_state.LearningJournalStore(lambda: tmp_path)
+    owner.ensure_pending("key", kind="approved_plan")
+    assert owner.claim("key")
+
+    assert observer.disable("key") is None
+    record = observer.load("key")
+    assert record is not None and record["status"] == "claimed"
+    owner.finish("key", succeeded=True)
+
+
+def test_abandoned_claim_terminal_race_is_idempotent(tmp_path: Path) -> None:
+    """A stale recovery read accepts a claim that became terminal."""
+    store = arming_state.LearningJournalStore(lambda: tmp_path)
+    store.ensure_pending("key", kind="approved_plan")
+    assert store.claim("key")
+    store.finish("key", succeeded=True)
+
+    record = store.fail_abandoned_claim("key", error="outcome_unknown")
+
+    assert record is not None and record["status"] == "succeeded"
+
+
 def test_terminal_learning_keeps_cleanup_recoverable(tmp_path: Path) -> None:
     """A terminal learn result remains discoverable until cleanup completes."""
     store = arming_state.LearningJournalStore(lambda: tmp_path)

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -214,6 +214,21 @@ def test_parse_args_default_max_workers_is_six() -> None:
     assert args.max_workers == 6
 
 
+def test_parse_args_learning_lane_defaults_and_overrides() -> None:
+    """Learning has one worker and one queue slot unless set explicitly."""
+    defaults = loop_runner._parse_args([])
+    assert defaults.learning_workers == 1
+    assert defaults.learning_queue_capacity == 1
+    assert defaults.no_learn is False
+
+    configured = loop_runner._parse_args(
+        ["--learning-workers", "2", "--learning-queue-capacity", "3", "--no-learn"]
+    )
+    assert configured.learning_workers == 2
+    assert configured.learning_queue_capacity == 3
+    assert configured.no_learn is True
+
+
 def test_parse_args_serialize_file_overlap_default_on() -> None:
     """File-overlap serialization is on by default; the flag disables it (#1623)."""
     assert loop_runner._parse_args([]).serialize_file_overlap is True

--- a/tests/unit/automation/test_mnemosyne_skill_host.py
+++ b/tests/unit/automation/test_mnemosyne_skill_host.py
@@ -208,7 +208,7 @@ def test_default_reader_reads_committed_git_output(
     def run(*_args: object, **_kwargs: object) -> SimpleNamespace:
         return SimpleNamespace(returncode=0, stdout="skills/debugging.md\n", stderr="")
 
-    monkeypatch.setattr("hephaestus.automation.mnemosyne_skill_host.subprocess.run", run)
+    monkeypatch.setattr("hephaestus.automation.mnemosyne_skill_host.run_subprocess", run)
 
     output = DefaultCorpusReader._subprocess_git_output(
         tmp_path, ("ls-tree", "-r", "--name-only", "b" * 40)
@@ -237,7 +237,7 @@ def test_default_reader_reports_committed_git_read_failures(
             raise result
         return result
 
-    monkeypatch.setattr("hephaestus.automation.mnemosyne_skill_host.subprocess.run", run)
+    monkeypatch.setattr("hephaestus.automation.mnemosyne_skill_host.run_subprocess", run)
 
     with pytest.raises(MnemosyneCorpusError, match=message):
         DefaultCorpusReader._subprocess_git_output(

--- a/tests/unit/automation/test_pi_mnemosyne_entrypoints.py
+++ b/tests/unit/automation/test_pi_mnemosyne_entrypoints.py
@@ -34,11 +34,11 @@ def test_learn_scopes_prepare_athena_only_when_learn_enabled() -> None:
     assert pipeline_requires_athena_executor(_config(stages=frozenset({StageName.MERGE_WAIT})))
 
 
-def test_dry_run_and_unrelated_scopes_do_not_prepare_mnemosyne() -> None:
+def test_dry_run_skips_host_but_every_live_scope_can_recover_learning() -> None:
     assert not pipeline_requires_athena_executor(_config(dry_run=True))
-    assert not pipeline_requires_athena_executor(_config(stages=frozenset({StageName.REPO})))
-    assert not pipeline_requires_athena_executor(_config(stages=frozenset({StageName.PR_REVIEW})))
-    assert not pipeline_requires_athena_executor(_config(stages=frozenset({StageName.FINISHED})))
+    assert pipeline_requires_athena_executor(_config(stages=frozenset({StageName.REPO})))
+    assert pipeline_requires_athena_executor(_config(stages=frozenset({StageName.PR_REVIEW})))
+    assert pipeline_requires_athena_executor(_config(stages=frozenset({StageName.FINISHED})))
 
 
 def test_advise_disabled_scope_does_not_prepare_for_advise_only_stage() -> None:

--- a/tests/unit/docs/test_agent_contract.py
+++ b/tests/unit/docs/test_agent_contract.py
@@ -46,7 +46,7 @@ REQUIRED_SECTIONS = {
         'dynamic = ["version"]',
         "Make sure all temporary files are in the build/ directory.",
     ),
-    "## AI-agent topology": ("seven in-memory stage queues",),
+    "## AI-agent topology": ("six main-lane queues and two\nauxiliary queues",),
     "## Canonical architecture reference": ("docs/architecture.md",),
 }
 

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -537,6 +537,18 @@ class TestRunSubprocessTimeoutLogging:
 
         mock_error.assert_not_called()
 
+    def test_tracked_process_falls_back_when_process_groups_are_unavailable(self) -> None:
+        """A non-POSIX host uses the normal bounded subprocess path."""
+        completed = subprocess.CompletedProcess(["tool"], 0, stdout="ok", stderr="")
+        with (
+            patch("hephaestus.utils.subprocess_registry.supported", return_value=False),
+            patch("subprocess.run", return_value=completed) as run,
+        ):
+            result = run_subprocess(["tool"], track_process_group=True)
+
+        assert result is completed
+        run.assert_called_once()
+
     @pytest.mark.skipif(
         not hasattr(os, "killpg"),
         reason="requires POSIX process groups",

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """Tests for general utilities."""
 
+import os
 import subprocess
+import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -533,3 +536,27 @@ class TestRunSubprocessTimeoutLogging:
                 run_subprocess(["sleep", "99"], timeout=1, log_on_error=False)
 
         mock_error.assert_not_called()
+
+    @pytest.mark.skipif(
+        not hasattr(os, "killpg"),
+        reason="requires POSIX process groups",
+    )
+    def test_tracked_timeout_terminates_descendants_within_bound(self) -> None:
+        """A timed-out tracked command cannot wait for a child that holds pipes."""
+        started = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_subprocess(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import subprocess,sys,time; "
+                        "subprocess.Popen([sys.executable,'-c','import time; time.sleep(5)']); "
+                        "time.sleep(5)"
+                    ),
+                ],
+                timeout=0.1,
+                track_process_group=True,
+            )
+
+        assert time.monotonic() - started < 2


### PR DESCRIPTION
Summary:

- Add a bounded auxiliary queue for approved-plan and post-merge learning.
- Keep learning work separate from the main worker pool.
- Keep each writer worktree until its learning record is terminal.
- Add durable recovery, bounded cross-lane handoffs, cleanup identity checks, shutdown behavior, metrics, and CLI help.

Review fixes:

- Keep queue permits and leases until a destination accepts a cross-lane handoff.
- Preserve writer worktrees when learning is pending or owned by another process.
- Bind detached review cleanup to the verified checkout head.
- Reject unsafe worktree cleanup identities.
- Add tests for blocked learning, dual completion lanes, restart recovery, shutdown, metrics, and capacity-one handoffs.
- Keep coordinator files within their fixed architecture budgets.

Validation:

- 7,842 tests passed, 13 skipped, and 7 deselected.
- Coverage is 85.64%.
- Ruff check and format passed.
- Full mypy passed.
- Signed commits and DCO trailers are verified.

Scope:

- This PR implements the bounded auxiliary scheduling, persistence, recovery, and cleanup infrastructure in #2756.
- It is part of #2705.
- Issue #2754 owns production construction of the host learning-delivery payload.

Closes #2756
