### PR TITLE
fix(agents): discover selected Pi isolation adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,12 +594,15 @@ Codex, and the currently fail-closed Pi provider boundary. It provides:
 - `run_codex_*` and `run_agent_*` text/session/resume helpers invoke direct
   providers through the neutral boundary. Public `run_pi_*` execution helpers
   also reject unadmitted automation; only `run_pi_smoke_session` is the fixed
-  tool-free, non-interactive operator smoke seam. Normal Pi automation remains
-  blocked until its stage scope contracts are complete;
+  tool-free, non-interactive operator smoke seam. Normal Pi automation requires
+  a reviewed external OS-isolation adapter. A fresh process loads only the
+  explicitly selected `HEPH_PI_ISOLATION_ADAPTER` factory from the
+  `hephaestus.pi_isolation_adapters` entry-point group; the base package ships
+  no adapter and never auto-selects one.
   `hephaestus-install-pi-plugins` installs and preflights the catalog-pinned Pi
-  CLI/package set, but passing preflight does not bypass #2518's lifecycle and
-  role-scope admission gate. The smoke seam is not admission evidence. See
-  ADR-0019, ADR-0020, and ADR-0023.
+  CLI/package set, but passing preflight does not bypass external isolation,
+  lifecycle, or role-scope admission gates. The smoke seam is not admission
+  evidence. See ADR-0019, ADR-0020, ADR-0023, and ADR-0029.
 - Claude is normally invoked via `hephaestus.automation.claude_invoke.invoke_claude_with_session`;
   the library-only fleet-sync conflict fallback uses `claude_code_sdk` with the scoped call-site
   controls below.

--- a/README.md
+++ b/README.md
@@ -345,9 +345,10 @@ plan and `hephaestus-install-pi-plugins --global --yes --no-approve` to install
 the safe global defaults. Passing package preflight does not admit normal Pi
 automation: in a standard installation, `--agent pi` fails before stage or
 wrapper dispatch because no OS-isolation adapter is bundled. A trusted host
-integration must explicitly register an adapter that enforces the resolved
-filesystem and network policy; the local setup otherwise supports only the
-explicit adapter-smoke seam.
+integration must provide a named `hephaestus.pi_isolation_adapters` entry point,
+and the operator must select it with `HEPH_PI_ISOLATION_ADAPTER`. That adapter
+enforces the resolved filesystem and network policy; the local setup otherwise
+supports only the explicit adapter-smoke seam.
 
 #### Running the automation loop from a source checkout (macOS / Codex)
 

