### PR TITLE
fix(automation): preserve rebase signing diagnostics

### DIFF
--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -2,6 +2,7 @@ import sys
 from typing import Any, cast
 
 import hephaestus.automation.pipeline.coordinator_observability as _observability
+from hephaestus.utils.git import bounded_git_diagnostic
 
 from .coordinator_contract import _CoordinatorHost
 from .coordinator_handoffs import PendingHandoffCoordinator
@@ -770,7 +771,7 @@ class CoordinatorRuntime(PendingHandoffCoordinator, _CoordinatorHost):
     @staticmethod
     def _job_result_event_fields(result: JobResult) -> dict[str, Any]:
         """Return bounded, output-free job result fields for durable event logs."""
-        fields = {
+        fields: dict[str, Any] = {
             "ok": result.ok,
             "interrupted": result.interrupted,
             "error": CoordinatorRuntime._job_result_error_class(result),
@@ -778,6 +779,20 @@ class CoordinatorRuntime(PendingHandoffCoordinator, _CoordinatorHost):
         }
         if result.worker_id:
             fields["worker_id"] = result.worker_id
+        value = result.value
+        if (
+            isinstance(value, dict)
+            and value.get("failure_kind") in {"signing", "continuation"}
+            and value.get("phase") in {"stage_conflicts", "validate_index", "rebase_continue"}
+        ):
+            fields["rebase_failure_diagnostic"] = {
+                "failure_kind": value["failure_kind"],
+                "phase": value["phase"],
+                "returncode": value.get("returncode"),
+                "receipt_error": bounded_git_diagnostic(value.get("receipt_error"), limit=500),
+                "stdout_tail": bounded_git_diagnostic(result.stdout_tail, limit=4000),
+                "stderr_tail": bounded_git_diagnostic(result.stderr_tail, limit=4000),
+            }
         return fields
 
     @staticmethod

--- a/hephaestus/automation/pipeline/coordinator_runtime.py
+++ b/hephaestus/automation/pipeline/coordinator_runtime.py
@@ -2,7 +2,7 @@ import sys
 from typing import Any, cast
 
 import hephaestus.automation.pipeline.coordinator_observability as _observability
-from hephaestus.utils.git import bounded_git_diagnostic
+from hephaestus.diagnostics import bounded_git_diagnostic
 
 from .coordinator_contract import _CoordinatorHost
 from .coordinator_handoffs import PendingHandoffCoordinator

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -1274,6 +1274,9 @@ class ImplementationStage(Stage):
                     item.issue,
                     result.error,
                 )
+                diagnostic = _rebase_failure_diagnostic(result)
+                if diagnostic is not None:
+                    item.payload["rebase_failure_diagnostic"] = diagnostic
                 item.payload["rebase_error"] = True
             return
 
@@ -2128,3 +2131,22 @@ class ImplementationStage(Stage):
             GIT_ERROR_RETRY_CAP,
         )
         return StageOutcome(Disposition.RETRY, note)
+
+
+def _rebase_failure_diagnostic(result: JobResult) -> dict[str, object] | None:
+    """Extract bounded rebase-recovery evidence from a host Git result."""
+    value = result.value
+    if not isinstance(value, dict):
+        return None
+    if value.get("failure_kind") not in {"signing", "continuation"}:
+        return None
+    if value.get("phase") not in {"stage_conflicts", "validate_index", "rebase_continue"}:
+        return None
+    return {
+        "failure_kind": value["failure_kind"],
+        "phase": value["phase"],
+        "returncode": value.get("returncode"),
+        "receipt_error": value.get("receipt_error"),
+        "stdout_tail": result.stdout_tail,
+        "stderr_tail": result.stderr_tail,
+    }

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -78,13 +78,13 @@ from hephaestus.automation.worktree_manager import (
     BranchWorktreeOwnedError,
     WorktreeManager,
 )
+from hephaestus.diagnostics import bounded_git_diagnostic
 from hephaestus.io.utils import write_secure
 from hephaestus.resilience import (
     CircuitBreakerOpenError,
     resilient_call,
 )
 from hephaestus.utils.file_lock import LockUnavailableError, file_lock
