### PR TITLE
fix(tidy): fail closed when gh tidy itself fails

### DIFF
--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -546,6 +546,7 @@ class TidyExecutionError(RuntimeError):
     """
 
     def __init__(self, exit_code: int) -> None:
+        """Record the failed command's exit code for the caller."""
         super().__init__(f"gh tidy exited with code {exit_code}")
         self.exit_code = exit_code
 

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -536,13 +536,24 @@ def _emit_tidy_environment_failure(json_output: bool) -> int:
     return 1
 
 
+class TidyExecutionError(RuntimeError):
+    """The underlying `gh tidy` command failed (non-zero exit).
+
+    Raised instead of parsing output that cannot be trusted. A failed rebase
+    with a branch checked out in another worktree is the canonical case
+    (Athena #103): parsing the partial output and claiming a clean result
+    fabricates a successful cleanup.
+    """
+
+    def __init__(self, exit_code: int) -> None:
+        super().__init__(f"gh tidy exited with code {exit_code}")
+        self.exit_code = exit_code
+
+
 def _run_tidy_and_find_problem_branches(trunk: str, dry_run: bool) -> list[str]:
     exit_code, output = _run_gh_tidy(trunk, dry_run)
     if exit_code != 0 and not dry_run:
-        logger.warning(
-            "gh tidy exited with code %d — proceeding to parse output anyway",
-            exit_code,
-        )
+        raise TidyExecutionError(exit_code)
     return parse_problem_branches(output)
 
 
@@ -654,7 +665,18 @@ def main() -> int:
     if args.cleanup_stale_worktrees:
         return _cleanup_stale_worktrees(repo_path, trunk, args.dry_run)
 
-    problem_branches = _run_tidy_and_find_problem_branches(trunk, args.dry_run)
+    try:
+        problem_branches = _run_tidy_and_find_problem_branches(trunk, args.dry_run)
+    except TidyExecutionError as error:
+        logger.error(
+            "gh tidy failed with exit code %d — cleanup state is unknown; "
+            "fix the underlying failures before claiming a clean result",
+            error.exit_code,
+        )
+        if args.json:
+            emit_json_status(1, message="gh tidy failed; cleanup state unknown")
+        return 1
+
     if not problem_branches:
         return _handle_no_problem_branches(args.json)
 

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for configuration utilities."""
 
+import os
 import sys
 
 import pytest
@@ -250,6 +251,13 @@ class TestMergeConfigs:
 
 class TestMergeWithEnv:
     """Tests for merge_with_env."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_ambient_hephaestus_environment(self, monkeypatch):
+        """Ensure each merge test controls every variable under its prefix."""
+        for key in tuple(os.environ):
+            if key.startswith("HEPHAESTUS_"):
+                monkeypatch.delenv(key)
 
     def test_env_variable_overrides(self, monkeypatch):
         """Environment variable overrides config value using __ as nesting delimiter."""

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -266,13 +266,24 @@ def test_dispatch_swarm_runs_codex_agents_in_threads(
 class TestTidyHandlers:
     """Tests for extracted tidy workflow handlers."""
 
-    def test_run_tidy_and_find_problem_branches_parses_even_after_gh_tidy_failure(
+    def test_run_tidy_and_find_problem_branches_fails_closed_on_gh_tidy_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """gh-tidy failures still return parseable problem branches."""
-        monkeypatch.setattr(tidy_module, "_run_gh_tidy", lambda trunk, dry_run: (2, ONE_PROBLEM))
+        """A non-zero gh tidy exit must raise, never fabricate a clean result.
 
-        assert tidy_module._run_tidy_and_find_problem_branches("main", False) == [
+        Athena #103: parsing partial output after gh tidy exited non-zero and
+        then claiming "All branches rebased cleanly" produced a false success.
+        The function now fails closed so callers cannot lie about cleanup state.
+        """
+        monkeypatch.setattr(tidy_module, "_run_gh_tidy", lambda trunk, dry_run: (128, ONE_PROBLEM))
+
+        with pytest.raises(tidy_module.TidyExecutionError) as excinfo:
+            tidy_module._run_tidy_and_find_problem_branches("main", False)
+        assert excinfo.value.exit_code == 128
+
+        # dry-run never mutates state, so it may still parse output for preview.
+        monkeypatch.setattr(tidy_module, "_run_gh_tidy", lambda trunk, dry_run: (128, ONE_PROBLEM))
+        assert tidy_module._run_tidy_and_find_problem_branches("main", True) == [
             "feature/my-branch"
         ]
 


### PR DESCRIPTION
Root cause of Athena #103: `_run_tidy_and_find_problem_branches` logged a WARNING on a non-zero `gh tidy` exit but kept parsing, and with no problem branches found the caller printed "All branches rebased cleanly — no swarm needed." and exited 0 — fabricating a successful cleanup.

## Fix
- `_run_tidy_and_find_problem_branches` now raises `TidyExecutionError` on a non-zero (non-dry-run) exit.
- `main` catches it, logs the failure at error level, emits the failure JSON envelope, and returns 1.
- The unit test that codified the old parse-anyway behavior now asserts the fail-closed contract (and that dry-run still previews).

Closes #2790