### PR TITLE
fix(nightly): unblock duplicate-collapse drain + align Pi smoke placement

### DIFF
--- a/hephaestus/automation/pipeline/coordinator_execution.py
+++ b/hephaestus/automation/pipeline/coordinator_execution.py
@@ -57,6 +57,13 @@ class ExecutionCoordinator(_CoordinatorHost):
 
     def _lane_handoff_capacity(self, item: WorkItem, target: StageName) -> bool:
         """Check destination capacity before source ownership is released."""
+        # FINISHED is a terminal sink, not a working lane: it must never reject
+        # a handoff or a burst of terminalizations would wedge the source drain
+        # (its lease stays active and the drain bails). This is the
+        # #2057 duplicate-collapse path — three copies of one issue terminalize
+        # in a single drain round while the first copy dispatches.
+        if target is StageName.FINISHED:
+            return True
         source_auxiliary = self._is_auxiliary_stage(item.stage)
         target_auxiliary = self._is_auxiliary_stage(target)
         if not source_auxiliary and target_auxiliary:

--- a/tests/integration/test_pi_plugin_package_smoke.py
+++ b/tests/integration/test_pi_plugin_package_smoke.py
@@ -60,7 +60,8 @@ def test_catalog_pinned_packages_install_and_preflight(
     pi_dir = Path(env["PI_CODING_AGENT_DIR"])
     for package in load_pi_package_catalog().packages:
         if package.kind == "npm":
-            assert (pi_dir / "npm" / "node_modules" / package.identity / "package.json").is_file(), (
+            pkg_manifest = pi_dir / "npm" / "node_modules" / package.identity / "package.json"
+            assert pkg_manifest.is_file(), (
                 f"npm package {package.identity} missing in Pi scoped agent dir {pi_dir}"
             )
 

--- a/tests/integration/test_pi_plugin_package_smoke.py
+++ b/tests/integration/test_pi_plugin_package_smoke.py
@@ -21,10 +21,8 @@ def test_catalog_pinned_packages_install_and_preflight(
     if os.environ.get("HEPHAESTUS_REQUIRE_PI_PACKAGE_SMOKE") != "1":
         pytest.skip("set HEPHAESTUS_REQUIRE_PI_PACKAGE_SMOKE=1 for live package evidence")
     command = shutil.which("hephaestus-install-pi-plugins")
-    npm = shutil.which("npm")
     assert command is not None, "installed console script is required"
     assert shutil.which("pi") is not None, "catalog-pinned Pi CLI is required"
-    assert npm is not None, "npm is required for global package-layout evidence"
     cwd = tmp_path / "repo"
     cwd.mkdir()
     env = dict(os.environ)
@@ -53,23 +51,19 @@ def test_catalog_pinned_packages_install_and_preflight(
     assert payload["ready"] is True
     assert payload["status"] == "ready"
 
-    npm_root_result = subprocess.run(
-        [npm, "root", "-g"],
-        cwd=cwd,
-        env=env,
-        text=True,
-        capture_output=True,
-        timeout=30,
-        check=False,
-    )
-    assert npm_root_result.returncode == 0, npm_root_result.stderr
-    npm_root = Path(npm_root_result.stdout.strip())
-    assert npm_root.is_absolute(), npm_root_result.stdout
+    # npm-kind packages install into the Pi scoped agent dir, not the system
+    # npm global root: the install plan runs `pi install <spec>` (#2764), which
+    # honors PI_CODING_AGENT_DIR. inspect_pi_package_inventory checks exactly
+    # this layout (scope_root/npm/node_modules), and the install report above
+    # already asserts ready=True. Assert the same canonical placement here so
+    # the smoke test and the inventory check can never drift.
+    pi_dir = Path(env["PI_CODING_AGENT_DIR"])
     for package in load_pi_package_catalog().packages:
         if package.kind == "npm":
-            assert (npm_root / package.identity / "package.json").is_file()
+            assert (pi_dir / "npm" / "node_modules" / package.identity / "package.json").is_file(), (
+                f"npm package {package.identity} missing in Pi scoped agent dir {pi_dir}"
+            )
 
-    pi_dir = Path(env["PI_CODING_AGENT_DIR"])
     sentinel = tmp_path / "compatible-sentinel-loaded"
     extension_dir = pi_dir / "extensions"
     extension_dir.mkdir(parents=True)

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1794,6 +1794,12 @@ class TestImplementationAdmission:
         the whole org-wide run.
         """
         coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        # No real plan comment exists for the fake issue; fail open (None) so
+        # the overlap selector dispatches without a GitHub fetch (#1952).
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._fetch_planned_files",
+            lambda issue, **_kwargs: None,
+        )
         ran: list[int] = []
 
         class RecordingStage(StubStage):
@@ -1842,6 +1848,12 @@ class TestImplementationAdmission:
         coordinator, _pool, _ = make_coordinator(
             tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=2
         )
+        # No real plan comments exist for the fake issues; fail open (None) so
+        # the overlap selector dispatches without a GitHub fetch (#2057).
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._fetch_planned_files",
+            lambda issue, **_kwargs: None,
+        )
         ran: list[str] = []
 
         class RecordingStage(StubStage):
@@ -1871,6 +1883,12 @@ class TestImplementationAdmission:
         """3+ copies of one issue: first dispatches, ALL later copies terminalize (#2057)."""
         coordinator, _pool, _ = make_coordinator(
             tmp_path, monkeypatch, max_workers=2, parallel_repos=2
+        )
+        # No real plan comment exists for the fake issue; fail open (None) so
+        # the overlap selector dispatches without a GitHub fetch (#2057).
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._fetch_planned_files",
+            lambda issue, **_kwargs: None,
         )
         ran: list[int] = []
 


### PR DESCRIPTION
Fixes the 2 failing nightly-tests on main (failing since #2768).

**Coordinator duplicate collapse** (`test_three_duplicates_collapse_to_first`, `test_duplicate_issue_numbers_collapse_to_first_queued`):
- Root cause: `_lane_handoff_capacity` treated FINISHED as an auxiliary learning lane (`learning_queue_capacity=1`). Terminalizing a second duplicate in one drain round was rejected -> its lease stayed active -> `if id(duplicate) in self._leases: return` fired -> drain bailed -> first-queued item never dispatched.
- Fix: FINISHED is a terminal sink and must never reject a handoff.
- Also made the 3 #2057 duplicate tests hermetic (mock `_fetch_planned_files` to None like their neighbors) so they never hit GitHub in CI.

**Pi catalog smoke** (`test_catalog_pinned_packages_install_and_preflight`):
- The install plan runs `pi install <spec>` which honors PI_CODING_AGENT_DIR (scoped agent dir), but the test asserted packages land in the system npm global root (`npm root -g`).
- Fix: assert the canonical placement (`$PI_CODING_AGENT_DIR/npm/node_modules/<identity>/package.json`) that `inspect_pi_package_inventory` already validates.

Local: 114 passed, 2 skipped (smoke is env-gated).

Closes #2454