### PR TITLE
fix(automation): restore source workspace lifecycle

### DIFF
--- a/hephaestus/agents/workspace.py
+++ b/hephaestus/agents/workspace.py
@@ -14,6 +14,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Self
 
+from hephaestus.utils.worktree_identity import source_worktree_name
+
 
 class WorkspaceBindingError(RuntimeError):
     """Raised when a workspace binding is malformed or no longer valid."""
@@ -228,7 +230,7 @@ def validate_workspace_binding(binding: WorkspaceBinding, *, allowed_tools: str 
         raise WorkspaceBindingError("source workspace binding is incomplete")
     if canonical == reusable_root.resolve(strict=True):
         raise WorkspaceBindingError("source-reading agent cannot use the reusable repository root")
-    expected_name = f"auto-{item_number}-{lane.value}"
+    expected_name = source_worktree_name(item_number, lane.value)
     if canonical.name != expected_name:
         raise WorkspaceBindingError(
             f"source workspace path must end in {expected_name!r}, got {canonical.name!r}"

--- a/hephaestus/automation/pipeline/git_cleanup.py
+++ b/hephaestus/automation/pipeline/git_cleanup.py
@@ -13,6 +13,7 @@ from hephaestus.automation.git_utils import (
 from hephaestus.automation.worktree_manager import WorktreeManager
 from hephaestus.utils.file_lock import file_lock
 from hephaestus.utils.helpers import get_repo_root
+from hephaestus.utils.worktree_identity import is_expected_managed_worktree_path
 
 from .git_jobs import GitJob
 from .job_results import JobResult
@@ -28,29 +29,11 @@ def _is_full_commit_sha(value: object) -> bool:
 
 def _is_expected_worktree_path(path: Path, *, repo_root: Path, issue_number: int) -> bool:
     """Bind destructive cleanup to one managed issue worktree identity."""
-    if issue_number <= 0:
-        return False
-    try:
-        resolved = path.resolve()
-        root = repo_root.resolve()
-    except OSError:
-        return False
-    issue_name = f"issue-{issue_number}"
-    direct_prefix = f"{issue_name}-direct-"
-    review_name = f"review-pr-{issue_number}"
-    review_generation = resolved.name.removeprefix(f"{review_name}-")
-    is_review_path = resolved.name == review_name or (
-        resolved.name.startswith(f"{review_name}-")
-        and review_generation.isdecimal()
-        and int(review_generation) > 0
+    return is_expected_managed_worktree_path(
+        path,
+        repo_root=repo_root,
+        issue_number=issue_number,
     )
-    if (
-        resolved.name != issue_name
-        and not resolved.name.startswith(direct_prefix)
-        and not is_review_path
-    ):
-        return False
-    return resolved.parent in {root, root / "build" / ".worktrees"}
 
 
 def _worktree_record(

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -612,9 +612,12 @@ def source_workspace_binding(
     if item_number is None:
         raise RuntimeError("source workspace requires an issue or pull request number")
     target = revision or str(
-        item.payload.get("reviewed_pr_head_sha")
+        item.payload.get("_worktree_cleanup_head_sha")
+        or item.payload.get("_impl_source_revision")
+        or item.payload.get("reviewed_pr_head_sha")
         or item.payload.get("pr_head_sha")
         or item.payload.get("_synced_default_branch_sha")
+        or item.payload.get("_direct_scope_base_sha")
         or ""
     )
     if len(target) != 40:

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -787,9 +787,9 @@ class ImplementationStage(Stage):
                 ctx,
                 SourceLane.IMPLEMENTATION,
                 revision=str(
-                    item.payload.get("reviewed_pr_head_sha")
-                    or item.payload.get("_worktree_cleanup_head_sha")
+                    item.payload.get("_worktree_cleanup_head_sha")
                     or item.payload.get("_impl_source_revision")
+                    or item.payload.get("reviewed_pr_head_sha")
                     or ""
                 ),
                 branch=item.branch or None,
@@ -1249,6 +1249,9 @@ class ImplementationStage(Stage):
                 if value.get("head_drift"):
                     item.payload[_REBASE_HEAD_DRIFT] = True
                 else:
+                    head_sha = value.get("head_sha")
+                    if is_full_commit_sha(head_sha):
+                        item.payload["_impl_source_revision"] = head_sha
                     item.payload["rebase_complete"] = True
             elif result.error == "mechanical rebase hit conflicts; resolution required":
                 logger.warning(
@@ -1265,6 +1268,10 @@ class ImplementationStage(Stage):
 
         if item.state == REBASE_CONTINUE_WAIT:
             if result.ok:
+                value = result.value if isinstance(result.value, dict) else {}
+                head_sha = value.get("head_sha")
+                if is_full_commit_sha(head_sha):
+                    item.payload["_impl_source_revision"] = head_sha
                 item.payload["rebase_complete"] = True
             elif (result.error or "").startswith("rebase conflict resolution required"):
                 self._record_rebase_conflict(item, result)

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -787,8 +787,8 @@ class ImplementationStage(Stage):
                 ctx,
                 SourceLane.IMPLEMENTATION,
                 revision=str(
-                    item.payload.get("_worktree_cleanup_head_sha")
-                    or item.payload.get("_impl_source_revision")
+                    item.payload.get("_impl_source_revision")
+                    or item.payload.get("_worktree_cleanup_head_sha")
                     or item.payload.get("reviewed_pr_head_sha")
                     or ""
                 ),

--- a/hephaestus/automation/pipeline/stages/learning.py
+++ b/hephaestus/automation/pipeline/stages/learning.py
@@ -84,6 +84,7 @@ class LearningStage:
             item.payload.get("_worktree_cleanup_head_sha")
             or item.payload.get("_impl_source_revision")
             or item.payload.get("_synced_default_branch_sha")
+            or item.payload.get("_direct_scope_base_sha")
             or ""
         )
         workspace = source_workspace_binding(

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -128,6 +128,7 @@ class LearningIntent:
 _POST_PROCESSING_PAYLOAD_KEYS = frozenset(
     {
         "_direct_scope_local_branch_cleanup",
+        "_direct_scope_base_sha",
         "_direct_scope_reservation",
         "_impl_source_revision",
         "_learning_primary_reason",

--- a/hephaestus/automation/source_worktree.py
+++ b/hephaestus/automation/source_worktree.py
@@ -162,6 +162,12 @@ class SourceWorkspaceManager:
                 raise SourceWorkspaceError(f"source workspace is dirty and preserved: {path}")
             desired_detached = lane is SourceLane.REVIEW or branch is None
             physical_revision = self._head_revision(path) if path.exists() else None
+            physical_branch = self._head_branch(path) if path.exists() else None
+            physical_checkout_matches = (
+                physical_branch is None
+                if desired_detached
+                else physical_branch == f"refs/heads/{branch}"
+            )
             can_reuse = (
                 old is not None
                 and path.exists()
@@ -170,6 +176,7 @@ class SourceWorkspaceManager:
                 and physical_revision == target
                 and old.detached == desired_detached
                 and old.branch == branch
+                and physical_checkout_matches
             )
             generation = (
                 old.generation
@@ -185,6 +192,7 @@ class SourceWorkspaceManager:
                 and old.path.resolve() == path.resolve()
                 and old.detached == desired_detached
                 and old.branch == branch
+                and physical_checkout_matches
             )
             if not can_reuse and not path_already_at_target:
                 self._replace_worktree(path, target, branch=None if desired_detached else branch)
@@ -323,6 +331,17 @@ class SourceWorkspaceManager:
         if result.returncode:
             raise SourceWorkspaceError(f"cannot inspect source workspace revision: {path}")
         return result.stdout.strip()
+
+    @staticmethod
+    def _head_branch(path: Path) -> str | None:
+        """Return the physical local branch ref, or ``None`` for detached HEAD."""
+        result = _git(path, "symbolic-ref", "-q", "HEAD", check=False)
+        if result.returncode == 1:
+            return None
+        branch = result.stdout.strip()
+        if result.returncode or not branch.startswith("refs/heads/"):
+            raise SourceWorkspaceError(f"cannot inspect source workspace branch: {path}")
+        return branch
 
     def _binding(self, receipt: SourceWorkspaceReceipt) -> WorkspaceBinding:
         return WorkspaceBinding.source(

--- a/hephaestus/automation/source_worktree.py
+++ b/hephaestus/automation/source_worktree.py
@@ -20,6 +20,7 @@ from hephaestus.agents.workspace import (
 from hephaestus.automation.worktree_manager import WorktreeManager
 from hephaestus.io.utils import write_secure
 from hephaestus.utils.file_lock import file_lock
+from hephaestus.utils.worktree_identity import source_worktree_name
 
 
 class SourceWorkspaceError(RuntimeError):
@@ -132,7 +133,7 @@ class SourceWorkspaceManager:
 
     def path_for(self, item_number: int, lane: SourceLane) -> Path:
         """Return the deterministic physical path for a lane."""
-        return self.base_dir / f"auto-{item_number}-{lane.value}"
+        return self.base_dir / source_worktree_name(item_number, lane.value)
 
     def ownership_key(self, item_number: int, lane: SourceLane) -> str:
         """Return the repository-qualified internal ownership key."""
@@ -160,11 +161,13 @@ class SourceWorkspaceManager:
             if path.exists() and self._is_dirty(path):
                 raise SourceWorkspaceError(f"source workspace is dirty and preserved: {path}")
             desired_detached = lane is SourceLane.REVIEW or branch is None
+            physical_revision = self._head_revision(path) if path.exists() else None
             can_reuse = (
                 old is not None
                 and path.exists()
                 and old.path.resolve() == path.resolve()
                 and old.revision == target
+                and physical_revision == target
                 and old.detached == desired_detached
                 and old.branch == branch
             )
@@ -175,7 +178,15 @@ class SourceWorkspaceManager:
                 if old
                 else 1
             )
-            if not can_reuse:
+            path_already_at_target = (
+                path.exists()
+                and physical_revision == target
+                and old is not None
+                and old.path.resolve() == path.resolve()
+                and old.detached == desired_detached
+                and old.branch == branch
+            )
+            if not can_reuse and not path_already_at_target:
                 self._replace_worktree(path, target, branch=None if desired_detached else branch)
             receipt = SourceWorkspaceReceipt(
                 repository=self.repository,
@@ -304,6 +315,14 @@ class SourceWorkspaceManager:
         if result.returncode:
             raise SourceWorkspaceError(f"cannot inspect source workspace: {path}")
         return bool(result.stdout)
+
+    @staticmethod
+    def _head_revision(path: Path) -> str:
+        """Return the physical worktree HEAD or fail before any replacement."""
+        result = _git(path, "rev-parse", "HEAD", check=False)
+        if result.returncode:
+            raise SourceWorkspaceError(f"cannot inspect source workspace revision: {path}")
+        return result.stdout.strip()
 
     def _binding(self, receipt: SourceWorkspaceReceipt) -> WorkspaceBinding:
         return WorkspaceBinding.source(

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.utils.file_lock import file_lock
+from hephaestus.utils.worktree_identity import source_worktree_name
 
 from .git_utils import get_repo_root, is_clean_working_tree, rebase_worktree_onto, run
 
@@ -333,14 +334,14 @@ class WorktreeManager:
             if source_lane == "review" and not isolated:
                 raise RuntimeError("review source lane must be isolated")
             isolated_key = (
-                f"auto-{issue_number}-review"
+                source_worktree_name(issue_number, "review")
                 if source_lane == "review"
                 else f"review-pr-{issue_number}"
             )
             if isolated_generation and source_lane != "review":
                 isolated_key = f"{isolated_key}-{isolated_generation}"
             direct_key = (
-                f"auto-{issue_number}-impl"
+                source_worktree_name(issue_number, "impl")
                 if source_lane == "impl"
                 else f"{issue_number}-direct-{direct_worktree_nonce}"
                 if direct_worktree_nonce is not None
@@ -445,7 +446,7 @@ class WorktreeManager:
         """Create or cleanly rebind the single detached review lane."""
         if refresh_base:
             self.refresh_base_branch(timeout=timeout)
-        key = f"auto-{issue_number}-review"
+        key = source_worktree_name(issue_number, "review")
         path = self.base_dir / key
         try:
             with file_lock(self._git_metadata_lock_path()):

--- a/hephaestus/utils/worktree_identity.py
+++ b/hephaestus/utils/worktree_identity.py
@@ -1,0 +1,52 @@
+"""Canonical names and cleanup identities for managed source worktrees."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SOURCE_WORKTREE_LANES = frozenset({"impl", "review"})
+
+
+def source_worktree_name(item_number: int, lane: str) -> str:
+    """Return the deterministic name for one source-reading lane."""
+    if item_number <= 0:
+        raise ValueError("source worktree item number must be positive")
+    if lane not in SOURCE_WORKTREE_LANES:
+        raise ValueError("source worktree lane must be 'impl' or 'review'")
+    return f"auto-{item_number}-{lane}"
+
+
+def is_expected_managed_worktree_path(
+    path: Path,
+    *,
+    repo_root: Path,
+    issue_number: int,
+) -> bool:
+    """Return whether ``path`` is a cleanup-safe managed worktree identity."""
+    if issue_number <= 0:
+        return False
+    try:
+        resolved = path.resolve()
+        root = repo_root.resolve()
+    except OSError:
+        return False
+    issue_name = f"issue-{issue_number}"
+    direct_prefix = f"{issue_name}-direct-"
+    review_name = f"review-pr-{issue_number}"
+    review_generation = resolved.name.removeprefix(f"{review_name}-")
+    is_review_path = resolved.name == review_name or (
+        resolved.name.startswith(f"{review_name}-")
+        and review_generation.isdecimal()
+        and int(review_generation) > 0
+    )
+    is_source_path = resolved.name in {
+        source_worktree_name(issue_number, lane) for lane in SOURCE_WORKTREE_LANES
+    }
+    if (
+        resolved.name != issue_name
+        and not resolved.name.startswith(direct_prefix)
+        and not is_review_path
+        and not is_source_path
+    ):
+        return False
+    return resolved.parent in {root, root / "build" / ".worktrees"}

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -712,13 +712,17 @@ class TestGate:
                 "remediation_threads": [{"id": "thread-1", "body": "fix it"}],
                 "reviewed_pr_head_sha": "a" * 40,
                 "_impl_source_revision": "b" * 40,
+                "_worktree_cleanup_head_sha": "c" * 40,
             }
         )
-        manager = SimpleNamespace()
-        manager.prepare = lambda *_args, **kwargs: SimpleNamespace(
-            cwd=Path("/tmp/current-writer"),
-            revision=kwargs.get("revision", _args[2]),
-        )
+        prepared: list[str] = []
+
+        def prepare(*args: Any, **_kwargs: Any) -> SimpleNamespace:
+            revision = str(args[2])
+            prepared.append(revision)
+            return SimpleNamespace(cwd=Path("/tmp/current-writer"), revision=revision)
+
+        manager = SimpleNamespace(prepare=prepare)
         paths = SimpleNamespace(
             repo_root="/tmp/repo",
             worktree="/tmp/repo/worktree",
@@ -730,6 +734,7 @@ class TestGate:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
         assert result.job.cwd == Path("/tmp/current-writer")
+        assert prepared == ["b" * 40]
         assert item.payload["_impl_source_revision"] == "b" * 40
 
     def test_rebase_conflict_uses_edit_only_agent_and_separate_budget(

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -678,6 +678,60 @@ class TestGate:
         stage.on_job_done(item, JobResult(ok=True, value={"rebased": True}), ctx)
         assert stage.step(item, ctx) == Continue(next_state="ADOPTED")
 
+    def test_successful_rebase_persists_published_head_for_remediation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A remediation turn binds to the post-rebase head, not the reviewed head."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_WAIT")
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "reviewed_pr_head_sha": "a" * 40,
+            }
+        )
+
+        stage.on_job_done(
+            item,
+            JobResult(ok=True, value={"rebased": True, "head_sha": "b" * 40}),
+            make_ctx(),
+        )
+
+        assert item.payload["_impl_source_revision"] == "b" * 40
+
+    def test_remediation_prefers_persisted_rebase_head(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The source workspace request uses the current writer revision."""
+        stage = ImplementationStage()
+        item = make_work_item(issue=1, pr=1001, state="IMPLEMENT_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload.update(
+            {
+                "implementation_remediation": True,
+                "remediation_threads": [{"id": "thread-1", "body": "fix it"}],
+                "reviewed_pr_head_sha": "a" * 40,
+                "_impl_source_revision": "b" * 40,
+            }
+        )
+        manager = SimpleNamespace()
+        manager.prepare = lambda *_args, **kwargs: SimpleNamespace(
+            cwd=Path("/tmp/current-writer"),
+            revision=kwargs.get("revision", _args[2]),
+        )
+        paths = SimpleNamespace(
+            repo_root="/tmp/repo",
+            worktree="/tmp/repo/worktree",
+            source_workspaces=manager,
+        )
+
+        result = stage.step(item, make_ctx(paths=paths))
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.cwd == Path("/tmp/current-writer")
+        assert item.payload["_impl_source_revision"] == "b" * 40
+
     def test_rebase_conflict_uses_edit_only_agent_and_separate_budget(
         self,
         make_ctx: Any,

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -20,7 +20,7 @@ from hephaestus.automation.pipeline.stages import (
     StageOutcome,
 )
 from hephaestus.automation.pipeline.stages.base import Disposition
-from hephaestus.automation.pipeline.work_item import LearningIntent
+from hephaestus.automation.pipeline.work_item import ItemResult, LearningIntent
 from hephaestus.automation.review_journal import plan_fingerprint, render_current_plan
 from hephaestus.automation.state_labels import STATE_PLAN_GO
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
@@ -102,18 +102,30 @@ def test_restored_direct_scope_learning_uses_captured_bootstrap_revision(
         github=_approved_github(),
         paths=paths,
     )
-    item = make_work_item(issue=2705, state="ENTER")
-    item.branch = "2705-auto-impl"
-    item.payload["_direct_scope_base_sha"] = revision
-    item.learning_intents.append(
-        LearningIntent.approved_plan(
-            repo=item.repo,
-            issue=2705,
-            plan_revision=8,
-            plan_fingerprint=_APPROVED_FINGERPRINT,
+    original = make_work_item(issue=2705, state="ENTER")
+    original.branch = "2705-auto-impl"
+    original.payload["_direct_scope_base_sha"] = revision
+    intent = LearningIntent.approved_plan(
+        repo=original.repo,
+        issue=2705,
+        plan_revision=8,
+        plan_fingerprint=_APPROVED_FINGERPRINT,
+    )
+    original.learning_intents.append(intent)
+    original.learning_resume_stage = StageName.IMPLEMENTATION
+    original.compact_for_post_processing(
+        ItemResult(
+            passed=False,
+            reason="restore learning",
+            final_stage=StageName.IMPLEMENTATION,
         )
     )
+    record = original.learning_journal_identity(intent)
+    item = make_work_item(issue=2705, state="ENTER")
+    item.branch = original.branch
+    item.learning_intents.append(intent)
     item.learning_resume_stage = StageName.IMPLEMENTATION
+    assert item.restore_post_processing(record)
     stage = LearningStage()
     stage.on_enter(item, ctx)
     item.state = "CLAIM"

--- a/tests/unit/automation/pipeline/stages/test_stage_learning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_learning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from hephaestus.automation.arming_state import LearningJournalStore
@@ -68,6 +69,59 @@ def test_learning_stage_owns_claim_and_submits_only_host_job(
     assert request.job.request.kind == "learn"
     record = journal.load(item.learning_intents[0].key)
     assert record is not None and record["status"] == "claimed"
+
+
+def test_restored_direct_scope_learning_uses_captured_bootstrap_revision(
+    tmp_path: Path, make_ctx: Any, make_work_item: Any
+) -> None:
+    """A restored direct item retains enough revision evidence for learning."""
+    revision = "a" * 40
+    prepared: list[str] = []
+
+    class SourceWorkspaces:
+        def prepare(
+            self,
+            _item_number: int,
+            _lane: Any,
+            target: str,
+            *,
+            branch: str | None = None,
+        ) -> Any:
+            del branch
+            prepared.append(target)
+            return SimpleNamespace(cwd=tmp_path, revision=target)
+
+    journal = LearningJournalStore(lambda: tmp_path)
+    paths = SimpleNamespace(
+        repo_root=tmp_path,
+        worktree=tmp_path,
+        source_workspaces=SourceWorkspaces(),
+    )
+    ctx = make_ctx(
+        learning_journal=journal,
+        github=_approved_github(),
+        paths=paths,
+    )
+    item = make_work_item(issue=2705, state="ENTER")
+    item.branch = "2705-auto-impl"
+    item.payload["_direct_scope_base_sha"] = revision
+    item.learning_intents.append(
+        LearningIntent.approved_plan(
+            repo=item.repo,
+            issue=2705,
+            plan_revision=8,
+            plan_fingerprint=_APPROVED_FINGERPRINT,
+        )
+    )
+    item.learning_resume_stage = StageName.IMPLEMENTATION
+    stage = LearningStage()
+    stage.on_enter(item, ctx)
+    item.state = "CLAIM"
+
+    request = stage.step(item, ctx)
+
+    assert isinstance(request, JobRequest)
+    assert prepared == [revision]
 
 
 def _claimed_learning(

--- a/tests/unit/automation/test_source_worktree.py
+++ b/tests/unit/automation/test_source_worktree.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from hephaestus.agents.workspace import SourceLane
+from hephaestus.automation.pipeline.git_cleanup import run_cleanup_job
+from hephaestus.automation.pipeline.git_jobs import GitJob
 from hephaestus.automation.source_worktree import (
     SourceWorkspaceError,
     SourceWorkspaceManager,
@@ -71,6 +73,46 @@ def test_review_rebinds_same_path_to_exact_revision(tmp_path: Path) -> None:
     assert rebound.generation == original.generation + 1
     assert _git(rebound.cwd, "rev-parse", "HEAD") == second
     assert _git(rebound.cwd, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"
+
+
+def test_review_rebinds_when_receipt_revision_does_not_match_physical_head(
+    tmp_path: Path,
+) -> None:
+    """A clean detached lane is reusable only after proving its physical HEAD."""
+    repo, first, second = _repository(tmp_path)
+    manager = SourceWorkspaceManager(repo, repository="example/project")
+    original = manager.prepare(9, SourceLane.REVIEW, second)
+    _git(original.cwd, "reset", "--hard", first)
+
+    rebound = manager.prepare(9, SourceLane.REVIEW, second)
+
+    assert rebound.generation == original.generation + 1
+    assert _git(rebound.cwd, "rev-parse", "HEAD") == second
+
+
+def test_current_review_lane_can_be_cleaned_by_pipeline_contract(tmp_path: Path) -> None:
+    """A review lane created with the current deterministic name is removable."""
+    repo, _, second = _repository(tmp_path)
+    manager = SourceWorkspaceManager(repo, repository="example/project")
+    binding = manager.prepare(7, SourceLane.REVIEW, second)
+
+    result = run_cleanup_job(
+        GitJob(
+            repo="example/project",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(binding.cwd),
+                "repo_root": str(repo),
+                "issue_number": 7,
+                "expected_head": second,
+                "expected_detached": True,
+            },
+        )
+    )
+
+    assert result.ok is True
+    assert not binding.cwd.exists()
 
 
 def test_dirty_lane_is_preserved_and_rejected(tmp_path: Path) -> None:

--- a/tests/unit/automation/test_source_worktree.py
+++ b/tests/unit/automation/test_source_worktree.py
@@ -90,6 +90,42 @@ def test_review_rebinds_when_receipt_revision_does_not_match_physical_head(
     assert _git(rebound.cwd, "rev-parse", "HEAD") == second
 
 
+def test_review_rebinds_when_physical_checkout_is_attached(tmp_path: Path) -> None:
+    """A review receipt cannot hide an attached physical checkout."""
+    repo, _, second = _repository(tmp_path)
+    manager = SourceWorkspaceManager(repo, repository="example/project")
+    original = manager.prepare(9, SourceLane.REVIEW, second)
+    _git(original.cwd, "switch", "-c", "wrong-review-branch")
+
+    rebound = manager.prepare(9, SourceLane.REVIEW, second)
+
+    assert rebound.generation == original.generation + 1
+    assert _git(rebound.cwd, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"
+
+
+def test_implementation_rebinds_when_physical_branch_is_wrong(tmp_path: Path) -> None:
+    """An attached lane is reusable only on its expected physical branch."""
+    repo, _, second = _repository(tmp_path)
+    manager = SourceWorkspaceManager(repo, repository="example/project")
+    original = manager.prepare(
+        9,
+        SourceLane.IMPLEMENTATION,
+        second,
+        branch="expected-implementation-branch",
+    )
+    _git(original.cwd, "switch", "-c", "wrong-implementation-branch")
+
+    rebound = manager.prepare(
+        9,
+        SourceLane.IMPLEMENTATION,
+        second,
+        branch="expected-implementation-branch",
+    )
+
+    assert rebound.generation == original.generation + 1
+    assert _git(rebound.cwd, "symbolic-ref", "HEAD") == "refs/heads/expected-implementation-branch"
+
+
 def test_current_review_lane_can_be_cleaned_by_pipeline_contract(tmp_path: Path) -> None:
     """A review lane created with the current deterministic name is removable."""
     repo, _, second = _repository(tmp_path)


### PR DESCRIPTION
## Summary

- centralize managed source-worktree naming and cleanup identity validation
- bind remediation to the published post-rebase head and validate physical workspace HEAD before reuse
- preserve direct-scope bootstrap revision evidence for restored learning work
- add regressions for the production failure paths observed after PR #2768

## Verification

- `uv run pytest tests/unit -q` (7479 passed, 34 skipped; 85.22% coverage)
- focused automation suite (440 passed)
- changed-file pre-commit suite

Closes #2784