--- a/docs/adr/0029-explicit-pi-isolation-adapter-bootstrap.md
+++ b/docs/adr/0029-explicit-pi-isolation-adapter-bootstrap.md
@@ -1,0 +1,66 @@
+# ADR-0029: Explicit Pi isolation-adapter bootstrap
+
+- Status: Accepted
+- Date: 2026-08-19
+- Tracks: #2791, #2738
+- Extends: ADR-0019, ADR-0020
+
+## Context
+
+Pi's model-visible tool flags do not provide the operating-system filesystem
+and network isolation required by the execution-policy matrix. Stage 5
+therefore made normal Pi automation depend on a reviewed, host-owned
+`PiIsolationAdapter` and kept stock installations fail-closed.
+
+The original registration function works only when an embedding application
+imports Hephaestus and registers an adapter in the same Python process. The
+Stage 6 conformance commands start installed console scripts as fresh
+processes, so an installed external broker had no explicit way to register
+itself before `resolve_agent("pi")` enforced the adapter gate.
+
+## Decision
+
+External broker packages may publish a zero-argument adapter factory in the
+`hephaestus.pi_isolation_adapters` Python entry-point group. A fresh process
+loads exactly one named factory only when the operator explicitly sets
+`HEPH_PI_ISOLATION_ADAPTER` to that public entry-point name.
+
+Hephaestus does not bundle a broker, enumerate and auto-select installed
+brokers, or fall back to direct Pi execution. Missing, duplicate, unloadable,
+or structurally invalid selected entry points raise
+`PiIsolationUnavailableError` before a provider process starts. Initialization
+diagnostics are not exposed because an external broker may contain private
+provider configuration.
+
+The existing in-process `register_pi_isolation_adapter()` seam remains
+available to embedding applications. Both bootstrap paths end at the same
+`PiIsolationAdapter.invoke()` boundary; the external implementation remains
+responsible for enforcing every filesystem and network grant in the resolved
+`ExecutionPolicy`.
+
+## Alternatives considered
+
+- **Bundle a Bubblewrap, container, or namespace adapter.** Rejected because
+  Hephaestus cannot currently enforce the provider-relay and constrained-web
+  contracts portably, and a partial adapter would weaken the Stage 5 boundary.
+- **Auto-load the only installed adapter.** Rejected because package
+  installation must not silently activate executable security-boundary code.
+- **Accept a module path or command from an environment variable.** Rejected
+  because a named packaging entry point provides an enumerable installation
+  contract and avoids inventing a second import or subprocess protocol.
+- **Require a custom Python wrapper for every console command.** Rejected
+  because it does not satisfy the documented installed-console workflow and
+  duplicates command dispatch outside Hephaestus.
+
+## Consequences
+
+- A host integration can bootstrap the same reviewed adapter across every
+  Hephaestus console entry point without modifying pipeline code.
+- Stock installations and installed-but-unselected broker packages remain
+  fail-closed.
+- Broker implementation, OS-level enforcement, adversarial validation, and
+  deployment remain a separate deliverable tracked by #2738; this decision
+  adds no claim that Stage 6 evidence is complete.
+- The entry-point group, environment variable, zero-argument factory, and
+  `PiIsolationAdapter` protocol form a public integration contract and require
+  compatibility review before future changes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ numbered, and listed here.
 | [0026](0026-auxiliary-host-learning-lane.md) | Auxiliary host-learning lane | Accepted |
 | [0027](0027-durable-plan-review-conversations.md) | Durable plan-review conversations | Accepted |
 | [0028](0028-source-reading-agent-workspace-isolation.md) | Deterministic source-reading agent workspace isolation | Accepted |
+| [0029](0029-explicit-pi-isolation-adapter-bootstrap.md) | Explicit Pi isolation-adapter bootstrap | Accepted |

--- a/docs/pi-private-provider.md
+++ b/docs/pi-private-provider.md
@@ -91,6 +91,28 @@ its model-visible tool flags cannot enforce the resolved filesystem or network
 policy. Do not treat a local model configuration, package readiness, or a
 successful smoke command as automation admission evidence.
 
+An external adapter package exposes its zero-argument factory through the
+`hephaestus.pi_isolation_adapters` Python entry-point group. A fresh console
+process loads it only when the operator explicitly selects its public name:
+
+```toml
+[project.entry-points."hephaestus.pi_isolation_adapters"]
+operator-broker = "operator_package.pi_broker:create_adapter"
+```
+
+```bash
+export HEPH_PI_ISOLATION_ADAPTER=operator-broker
+hephaestus-plan-issues --agent pi --parallel 1 --json
+```
+
+The factory must return an object implementing
+`hephaestus.agents.runtime.PiIsolationAdapter`. Installing a package does not
+activate it, and Hephaestus never auto-selects among installed adapters. A
+missing, duplicate, unloadable, or invalid selected entry point fails before a
+Pi provider process starts. The external package remains responsible for
+reviewed enforcement of every filesystem and network grant it receives. See
+[ADR-0029](adr/0029-explicit-pi-isolation-adapter-bootstrap.md).
+
 ## Athena package acceptance
 
 The accepted Pi CLI and package set are recorded in the packaged catalog. Inspect

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -263,11 +263,12 @@ def _load_configured_pi_isolation_adapter() -> None:
     try:
         factory = matches[0].load()
         adapter = factory()
+        invoke = getattr(adapter, "invoke", None)
     except Exception:
         raise PiIsolationUnavailableError(
             f"Pi isolation adapter {adapter_name!r} could not be initialized"
         ) from None