-from hephaestus.utils.git import bounded_git_diagnostic
 from hephaestus.utils.helpers import get_repo_root
 
 logger = logging.getLogger(__name__)

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1225,11 +1225,11 @@ def _parse_host_git_signing_config(raw: str) -> dict[str, str] | None:
 
 def _validated_signing_key(value: str) -> Path | None:
     """Resolve an absolute, private, regular SSH signing key path."""
-    signing_key = Path(value).expanduser()
     try:
+        signing_key = Path(value).expanduser()
         resolved_key = signing_key.resolve(strict=True)
         mode = resolved_key.stat().st_mode
-    except OSError:
+    except (OSError, RuntimeError, ValueError):
         return None
     if (
         not signing_key.is_absolute()

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -84,6 +84,7 @@ from hephaestus.resilience import (
     resilient_call,
 )
 from hephaestus.utils.file_lock import LockUnavailableError, file_lock
+from hephaestus.utils.git import bounded_git_diagnostic
 from hephaestus.utils.helpers import get_repo_root
 
 logger = logging.getLogger(__name__)
@@ -1198,6 +1199,108 @@ def _controlled_git_env() -> dict[str, str]:
     env["PATH"] = os.pathsep.join(path_entries)
     env["GIT_PAGER"] = "cat"
     env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
+
+
+_HOST_SIGNING_CONFIG_KEYS = (
+    "user.name",
+    "user.email",
+    "gpg.format",
+    "user.signingkey",
+)
+
+
+def _parse_host_git_signing_config(raw: str) -> dict[str, str] | None:
+    """Parse the exact allowlisted signing keys from Git's NUL output."""
+    parsed: dict[str, str] = {}
+    for entry in raw.split("\0"):
+        if not entry:
+            continue
+        key, separator, value = entry.partition("\n")
+        if not separator or key not in _HOST_SIGNING_CONFIG_KEYS or key in parsed:
+            return None
+        parsed[key] = value
+    return parsed if set(parsed) == set(_HOST_SIGNING_CONFIG_KEYS) else None
+
+
+def _validated_signing_key(value: str) -> Path | None:
+    """Resolve an absolute, private, regular SSH signing key path."""
+    signing_key = Path(value).expanduser()
+    try:
+        resolved_key = signing_key.resolve(strict=True)
+        mode = resolved_key.stat().st_mode
+    except OSError:
+        return None
+    if (
+        not signing_key.is_absolute()
+        or signing_key.is_symlink()
+        or not resolved_key.is_file()
+        or mode & 0o022
+    ):
+        return None
+    return resolved_key
+
+
+def _read_host_git_signing_config(cwd: Path, *, timeout: int) -> dict[str, str] | None:
+    """Read and validate the minimum host identity needed for policy signing."""
+    trusted_git = _trusted_git_executable()
+    if trusted_git is None:
+        return None
+    env = os.environ.copy()
+    for key in _FETCH_ENV_BLOCKLIST:
+        env.pop(key, None)
+    for key in tuple(env):
+        if key == "GIT_CONFIG_COUNT" or key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            env.pop(key)
+    env.pop("GIT_CONFIG_GLOBAL", None)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    expression = "^(user\\.name|user\\.email|gpg\\.format|user\\.signingkey)$"
+    try:
+        result = subprocess.run(
+            [trusted_git, "config", "--global", "--null", "--get-regexp", expression],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    parsed = _parse_host_git_signing_config(result.stdout)
+    if parsed is None:
+        return None
+    if parsed["gpg.format"] != "ssh":
+        return None
+    if any(
+        not value or len(value) > 4096 or any(ord(character) < 32 for character in value)
+        for value in parsed.values()
+    ):
+        return None
+    resolved_key = _validated_signing_key(parsed["user.signingkey"])
+    if resolved_key is None:
+        return None
+    parsed["user.signingkey"] = str(resolved_key)
+    return parsed
+
+
+def _controlled_git_signing_env(cwd: Path, *, timeout: int) -> dict[str, str] | JobResult:
+    """Return the controlled Git environment with an allowlisted signing identity."""
+    signing = _read_host_git_signing_config(cwd, timeout=timeout)
+    if signing is None:
+        return JobResult(
+            ok=False,
+            value={"failure_kind": "signing_configuration"},
+            error="host signing configuration unavailable",
+        )
+    env = _controlled_git_env()
+    injected = {**signing, "commit.gpgsign": "true"}
+    env["GIT_CONFIG_COUNT"] = str(len(injected))
+    for index, (key, value) in enumerate(injected.items()):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
     return env
 
 
@@ -2666,37 +2769,73 @@ class WorkerPool:
         timeout: int,
     ) -> JobResult | None:
         """Stage only validated conflicts and let Git continue the policy rebase."""
+        env = _controlled_git_signing_env(cwd, timeout=timeout)
+        if isinstance(env, JobResult):
+            return env
+        env["GIT_EDITOR"] = "true"
+        phase = "stage_conflicts"
         try:
             git_utils.run(["git", "add", "--", *paths], cwd=cwd, timeout=timeout)
+            phase = "validate_index"
             git_utils.run(
                 ["git", "diff", "--cached", "--check"],
                 cwd=cwd,
                 timeout=timeout,
             )
-            env = _controlled_git_env()
-            env["GIT_EDITOR"] = "true"
+            phase = "rebase_continue"
             git_utils.run(
                 ["git", "rebase", "--continue"],
                 cwd=cwd,
                 env=env,
                 timeout=timeout,
             )
-        except subprocess.CalledProcessError:
-            next_receipt = self._conflict_receipt(
-                cwd,
-                remote=remote,
-                base_branch="main",
-                expected_remote_sha=expected_remote_sha,
-                timeout=timeout,
-            )
-            if isinstance(next_receipt, dict):
-                next_receipt["base_sha"] = base_sha
-                return JobResult(
-                    ok=False,
-                    value=next_receipt,
-                    error="rebase conflict resolution required: additional conflicts found",
+        except subprocess.CalledProcessError as exc:
+            next_receipt: dict[str, object] | JobResult | None = None
+            if phase == "rebase_continue":
+                next_receipt = self._conflict_receipt(
+                    cwd,
+                    remote=remote,
+                    base_branch="main",
+                    expected_remote_sha=expected_remote_sha,
+                    timeout=timeout,
                 )
-            return JobResult(ok=False, error="host could not continue rebase")
+                if isinstance(next_receipt, dict):
+                    next_receipt["base_sha"] = base_sha
+                    return JobResult(
+                        ok=False,
+                        value=next_receipt,
+                        error="rebase conflict resolution required: additional conflicts found",
+                    )
+            stdout_tail = bounded_git_diagnostic(exc.stdout, limit=_TAIL)
+            stderr_tail = bounded_git_diagnostic(exc.stderr, limit=_TAIL)
+            diagnostic = f"{stdout_tail}\n{stderr_tail}".lower()
+            signing_failure = any(
+                marker in diagnostic
+                for marker in (
+                    "cannot run gpg",
+                    "failed to sign",
+                    "gpg failed",
+                    "failed to write commit object",
+                )
+            )
+            failure_kind = "signing" if signing_failure else "continuation"
+            receipt_error = next_receipt.error if isinstance(next_receipt, JobResult) else None
+            return JobResult(
+                ok=False,
+                value={
+                    "failure_kind": failure_kind,
+                    "phase": phase,
+                    "returncode": exc.returncode,
+                    "receipt_error": receipt_error,
+                },
+                error=(
+                    "host rebase continuation signing failed"
+                    if signing_failure
+                    else f"host rebase {phase} failed"
+                ),
+                stdout_tail=stdout_tail,
+                stderr_tail=stderr_tail,
+            )
         return None
 
     @staticmethod

--- a/hephaestus/diagnostics.py
+++ b/hephaestus/diagnostics.py
@@ -1,0 +1,51 @@
+"""Pure helpers for redacting and bounding durable diagnostic text."""
+
+from __future__ import annotations
+
+import re
+
+_DEFAULT_DIAGNOSTIC_LIMIT = 2000
+_REDACTED_GIT_URL = "<redacted-git-url>"
+_REDACTED_VALUE = "<redacted-value>"
+_GIT_URL_RE = re.compile(r"\b(?:https?|ssh|git)://\S+", re.IGNORECASE)
+_GIT_SCP_REMOTE_RE = re.compile(r"(?<![\w./-])(?:[\w.-]+@)?[\w.-]+:\S+(?:\.git)?")
+_GIT_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(access_token|auth_token|oauth_token|token|password|passwd|secret|credential)="
+    r"([^&\s]+)"
+)
+_GIT_AUTH_HEADER_RE = re.compile(r"(?i)\b(authorization:\s*(?:basic|bearer)\s+)\S+")
+_GITHUB_TOKEN_RE = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github"
+    r"_pat_[A-Za-z0-9_]{20,})\b"
+)
+
+
+def _diagnostic_text(value: object) -> str:
+    """Return diagnostic stream data as safely decoded text."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def redact_git_diagnostic(value: object) -> str:
+    """Return Git diagnostic text with credential-bearing values redacted."""
+    redacted = _GIT_AUTH_HEADER_RE.sub(r"\1" + _REDACTED_VALUE, _diagnostic_text(value))
+    redacted = _GIT_SECRET_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}={_REDACTED_VALUE}", redacted
+    )
+    redacted = _GITHUB_TOKEN_RE.sub(_REDACTED_VALUE, redacted)
+    redacted = _GIT_URL_RE.sub(_REDACTED_GIT_URL, redacted)
+    return _GIT_SCP_REMOTE_RE.sub(_REDACTED_GIT_URL, redacted)
+
+
+def bounded_git_diagnostic(
+    value: object,
+    *,
+    limit: int = _DEFAULT_DIAGNOSTIC_LIMIT,
+) -> str:
+    """Return a credential-redacted, bounded Git diagnostic tail."""
+    if limit <= 0:
+        raise ValueError("Git diagnostic limit must be positive")
+    return redact_git_diagnostic(value)[-limit:]

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -137,6 +137,13 @@ def _redact_git_diagnostics(value: str) -> str:
     return redacted
 
 
+def bounded_git_diagnostic(value: object, *, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
+    """Return a credential-redacted, bounded Git diagnostic tail."""
+    if limit <= 0:
+        raise ValueError("Git diagnostic limit must be positive")
+    return _redact_git_diagnostics(_as_text(value))[-limit:]
+
+
 def _format_git_cmd_for_log(cmd: list[str]) -> str:
     """Return a redacted Git command string for logs."""
     return " ".join(_redact_git_diagnostics(part) for part in cmd)

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import logging
-import re
 import subprocess
 from pathlib import Path
 from typing import Any
 
+from hephaestus.diagnostics import (
+    bounded_git_diagnostic as bounded_git_diagnostic,
+    redact_git_diagnostic as _redact_git_diagnostics,
+)
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
 from hephaestus.utils.retry import is_network_error, retry_with_backoff
 
@@ -45,21 +48,6 @@ _GIT_GLOBAL_FLAGS = frozenset(
     }
 )
 _LOG_STREAM_TAIL_MAX = 2000
-
-
-_REDACTED_GIT_URL = "<redacted-git-url>"
-_REDACTED_VALUE = "<redacted-value>"
-_GIT_URL_RE = re.compile(r"\b(?:https?|ssh|git)://\S+", re.IGNORECASE)
-_GIT_SCP_REMOTE_RE = re.compile(r"(?<![\w./-])(?:[\w.-]+@)?[\w.-]+:\S+(?:\.git)?")
-_GIT_SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?i)\b(access_token|auth_token|oauth_token|token|password|passwd|secret|credential)="
-    r"([^&\s]+)"
-)
-_GIT_AUTH_HEADER_RE = re.compile(r"(?i)\b(authorization:\s*(?:basic|bearer)\s+)\S+")
-_GITHUB_TOKEN_RE = re.compile(
-    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github"
-    r"_pat_[A-Za-z0-9_]{20,})\b"
-)
 
 
 def _cwd_arg(cwd: Path | str | None) -> str | None:
@@ -123,25 +111,6 @@ def _tail_for_log(value: str, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
         return value
     omitted = len(value) - limit
     return f"...({omitted} earlier chars){value[-limit:]}"
-
-
-def _redact_git_diagnostics(value: str) -> str:
-    """Return Git diagnostics with credential-bearing values redacted."""
-    redacted = _GIT_AUTH_HEADER_RE.sub(r"\1" + _REDACTED_VALUE, value)
-    redacted = _GIT_SECRET_ASSIGNMENT_RE.sub(
-        lambda match: f"{match.group(1)}={_REDACTED_VALUE}", redacted
-    )
-    redacted = _GITHUB_TOKEN_RE.sub(_REDACTED_VALUE, redacted)
-    redacted = _GIT_URL_RE.sub(_REDACTED_GIT_URL, redacted)
-    redacted = _GIT_SCP_REMOTE_RE.sub(_REDACTED_GIT_URL, redacted)
-    return redacted
-
-
-def bounded_git_diagnostic(value: object, *, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
-    """Return a credential-redacted, bounded Git diagnostic tail."""
-    if limit <= 0:
-        raise ValueError("Git diagnostic limit must be positive")
-    return _redact_git_diagnostics(_as_text(value))[-limit:]
 
 
 def _format_git_cmd_for_log(cmd: list[str]) -> str:

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -7,10 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from hephaestus.diagnostics import (
-    bounded_git_diagnostic as bounded_git_diagnostic,
-    redact_git_diagnostic as _redact_git_diagnostics,
-)
+from hephaestus.diagnostics import redact_git_diagnostic as _redact_git_diagnostics
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
 from hephaestus.utils.retry import is_network_error, retry_with_backoff
 

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -818,6 +818,40 @@ class TestGate:
         assert item.attempts["implement"] == ctx.budget("implement")
         assert item.attempts["rebase_conflict"] == 1
 
+    def test_rebase_continuation_failure_retains_safe_diagnostic(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Terminal rebase failures preserve host-redacted recovery evidence."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REBASE_CONTINUE_WAIT")
+
+        stage.on_job_done(
+            item,
+            JobResult(
+                ok=False,
+                error="host rebase continuation signing failed",
+                value={
+                    "failure_kind": "signing",
+                    "phase": "rebase_continue",
+                    "returncode": 128,
+                    "receipt_error": "receipt unavailable",
+                },
+                stdout_tail="safe stdout",
+                stderr_tail="safe stderr",
+            ),
+            ctx,
+        )
+
+        assert item.payload["rebase_failure_diagnostic"] == {
+            "failure_kind": "signing",
+            "phase": "rebase_continue",
+            "returncode": 128,
+            "receipt_error": "receipt unavailable",
+            "stdout_tail": "safe stdout",
+            "stderr_tail": "safe stderr",
+        }
+
     def test_successful_conflict_agent_requires_host_completion_before_flags_clear(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -3232,6 +3232,32 @@ class TestDurableEventLog:
         complete = next(record for record in records if record["event"] == "complete")
         assert complete["fields"][-1]["worker_id"] == "hephaestus-pipeline-worker_0"
 
+    def test_job_event_retains_bounded_rebase_failure_diagnostic(self) -> None:
+        """Host-owned, redacted rebase evidence survives in the durable event."""
+        fields = Coordinator._job_result_event_fields(
+            JobResult(
+                ok=False,
+                error="host rebase continuation signing failed",
+                value={
+                    "failure_kind": "signing",
+                    "phase": "rebase_continue",
+                    "returncode": 128,
+                    "receipt_error": "receipt unavailable",
+                },
+                stdout_tail="safe stdout",
+                stderr_tail="safe stderr",
+            )
+        )
+
+        assert fields["rebase_failure_diagnostic"] == {
+            "failure_kind": "signing",
+            "phase": "rebase_continue",
+            "returncode": 128,
+            "receipt_error": "receipt unavailable",
+            "stdout_tail": "safe stdout",
+            "stderr_tail": "safe stderr",
+        }
+
     def test_submit_forwards_claim_context_to_worker_pool(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -3805,6 +3805,263 @@ class TestGitOps:
             timeout=60,
         )
 
+    def test_continue_rebase_recovers_two_real_conflicts_and_publishes(
+        self,
+        pool: WorkerPool,
+        tmp_path: Path,
+    ) -> None:
+        """Sequential real conflicts each yield a receipt before exact publication."""
+        origin = tmp_path / "origin.git"
+        checkout = tmp_path / "checkout"
+        signing_key = tmp_path / "signing-key"
+        subprocess.run(
+            ["git", "init", "--bare", "--quiet", str(origin)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "init", "--initial-branch", "main", str(checkout)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [
+                _executable_path("ssh-keygen"),
+                "-q",
+                "-t",
+                "ed25519",
+                "-N",
+                "",
+                "-f",
+                str(signing_key),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for key, value in (
+            ("user.name", "Test User"),
+            ("user.email", "test@example.invalid"),
+            ("gpg.format", "ssh"),
+            ("user.signingkey", str(signing_key)),
+            ("commit.gpgsign", "false"),
+        ):
+            subprocess.run(
+                ["git", "config", key, value],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        subprocess.run(
+            ["git", "remote", "add", "origin", str(origin)],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        (checkout / "a.txt").write_text("base-a\n", encoding="utf-8")
+        (checkout / "b.txt").write_text("base-b\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "a.txt", "b.txt"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "test: add base files"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "push", "-u", "origin", "main"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "switch", "-c", "7-auto-impl"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        (checkout / "a.txt").write_text("topic-a\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "commit", "-am", "fix: change a"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        (checkout / "b.txt").write_text("topic-b\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "commit", "-am", "fix: change b"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "push", "-u", "origin", "7-auto-impl"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        expected_remote_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        subprocess.run(
+            ["git", "switch", "main"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        (checkout / "a.txt").write_text("main-a\n", encoding="utf-8")
+        (checkout / "b.txt").write_text("main-b\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "commit", "-am", "test: change base files"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "push", "origin", "main"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "switch", "7-auto-impl"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        signing = {
+            "user.name": "Test User",
+            "user.email": "test@example.invalid",
+            "gpg.format": "ssh",
+            "user.signingkey": str(signing_key),
+        }
+        rebase_job = GitJob(
+            repo="test/repo",
+            op="rebase",
+            timeout_s=60,
+            kwargs={
+                "cwd": checkout,
+                "base_branch": "main",
+                "remote": "origin",
+                "publish_rebased_head": True,
+                "branch": "7-auto-impl",
+                "expected_remote_sha": expected_remote_sha,
+            },
+        )
+
+        with patch(f"{_WP}._read_host_git_signing_config", return_value=signing):
+            first = pool._git_rebase(rebase_job)
+            assert first.ok is False
+            assert first.error == "mechanical rebase hit conflicts; resolution required"
+            assert isinstance(first.value, dict)
+            assert first.value["conflict_paths"] == ("a.txt",)
+            assert first.value["base_sha"] == base_sha
+
+            (checkout / "a.txt").write_text("resolved-a\n", encoding="utf-8")
+            first_continuation = GitJob(
+                repo="test/repo",
+                op="continue_rebase",
+                timeout_s=60,
+                kwargs={
+                    "cwd": checkout,
+                    "remote": "origin",
+                    "branch": "7-auto-impl",
+                    **{key: value for key, value in first.value.items() if key != "rebased"},
+                },
+            )
+            second = pool._git_continue_rebase(first_continuation)
+            assert second.ok is False
+            assert second.error == (
+                "rebase conflict resolution required: additional conflicts found"
+            )
+            assert isinstance(second.value, dict)
+            assert second.value["conflict_paths"] == ("b.txt",)
+            assert second.value["base_sha"] == base_sha
+
+            (checkout / "b.txt").write_text("resolved-b\n", encoding="utf-8")
+            second_continuation = GitJob(
+                repo="test/repo",
+                op="continue_rebase",
+                timeout_s=60,
+                kwargs={
+                    "cwd": checkout,
+                    "remote": "origin",
+                    "branch": "7-auto-impl",
+                    **{key: value for key, value in second.value.items() if key != "rebased"},
+                },
+            )
+            completed = pool._git_continue_rebase(second_continuation)
+
+        assert completed.ok is True
+        assert isinstance(completed.value, dict)
+        assert completed.value["rebased"] is True
+        assert completed.value["published"] is True
+        published_sha = str(completed.value["head_sha"])
+        remote_sha = subprocess.run(
+            ["git", "ls-remote", "origin", "refs/heads/7-auto-impl"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()[0]
+        assert remote_sha == published_sha
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", base_sha, published_sha],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        for commit in subprocess.run(
+            ["git", "rev-list", f"{base_sha}..{published_sha}"],
+            cwd=checkout,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split():
+            raw_commit = subprocess.run(
+                ["git", "cat-file", "-p", commit],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            assert "\ngpgsig " in f"\n{raw_commit}"
+            assert "Signed-off-by: Test User <test@example.invalid>" in raw_commit
+
     def test_writer_rebase_keeps_exact_head_when_current_base_is_already_ancestor(
         self,
         pool: WorkerPool,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -22,7 +22,6 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
-import hephaestus.automation.pipeline.worker_pool as worker_pool_module
 from hephaestus.agents.execution_policy import (
     AgentOperation,
     AgentRole,
@@ -53,6 +52,7 @@ from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.worker_pool import (
     WorkerPool,
     _confirmed_pytest_failure,
+    _controlled_git_signing_env,
     _hdiutil_create_argv,
     _host_validation_failure_kind,
     _host_verification_command,
@@ -146,7 +146,7 @@ def test_controlled_git_signing_env_reinjects_only_validated_identity(
         return_value=signing,
         create=True,
     ):
-        env = worker_pool_module._controlled_git_signing_env(tmp_path, timeout=60)
+        env = _controlled_git_signing_env(tmp_path, timeout=60)
 
     assert isinstance(env, dict)
     assert env["GIT_CONFIG_GLOBAL"] == os.devnull

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -65,6 +65,7 @@ from hephaestus.automation.pipeline.worker_pool import (
     _trusted_gh_executable,
     _trusted_git_executable,
     _unsafe_local_git_config_key,
+    _validated_signing_key,
     _verifier_owned_runtime_environment,
 )
 from hephaestus.automation.session_naming import (
@@ -156,6 +157,12 @@ def test_controlled_git_signing_env_reinjects_only_validated_identity(
         env[f"GIT_CONFIG_KEY_{index}"]: env[f"GIT_CONFIG_VALUE_{index}"] for index in range(5)
     }
     assert injected == {**signing, "commit.gpgsign": "true"}
+
+
+@pytest.mark.parametrize("value", ["~no_such_signing_user/key", "key\x00suffix"])
+def test_validated_signing_key_rejects_malformed_paths(value: str) -> None:
+    """Malformed host signing-key configuration fails closed without a crash."""
+    assert _validated_signing_key(value) is None
 
 
 @pytest.fixture

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -22,6 +22,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
+import hephaestus.automation.pipeline.worker_pool as worker_pool_module
 from hephaestus.agents.execution_policy import (
     AgentOperation,
     AgentRole,
@@ -128,6 +129,33 @@ def test_trusted_git_executable_rejects_discovered_binary_outside_fixed_roots(
     monkeypatch.setattr(f"{_WP}._TRUSTED_GIT_CANDIDATES", ())
 
     assert _trusted_git_executable() is None
+
+
+def test_controlled_git_signing_env_reinjects_only_validated_identity(
+    tmp_path: Path,
+) -> None:
+    """A policy rebase keeps signing identity without restoring ambient config."""
+    signing = {
+        "user.name": "Test User",
+        "user.email": "test@example.invalid",
+        "gpg.format": "ssh",
+        "user.signingkey": str(tmp_path / "signing-key"),
+    }
+    with patch(
+        f"{_WP}._read_host_git_signing_config",
+        return_value=signing,
+        create=True,
+    ):
+        env = worker_pool_module._controlled_git_signing_env(tmp_path, timeout=60)
+
+    assert isinstance(env, dict)
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["GIT_CONFIG_COUNT"] == "5"
+    injected = {
+        env[f"GIT_CONFIG_KEY_{index}"]: env[f"GIT_CONFIG_VALUE_{index}"] for index in range(5)
+    }
+    assert injected == {**signing, "commit.gpgsign": "true"}
 
 
 @pytest.fixture
@@ -3605,6 +3633,51 @@ class TestGitOps:
         assert result.ok is False
         assert result.error == "remote writer head changed during conflict resolution"
 
+    def test_continue_rebase_reports_signing_failure_diagnostics(
+        self, pool: WorkerPool, tmp_path: Path
+    ) -> None:
+        """A signing failure is distinct from a follow-up content conflict."""
+        failure = subprocess.CalledProcessError(
+            128,
+            ["git", "rebase", "--continue"],
+            output="rebase output",
+            stderr="error: cannot run gpg: No such file or directory",
+        )
+        with (
+            patch(f"{_WP}._controlled_git_signing_env", return_value={"GIT_EDITOR": "true"}),
+            patch(
+                f"{_WP}.git_utils.run",
+                side_effect=[MagicMock(), MagicMock(), failure],
+            ),
+            patch.object(
+                pool,
+                "_conflict_receipt",
+                return_value=JobResult(
+                    ok=False,
+                    error="paused rebase conflict paths invalid",
+                ),
+            ),
+        ):
+            result = pool._continue_rebase_process(
+                tmp_path,
+                remote="origin",
+                base_sha="b" * 40,
+                expected_remote_sha="a" * 40,
+                paths=("x.py",),
+                timeout=60,
+            )
+
+        assert result is not None and result.ok is False
+        assert result.error == "host rebase continuation signing failed"
+        assert result.value == {
+            "failure_kind": "signing",
+            "phase": "rebase_continue",
+            "returncode": 128,
+            "receipt_error": "paused rebase conflict paths invalid",
+        }
+        assert result.stdout_tail == "rebase output"
+        assert "cannot run gpg" in result.stderr_tail
+
     def test_continue_rebase_rejects_missing_captured_base_ancestry(
         self, pool: WorkerPool, tmp_path: Path
     ) -> None:
@@ -3620,6 +3693,7 @@ class TestGitOps:
         with (
             patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
             patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}._controlled_git_signing_env", return_value={}),
             patch(f"{_WP}.git_utils.run") as run,
         ):
             run.side_effect = [
@@ -3657,6 +3731,7 @@ class TestGitOps:
         with (
             patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
             patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}._controlled_git_signing_env", return_value={}),
             patch(f"{_WP}.git_utils.run") as run,
         ):
             run.side_effect = [
@@ -3694,6 +3769,7 @@ class TestGitOps:
         with (
             patch.object(pool, "_read_remote_branch_head", return_value="a" * 40),
             patch.object(pool, "_conflict_receipt", return_value=receipt),
+            patch(f"{_WP}._controlled_git_signing_env", return_value={}),
             patch.object(pool, "_read_publish_head", return_value="d" * 40),
             patch(f"{_WP}.git_utils.push_head_to_branch") as push,
             patch(f"{_WP}.git_utils.run") as run,

--- a/tests/unit/utils/test_git.py
+++ b/tests/unit/utils/test_git.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import hephaestus.utils as utils_pkg
 import hephaestus.utils.git as shared_git
+from hephaestus.diagnostics import bounded_git_diagnostic
 from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 
@@ -17,7 +18,7 @@ def test_bounded_git_diagnostic_redacts_credentials_before_truncation() -> None:
         "earlier output " * 20 + "https://operator:credential-value@example.invalid/repository.git"
     )
 
-    result = shared_git.bounded_git_diagnostic(diagnostic, limit=80)
+    result = bounded_git_diagnostic(diagnostic, limit=80)
 
     assert len(result) <= 80
     assert "credential-value" not in result

--- a/tests/unit/utils/test_git.py
+++ b/tests/unit/utils/test_git.py
@@ -11,6 +11,19 @@ import hephaestus.utils.git as shared_git
 from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 
+def test_bounded_git_diagnostic_redacts_credentials_before_truncation() -> None:
+    """Durable Git failure evidence is bounded and excludes credential values."""
+    diagnostic = (
+        "earlier output " * 20 + "https://operator:credential-value@example.invalid/repository.git"
+    )
+
+    result = shared_git.bounded_git_diagnostic(diagnostic, limit=80)
+
+    assert len(result) <= 80
+    assert "credential-value" not in result
+    assert "<redacted-git-url>" in result
+
+
 def test_run_git_routes_through_standard_subprocess_helper() -> None:
     """run_git normalizes git commands and uses the shared subprocess adapter."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")


### PR DESCRIPTION
Summary:
- reinject only validated SSH signing identity into controlled rebase continuation
- preserve bounded redacted Git diagnostics for signing and continuation failures
- distinguish follow-up conflicts from host signing failures

Validation:
- uv run pytest tests/unit -q
- uv run pytest --no-cov -q tests/unit/automation/pipeline/test_worker_pool.py tests/unit/utils/test_git.py
- uv run ruff check ...
- uv run mypy hephaestus/automation/pipeline/worker_pool.py hephaestus/utils/git.py

Closes #2783
