### PR TITLE
fix(automation): allow untracked intake files

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -701,13 +701,13 @@ Before it reads a direct `--issues` / `--prs` scope, performs a label mutation,
 or dispatches an agent, repo intake proves its reusable checkout is the
 expected repository, clean, on the remote default branch, and fast-forwarded
 to that branch's fetched head. Here, clean means that
-`git status --porcelain --untracked-files=all` reports neither tracked changes
-nor non-ignored untracked files. Every log, build product, and other
-intermediate file created before this check must therefore be covered by the
-repository's `.gitignore`; `build/` is the sanctioned scratch location. A
-missing checkout is cloned and then subjected to the same synchronization
-proof. Any failure is terminal for that scope; it never falls through to an
-ambient or stale checkout.
+`git status --porcelain --untracked-files=no` reports no staged or unstaged
+tracked changes. Untracked files stay in place and do not block intake because
+issue implementation runs in isolated worktrees. Writer-worktree commit and
+cleanup checks remain strict and include untracked files. A missing checkout is
+cloned and then subjected to the same synchronization proof. Any failure is
+terminal for that scope; it never falls through to an ambient or stale
+checkout.
 
 #### Boundary diagram
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2631,8 +2631,8 @@ class WorkerPool:
     def _git_sync_checkout(self, job: GitJob) -> JobResult:
         """Validate and fast-forward a clean reusable checkout.
 
-        Generated and intermediate files must be covered by the repository's
-        ignore rules; any other uncommitted path blocks synchronization.
+        Tracked staged or unstaged changes block synchronization. Untracked
+        files are left in place because issue work runs in isolated worktrees.
         """
         expected_repo = str(job.kwargs.get("repo") or "")
         dest = str(job.kwargs.get("dest") or "")
@@ -2696,7 +2696,7 @@ class WorkerPool:
                 "core.fsmonitor=false",
                 "status",
                 "--porcelain",
-                "--untracked-files=all",
+                "--untracked-files=no",
             ],
             cwd=checkout,
             timeout=timeout_s,
@@ -2759,7 +2759,7 @@ class WorkerPool:
                 "core.fsmonitor=false",
                 "status",
                 "--porcelain",
-                "--untracked-files=all",
+                "--untracked-files=no",
             ],
             cwd=checkout,
             timeout=timeout_s,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -4307,7 +4307,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -4363,7 +4363,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -4407,7 +4407,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -4494,8 +4494,8 @@ class TestGitOps:
             for argv in argvs
         )
 
-    def test_checkout_state_rejects_untracked_files(self, tmp_path: Path) -> None:
-        """Non-ignored intermediate files keep a reusable checkout from synchronizing."""
+    def test_checkout_state_allows_untracked_files(self, tmp_path: Path) -> None:
+        """Untracked files do not block reusable-main synchronization."""
         checkout = tmp_path / "checkout"
         subprocess.run(
             ["git", "init", "-b", "main", str(checkout)],
@@ -4504,11 +4504,14 @@ class TestGitOps:
         )
         (checkout / "intermediate.txt").write_text("pipeline output\n")
 
-        assert WorkerPool._checkout_state_error(
-            checkout=checkout,
-            default_branch="main",
-            timeout_s=120,
-        ) == (f"checkout has uncommitted changes: {checkout}: ?? intermediate.txt")
+        assert (
+            WorkerPool._checkout_state_error(
+                checkout=checkout,
+                default_branch="main",
+                timeout_s=120,
+            )
+            is None
+        )
 
     def test_checkout_state_allows_ignored_intermediate_files(self, tmp_path: Path) -> None:
         """Ignored build and log output do not make a reusable checkout dirty."""
@@ -4548,6 +4551,47 @@ class TestGitOps:
             is None
         )
 
+    @pytest.mark.parametrize("staged", [False, True])
+    def test_checkout_state_rejects_tracked_changes(self, tmp_path: Path, *, staged: bool) -> None:
+        """Tracked staged and unstaged edits block reusable-main synchronization."""
+        checkout = tmp_path / "checkout"
+        subprocess.run(
+            ["git", "init", "-b", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+        )
+        tracked = checkout / "tracked.txt"
+        tracked.write_text("before\n")
+        subprocess.run(["git", "add", "tracked.txt"], cwd=checkout, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test User",
+                "-c",
+                "user.email=test@example.invalid",
+                "commit",
+                "-m",
+                "test: add tracked file",
+            ],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+        )
+        tracked.write_text("after\n")
+        if staged:
+            subprocess.run(["git", "add", "tracked.txt"], cwd=checkout, check=True)
+
+        error = WorkerPool._checkout_state_error(
+            checkout=checkout,
+            default_branch="main",
+            timeout_s=120,
+        )
+
+        assert error is not None
+        assert "checkout has uncommitted changes" in error
+        assert "tracked.txt" in error
+
     def test_sync_checkout_rejects_dirty_worktree_before_fetching(
         self,
         pool: WorkerPool,
@@ -4585,7 +4629,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -5137,7 +5181,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,
@@ -5199,7 +5243,7 @@ class TestGitOps:
                     "core.fsmonitor=false",
                     "status",
                     "--porcelain",
-                    "--untracked-files=all",
+                    "--untracked-files=no",
                 ],
                 cwd=checkout,
                 timeout=120,


### PR DESCRIPTION
Summary:

- Allow untracked files in the reusable main checkout during repository intake.
- Continue to reject staged and unstaged tracked changes before and after fetch.
- Keep strict writer-worktree commit and cleanup checks unchanged.
- Document the tracked-only intake contract.

Validation:

- 1,578 pipeline and documentation tests passed.
- 207 worker-pool tests passed.
- Full Ruff check and format passed.
- Full mypy passed for 680 files.
- All pre-commit hooks passed.

Closes #2762