-    if not callable(getattr(adapter, "invoke", None)):
+    if not callable(invoke):
         raise PiIsolationUnavailableError(
             f"Pi isolation adapter {adapter_name!r} does not implement invoke()"
         )

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -1938,6 +1938,8 @@ def _run_pi_with_policy(
     """
     command = _pi_base_cmd(session_id=session_id)
     command.extend(_pi_policy_args(policy))
+    if _PI_ISOLATION_ADAPTER is None:
+        _load_configured_pi_isolation_adapter()
     adapter = _PI_ISOLATION_ADAPTER
     if adapter is None:
         raise PiIsolationUnavailableError(

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -17,6 +17,7 @@ import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
@@ -75,6 +76,8 @@ CODEX_PARENT_CONTEXT_ENV_VARS = ("CODEX_THREAD_ID",)
 CLAUDE_READ_ONLY_TOOLS = "Read,Glob,Grep"
 PI_PROVIDER_ENV = "HEPH_PI_PROVIDER"
 PI_MODEL_ENV = "HEPH_PI_MODEL"
+PI_ISOLATION_ADAPTER_ENV = "HEPH_PI_ISOLATION_ADAPTER"
+PI_ISOLATION_ADAPTER_ENTRY_POINT_GROUP = "hephaestus.pi_isolation_adapters"
 PI_MODEL_CONFIG_RELATIVE_PATH = Path(".pi") / "agent" / "models.json"
 PI_PRIVATE_DENYLIST_FILENAME = ".heph-private-denylist"
 PI_PROJECT_DENYLIST_FILENAME = ".heph-project-denylist"
@@ -236,8 +239,45 @@ def register_pi_isolation_adapter(adapter: PiIsolationAdapter) -> None:
     _PI_ISOLATION_ADAPTER = adapter
 
 
+def _load_configured_pi_isolation_adapter() -> None:
+    """Load the explicitly selected host adapter for a fresh CLI process."""
+    adapter_name = os.environ.get(PI_ISOLATION_ADAPTER_ENV, "").strip()
+    if not adapter_name:
+        return
+    try:
+        matches = tuple(
+            entry_points(
+                group=PI_ISOLATION_ADAPTER_ENTRY_POINT_GROUP,
+                name=adapter_name,
+            )
+        )
+    except Exception:
+        raise PiIsolationUnavailableError(
+            f"Pi isolation adapter {adapter_name!r} could not be discovered"
+        ) from None
+    if len(matches) != 1:
+        raise PiIsolationUnavailableError(
+            f"Pi isolation adapter {adapter_name!r} is not installed exactly once in "
+            f"entry-point group {PI_ISOLATION_ADAPTER_ENTRY_POINT_GROUP!r}"
+        )
+    try:
+        factory = matches[0].load()
+        adapter = factory()
+    except Exception:
+        raise PiIsolationUnavailableError(
+            f"Pi isolation adapter {adapter_name!r} could not be initialized"
+        ) from None
+    if not callable(getattr(adapter, "invoke", None)):
+        raise PiIsolationUnavailableError(
+            f"Pi isolation adapter {adapter_name!r} does not implement invoke()"
+        )
+    register_pi_isolation_adapter(adapter)
+
+
 def _require_pi_isolation_adapter() -> None:
     """Fail at provider selection when this installation has no Pi broker."""
+    if _PI_ISOLATION_ADAPTER is None:
+        _load_configured_pi_isolation_adapter()
     if _PI_ISOLATION_ADAPTER is None:
         raise PiIsolationUnavailableError(
             "Pi automation is N/A: this installation has no registered host "

--- a/tests/unit/agents/test_execution_policy.py
+++ b/tests/unit/agents/test_execution_policy.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from typing import cast
 
 import pytest
@@ -156,6 +159,8 @@ def test_ready_pi_is_explicitly_na_without_a_registered_isolation_adapter(
     )
     monkeypatch.setattr(agent_runtime, "is_agent_authenticated", lambda _agent: True)
     monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.delenv("HEPH_PI_ISOLATION_ADAPTER", raising=False)
+    monkeypatch.setattr(agent_runtime, "entry_points", pytest.fail, raising=False)
 
     with pytest.raises(agent_runtime.PiIsolationUnavailableError, match="Pi automation is N/A"):
         agent_runtime.resolve_agent("pi", cwd=tmp_path)
@@ -176,10 +181,193 @@ def test_registered_host_adapter_admits_pi_selection(
     )
     monkeypatch.setattr(agent_runtime, "is_agent_authenticated", lambda _agent: True)
     monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "must-not-be-loaded")
+    monkeypatch.setattr(agent_runtime, "entry_points", pytest.fail, raising=False)
 
     agent_runtime.register_pi_isolation_adapter(Adapter())
 
     assert agent_runtime.resolve_agent("pi", cwd=tmp_path) == "pi"
+
+
+def test_named_host_adapter_entry_point_admits_fresh_cli_process(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicitly selected installed adapter bootstraps a fresh process."""
+    from hephaestus.agents.pi_plugins import PiPreflightResult
+
+    class Adapter:
+        def invoke(self, **_kwargs: object) -> agent_runtime.AgentRunResult:
+            raise AssertionError("selection must not invoke the adapter")
+
+    class EntryPoint:
+        def load(self) -> object:
+            def factory() -> Adapter:
+                return Adapter()
+
+            return factory
+
+    observed: list[dict[str, str]] = []
+
+    def entry_points(**kwargs: str) -> tuple[EntryPoint, ...]:
+        observed.append(kwargs)
+        return (EntryPoint(),)
+
+    monkeypatch.setattr(
+        agent_runtime, "preflight_pi_environment", lambda _cwd: PiPreflightResult.ready_result()
+    )
+    monkeypatch.setattr(agent_runtime, "is_agent_authenticated", lambda _agent: True)
+    monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.setattr(agent_runtime, "entry_points", entry_points, raising=False)
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "operator-broker")
+
+    assert agent_runtime.resolve_agent("pi", cwd=tmp_path) == "pi"
+    assert observed == [
+        {
+            "group": "hephaestus.pi_isolation_adapters",
+            "name": "operator-broker",
+        }
+    ]
+    assert agent_runtime._PI_ISOLATION_ADAPTER is not None
+
+
+def test_installed_host_adapter_bootstraps_in_a_fresh_python_process(tmp_path) -> None:
+    """Installed entry-point metadata is sufficient without in-process registration."""
+    fixture_root = tmp_path / "fixture"
+    fixture_root.mkdir()
+    (fixture_root / "fixture_adapter.py").write_text(
+        "class Adapter:\n"
+        "    def invoke(self, **kwargs):\n"
+        "        raise AssertionError('selection must not invoke the adapter')\n"
+        "\n"
+        "def create_adapter():\n"
+        "    return Adapter()\n",
+        encoding="utf-8",
+    )
+    metadata = fixture_root / "fixture_adapter-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "entry_points.txt").write_text(
+        "[hephaestus.pi_isolation_adapters]\nprocess-fixture = fixture_adapter:create_adapter\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HEPH_PI_ISOLATION_ADAPTER"] = "process-fixture"
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(fixture_root), env.get("PYTHONPATH", "")) if part
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hephaestus.agents import runtime; "
+            "runtime._require_pi_isolation_adapter(); print('loaded')",
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "loaded"
+
+
+@pytest.mark.parametrize("match_count", [0, 2])
+def test_named_host_adapter_requires_one_exact_entry_point(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, match_count: int
+) -> None:
+    """A missing or ambiguous broker selection fails before authentication."""
+    from hephaestus.agents.pi_plugins import PiPreflightResult
+
+    class EntryPoint:
+        pass
+
+    monkeypatch.setattr(
+        agent_runtime, "preflight_pi_environment", lambda _cwd: PiPreflightResult.ready_result()
+    )
+    monkeypatch.setattr(agent_runtime, "is_agent_authenticated", pytest.fail)
+    monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.setattr(
+        agent_runtime,
+        "entry_points",
+        lambda **_kwargs: tuple(EntryPoint() for _index in range(match_count)),
+        raising=False,
+    )
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "operator-broker")
+
+    with pytest.raises(
+        agent_runtime.PiIsolationUnavailableError,
+        match="not installed exactly once",
+    ):
+        agent_runtime.resolve_agent("pi", cwd=tmp_path)
+
+
+@pytest.mark.parametrize("failure", ["discover", "load", "initialize"])
+def test_named_host_adapter_sanitizes_external_factory_failures(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    """Private diagnostics never escape discovery, loading, or initialization."""
+    from hephaestus.agents.pi_plugins import PiPreflightResult
+
+    class EntryPoint:
+        def load(self) -> object:
+            if failure == "load":
+                raise RuntimeError("private load diagnostic")
+
+            def factory() -> object:
+                raise RuntimeError("private initialization diagnostic")
+
+            return factory
+
+    monkeypatch.setattr(
+        agent_runtime, "preflight_pi_environment", lambda _cwd: PiPreflightResult.ready_result()
+    )
+    monkeypatch.setattr(agent_runtime, "is_agent_authenticated", pytest.fail)
+    monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+
+    def entry_points(**_kwargs: str) -> tuple[EntryPoint, ...]:
+        if failure == "discover":
+            raise RuntimeError("private discovery diagnostic")
+        return (EntryPoint(),)
+
+    monkeypatch.setattr(agent_runtime, "entry_points", entry_points, raising=False)
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "operator-broker")
+
+    with pytest.raises(
+        agent_runtime.PiIsolationUnavailableError,
+        match="could not be discovered" if failure == "discover" else "could not be initialized",
+    ) as exc_info:
+        agent_runtime.resolve_agent("pi", cwd=tmp_path)
+
+    assert "private" not in str(exc_info.value)
+
+
+def test_named_host_adapter_rejects_an_invalid_protocol(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A factory result without a callable invoke boundary remains unadmitted."""
+    from hephaestus.agents.pi_plugins import PiPreflightResult
+
+    class EntryPoint:
+        def load(self) -> object:
+            return object
+
+    monkeypatch.setattr(
+        agent_runtime, "preflight_pi_environment", lambda _cwd: PiPreflightResult.ready_result()
+    )
+    monkeypatch.setattr(agent_runtime, "is_agent_authenticated", pytest.fail)
+    monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.setattr(
+        agent_runtime, "entry_points", lambda **_kwargs: (EntryPoint(),), raising=False
+    )
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "operator-broker")
+
+    with pytest.raises(
+        agent_runtime.PiIsolationUnavailableError,
+        match=r"does not implement invoke\(\)",
+    ):
+        agent_runtime.resolve_agent("pi", cwd=tmp_path)
 
 
 def test_pi_policy_dispatch_fails_before_provider_without_os_adapter(

--- a/tests/unit/agents/test_execution_policy.py
+++ b/tests/unit/agents/test_execution_policy.py
@@ -276,6 +276,41 @@ def test_installed_host_adapter_bootstraps_in_a_fresh_python_process(tmp_path) -
     assert completed.stdout.strip() == "loaded"
 
 
+def test_named_host_adapter_bootstraps_before_direct_policy_dispatch(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Direct library callers load the selected adapter before provider dispatch."""
+    received: dict[str, object] = {}
+
+    class Adapter:
+        def invoke(self, **kwargs: object) -> agent_runtime.AgentRunResult:
+            received.update(kwargs)
+            return agent_runtime.AgentRunResult(stdout="reviewed", stderr="")
+
+    class EntryPoint:
+        def load(self) -> object:
+            return Adapter
+
+    monkeypatch.setattr(agent_runtime, "_require_pi_automation_admission", lambda _cwd: None)
+    monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.setattr(
+        agent_runtime, "entry_points", lambda **_kwargs: (EntryPoint(),), raising=False
+    )
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "operator-broker")
+    request = ExecutionRequest(
+        AgentRole.PR_REVIEWER,
+        AgentOperation.PR_REVIEW,
+        SessionLifecycle.ONE_SHOT,
+    )
+
+    result = agent_runtime.run_agent_text(
+        "pi", "review", cwd=tmp_path, timeout=30, execution_request=request
+    )
+
+    assert result.stdout == "reviewed"
+    assert received["prompt"] == "review"
+
+
 @pytest.mark.parametrize("match_count", [0, 2])
 def test_named_host_adapter_requires_one_exact_entry_point(
     tmp_path, monkeypatch: pytest.MonkeyPatch, match_count: int

--- a/tests/unit/agents/test_execution_policy.py
+++ b/tests/unit/agents/test_execution_policy.py
@@ -254,13 +254,16 @@ def test_installed_host_adapter_bootstraps_in_a_fresh_python_process(tmp_path) -
     env["PYTHONPATH"] = os.pathsep.join(
         part for part in (str(fixture_root), env.get("PYTHONPATH", "")) if part
     )
+    process_code = (
+        "from hephaestus.agents import runtime; "
+        + "runtime._require_pi_isolation_adapter(); print('loaded')"
+    )
 
     completed = subprocess.run(
         [
             sys.executable,
             "-c",
-            "from hephaestus.agents import runtime; "
-            "runtime._require_pi_isolation_adapter(); print('loaded')",
+            process_code,
         ],
         check=False,
         capture_output=True,

--- a/tests/unit/agents/test_execution_policy.py
+++ b/tests/unit/agents/test_execution_policy.py
@@ -408,6 +408,40 @@ def test_named_host_adapter_rejects_an_invalid_protocol(
         agent_runtime.resolve_agent("pi", cwd=tmp_path)
 
 
+def test_named_host_adapter_sanitizes_protocol_attribute_failures(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """External attribute diagnostics never escape protocol validation."""
+    from hephaestus.agents.pi_plugins import PiPreflightResult
+
+    class Adapter:
+        @property
+        def invoke(self) -> object:
+            raise RuntimeError("private validation diagnostic")
+
+    class EntryPoint:
+        def load(self) -> object:
+            return Adapter
+
+    monkeypatch.setattr(
+        agent_runtime, "preflight_pi_environment", lambda _cwd: PiPreflightResult.ready_result()
+    )
+    monkeypatch.setattr(agent_runtime, "is_agent_authenticated", pytest.fail)
+    monkeypatch.setattr(agent_runtime, "_PI_ISOLATION_ADAPTER", None)
+    monkeypatch.setattr(
+        agent_runtime, "entry_points", lambda **_kwargs: (EntryPoint(),), raising=False
+    )
+    monkeypatch.setenv("HEPH_PI_ISOLATION_ADAPTER", "operator-broker")
+
+    with pytest.raises(
+        agent_runtime.PiIsolationUnavailableError,
+        match="could not be initialized",
+    ) as exc_info:
+        agent_runtime.resolve_agent("pi", cwd=tmp_path)
+
+    assert "private" not in str(exc_info.value)
+
+
 def test_pi_policy_dispatch_fails_before_provider_without_os_adapter(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- load only the explicitly selected `hephaestus.pi_isolation_adapters` factory in fresh processes
- preserve stock fail-closed behavior and in-process registration precedence
- bootstrap the selected adapter before direct policy dispatch
- sanitize discovery, initialization, and protocol-attribute failures without leaking private diagnostics

## Root cause

The existing adapter registration seam worked only inside an embedding Python process. Installed console commands start fresh processes, leaving the external broker in #2738 impossible to select without mixing its discovery contract into the blocked Stage 6 PR.

## Prerequisite

The platform-aware host-verification receipt contract discovered during review was isolated into #2793 and merged through PR #2794. This branch is rebased onto that merge; unsupported platforms now produce exact-head `status: skipped` N/A receipts without executing PR code, while supported-host failures remain fail closed.

## Validation

- Pi runtime, execution-policy, plugin, session, confinement, ADR, and documentation suites: 197 passed, 1 skipped
- Ruff check and format validation passed
- mypy passed for the changed Python files
- configured pre-commit checks passed for every changed path

Closes #2791