### PR TITLE
fix(agents): accept percentage-free Codex skill notice

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -1237,6 +1237,7 @@ _CODEX_FAILED_TOOL_STATUSES = frozenset({"failed", "declined"})
 _CODEX_APP_SERVER_STREAM_LAG_PREFIX = "in-process app-server event stream lagged; dropped "
 _CODEX_APP_SERVER_STREAM_LAG_SUFFIX = " events"
 _CODEX_SKILLS_BUDGET_PREFIX = "Skill descriptions were shortened to fit the "
+_CODEX_SKILLS_BUDGET_PLAIN_MARKER = "skills context budget."
 _CODEX_SKILLS_BUDGET_MARKER = "% skills context budget."
 
 
@@ -1286,9 +1287,10 @@ def _is_codex_nonfatal_error_item(message: str) -> bool:
         return True
     if not message.startswith(_CODEX_SKILLS_BUDGET_PREFIX):
         return False
-    percentage, marker, _guidance = message[len(_CODEX_SKILLS_BUDGET_PREFIX) :].partition(
-        _CODEX_SKILLS_BUDGET_MARKER
-    )
+    remainder = message[len(_CODEX_SKILLS_BUDGET_PREFIX) :]
+    if remainder.startswith(_CODEX_SKILLS_BUDGET_PLAIN_MARKER):
+        return True
+    percentage, marker, _guidance = remainder.partition(_CODEX_SKILLS_BUDGET_MARKER)
     percentage_parts = percentage.split(".", maxsplit=1)
     return bool(
         marker and all(part and part.isascii() and part.isdigit() for part in percentage_parts)

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -1237,7 +1237,10 @@ _CODEX_FAILED_TOOL_STATUSES = frozenset({"failed", "declined"})
 _CODEX_APP_SERVER_STREAM_LAG_PREFIX = "in-process app-server event stream lagged; dropped "
 _CODEX_APP_SERVER_STREAM_LAG_SUFFIX = " events"
 _CODEX_SKILLS_BUDGET_PREFIX = "Skill descriptions were shortened to fit the "
-_CODEX_SKILLS_BUDGET_PLAIN_MARKER = "skills context budget."
+_CODEX_SKILLS_BUDGET_PLAIN_NOTICE = (
+    "skills context budget. Codex can still see every skill, but some descriptions are shorter. "
+    "Disable unused skills or plugins to leave more room for the rest."
+)
 _CODEX_SKILLS_BUDGET_MARKER = "% skills context budget."
 
 
@@ -1288,7 +1291,7 @@ def _is_codex_nonfatal_error_item(message: str) -> bool:
     if not message.startswith(_CODEX_SKILLS_BUDGET_PREFIX):
         return False
     remainder = message[len(_CODEX_SKILLS_BUDGET_PREFIX) :]
-    if remainder.startswith(_CODEX_SKILLS_BUDGET_PLAIN_MARKER):
+    if remainder == _CODEX_SKILLS_BUDGET_PLAIN_NOTICE:
         return True
     percentage, marker, _guidance = remainder.partition(_CODEX_SKILLS_BUDGET_MARKER)
     percentage_parts = percentage.split(".", maxsplit=1)

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -505,6 +505,20 @@ def test_run_codex_session_rejects_nested_sandbox_tool_failure_with_no_edits(
                 "type": "item.completed",
                 "item": {
                     "id": "item_1",
+                    "type": "error",
+                    "message": (
+                        "Skill descriptions were shortened to fit the skills context budget "
+                        "but could not be loaded."
+                    ),
+                },
+            },
+            "Skill descriptions were shortened to fit the skills context budget but could not",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
                     "type": "file_change",
                     "status": "failed",
                     "changes": [],
@@ -765,13 +779,18 @@ def test_run_codex_session_allows_app_server_stream_lag_after_successful_edits(
             "Skill descriptions were shortened to fit the 7.5% skills context budget. "
             "Some descriptions use compact summaries."
         ),
+        (
+            "Skill descriptions were shortened to fit the skills context budget. "
+            "Codex can still see every skill, but some descriptions are shorter. "
+            "Disable unused skills or plugins to leave more room for the rest."
+        ),
     ],
 )
 def test_run_codex_session_allows_skills_budget_notice_after_successful_turn(
     tmp_path: Path,
     notice: str,
 ) -> None:
-    """Skills-budget percentage and guidance changes do not discard final output."""
+    """Skills-budget format and guidance changes do not discard final output."""
 
     def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
         stdout = "\n".join(

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -519,6 +519,20 @@ def test_run_codex_session_rejects_nested_sandbox_tool_failure_with_no_edits(
                 "type": "item.completed",
                 "item": {
                     "id": "item_1",
+                    "type": "error",
+                    "message": (
+                        "Skill descriptions were shortened to fit the skills context budget. "
+                        "Skills could not be loaded."
+                    ),
+                },
+            },
+            "Skill descriptions were shortened to fit the skills context budget. Skills could",
+        ),
+        (
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
                     "type": "file_change",
                     "status": "failed",
                     "changes": [],

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import queue
@@ -1690,6 +1691,74 @@ class TestAgentErrorHandling:
         assert result.error is not None
         assert result.error.startswith("agent_error: codex_nested_sandbox_unsupported")
         assert "outside the enclosing API sandbox" in result.error
+
+    def test_codex_skills_budget_notice_does_not_open_agent_breaker(
+        self,
+        pool: WorkerPool,
+    ) -> None:
+        """An informational Codex notice remains successful across the worker boundary."""
+        job = _agent_job(agent="codex")
+        breaker = get_circuit_breaker("agent:codex")
+        notice = (
+            "Skill descriptions were shortened to fit the skills context budget. "
+            "Codex can still see every skill, but some descriptions are shorter. "
+            "Disable unused skills or plugins to leave more room for the rest."
+        )
+
+        def fake_popen(cmd: list[str], **_kwargs: Any) -> MagicMock:
+            stdout = "\n".join(
+                [
+                    json.dumps({"type": "thread.started", "thread_id": "codex-session"}),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "id": "item_1",
+                                "type": "error",
+                                "message": notice,
+                            },
+                        }
+                    ),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            )
+            output_path = Path(cmd[cmd.index("--output-last-message") + 1])
+            output_path.write_text(
+                "Completed despite the informational notice.",
+                encoding="utf-8",
+            )
+            process = MagicMock()
+            process.pid = 2468
+            process.returncode = 0
+            process.communicate.return_value = (stdout, "")
+            process.poll.return_value = 0
+            return process
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="codex"),
+            patch(
+                "hephaestus.agents.runtime.codex_approval_args",
+                return_value=[],
+            ),
+            patch(
+                "hephaestus.agents.runtime._codex_extra_writable_dirs",
+                return_value=[],
+            ),
+            patch(
+                "hephaestus.agents.runtime.subprocess.Popen",
+                side_effect=fake_popen,
+            ),
+            patch(
+                f"{_WP}.subprocess_registry.track_process_group",
+                side_effect=lambda _pid: nullcontext(),
+            ),
+        ):
+            results = [pool._run_agent(job) for _ in range(breaker.failure_threshold + 1)]
+
+        assert all(result.ok for result in results)
+        assert all(result.error is None for result in results)
+        assert breaker.snapshot()["state"] == "closed"
+        assert breaker.snapshot()["failure_count"] == 0
 
     def test_generic_exception_converted_to_error_result(
         self,


### PR DESCRIPTION
## Summary

- Treat the percentage-free Codex skills-context budget notice as informational.
- Preserve support for percentage-form notices.
- Keep malformed near-matches classified as provider failures.

## Verification

- Runtime tests: 125 passed.
- Worker failure-boundary test: 1 passed.
- Full suite: 7,846 passed, 13 skipped, and 7 deselected.
- Coverage: 85.64%.
- Ruff check, Ruff format check, mypy, and git diff check passed.

Closes #2771