### PR TITLE
fix(tidy): auto-delete merged branches

### DIFF
--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Single-repo gh-tidy wrapper with agent conflict resolution.
 
-Runs `gh tidy --rebase-all --trunk <default_branch>` interactively (stdin
-passes through so the user can answer gh-tidy's own y/N delete prompts), then
+Runs `gh tidy --rebase-all --auto-delete-merged --trunk <default_branch>`, then
 spawns the selected coding agent per branch that gh-tidy failed to rebase.
 
 The swarm is constrained: it MUST NOT delete any branch or any worktree that
@@ -248,12 +247,20 @@ def parse_problem_branches(output: str) -> list[str]:
 
 
 def _run_gh_tidy(trunk: str, dry_run: bool) -> tuple[int, str]:
-    """Run gh tidy interactively, tee output to terminal + buffer.
+    """Run gh tidy with unattended merged-branch cleanup.
 
     Returns (exit_code, combined_output_buffer).
-    Stdin is connected to the user's terminal so gh-tidy's y/N prompts work.
+    Output is streamed to the terminal while also being retained for parsing.
     """
-    cmd = ["gh", "tidy", "--rebase-all", "--trunk", trunk, "--skip-gc"]
+    cmd = [
+        "gh",
+        "tidy",
+        "--rebase-all",
+        "--auto-delete-merged",
+        "--trunk",
+        trunk,
+        "--skip-gc",
+    ]
     if dry_run:
         logger.info("[dry-run] Would run: %s", " ".join(cmd))
         return 0, ""
@@ -261,10 +268,9 @@ def _run_gh_tidy(trunk: str, dry_run: bool) -> tuple[int, str]:
     logger.info("Running: %s", " ".join(cmd))
     buf: list[str] = []
 
-    # Use Popen so we can tee output while keeping stdin connected to the TTY.
+    # Use Popen so output can be tee'd to the terminal and retained for parsing.
     # Intentionally NOT routed through hephaestus.github.client.gh_call: that
-    # adapter captures stdout/stderr and detaches stdin, which would break
-    # gh-tidy's interactive y/N delete prompts (the whole point of this call).
+    # adapter captures stdout/stderr and would prevent live progress output.
     with subprocess.Popen(
         cmd,
         stdin=sys.stdin,

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -149,6 +149,38 @@ def test_no_problem_header_at_all() -> None:
     assert result == []
 
 
+def test_run_gh_tidy_rebases_and_auto_deletes_merged_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gh-tidy boundary uses the complete unattended cleanup argv."""
+    process = MagicMock()
+    process.stdout = iter(())
+    process.returncode = 0
+    popen = MagicMock()
+    popen.return_value.__enter__.return_value = process
+    monkeypatch.setattr(tidy_module.subprocess, "Popen", popen)
+
+    assert tidy_module._run_gh_tidy("main", dry_run=False) == (0, "")
+
+    popen.assert_called_once_with(
+        [
+            "gh",
+            "tidy",
+            "--rebase-all",
+            "--auto-delete-merged",
+            "--trunk",
+            "main",
+            "--skip-gc",
+        ],
+        stdin=tidy_module.sys.stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    process.wait.assert_called_once_with()
+
+
 def test_parse_worktree_porcelain_skips_main_and_detached_worktrees() -> None:
     """Cleanup candidates require a non-main worktree with an attached branch."""
     assert hasattr(tidy_module, "_parse_worktree_porcelain")


### PR DESCRIPTION
## Summary

- pass both `--rebase-all` and `--auto-delete-merged` to the internal `gh tidy` invocation
- update the wrapper documentation to describe unattended merged-branch cleanup
- add an exact-argv subprocess-boundary regression test

## Verification

- RED: focused regression failed because `--auto-delete-merged` was absent
- GREEN: focused regression passed
- `26 passed, 9 deselected` for the non-throttled tidy test selection
- Ruff check and format check passed
- focused mypy passed
- changed-file pre-commit hooks passed

## Known pre-existing test issue

The complete tidy test module stalls in `test_detect_default_branch_with_timeout` because it patches `subprocess.run` while production enters the shared GitHub throttle before that seam. This change does not modify that unrelated behavior.

Closes #2773