### PR TITLE
fix(automation): permit clean source worktrees

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -2994,13 +2994,6 @@ class WorkerPool:
         ).stdout.strip()
         if not default_branch:
             return JobResult(ok=False, error=f"repository has no default branch: {expected_repo}")
-        if branch != default_branch:
-            return JobResult(
-                ok=False,
-                error=(
-                    f"checkout is not on its default branch {default_branch}: currently on {branch}"
-                ),
-            )
         return self._fast_forward_checkout(
             checkout=checkout,
             default_branch=default_branch,
@@ -3009,8 +3002,11 @@ class WorkerPool:
         )
 
     @staticmethod
-    def _checkout_state_error(*, checkout: Path, default_branch: str, timeout_s: int) -> str | None:
-        """Return the clean-default-branch validation error, if any."""
+    def _checkout_state_error(
+        *, checkout: Path, timeout_s: int, default_branch: str | None = None
+    ) -> str | None:
+        """Return the clean, attached-checkout validation error, if any."""
+        del default_branch
         status = git_utils.run(
             [
                 "git",
@@ -3037,8 +3033,6 @@ class WorkerPool:
         branch = branch_result.stdout.strip()
         if branch_result.returncode != 0 or not branch:
             return f"checkout is detached: {checkout}"
-        if branch != default_branch:
-            return f"checkout is not on its default branch {default_branch}: currently on {branch}"
         return None
 
     @staticmethod
@@ -3097,7 +3091,6 @@ class WorkerPool:
         )
         if validation_error := WorkerPool._checkout_state_error(
             checkout=checkout,
-            default_branch=default_branch,
             timeout_s=timeout_s,
         ):
             return JobResult(ok=False, error=validation_error)
@@ -3149,7 +3142,6 @@ class WorkerPool:
             )
         if validation_error := WorkerPool._checkout_state_error(
             checkout=checkout,
-            default_branch=default_branch,
             timeout_s=timeout_s,
         ):
             return JobResult(ok=False, error=validation_error)

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -5600,13 +5600,13 @@ class TestGitOps:
         assert result.ok is False
         assert "expected origin owner/name" in (result.error or "")
 
-    def test_sync_checkout_rejects_checkout_not_on_default_branch(
+    def test_sync_checkout_accepts_clean_attached_checkout_on_nondefault_branch(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
     ) -> None:
-        """A reusable feature branch is not silently advanced as though it were main."""
+        """A clean attached runner branch may safely follow the default branch."""
         checkout = tmp_path / "checkout"
         checkout.mkdir()
         job = GitJob(
@@ -5621,47 +5621,20 @@ class TestGitOps:
                 subprocess.CompletedProcess([], 0, stdout=""),
                 subprocess.CompletedProcess([], 0, stdout="feature\n"),
                 subprocess.CompletedProcess([], 0, stdout="main\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="feature\n"),
+                subprocess.CompletedProcess([], 0, stdout="0\t0\n"),
+                subprocess.CompletedProcess([], 0),
+                subprocess.CompletedProcess([], 0, stdout=""),
+                subprocess.CompletedProcess([], 0, stdout="feature\n"),
+                subprocess.CompletedProcess([], 0, stdout="a" * 40 + "\n" + "a" * 40 + "\n"),
             ]
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
-        assert mock_run.call_args_list == [
-            call(
-                ["git", "remote", "get-url", "origin"],
-                cwd=checkout,
-                timeout=120,
-                env=ANY,
-            ),
-            call(
-                [
-                    "git",
-                    "-c",
-                    "core.fsmonitor=false",
-                    "status",
-                    "--porcelain",
-                    "--untracked-files=no",
-                ],
-                cwd=checkout,
-                timeout=120,
-                env=ANY,
-            ),
-            call(
-                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
-                cwd=checkout,
-                check=False,
-                log_errors=False,
-                timeout=120,
-                env=ANY,
-            ),
-            call(
-                [_trusted_gh_executable(), "api", "repos/owner/name", "--jq", ".default_branch"],
-                cwd=checkout,
-                timeout=120,
-                env=ANY,
-            ),
-        ]
-        assert result.ok is False
-        assert "not on its default branch" in (result.error or "")
+        assert result.ok is True
+        assert result.value == "a" * 40
 
     def test_sync_checkout_rejects_detached_head_before_fetching(
         self,


### PR DESCRIPTION
## Summary\n\nPermit a clean, attached automation source worktree to follow the repository default branch even when its local branch has a different name.\n\nAll origin, cleanliness, attached-HEAD, ancestry, and fast-forward checks remain enforced.\n\n## Validation\n\n- Focused checkout-policy regression suite (7 passed)\n- Ruff, formatting, and Mypy\n- Mandatory full pre-push suite: 7,936 passed, 13 skipped\n\nCloses #2799\n\nTracking issue: https://github.com/HomericIntelligence/Hephaestus/issues/2799